### PR TITLE
Makefile: Fix kernel source location

### DIFF
--- a/driver/Makefile
+++ b/driver/Makefile
@@ -1,12 +1,15 @@
 sysdig-probe-y += main.o flags_table.o ppm_events.o ppm_fillers.o event_table.o syscall_table.o syscall_info_table.o
 obj-m += sysdig-probe.o
 ccflags-y := 
+
+KERNELDIR 		?= /lib/modules/$(shell uname -r)/build
+
 TOP := $(shell pwd)
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(TOP) modules
+	make -C $(KERNELDIR) M=$(TOP) modules
  
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(TOP) clean
+	make -C $(KERNELDIR) M=$(TOP) clean
 
 install: all
-	make -C /lib/modules/$(shell uname -r)/build M=$(TOP) modules_install
+	make -C $(KERNELDIR) M=$(TOP) modules_install


### PR DESCRIPTION
This fixes the build to allow it to work against a kernel source tree
that is not the running kernel version, which is a requirement for most
all build systems.
