### PR TITLE
[8] convert TCP/UDP ports into protocol names and vice versa

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -5,6 +5,8 @@ include_directories(third-party/jsoncpp)
 include_directories(third-party/jsoncpp)
 include_directories(${PROJECT_SOURCE_DIR}/third-party/LuaJIT-2.0.2/src)
 
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 add_library(sinsp STATIC
 	chisel.cpp
 	event.cpp
@@ -14,6 +16,7 @@ add_library(sinsp STATIC
 	filter.cpp
 	filterchecks.cpp
 	ifinfo.cpp
+	servparse.cpp
 	internal_metrics.cpp
 	third-party/jsoncpp/jsoncpp.cpp
 	logger.cpp
@@ -30,7 +33,13 @@ if(NOT WIN32)
 	target_link_libraries(sinsp
 		${PROJECT_SOURCE_DIR}/third-party/LuaJIT-2.0.2/src/libluajit.a
 		dl)
+
+	install(FILES services
+		DESTINATION share/sysdig)
+
 else()
 	target_link_libraries(sinsp
 		${PROJECT_SOURCE_DIR}/third-party/LuaJIT-2.0.2/src/lua51.lib)
 endif()
+
+configure_file(config.h.in config.h)

--- a/userspace/libsinsp/config.h.in
+++ b/userspace/libsinsp/config.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define SYSDIG_SHARE_DIR "${CMAKE_INSTALL_PREFIX}/share/sysdig"

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -480,6 +480,8 @@ void sinsp_filter_check::string_to_rawval(const char* str, ppm_param_type ptype)
 			*(uint8_t*)(&m_val_storage[0]) = sinsp_numparser::parseu8(str);
 			break;
 		case PT_PORT: // This can be resolved in the future
+			*(uint16_t*)(&m_val_storage[0]) = service::toPort(str);
+			break;
 		case PT_FLAGS16:
 		case PT_UINT16:
 			*(uint16_t*)(&m_val_storage[0]) = sinsp_numparser::parseu16(str);

--- a/userspace/libsinsp/services
+++ b/userspace/libsinsp/services
@@ -1,0 +1,11308 @@
+# This is a local copy of the IANA port-numbers file.
+#
+# $Id: services 51836 2013-09-08 14:19:21Z gerald $
+#
+# Wireshark uses it to resolve port numbers into human readable
+# service names, e.g. TCP port 80 -> http.
+#
+# It is subject to copyright and being used with IANA's permission:
+# http://www.wireshark.org/lists/wireshark-dev/200708/msg00160.html
+#
+# The original file can be found at:
+# http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.csv
+#
+
+tcpmux              1/tcp # TCP Port Service Multiplexer [Mark_Lottor] [Mark_Lottor]
+tcpmux              1/udp # TCP Port Service Multiplexer [Mark_Lottor] [Mark_Lottor]
+compressnet         2/tcp # Management Utility
+compressnet         2/udp # Management Utility
+compressnet         3/tcp # Compression Process [Bernie_Volz] [Bernie_Volz]
+compressnet         3/udp # Compression Process [Bernie_Volz] [Bernie_Volz]
+rje                 5/tcp # Remote Job Entry [Jon_Postel] [Jon_Postel]
+rje                 5/udp # Remote Job Entry [Jon_Postel] [Jon_Postel]
+echo                7/tcp # Echo [Jon_Postel] [Jon_Postel]
+echo                7/udp # Echo [Jon_Postel] [Jon_Postel]
+discard             9/tcp # Discard [Jon_Postel] [Jon_Postel]
+discard             9/udp # Discard [Jon_Postel] [Jon_Postel]
+discard             9/sctp # Discard [Randall_Stewart] [Randall_Stewart] [RFC4960]
+discard             9/dccp # Discard [Eddie_Kohler] [Eddie_Kohler] [RFC4340] 1145656131
+systat             11/tcp # Active Users [Jon_Postel] [Jon_Postel]
+systat             11/udp # Active Users [Jon_Postel] [Jon_Postel]
+daytime            13/tcp # Daytime [Jon_Postel] [Jon_Postel] [RFC867]
+daytime            13/udp # Daytime [Jon_Postel] [Jon_Postel] [RFC867]
+qotd               17/tcp # Quote of the Day [Jon_Postel] [Jon_Postel]
+qotd               17/udp # Quote of the Day [Jon_Postel] [Jon_Postel]
+msp                18/tcp # Message Send Protocol (historic) [Rina_Nethaniel] [Rina_Nethaniel]
+msp                18/udp # Message Send Protocol (historic) [Rina_Nethaniel] [Rina_Nethaniel]
+chargen            19/tcp # Character Generator
+chargen            19/udp # Character Generator
+ftp-data           20/tcp # File Transfer [Default Data] [Jon_Postel] [Jon_Postel]
+ftp-data           20/udp # File Transfer [Default Data] [Jon_Postel] [Jon_Postel]
+ftp-data           20/sctp # FTP [Randall_Stewart] [Randall_Stewart] [RFC4960]
+ftp                21/tcp # File Transfer [Control] [Jon_Postel] [Jon_Postel] [RFC959] Defined TXT keys: u=<username> p=<password> path=<path>
+ftp                21/udp # File Transfer [Control] [Jon_Postel] [Jon_Postel] [RFC959] Defined TXT keys: u=<username> p=<password> path=<path>
+ftp                21/sctp # FTP [Randall_Stewart] [Randall_Stewart] [RFC4960] Defined TXT keys: u=<username> p=<password> path=<path>
+ssh                22/tcp # The Secure Shell (SSH) Protocol [RFC4251] Defined TXT keys: u=<username> p=<password>
+ssh                22/udp # The Secure Shell (SSH) Protocol [RFC4251] Defined TXT keys: u=<username> p=<password>
+ssh                22/sctp # SSH [Randall_Stewart] [Randall_Stewart] [RFC4960] Defined TXT keys: u=<username> p=<password>
+telnet             23/tcp # Telnet [Jon_Postel] [Jon_Postel] [RFC854] Defined TXT keys: u=<username> p=<password>
+telnet             23/udp # Telnet [Jon_Postel] [Jon_Postel] [RFC854] Defined TXT keys: u=<username> p=<password>
+smtp               25/tcp # Simple Mail Transfer [Jon_Postel] [Jon_Postel]
+smtp               25/udp # Simple Mail Transfer [Jon_Postel] [Jon_Postel]
+nsw-fe             27/tcp # NSW User System FE [Robert_Thomas] [Robert_Thomas]
+nsw-fe             27/udp # NSW User System FE [Robert_Thomas] [Robert_Thomas]
+msg-icp            29/tcp # MSG ICP [Robert_Thomas] [Robert_Thomas]
+msg-icp            29/udp # MSG ICP [Robert_Thomas] [Robert_Thomas]
+msg-auth           31/tcp # MSG Authentication [Robert_Thomas] [Robert_Thomas]
+msg-auth           31/udp # MSG Authentication [Robert_Thomas] [Robert_Thomas]
+dsp                33/tcp # Display Support Protocol [Ed_Cain] [Ed_Cain]
+dsp                33/udp # Display Support Protocol [Ed_Cain] [Ed_Cain]
+time               37/tcp # Time [Jon_Postel] [Jon_Postel]
+time               37/udp # Time [Jon_Postel] [Jon_Postel]
+rap                38/tcp # Route Access Protocol [Robert_Ullmann] [Robert_Ullmann]
+rap                38/udp # Route Access Protocol [Robert_Ullmann] [Robert_Ullmann]
+rlp                39/tcp # Resource Location Protocol [Mike_Accetta] [Mike_Accetta]
+rlp                39/udp # Resource Location Protocol [Mike_Accetta] [Mike_Accetta]
+graphics           41/tcp # Graphics
+graphics           41/udp # Graphics
+name               42/tcp # Host Name Server
+name               42/udp # Host Name Server
+nameserver         42/tcp # Host Name Server
+nameserver         42/udp # Host Name Server
+nicname            43/tcp # Who Is
+nicname            43/udp # Who Is
+mpm-flags          44/tcp # MPM FLAGS Protocol
+mpm-flags          44/udp # MPM FLAGS Protocol
+mpm                45/tcp # Message Processing Module [recv]
+mpm                45/udp # Message Processing Module [recv]
+mpm-snd            46/tcp # MPM [default send] [Jon_Postel] [Jon_Postel]
+mpm-snd            46/udp # MPM [default send] [Jon_Postel] [Jon_Postel]
+ni-ftp             47/tcp # NI FTP [Steve_Kille] [Steve_Kille]
+ni-ftp             47/udp # NI FTP [Steve_Kille] [Steve_Kille]
+auditd             48/tcp # Digital Audit Daemon [Larry_Scott] [Larry_Scott]
+auditd             48/udp # Digital Audit Daemon [Larry_Scott] [Larry_Scott]
+tacacs             49/tcp # Login Host Protocol (TACACS) [Pieter_Ditmars] [Pieter_Ditmars]
+tacacs             49/udp # Login Host Protocol (TACACS) [Pieter_Ditmars] [Pieter_Ditmars]
+re-mail-ck         50/tcp # Remote Mail Checking Protocol [Steve_Dorner] [Steve_Dorner]
+re-mail-ck         50/udp # Remote Mail Checking Protocol [Steve_Dorner] [Steve_Dorner]
+xns-time           52/tcp # XNS Time Protocol [Susie_Armstrong] [Susie_Armstrong]
+xns-time           52/udp # XNS Time Protocol [Susie_Armstrong] [Susie_Armstrong]
+domain             53/tcp # Domain Name Server [Paul_Mockapetris] [Paul_Mockapetris]
+domain             53/udp # Domain Name Server [Paul_Mockapetris] [Paul_Mockapetris]
+xns-ch             54/tcp # XNS Clearinghouse [Susie_Armstrong] [Susie_Armstrong]
+xns-ch             54/udp # XNS Clearinghouse [Susie_Armstrong] [Susie_Armstrong]
+isi-gl             55/tcp # ISI Graphics Language
+isi-gl             55/udp # ISI Graphics Language
+xns-auth           56/tcp # XNS Authentication [Susie_Armstrong] [Susie_Armstrong]
+xns-auth           56/udp # XNS Authentication [Susie_Armstrong] [Susie_Armstrong]
+xns-mail           58/tcp # XNS Mail [Susie_Armstrong] [Susie_Armstrong]
+xns-mail           58/udp # XNS Mail [Susie_Armstrong] [Susie_Armstrong]
+ni-mail            61/tcp # NI MAIL [Steve_Kille] [Steve_Kille]
+ni-mail            61/udp # NI MAIL [Steve_Kille] [Steve_Kille]
+acas               62/tcp # ACA Services [E_Wald] [E_Wald]
+acas               62/udp # ACA Services [E_Wald] [E_Wald]
+whoispp            63/tcp # whois++IANA assigned this well-formed service name as a replacement for "whois++". [Rickard_Schoultz] [Rickard_Schoultz]
+whois++            63/tcp # whois++ [Rickard_Schoultz] [Rickard_Schoultz] This entry is an alias to "whoispp".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+whoispp            63/udp # whois++IANA assigned this well-formed service name as a replacement for "whois++". [Rickard_Schoultz] [Rickard_Schoultz]
+whois++            63/udp # whois++ [Rickard_Schoultz] [Rickard_Schoultz] This entry is an alias to "whoispp".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+covia              64/tcp # Communications Integrator (CI) [Dan_Smith] [Dan_Smith]
+covia              64/udp # Communications Integrator (CI) [Dan_Smith] [Dan_Smith]
+tacacs-ds          65/tcp # TACACS-Database Service [Kathy_Huber] [Kathy_Huber]
+tacacs-ds          65/udp # TACACS-Database Service [Kathy_Huber] [Kathy_Huber]
+sql-net            66/tcp # Oracle SQL*NETIANA assigned this well-formed service name as a replacement for "sql*net". [Jack_Haverty] [Jack_Haverty]
+sql*net            66/tcp # Oracle SQL*NET [Jack_Haverty] [Jack_Haverty] This entry is an alias to "sql-net".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+sql-net            66/udp # Oracle SQL*NETIANA assigned this well-formed service name as a replacement for "sql*net". [Jack_Haverty] [Jack_Haverty]
+sql*net            66/udp # Oracle SQL*NET [Jack_Haverty] [Jack_Haverty] This entry is an alias to "sql-net".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+bootps             67/tcp # Bootstrap Protocol Server [Bill_Croft] [Bill_Croft] [RFC951] Defined TXT keys: None
+bootps             67/udp # Bootstrap Protocol Server
+bootpc             68/tcp # Bootstrap Protocol Client [Bill_Croft] [Bill_Croft]
+bootpc             68/udp # Bootstrap Protocol Client [Bill_Croft] [Bill_Croft]
+tftp               69/tcp # Trivial File Transfer [David_Clark] [David_Clark]
+tftp               69/udp # Trivial File Transfer [David_Clark] [David_Clark]
+gopher             70/tcp # Gopher [Mark_McCahill] [Mark_McCahill]
+gopher             70/udp # Gopher [Mark_McCahill] [Mark_McCahill]
+netrjs-1           71/tcp # Remote Job Service
+netrjs-1           71/udp # Remote Job Service
+netrjs-2           72/tcp # Remote Job Service
+netrjs-2           72/udp # Remote Job Service
+netrjs-3           73/tcp # Remote Job Service
+netrjs-3           73/udp # Remote Job Service
+netrjs-4           74/tcp # Remote Job Service [Bob_Braden] [Bob_Braden]
+netrjs-4           74/udp # Remote Job Service [Bob_Braden] [Bob_Braden]
+deos               76/tcp # Distributed External Object Store [Robert_Ullmann] [Robert_Ullmann]
+deos               76/udp # Distributed External Object Store [Robert_Ullmann] [Robert_Ullmann]
+vettcp             78/tcp # vettcp [Christopher_Leong] [Christopher_Leong]
+vettcp             78/udp # vettcp [Christopher_Leong] [Christopher_Leong]
+finger             79/tcp # Finger [David_Zimmerman] [David_Zimmerman] Unauthorized use by some mail users (see [RFC4146] for details)
+finger             79/udp # Finger [David_Zimmerman] [David_Zimmerman] Unauthorized use by some mail users (see [RFC4146] for details)
+http               80/tcp # World Wide Web HTTP Defined TXT keys: u=<username> p=<password> path=<path to document>
+http               80/udp # World Wide Web HTTP Defined TXT keys: u=<username> p=<password> path=<path to document>
+http               80/sctp # HTTP [Randall_Stewart] [Randall_Stewart] [RFC4960] Defined TXT keys: u=<username> p=<password> path=<path to document>
+xfer               82/tcp # XFER Utility [Thomas_M_Smith] [Thomas_M_Smith]
+xfer               82/udp # XFER Utility [Thomas_M_Smith] [Thomas_M_Smith]
+mit-ml-dev         83/tcp # MIT ML Device [David_Reed] [David_Reed]
+mit-ml-dev         83/udp # MIT ML Device [David_Reed] [David_Reed]
+ctf                84/tcp # Common Trace Facility [Hugh_Thomas] [Hugh_Thomas]
+ctf                84/udp # Common Trace Facility [Hugh_Thomas] [Hugh_Thomas]
+mit-ml-dev         85/tcp # MIT ML Device [David_Reed] [David_Reed]
+mit-ml-dev         85/udp # MIT ML Device [David_Reed] [David_Reed]
+mfcobol            86/tcp # Micro Focus Cobol [Simon_Edwards] [Simon_Edwards]
+mfcobol            86/udp # Micro Focus Cobol [Simon_Edwards] [Simon_Edwards]
+kerberos           88/tcp # Kerberos [B_Clifford_Neuman] [B_Clifford_Neuman]
+kerberos           88/udp # Kerberos [B_Clifford_Neuman] [B_Clifford_Neuman]
+su-mit-tg          89/tcp # SU/MIT Telnet Gateway [Mark_Crispin] [Mark_Crispin]
+su-mit-tg          89/udp # SU/MIT Telnet Gateway [Mark_Crispin] [Mark_Crispin]
+dnsix              90/tcp # DNSIX Securit Attribute Token Map [Charles_Watt] [Charles_Watt] PORT 90 also being used unofficially by Pointcast
+dnsix              90/udp # DNSIX Securit Attribute Token Map [Charles_Watt] [Charles_Watt] PORT 90 also being used unofficially by Pointcast
+mit-dov            91/tcp # MIT Dover Spooler [Eliot_Moss] [Eliot_Moss]
+mit-dov            91/udp # MIT Dover Spooler [Eliot_Moss] [Eliot_Moss]
+npp                92/tcp # Network Printing Protocol [Louis_Mamakos] [Louis_Mamakos]
+npp                92/udp # Network Printing Protocol [Louis_Mamakos] [Louis_Mamakos]
+dcp                93/tcp # Device Control Protocol [Daniel_Tappan] [Daniel_Tappan]
+dcp                93/udp # Device Control Protocol [Daniel_Tappan] [Daniel_Tappan]
+objcall            94/tcp # Tivoli Object Dispatcher [Tom_Bereiter] [Tom_Bereiter]
+objcall            94/udp # Tivoli Object Dispatcher [Tom_Bereiter] [Tom_Bereiter]
+supdup             95/tcp # SUPDUP [Mark_Crispin] [Mark_Crispin]
+supdup             95/udp # SUPDUP [Mark_Crispin] [Mark_Crispin]
+dixie              96/tcp # DIXIE Protocol Specification [Tim_Howes] [Tim_Howes]
+dixie              96/udp # DIXIE Protocol Specification [Tim_Howes] [Tim_Howes]
+swift-rvf          97/tcp # Swift Remote Virtural File Protocol [Maurice_R_Turcotte] [Maurice_R_Turcotte]
+swift-rvf          97/udp # Swift Remote Virtural File Protocol [Maurice_R_Turcotte] [Maurice_R_Turcotte]
+tacnews            98/tcp # TAC News [Jon_Postel] [Jon_Postel]
+tacnews            98/udp # TAC News [Jon_Postel] [Jon_Postel]
+metagram           99/tcp # Metagram Relay [Geoff_Goodfellow] [Geoff_Goodfellow]
+metagram           99/udp # Metagram Relay [Geoff_Goodfellow] [Geoff_Goodfellow]
+hostname          101/tcp # NIC Host Name Server [Jon_Postel] [Jon_Postel]
+hostname          101/udp # NIC Host Name Server [Jon_Postel] [Jon_Postel]
+iso-tsap          102/tcp # ISO-TSAP Class 0 [Marshall_Rose] [Marshall_Rose]
+iso-tsap          102/udp # ISO-TSAP Class 0 [Marshall_Rose] [Marshall_Rose]
+gppitnp           103/tcp # Genesis Point-to-Point Trans Net
+gppitnp           103/udp # Genesis Point-to-Point Trans Net
+acr-nema          104/tcp # ACR-NEMA Digital Imag. & Comm. 300 [Patrick_McNamee] [Patrick_McNamee]
+acr-nema          104/udp # ACR-NEMA Digital Imag. & Comm. 300 [Patrick_McNamee] [Patrick_McNamee]
+cso               105/tcp # CCSO name server protocol [Martin_Hamilton] [Martin_Hamilton]
+cso               105/udp # CCSO name server protocol [Martin_Hamilton] [Martin_Hamilton]
+csnet-ns          105/tcp # Mailbox Name Nameserver [Marvin_Solomon] [Marvin_Solomon]
+csnet-ns          105/udp # Mailbox Name Nameserver [Marvin_Solomon] [Marvin_Solomon]
+3com-tsmux        106/tcp # 3COM-TSMUX [Jeremy_Siegel] [Jeremy_Siegel] Known Unauthorized Use on 106
+3com-tsmux        106/udp # 3COM-TSMUX [Jeremy_Siegel] [Jeremy_Siegel] Known Unauthorized Use on 106
+rtelnet           107/tcp # Remote Telnet Service [Jon_Postel] [Jon_Postel]
+rtelnet           107/udp # Remote Telnet Service [Jon_Postel] [Jon_Postel]
+snagas            108/tcp # SNA Gateway Access Server [Kevin_Murphy] [Kevin_Murphy]
+snagas            108/udp # SNA Gateway Access Server [Kevin_Murphy] [Kevin_Murphy]
+pop2              109/tcp # Post Office Protocol - Version 2 [Joyce_K_Reynolds] [Joyce_K_Reynolds]
+pop2              109/udp # Post Office Protocol - Version 2 [Joyce_K_Reynolds] [Joyce_K_Reynolds]
+pop3              110/tcp # Post Office Protocol - Version 3 [Marshall_Rose] [Marshall_Rose]
+pop3              110/udp # Post Office Protocol - Version 3 [Marshall_Rose] [Marshall_Rose]
+sunrpc            111/tcp # SUN Remote Procedure Call [Chuck_McManis] [Chuck_McManis]
+sunrpc            111/udp # SUN Remote Procedure Call [Chuck_McManis] [Chuck_McManis]
+mcidas            112/tcp # McIDAS Data Transmission Protocol [Glenn_Davis] [Glenn_Davis]
+mcidas            112/udp # McIDAS Data Transmission Protocol [Glenn_Davis] [Glenn_Davis]
+ident             113/tcp # 
+auth              113/tcp # Authentication Service [Mike_St_Johns] [Mike_St_Johns]
+auth              113/udp # Authentication Service [Mike_St_Johns] [Mike_St_Johns]
+sftp              115/tcp # Simple File Transfer Protocol [Mark_Lottor] [Mark_Lottor]
+sftp              115/udp # Simple File Transfer Protocol [Mark_Lottor] [Mark_Lottor]
+ansanotify        116/tcp # ANSA REX Notify [Nicola_J_Howarth] [Nicola_J_Howarth]
+ansanotify        116/udp # ANSA REX Notify [Nicola_J_Howarth] [Nicola_J_Howarth]
+uucp-path         117/tcp # UUCP Path Service
+uucp-path         117/udp # UUCP Path Service
+sqlserv           118/tcp # SQL Services [Larry_Barnes] [Larry_Barnes]
+sqlserv           118/udp # SQL Services [Larry_Barnes] [Larry_Barnes]
+nntp              119/tcp # Network News Transfer Protocol [Phil_Lapsley] [Phil_Lapsley]
+nntp              119/udp # Network News Transfer Protocol [Phil_Lapsley] [Phil_Lapsley]
+cfdptkt           120/tcp # CFDPTKT [John_Ioannidis] [John_Ioannidis]
+cfdptkt           120/udp # CFDPTKT [John_Ioannidis] [John_Ioannidis]
+erpc              121/tcp # Encore Expedited Remote Pro.Call [Jack_ONeil] [Jack_ONeil]
+erpc              121/udp # Encore Expedited Remote Pro.Call [Jack_ONeil] [Jack_ONeil]
+smakynet          122/tcp # SMAKYNET [Pierre_Arnaud] [Pierre_Arnaud]
+smakynet          122/udp # SMAKYNET [Pierre_Arnaud] [Pierre_Arnaud]
+ntp               123/tcp # Network Time Protocol [Dave_Mills] [Dave_Mills] [RFC5905]
+ntp               123/udp # Network Time Protocol [Dave_Mills] [Dave_Mills] [RFC5905]
+ansatrader        124/tcp # ANSA REX Trader [Nicola_J_Howarth] [Nicola_J_Howarth]
+ansatrader        124/udp # ANSA REX Trader [Nicola_J_Howarth] [Nicola_J_Howarth]
+locus-map         125/tcp # Locus PC-Interface Net Map Ser [Eric_Peterson] [Eric_Peterson]
+locus-map         125/udp # Locus PC-Interface Net Map Ser [Eric_Peterson] [Eric_Peterson]
+nxedit            126/tcp # NXEdit [Don_Payette] [Don_Payette] Port 126 Previously assigned to application belowunitary         126/tcp    Unisys Unitary Loginunitary         126/udp    Unisys Unitary Login<feil&kronos.nisd.cam.unisys.com>Port 126 Previously assigned to application above
+nxedit            126/udp # NXEdit [Don_Payette] [Don_Payette] Port 126 Previously assigned to application belowunitary         126/tcp    Unisys Unitary Loginunitary         126/udp    Unisys Unitary Login<feil&kronos.nisd.cam.unisys.com>Port 126 Previously assigned to application above
+locus-con         127/tcp # Locus PC-Interface Conn Server [Eric_Peterson] [Eric_Peterson]
+locus-con         127/udp # Locus PC-Interface Conn Server [Eric_Peterson] [Eric_Peterson]
+gss-xlicen        128/tcp # GSS X License Verification [John_Light] [John_Light]
+gss-xlicen        128/udp # GSS X License Verification [John_Light] [John_Light]
+pwdgen            129/tcp # Password Generator Protocol [Frank_J_Wacho] [Frank_J_Wacho]
+pwdgen            129/udp # Password Generator Protocol [Frank_J_Wacho] [Frank_J_Wacho]
+cisco-fna         130/tcp # cisco FNATIVE
+cisco-fna         130/udp # cisco FNATIVE
+cisco-tna         131/tcp # cisco TNATIVE
+cisco-tna         131/udp # cisco TNATIVE
+cisco-sys         132/tcp # cisco SYSMAINT
+cisco-sys         132/udp # cisco SYSMAINT
+statsrv           133/tcp # Statistics Service [Dave_Mills_2] [Dave_Mills_2]
+statsrv           133/udp # Statistics Service [Dave_Mills_2] [Dave_Mills_2]
+ingres-net        134/tcp # INGRES-NET Service [Mike_Berrow] [Mike_Berrow]
+ingres-net        134/udp # INGRES-NET Service [Mike_Berrow] [Mike_Berrow]
+epmap             135/tcp # DCE endpoint resolution [Joe_Pato] [Joe_Pato]
+epmap             135/udp # DCE endpoint resolution [Joe_Pato] [Joe_Pato]
+profile           136/tcp # PROFILE Naming System [Larry_Peterson] [Larry_Peterson]
+profile           136/udp # PROFILE Naming System [Larry_Peterson] [Larry_Peterson]
+netbios-ns        137/tcp # NETBIOS Name Service
+netbios-ns        137/udp # NETBIOS Name Service
+netbios-dgm       138/tcp # NETBIOS Datagram Service
+netbios-dgm       138/udp # NETBIOS Datagram Service
+netbios-ssn       139/tcp # NETBIOS Session Service [Jon_Postel] [Jon_Postel]
+netbios-ssn       139/udp # NETBIOS Session Service [Jon_Postel] [Jon_Postel]
+emfis-data        140/tcp # EMFIS Data Service
+emfis-data        140/udp # EMFIS Data Service
+emfis-cntl        141/tcp # EMFIS Control Service [Gerd_Beling] [Gerd_Beling]
+emfis-cntl        141/udp # EMFIS Control Service [Gerd_Beling] [Gerd_Beling]
+bl-idm            142/tcp # Britton-Lee IDM [Susie_Snitzer] [Susie_Snitzer]
+bl-idm            142/udp # Britton-Lee IDM [Susie_Snitzer] [Susie_Snitzer]
+imap              143/tcp # Internet Message Access Protocol [Mark_Crispin_2] [Mark_Crispin_2]
+imap              143/udp # Internet Message Access Protocol [Mark_Crispin_2] [Mark_Crispin_2]
+uma               144/tcp # Universal Management Architecture [Jay_Whitney] [Jay_Whitney]
+uma               144/udp # Universal Management Architecture [Jay_Whitney] [Jay_Whitney]
+uaac              145/tcp # UAAC Protocol [David_A_Gomberg] [David_A_Gomberg]
+uaac              145/udp # UAAC Protocol [David_A_Gomberg] [David_A_Gomberg]
+iso-tp0           146/tcp # ISO-IP0
+iso-tp0           146/udp # ISO-IP0
+iso-ip            147/tcp # ISO-IP [Marshall_Rose] [Marshall_Rose]
+iso-ip            147/udp # ISO-IP [Marshall_Rose] [Marshall_Rose]
+jargon            148/tcp # Jargon [Bill_Weinman] [Bill_Weinman]
+jargon            148/udp # Jargon [Bill_Weinman] [Bill_Weinman]
+aed-512           149/tcp # AED 512 Emulation Service [Albert_G_Broscius] [Albert_G_Broscius]
+aed-512           149/udp # AED 512 Emulation Service [Albert_G_Broscius] [Albert_G_Broscius]
+sql-net           150/tcp # SQL-NET [Martin_Picard] [Martin_Picard]
+sql-net           150/udp # SQL-NET [Martin_Picard] [Martin_Picard]
+hems              151/tcp # HEMS
+hems              151/udp # HEMS
+bftp              152/tcp # Background File Transfer Program [Annette_DeSchon] [Annette_DeSchon]
+bftp              152/udp # Background File Transfer Program [Annette_DeSchon] [Annette_DeSchon]
+sgmp              153/tcp # SGMP [Marty_Schoffstahl] [Marty_Schoffstahl]
+sgmp              153/udp # SGMP [Marty_Schoffstahl] [Marty_Schoffstahl]
+netsc-prod        154/tcp # NETSC
+netsc-prod        154/udp # NETSC
+netsc-dev         155/tcp # NETSC [Sergio_Heker] [Sergio_Heker]
+netsc-dev         155/udp # NETSC [Sergio_Heker] [Sergio_Heker]
+sqlsrv            156/tcp # SQL Service [Craig_Rogers] [Craig_Rogers]
+sqlsrv            156/udp # SQL Service [Craig_Rogers] [Craig_Rogers]
+knet-cmp          157/tcp # KNET/VM Command/Message Protocol [Gary_S_Malkin] [Gary_S_Malkin]
+knet-cmp          157/udp # KNET/VM Command/Message Protocol [Gary_S_Malkin] [Gary_S_Malkin]
+pcmail-srv        158/tcp # PCMail Server [Mark_L_Lambert] [Mark_L_Lambert]
+pcmail-srv        158/udp # PCMail Server [Mark_L_Lambert] [Mark_L_Lambert]
+nss-routing       159/tcp # NSS-Routing [Yakov_Rekhter] [Yakov_Rekhter]
+nss-routing       159/udp # NSS-Routing [Yakov_Rekhter] [Yakov_Rekhter]
+sgmp-traps        160/tcp # SGMP-TRAPS [Marty_Schoffstahl] [Marty_Schoffstahl]
+sgmp-traps        160/udp # SGMP-TRAPS [Marty_Schoffstahl] [Marty_Schoffstahl]
+snmp              161/tcp # SNMP
+snmp              161/udp # SNMP
+snmptrap          162/tcp # SNMPTRAP [Marshall_Rose] [Marshall_Rose]
+snmptrap          162/udp # SNMPTRAP [Marshall_Rose] [Marshall_Rose]
+cmip-man          163/tcp # CMIP/TCP Manager
+cmip-man          163/udp # CMIP/TCP Manager
+cmip-agent        164/tcp # CMIP/TCP Agent [Amatzia_Ben_Artzi] [Amatzia_Ben_Artzi]
+cmip-agent        164/udp # CMIP/TCP Agent [Amatzia_Ben_Artzi] [Amatzia_Ben_Artzi]
+xns-courier       165/tcp # Xerox [Susie_Armstrong_2] [Susie_Armstrong_2]
+xns-courier       165/udp # Xerox [Susie_Armstrong_2] [Susie_Armstrong_2]
+s-net             166/tcp # Sirius Systems [Brian_Lloyd] [Brian_Lloyd]
+s-net             166/udp # Sirius Systems [Brian_Lloyd] [Brian_Lloyd]
+namp              167/tcp # NAMP [Marty_Schoffstahl] [Marty_Schoffstahl]
+namp              167/udp # NAMP [Marty_Schoffstahl] [Marty_Schoffstahl]
+rsvd              168/tcp # RSVD [Alan_Sandell] [Alan_Sandell] 2008-05-01
+rsvd              168/udp # RSVD [Alan_Sandell] [Alan_Sandell] 2008-05-01
+send              169/tcp # SEND [William_Oldwin] [William_Oldwin] 2013-06-17
+send              169/udp # SEND [William_Oldwin] [William_Oldwin] 2013-06-17
+print-srv         170/tcp # Network PostScript [Brian_Reid] [Brian_Reid]
+print-srv         170/udp # Network PostScript [Brian_Reid] [Brian_Reid]
+multiplex         171/tcp # Network Innovations Multiplex
+multiplex         171/udp # Network Innovations Multiplex
+cl-1              172/tcp # Network Innovations CL/1IANA assigned this well-formed service name as a replacement for "cl/1". [Kevin_DeVault] [Kevin_DeVault]
+cl/1              172/tcp # Network Innovations CL/1 [Kevin_DeVault] [Kevin_DeVault] This entry is an alias to "cl-1".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+cl-1              172/udp # Network Innovations CL/1IANA assigned this well-formed service name as a replacement for "cl/1". [Kevin_DeVault] [Kevin_DeVault]
+cl/1              172/udp # Network Innovations CL/1 [Kevin_DeVault] [Kevin_DeVault] This entry is an alias to "cl-1".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+xyplex-mux        173/tcp # Xyplex [Bob_Stewart] [Bob_Stewart]
+xyplex-mux        173/udp # Xyplex [Bob_Stewart] [Bob_Stewart]
+mailq             174/tcp # MAILQ [Rayan_Zachariassen] [Rayan_Zachariassen]
+mailq             174/udp # MAILQ [Rayan_Zachariassen] [Rayan_Zachariassen]
+vmnet             175/tcp # VMNET [Christopher_Tengi] [Christopher_Tengi]
+vmnet             175/udp # VMNET [Christopher_Tengi] [Christopher_Tengi]
+genrad-mux        176/tcp # GENRAD-MUX [Ron_Thornton] [Ron_Thornton]
+genrad-mux        176/udp # GENRAD-MUX [Ron_Thornton] [Ron_Thornton]
+xdmcp             177/tcp # X Display Manager Control Protocol [Robert_W_Scheifler] [Robert_W_Scheifler]
+xdmcp             177/udp # X Display Manager Control Protocol [Robert_W_Scheifler] [Robert_W_Scheifler]
+nextstep          178/tcp # NextStep Window Server [Leo_Hourvitz] [Leo_Hourvitz]
+nextstep          178/udp # NextStep Window Server [Leo_Hourvitz] [Leo_Hourvitz]
+bgp               179/tcp # Border Gateway Protocol [Kirk_Lougheed] [Kirk_Lougheed]
+bgp               179/udp # Border Gateway Protocol [Kirk_Lougheed] [Kirk_Lougheed]
+bgp               179/sctp # BGP [Randall_Stewart] [Randall_Stewart] [RFC4960]
+ris               180/tcp # Intergraph [Dave_Buehmann] [Dave_Buehmann]
+ris               180/udp # Intergraph [Dave_Buehmann] [Dave_Buehmann]
+unify             181/tcp # Unify [Daegis_Inc] [Chris_Anderson] 2012-07-31
+unify             181/udp # Unify [Daegis_Inc] [Chris_Anderson] 2012-07-31
+audit             182/tcp # Unisys Audit SITP [Gil_Greenbaum] [Gil_Greenbaum]
+audit             182/udp # Unisys Audit SITP [Gil_Greenbaum] [Gil_Greenbaum]
+ocbinder          183/tcp # OCBinder
+ocbinder          183/udp # OCBinder
+ocserver          184/tcp # OCServer [Jerrilynn_Okamura] [Jerrilynn_Okamura]
+ocserver          184/udp # OCServer [Jerrilynn_Okamura] [Jerrilynn_Okamura]
+remote-kis        185/tcp # Remote-KIS
+remote-kis        185/udp # Remote-KIS
+kis               186/tcp # KIS Protocol [Ralph_Droms] [Ralph_Droms]
+kis               186/udp # KIS Protocol [Ralph_Droms] [Ralph_Droms]
+aci               187/tcp # Application Communication Interface [Rick_Carlos] [Rick_Carlos]
+aci               187/udp # Application Communication Interface [Rick_Carlos] [Rick_Carlos]
+mumps             188/tcp # Plus Five's MUMPS [Hokey_Stenn] [Hokey_Stenn]
+mumps             188/udp # Plus Five's MUMPS [Hokey_Stenn] [Hokey_Stenn]
+qft               189/tcp # Queued File Transport [Wayne_Schroeder] [Wayne_Schroeder]
+qft               189/udp # Queued File Transport [Wayne_Schroeder] [Wayne_Schroeder]
+gacp              190/tcp # Gateway Access Control Protocol [C_Philip_Wood] [C_Philip_Wood]
+gacp              190/udp # Gateway Access Control Protocol [C_Philip_Wood] [C_Philip_Wood]
+prospero          191/tcp # Prospero Directory Service [B_Clifford_Neuman] [B_Clifford_Neuman]
+prospero          191/udp # Prospero Directory Service [B_Clifford_Neuman] [B_Clifford_Neuman]
+osu-nms           192/tcp # OSU Network Monitoring System [Doug_Karl] [Doug_Karl]
+osu-nms           192/udp # OSU Network Monitoring System [Doug_Karl] [Doug_Karl]
+srmp              193/tcp # Spider Remote Monitoring Protocol [Ted_J_Socolofsky] [Ted_J_Socolofsky]
+srmp              193/udp # Spider Remote Monitoring Protocol [Ted_J_Socolofsky] [Ted_J_Socolofsky]
+irc               194/tcp # Internet Relay Chat Protocol [Jarkko_Oikarinen] [Jarkko_Oikarinen]
+irc               194/udp # Internet Relay Chat Protocol [Jarkko_Oikarinen] [Jarkko_Oikarinen]
+dn6-nlm-aud       195/tcp # DNSIX Network Level Module Audit
+dn6-nlm-aud       195/udp # DNSIX Network Level Module Audit
+dn6-smm-red       196/tcp # DNSIX Session Mgt Module Audit Redir [Lawrence_Lebahn] [Lawrence_Lebahn]
+dn6-smm-red       196/udp # DNSIX Session Mgt Module Audit Redir [Lawrence_Lebahn] [Lawrence_Lebahn]
+dls               197/tcp # Directory Location Service
+dls               197/udp # Directory Location Service
+dls-mon           198/tcp # Directory Location Service Monitor [Scott_Bellew] [Scott_Bellew]
+dls-mon           198/udp # Directory Location Service Monitor [Scott_Bellew] [Scott_Bellew]
+smux              199/tcp # SMUX [Marshall_Rose] [Marshall_Rose]
+smux              199/udp # SMUX [Marshall_Rose] [Marshall_Rose]
+src               200/tcp # IBM System Resource Controller [Gerald_McBrearty] [Gerald_McBrearty]
+src               200/udp # IBM System Resource Controller [Gerald_McBrearty] [Gerald_McBrearty]
+at-rtmp           201/tcp # AppleTalk Routing Maintenance
+at-rtmp           201/udp # AppleTalk Routing Maintenance
+at-nbp            202/tcp # AppleTalk Name Binding
+at-nbp            202/udp # AppleTalk Name Binding
+at-3              203/tcp # AppleTalk Unused
+at-3              203/udp # AppleTalk Unused
+at-echo           204/tcp # AppleTalk Echo
+at-echo           204/udp # AppleTalk Echo
+at-5              205/tcp # AppleTalk Unused
+at-5              205/udp # AppleTalk Unused
+at-zis            206/tcp # AppleTalk Zone Information
+at-zis            206/udp # AppleTalk Zone Information
+at-7              207/tcp # AppleTalk Unused
+at-7              207/udp # AppleTalk Unused
+at-8              208/tcp # AppleTalk Unused [Rob_Chandhok] [Rob_Chandhok]
+at-8              208/udp # AppleTalk Unused [Rob_Chandhok] [Rob_Chandhok]
+qmtp              209/tcp # The Quick Mail Transfer Protocol [Dan_Bernstein] [Dan_Bernstein]
+qmtp              209/udp # The Quick Mail Transfer Protocol [Dan_Bernstein] [Dan_Bernstein]
+z39-50            210/tcp # ANSI Z39.50IANA assigned this well-formed service name as a replacement for "z39.50". [Mark_H_Needleman] [Mark_H_Needleman]
+z39.50            210/tcp # ANSI Z39.50 [Mark_H_Needleman] [Mark_H_Needleman] This entry is an alias to "z39-50".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+z39-50            210/udp # ANSI Z39.50IANA assigned this well-formed service name as a replacement for "z39.50". [Mark_H_Needleman] [Mark_H_Needleman]
+z39.50            210/udp # ANSI Z39.50 [Mark_H_Needleman] [Mark_H_Needleman] This entry is an alias to "z39-50".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+914c-g            211/tcp # Texas Instruments 914C/G TerminalIANA assigned this well-formed service name as a replacement for "914c/g". [Bill_Harrell] [Bill_Harrell]
+914c/g            211/tcp # Texas Instruments 914C/G Terminal [Bill_Harrell] [Bill_Harrell] This entry is an alias to "914c-g".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+914c-g            211/udp # Texas Instruments 914C/G TerminalIANA assigned this well-formed service name as a replacement for "914c/g". [Bill_Harrell] [Bill_Harrell]
+914c/g            211/udp # Texas Instruments 914C/G Terminal [Bill_Harrell] [Bill_Harrell] This entry is an alias to "914c-g".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+anet              212/tcp # ATEXSSTR [Jim_Taylor] [Jim_Taylor]
+anet              212/udp # ATEXSSTR [Jim_Taylor] [Jim_Taylor]
+ipx               213/tcp # IPX [Don_Provan] [Don_Provan]
+ipx               213/udp # IPX [Don_Provan] [Don_Provan]
+vmpwscs           214/tcp # VM PWSCS [Dan_Shia] [Dan_Shia]
+vmpwscs           214/udp # VM PWSCS [Dan_Shia] [Dan_Shia]
+softpc            215/tcp # Insignia Solutions [Martyn_Thomas] [Martyn_Thomas]
+softpc            215/udp # Insignia Solutions [Martyn_Thomas] [Martyn_Thomas]
+CAIlic            216/tcp # Computer Associates Int'l License Server [Chuck_Spitz] [Chuck_Spitz]
+CAIlic            216/udp # Computer Associates Int'l License Server [Chuck_Spitz] [Chuck_Spitz]
+dbase             217/tcp # dBASE Unix [Don_Gibson] [Don_Gibson]
+dbase             217/udp # dBASE Unix [Don_Gibson] [Don_Gibson]
+mpp               218/tcp # Netix Message Posting Protocol [Shannon_Yeh] [Shannon_Yeh]
+mpp               218/udp # Netix Message Posting Protocol [Shannon_Yeh] [Shannon_Yeh]
+uarps             219/tcp # Unisys ARPs [Ashok_Marwaha] [Ashok_Marwaha]
+uarps             219/udp # Unisys ARPs [Ashok_Marwaha] [Ashok_Marwaha]
+imap3             220/tcp # Interactive Mail Access Protocol v3 [James_Rice] [James_Rice]
+imap3             220/udp # Interactive Mail Access Protocol v3 [James_Rice] [James_Rice]
+fln-spx           221/tcp # Berkeley rlogind with SPX auth
+fln-spx           221/udp # Berkeley rlogind with SPX auth
+rsh-spx           222/tcp # Berkeley rshd with SPX auth
+rsh-spx           222/udp # Berkeley rshd with SPX auth
+cdc               223/tcp # Certificate Distribution Center [Kannan_Alagappan] [Kannan_Alagappan]
+cdc               223/udp # Certificate Distribution Center [Kannan_Alagappan] [Kannan_Alagappan]
+masqdialer        224/tcp # masqdialer [Charles_Wright] [Charles_Wright] Possible Conflict of Port 222 with "Masqdialer"
+masqdialer        224/udp # masqdialer [Charles_Wright] [Charles_Wright] Possible Conflict of Port 222 with "Masqdialer"
+direct            242/tcp # Direct [Herb_Sutter] [Herb_Sutter]
+direct            242/udp # Direct [Herb_Sutter] [Herb_Sutter]
+sur-meas          243/tcp # Survey Measurement [Dave_Clark] [Dave_Clark]
+sur-meas          243/udp # Survey Measurement [Dave_Clark] [Dave_Clark]
+inbusiness        244/tcp # inbusiness [Derrick_Hisatake] [Derrick_Hisatake]
+inbusiness        244/udp # inbusiness [Derrick_Hisatake] [Derrick_Hisatake]
+link              245/tcp # LINK
+link              245/udp # LINK
+dsp3270           246/tcp # Display Systems Protocol [Weldon_J_Showalter] [Weldon_J_Showalter]
+dsp3270           246/udp # Display Systems Protocol [Weldon_J_Showalter] [Weldon_J_Showalter]
+subntbcst-tftp    247/tcp # SUBNTBCST_TFTPIANA assigned this well-formed service name as a replacement for "subntbcst_tftp". [John_Fake] [John_Fake]
+subntbcst_tftp    247/tcp # SUBNTBCST_TFTP [John_Fake] [John_Fake] This entry is an alias to "subntbcst-tftp".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+subntbcst-tftp    247/udp # SUBNTBCST_TFTPIANA assigned this well-formed service name as a replacement for "subntbcst_tftp". [John_Fake] [John_Fake]
+subntbcst_tftp    247/udp # SUBNTBCST_TFTP [John_Fake] [John_Fake] This entry is an alias to "subntbcst-tftp".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+bhfhs             248/tcp # bhfhs [John_Kelly] [John_Kelly]
+bhfhs             248/udp # bhfhs [John_Kelly] [John_Kelly]
+rap               256/tcp # RAP [J_S_Greenfield] [J_S_Greenfield]
+rap               256/udp # RAP [J_S_Greenfield] [J_S_Greenfield]
+set               257/tcp # Secure Electronic Transaction [Donald_Eastlake] [Donald_Eastlake]
+set               257/udp # Secure Electronic Transaction [Donald_Eastlake] [Donald_Eastlake]
+esro-gen          259/tcp # Efficient Short Remote Operations [Mohsen_Banan] [Mohsen_Banan]
+esro-gen          259/udp # Efficient Short Remote Operations [Mohsen_Banan] [Mohsen_Banan]
+openport          260/tcp # Openport [John_Marland] [John_Marland]
+openport          260/udp # Openport [John_Marland] [John_Marland]
+nsiiops           261/tcp # IIOP Name Service over TLS/SSL [Jeff_Stewart] [Jeff_Stewart]
+nsiiops           261/udp # IIOP Name Service over TLS/SSL [Jeff_Stewart] [Jeff_Stewart]
+arcisdms          262/tcp # Arcisdms [Russell_Crook] [Russell_Crook]
+arcisdms          262/udp # Arcisdms [Russell_Crook] [Russell_Crook]
+hdap              263/tcp # HDAP [Troy_Gau] [Troy_Gau]
+hdap              263/udp # HDAP [Troy_Gau] [Troy_Gau]
+bgmp              264/tcp # BGMP [Dave_Thaler] [Dave_Thaler]
+bgmp              264/udp # BGMP [Dave_Thaler] [Dave_Thaler]
+x-bone-ctl        265/tcp # X-Bone CTL [Joe_Touch] [Joe_Touch]
+x-bone-ctl        265/udp # X-Bone CTL [Joe_Touch] [Joe_Touch]
+sst               266/tcp # SCSI on ST [Donald_D_Woelz] [Donald_D_Woelz]
+sst               266/udp # SCSI on ST [Donald_D_Woelz] [Donald_D_Woelz]
+td-service        267/tcp # Tobit David Service Layer
+td-service        267/udp # Tobit David Service Layer
+td-replica        268/tcp # Tobit David Replica [Franz_Josef_Leuders] [Franz_Josef_Leuders]
+td-replica        268/udp # Tobit David Replica [Franz_Josef_Leuders] [Franz_Josef_Leuders]
+manet             269/tcp # MANET Protocols [RFC5498]
+manet             269/udp # MANET Protocols [RFC5498]
+gist              270/udp # Q-mode encapsulation for GIST messages [RFC5971]
+pt-tls            271/tcp # IETF Network Endpoint Assessment (NEA) Posture Transport Protocol over TLS (PT-TLS) [IESG] [IETF_Chair] 2012-07-31 [RFC6876]
+http-mgmt         280/tcp # http-mgmt [Adrian_Pell] [Adrian_Pell]
+http-mgmt         280/udp # http-mgmt [Adrian_Pell] [Adrian_Pell]
+personal-link     281/tcp # Personal Link [Dan_Cummings] [Dan_Cummings]
+personal-link     281/udp # Personal Link [Dan_Cummings] [Dan_Cummings]
+cableport-ax      282/tcp # Cable Port A/X [Craig_Langfahl] [Craig_Langfahl]
+cableport-ax      282/udp # Cable Port A/X [Craig_Langfahl] [Craig_Langfahl]
+rescap            283/tcp # rescap [Paul_Hoffman] [Paul_Hoffman]
+rescap            283/udp # rescap [Paul_Hoffman] [Paul_Hoffman]
+corerjd           284/tcp # corerjd [Chris_Thornhill] [Chris_Thornhill]
+corerjd           284/udp # corerjd [Chris_Thornhill] [Chris_Thornhill]
+fxp               286/tcp # FXP Communication [James_Darnall] [James_Darnall]
+fxp               286/udp # FXP Communication [James_Darnall] [James_Darnall]
+k-block           287/tcp # K-BLOCK [Simon_P_Jackson] [Simon_P_Jackson]
+k-block           287/udp # K-BLOCK [Simon_P_Jackson] [Simon_P_Jackson]
+novastorbakcup    308/tcp # Novastor Backup [Brian_Dickman] [Brian_Dickman]
+novastorbakcup    308/udp # Novastor Backup [Brian_Dickman] [Brian_Dickman]
+entrusttime       309/tcp # EntrustTime [Peter_Whittaker] [Peter_Whittaker]
+entrusttime       309/udp # EntrustTime [Peter_Whittaker] [Peter_Whittaker]
+bhmds             310/tcp # bhmds [John_Kelly] [John_Kelly]
+bhmds             310/udp # bhmds [John_Kelly] [John_Kelly]
+asip-webadmin     311/tcp # AppleShare IP WebAdmin [Ann_Huang] [Ann_Huang]
+asip-webadmin     311/udp # AppleShare IP WebAdmin [Ann_Huang] [Ann_Huang]
+vslmp             312/tcp # VSLMP [Gerben_Wierda] [Gerben_Wierda]
+vslmp             312/udp # VSLMP [Gerben_Wierda] [Gerben_Wierda]
+magenta-logic     313/tcp # Magenta Logic [Karl_Rousseau] [Karl_Rousseau]
+magenta-logic     313/udp # Magenta Logic [Karl_Rousseau] [Karl_Rousseau]
+opalis-robot      314/tcp # Opalis Robot [Laurent_Domenech] [Laurent_Domenech]
+opalis-robot      314/udp # Opalis Robot [Laurent_Domenech] [Laurent_Domenech]
+dpsi              315/tcp # DPSI [Tony_Scamurra] [Tony_Scamurra]
+dpsi              315/udp # DPSI [Tony_Scamurra] [Tony_Scamurra]
+decauth           316/tcp # decAuth [Michael_Agishtein] [Michael_Agishtein]
+decauth           316/udp # decAuth [Michael_Agishtein] [Michael_Agishtein]
+zannet            317/tcp # Zannet [Zan_Oliphant] [Zan_Oliphant]
+zannet            317/udp # Zannet [Zan_Oliphant] [Zan_Oliphant]
+pkix-timestamp    318/tcp # PKIX TimeStamp [Robert_Zuccherato] [Robert_Zuccherato]
+pkix-timestamp    318/udp # PKIX TimeStamp [Robert_Zuccherato] [Robert_Zuccherato]
+ptp-event         319/tcp # PTP Event [Kang_Lee] [Kang_Lee] 2010-07-27
+ptp-event         319/udp # PTP Event [Kang_Lee] [Kang_Lee] 2010-07-27
+ptp-general       320/tcp # PTP General [Kang_Lee] [Kang_Lee] 2010-07-27
+ptp-general       320/udp # PTP General [Kang_Lee] [Kang_Lee] 2010-07-27
+pip               321/tcp # PIP [Gordon_Mohr] [Gordon_Mohr]
+pip               321/udp # PIP [Gordon_Mohr] [Gordon_Mohr]
+rtsps             322/tcp # RTSPS [Anders_Klemets] [Anders_Klemets]
+rtsps             322/udp # RTSPS [Anders_Klemets] [Anders_Klemets]
+rpki-rtr          323/tcp # Resource PKI to Router Protocol [IESG] [IETF_Chair] [RFC6810]
+rpki-rtr-tls      324/tcp # Resource PKI to Router Protocol over TLS [IESG] [IETF_Chair] [RFC6810]
+texar             333/tcp # Texar Security Port [Eugen_Bacic] [Eugen_Bacic]
+texar             333/udp # Texar Security Port [Eugen_Bacic] [Eugen_Bacic]
+pdap              344/tcp # Prospero Data Access Protocol [B_Clifford_Neuman] [B_Clifford_Neuman]
+pdap              344/udp # Prospero Data Access Protocol [B_Clifford_Neuman] [B_Clifford_Neuman]
+pawserv           345/tcp # Perf Analysis Workbench
+pawserv           345/udp # Perf Analysis Workbench
+zserv             346/tcp # Zebra server
+zserv             346/udp # Zebra server
+fatserv           347/tcp # Fatmen Server
+fatserv           347/udp # Fatmen Server
+csi-sgwp          348/tcp # Cabletron Management Protocol
+csi-sgwp          348/udp # Cabletron Management Protocol
+mftp              349/tcp # mftp [Dave_Feinleib] [Dave_Feinleib]
+mftp              349/udp # mftp [Dave_Feinleib] [Dave_Feinleib]
+matip-type-a      350/tcp # MATIP Type A [Alain_Robert] [Alain_Robert] [RFC2351]
+matip-type-a      350/udp # MATIP Type A [Alain_Robert] [Alain_Robert] [RFC2351]
+matip-type-b      351/tcp # MATIP Type B [Alain_Robert] [Alain_Robert] [RFC2351]
+matip-type-b      351/udp # MATIP Type B [Alain_Robert] [Alain_Robert] [RFC2351]
+bhoetty           351/tcp # bhoetty [John_Kelly] [John_Kelly] This entry records an unassigned but widespread use(added 5/21/97)
+bhoetty           351/udp # bhoetty [John_Kelly] [John_Kelly] This entry records an unassigned but widespread use(added 5/21/97)
+dtag-ste-sb       352/tcp # DTAG [Ruediger_Wald] [Ruediger_Wald] (assigned long ago)
+dtag-ste-sb       352/udp # DTAG [Ruediger_Wald] [Ruediger_Wald] (assigned long ago)
+bhoedap4          352/tcp # bhoedap4 [John_Kelly] [John_Kelly] This entry records an unassigned but widespread use(added 5/21/97)
+bhoedap4          352/udp # bhoedap4 [John_Kelly] [John_Kelly] This entry records an unassigned but widespread use(added 5/21/97)
+ndsauth           353/tcp # NDSAUTH [Jayakumar_Ramalingam] [Jayakumar_Ramalingam]
+ndsauth           353/udp # NDSAUTH [Jayakumar_Ramalingam] [Jayakumar_Ramalingam]
+bh611             354/tcp # bh611 [John_Kelly] [John_Kelly]
+bh611             354/udp # bh611 [John_Kelly] [John_Kelly]
+datex-asn         355/tcp # DATEX-ASN [Kenneth_Vaughn] [Kenneth_Vaughn]
+datex-asn         355/udp # DATEX-ASN [Kenneth_Vaughn] [Kenneth_Vaughn]
+cloanto-net-1     356/tcp # Cloanto Net 1 [Michael_Battilana] [Michael_Battilana] 2010-04-30
+cloanto-net-1     356/udp # Cloanto Net 1 [Michael_Battilana] [Michael_Battilana] 2010-04-30
+bhevent           357/tcp # bhevent [John_Kelly] [John_Kelly]
+bhevent           357/udp # bhevent [John_Kelly] [John_Kelly]
+shrinkwrap        358/tcp # Shrinkwrap [Bill_Simpson] [Bill_Simpson]
+shrinkwrap        358/udp # Shrinkwrap [Bill_Simpson] [Bill_Simpson]
+nsrmp             359/tcp # Network Security Risk Management Protocol [Eric_Jacksch] [Eric_Jacksch]
+nsrmp             359/udp # Network Security Risk Management Protocol [Eric_Jacksch] [Eric_Jacksch]
+scoi2odialog      360/tcp # scoi2odialog [Keith_Petley] [Keith_Petley]
+scoi2odialog      360/udp # scoi2odialog [Keith_Petley] [Keith_Petley]
+semantix          361/tcp # Semantix [Semantix] [Semantix]
+semantix          361/udp # Semantix [Semantix] [Semantix]
+srssend           362/tcp # SRS Send [Curt_Mayer] [Curt_Mayer]
+srssend           362/udp # SRS Send [Curt_Mayer] [Curt_Mayer]
+rsvp-tunnel       363/tcp # RSVP TunnelIANA assigned this well-formed service name as a replacement for "rsvp_tunnel". [Andreas_Terzis] [Andreas_Terzis]
+rsvp_tunnel       363/tcp # RSVP Tunnel [Andreas_Terzis] [Andreas_Terzis] This entry is an alias to "rsvp-tunnel".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+rsvp-tunnel       363/udp # RSVP TunnelIANA assigned this well-formed service name as a replacement for "rsvp_tunnel". [Andreas_Terzis] [Andreas_Terzis]
+rsvp_tunnel       363/udp # RSVP Tunnel [Andreas_Terzis] [Andreas_Terzis] This entry is an alias to "rsvp-tunnel".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+aurora-cmgr       364/tcp # Aurora CMGR [Philip_Budne] [Philip_Budne]
+aurora-cmgr       364/udp # Aurora CMGR [Philip_Budne] [Philip_Budne]
+dtk               365/tcp # DTK [Fred_Cohen] [Fred_Cohen]
+dtk               365/udp # DTK [Fred_Cohen] [Fred_Cohen]
+odmr              366/tcp # ODMR [Randall_Gellens] [Randall_Gellens]
+odmr              366/udp # ODMR [Randall_Gellens] [Randall_Gellens]
+mortgageware      367/tcp # MortgageWare [Ole_Hellevik] [Ole_Hellevik]
+mortgageware      367/udp # MortgageWare [Ole_Hellevik] [Ole_Hellevik]
+qbikgdp           368/tcp # QbikGDP [Adrien_de_Croy] [Adrien_de_Croy]
+qbikgdp           368/udp # QbikGDP [Adrien_de_Croy] [Adrien_de_Croy]
+rpc2portmap       369/tcp # rpc2portmap
+rpc2portmap       369/udp # rpc2portmap
+codaauth2         370/tcp # codaauth2 [Robert_Watson] [Robert_Watson]
+codaauth2         370/udp # codaauth2 [Robert_Watson] [Robert_Watson]
+clearcase         371/tcp # Clearcase [Dave_LeBlang] [Dave_LeBlang]
+clearcase         371/udp # Clearcase [Dave_LeBlang] [Dave_LeBlang]
+ulistproc         372/tcp # ListProcessor [Anastasios_Kotsikona] [Anastasios_Kotsikona]
+ulistproc         372/udp # ListProcessor [Anastasios_Kotsikona] [Anastasios_Kotsikona]
+legent-1          373/tcp # Legent Corporation
+legent-1          373/udp # Legent Corporation
+legent-2          374/tcp # Legent Corporation [Keith_Boyce] [Keith_Boyce]
+legent-2          374/udp # Legent Corporation [Keith_Boyce] [Keith_Boyce]
+hassle            375/tcp # Hassle [Reinhard_Doelz] [Reinhard_Doelz]
+hassle            375/udp # Hassle [Reinhard_Doelz] [Reinhard_Doelz]
+nip               376/tcp # Amiga Envoy Network Inquiry Proto [Heinz_Wrobel] [Heinz_Wrobel]
+nip               376/udp # Amiga Envoy Network Inquiry Proto [Heinz_Wrobel] [Heinz_Wrobel]
+tnETOS            377/tcp # NEC Corporation
+tnETOS            377/udp # NEC Corporation
+dsETOS            378/tcp # NEC Corporation [Tomoo_Fujita] [Tomoo_Fujita]
+dsETOS            378/udp # NEC Corporation [Tomoo_Fujita] [Tomoo_Fujita]
+is99c             379/tcp # TIA/EIA/IS-99 modem client
+is99c             379/udp # TIA/EIA/IS-99 modem client
+is99s             380/tcp # TIA/EIA/IS-99 modem server [Frank_Quick] [Frank_Quick]
+is99s             380/udp # TIA/EIA/IS-99 modem server [Frank_Quick] [Frank_Quick]
+hp-collector      381/tcp # hp performance data collector
+hp-collector      381/udp # hp performance data collector
+hp-managed-node   382/tcp # hp performance data managed node
+hp-managed-node   382/udp # hp performance data managed node
+hp-alarm-mgr      383/tcp # hp performance data alarm manager [Frank_Blakely] [Frank_Blakely]
+hp-alarm-mgr      383/udp # hp performance data alarm manager [Frank_Blakely] [Frank_Blakely]
+arns              384/tcp # A Remote Network Server System [David_Hornsby] [David_Hornsby]
+arns              384/udp # A Remote Network Server System [David_Hornsby] [David_Hornsby]
+ibm-app           385/tcp # IBM Application [Lisa_Tomita] [Lisa_Tomita]
+ibm-app           385/udp # IBM Application [Lisa_Tomita] [Lisa_Tomita]
+asa               386/tcp # ASA Message Router Object Def. [Steve_Laitinen] [Steve_Laitinen]
+asa               386/udp # ASA Message Router Object Def. [Steve_Laitinen] [Steve_Laitinen]
+aurp              387/tcp # Appletalk Update-Based Routing Pro. [Chris_Ranch] [Chris_Ranch]
+aurp              387/udp # Appletalk Update-Based Routing Pro. [Chris_Ranch] [Chris_Ranch]
+unidata-ldm       388/tcp # Unidata LDM [University_Corporation_for_Atmospheric_Research2] [Steven_Emmerson2] 2012-05-18
+unidata-ldm       388/udp # Unidata LDM [University_Corporation_for_Atmospheric_Research2] [Steven_Emmerson2] 2012-05-18
+ldap              389/tcp # Lightweight Directory Access Protocol [Tim_Howes] [Tim_Howes]
+ldap              389/udp # Lightweight Directory Access Protocol [Tim_Howes] [Tim_Howes]
+uis               390/tcp # UIS [Ed_Barron] [Ed_Barron]
+uis               390/udp # UIS [Ed_Barron] [Ed_Barron]
+synotics-relay    391/tcp # SynOptics SNMP Relay Port
+synotics-relay    391/udp # SynOptics SNMP Relay Port
+synotics-broker   392/tcp # SynOptics Port Broker Port [Illan_Raab] [Illan_Raab]
+synotics-broker   392/udp # SynOptics Port Broker Port [Illan_Raab] [Illan_Raab]
+meta5             393/tcp # Meta5 [Jim_Kanzler] [Jim_Kanzler]
+meta5             393/udp # Meta5 [Jim_Kanzler] [Jim_Kanzler]
+embl-ndt          394/tcp # EMBL Nucleic Data Transfer [Peter_Gad] [Peter_Gad]
+embl-ndt          394/udp # EMBL Nucleic Data Transfer [Peter_Gad] [Peter_Gad]
+netcp             395/tcp # NetScout Control Protocol [Ashwani_Singhal] [Ashwani_Singhal] 2010-04-07
+netcp             395/udp # NetScout Control Protocol [Ashwani_Singhal] [Ashwani_Singhal] 2010-04-07
+netware-ip        396/tcp # Novell Netware over IP
+netware-ip        396/udp # Novell Netware over IP
+mptn              397/tcp # Multi Protocol Trans. Net. [Soumitra_Sarkar] [Soumitra_Sarkar]
+mptn              397/udp # Multi Protocol Trans. Net. [Soumitra_Sarkar] [Soumitra_Sarkar]
+kryptolan         398/tcp # Kryptolan [Peter_de_Laval] [Peter_de_Laval]
+kryptolan         398/udp # Kryptolan [Peter_de_Laval] [Peter_de_Laval]
+iso-tsap-c2       399/tcp # ISO Transport Class 2 Non-Control over TCP [Yanick_Pouffary] [Yanick_Pouffary]
+iso-tsap-c2       399/udp # ISO Transport Class 2 Non-Control over UDP [Yanick_Pouffary] [Yanick_Pouffary]
+osb-sd            400/tcp # Oracle Secure Backup [Joseph_Dziedzic] [Joseph_Dziedzic] 2008-06-06 Formerly was Workstation Solutions
+osb-sd            400/udp # Oracle Secure Backup [Joseph_Dziedzic] [Joseph_Dziedzic] 2008-06-06 Formerly was Workstation Solutions
+ups               401/tcp # Uninterruptible Power Supply [Charles_Bennett] [Charles_Bennett] 2008-08-29
+ups               401/udp # Uninterruptible Power Supply [Charles_Bennett] [Charles_Bennett] 2008-08-29
+genie             402/tcp # Genie Protocol [Mark_Hankin] [Mark_Hankin]
+genie             402/udp # Genie Protocol [Mark_Hankin] [Mark_Hankin]
+decap             403/tcp # decap
+decap             403/udp # decap
+nced              404/tcp # nced
+nced              404/udp # nced
+ncld              405/tcp # ncld [Richard_Jones] [Richard_Jones]
+ncld              405/udp # ncld [Richard_Jones] [Richard_Jones]
+imsp              406/tcp # Interactive Mail Support Protocol [John_Myers] [John_Myers]
+imsp              406/udp # Interactive Mail Support Protocol [John_Myers] [John_Myers]
+timbuktu          407/tcp # Timbuktu [Marc_Epard] [Marc_Epard]
+timbuktu          407/udp # Timbuktu [Marc_Epard] [Marc_Epard]
+prm-sm            408/tcp # Prospero Resource Manager Sys. Man.
+prm-sm            408/udp # Prospero Resource Manager Sys. Man.
+prm-nm            409/tcp # Prospero Resource Manager Node Man. [B_Clifford_Neuman] [B_Clifford_Neuman]
+prm-nm            409/udp # Prospero Resource Manager Node Man. [B_Clifford_Neuman] [B_Clifford_Neuman]
+decladebug        410/tcp # DECLadebug Remote Debug Protocol [Hewlett_Packard] [Hewlett_Packard]
+decladebug        410/udp # DECLadebug Remote Debug Protocol [Hewlett_Packard] [Hewlett_Packard]
+rmt               411/tcp # Remote MT Protocol [Peter_Eriksson] [Peter_Eriksson]
+rmt               411/udp # Remote MT Protocol [Peter_Eriksson] [Peter_Eriksson]
+synoptics-trap    412/tcp # Trap Convention Port [Illan_Raab] [Illan_Raab]
+synoptics-trap    412/udp # Trap Convention Port [Illan_Raab] [Illan_Raab]
+smsp              413/tcp # Storage Management Services Protocol [Murthy_Srinivas] [Murthy_Srinivas]
+smsp              413/udp # Storage Management Services Protocol [Murthy_Srinivas] [Murthy_Srinivas]
+infoseek          414/tcp # InfoSeek [Steve_Kirsch] [Steve_Kirsch]
+infoseek          414/udp # InfoSeek [Steve_Kirsch] [Steve_Kirsch]
+bnet              415/tcp # BNet [Jim_Mertz] [Jim_Mertz]
+bnet              415/udp # BNet [Jim_Mertz] [Jim_Mertz]
+silverplatter     416/tcp # Silverplatter [Peter_Ciuffetti] [Peter_Ciuffetti]
+silverplatter     416/udp # Silverplatter [Peter_Ciuffetti] [Peter_Ciuffetti]
+onmux             417/tcp # Onmux [Stephen_Hanna] [Stephen_Hanna]
+onmux             417/udp # Onmux [Stephen_Hanna] [Stephen_Hanna]
+hyper-g           418/tcp # Hyper-G [Frank_Kappe] [Frank_Kappe]
+hyper-g           418/udp # Hyper-G [Frank_Kappe] [Frank_Kappe]
+ariel1            419/tcp # Ariel 1 [Joel_Karafin] [Joel_Karafin]
+ariel1            419/udp # Ariel 1 [Joel_Karafin] [Joel_Karafin]
+smpte             420/tcp # SMPTE [Si_Becker] [Si_Becker]
+smpte             420/udp # SMPTE [Si_Becker] [Si_Becker]
+ariel2            421/tcp # Ariel 2
+ariel2            421/udp # Ariel 2
+ariel3            422/tcp # Ariel 3 [Joel_Karafin] [Joel_Karafin]
+ariel3            422/udp # Ariel 3 [Joel_Karafin] [Joel_Karafin]
+opc-job-start     423/tcp # IBM Operations Planning and Control Start
+opc-job-start     423/udp # IBM Operations Planning and Control Start
+opc-job-track     424/tcp # IBM Operations Planning and Control Track [Conny_Larsson] [Conny_Larsson]
+opc-job-track     424/udp # IBM Operations Planning and Control Track [Conny_Larsson] [Conny_Larsson]
+icad-el           425/tcp # ICAD [Larry_Stone] [Larry_Stone]
+icad-el           425/udp # ICAD [Larry_Stone] [Larry_Stone]
+smartsdp          426/tcp # smartsdp [Marie_Pierre_Belange] [Marie_Pierre_Belange]
+smartsdp          426/udp # smartsdp [Marie_Pierre_Belange] [Marie_Pierre_Belange]
+svrloc            427/tcp # Server Location [Veizades] [Veizades]
+svrloc            427/udp # Server Location [Veizades] [Veizades]
+ocs-cmu           428/tcp # OCS_CMUIANA assigned this well-formed service name as a replacement for "ocs_cmu".
+ocs_cmu           428/tcp # OCS_CMU This entry is an alias to "ocs-cmu".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+ocs-cmu           428/udp # OCS_CMUIANA assigned this well-formed service name as a replacement for "ocs_cmu".
+ocs_cmu           428/udp # OCS_CMU This entry is an alias to "ocs-cmu".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+ocs-amu           429/tcp # OCS_AMUIANA assigned this well-formed service name as a replacement for "ocs_amu". [Florence_Wyman] [Florence_Wyman]
+ocs_amu           429/tcp # OCS_AMU [Florence_Wyman] [Florence_Wyman] This entry is an alias to "ocs-amu".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+ocs-amu           429/udp # OCS_AMUIANA assigned this well-formed service name as a replacement for "ocs_amu". [Florence_Wyman] [Florence_Wyman]
+ocs_amu           429/udp # OCS_AMU [Florence_Wyman] [Florence_Wyman] This entry is an alias to "ocs-amu".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+utmpsd            430/tcp # UTMPSD
+utmpsd            430/udp # UTMPSD
+utmpcd            431/tcp # UTMPCD
+utmpcd            431/udp # UTMPCD
+iasd              432/tcp # IASD [Nir_Baroz] [Nir_Baroz]
+iasd              432/udp # IASD [Nir_Baroz] [Nir_Baroz]
+nnsp              433/tcp # NNSP [Rob_Robertson] [Rob_Robertson]
+nnsp              433/udp # NNSP [Rob_Robertson] [Rob_Robertson]
+mobileip-agent    434/tcp # MobileIP-Agent
+mobileip-agent    434/udp # MobileIP-Agent
+mobilip-mn        435/tcp # MobilIP-MN [Kannan_Alagappan_2] [Kannan_Alagappan_2]
+mobilip-mn        435/udp # MobilIP-MN [Kannan_Alagappan_2] [Kannan_Alagappan_2]
+dna-cml           436/tcp # DNA-CML [Dan_Flowers] [Dan_Flowers]
+dna-cml           436/udp # DNA-CML [Dan_Flowers] [Dan_Flowers]
+comscm            437/tcp # comscm [Jim_Teague] [Jim_Teague]
+comscm            437/udp # comscm [Jim_Teague] [Jim_Teague]
+dsfgw             438/tcp # dsfgw [Andy_McKeen] [Andy_McKeen]
+dsfgw             438/udp # dsfgw [Andy_McKeen] [Andy_McKeen]
+dasp              439/tcp # dasp [Thomas_Obermair] [Thomas_Obermair]
+dasp              439/udp # dasp [Thomas_Obermair] [Thomas_Obermair]
+sgcp              440/tcp # sgcp [Marshall_Rose] [Marshall_Rose]
+sgcp              440/udp # sgcp [Marshall_Rose] [Marshall_Rose]
+decvms-sysmgt     441/tcp # decvms-sysmgt [Lee_Barton] [Lee_Barton]
+decvms-sysmgt     441/udp # decvms-sysmgt [Lee_Barton] [Lee_Barton]
+cvc-hostd         442/tcp # cvc_hostdIANA assigned this well-formed service name as a replacement for "cvc_hostd". [Bill_Davidson] [Bill_Davidson]
+cvc_hostd         442/tcp # cvc_hostd [Bill_Davidson] [Bill_Davidson] This entry is an alias to "cvc-hostd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+cvc-hostd         442/udp # cvc_hostdIANA assigned this well-formed service name as a replacement for "cvc_hostd". [Bill_Davidson] [Bill_Davidson]
+cvc_hostd         442/udp # cvc_hostd [Bill_Davidson] [Bill_Davidson] This entry is an alias to "cvc-hostd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+https             443/tcp # http protocol over TLS/SSL [Kipp_E_B_Hickman] [Kipp_E_B_Hickman]
+https             443/udp # http protocol over TLS/SSL [Kipp_E_B_Hickman] [Kipp_E_B_Hickman]
+https             443/sctp # HTTPS [Randall_Stewart] [Randall_Stewart] [RFC4960]
+snpp              444/tcp # Simple Network Paging Protocol [RFC1568]
+snpp              444/udp # Simple Network Paging Protocol [RFC1568]
+microsoft-ds      445/tcp # Microsoft-DS [Pradeep_Bahl] [Pradeep_Bahl]
+microsoft-ds      445/udp # Microsoft-DS [Pradeep_Bahl] [Pradeep_Bahl]
+ddm-rdb           446/tcp # DDM-Remote Relational Database Access
+ddm-rdb           446/udp # DDM-Remote Relational Database Access
+ddm-dfm           447/tcp # DDM-Distributed File Management [Steven_Ritland] [Steven_Ritland]
+ddm-dfm           447/udp # DDM-Distributed File Management [Steven_Ritland] [Steven_Ritland]
+ddm-ssl           448/tcp # DDM-Remote DB Access Using Secure Sockets [Steven_Ritland] [Steven_Ritland]
+ddm-ssl           448/udp # DDM-Remote DB Access Using Secure Sockets [Steven_Ritland] [Steven_Ritland]
+as-servermap      449/tcp # AS Server Mapper [Barbara_Foss] [Barbara_Foss]
+as-servermap      449/udp # AS Server Mapper [Barbara_Foss] [Barbara_Foss]
+tserver           450/tcp # Computer Supported Telecomunication Applications [Harvey_S_Schultz] [Harvey_S_Schultz]
+tserver           450/udp # Computer Supported Telecomunication Applications [Harvey_S_Schultz] [Harvey_S_Schultz]
+sfs-smp-net       451/tcp # Cray Network Semaphore server
+sfs-smp-net       451/udp # Cray Network Semaphore server
+sfs-config        452/tcp # Cray SFS config server [Walter_Poxon] [Walter_Poxon]
+sfs-config        452/udp # Cray SFS config server [Walter_Poxon] [Walter_Poxon]
+creativeserver    453/tcp # CreativeServer
+creativeserver    453/udp # CreativeServer
+contentserver     454/tcp # ContentServer
+contentserver     454/udp # ContentServer
+creativepartnr    455/tcp # CreativePartnr [Jesus_Ortiz] [Jesus_Ortiz]
+creativepartnr    455/udp # CreativePartnr [Jesus_Ortiz] [Jesus_Ortiz]
+macon-tcp         456/tcp # macon-tcp [Yoshinobu_Inoue] [Yoshinobu_Inoue]
+macon-udp         456/udp # macon-udp [Yoshinobu_Inoue] [Yoshinobu_Inoue]
+scohelp           457/tcp # scohelp [Faith_Zack] [Faith_Zack]
+scohelp           457/udp # scohelp [Faith_Zack] [Faith_Zack]
+appleqtc          458/tcp # apple quick time [Murali_Ranganathan] [Murali_Ranganathan]
+appleqtc          458/udp # apple quick time [Murali_Ranganathan] [Murali_Ranganathan]
+ampr-rcmd         459/tcp # ampr-rcmd [Rob_Janssen] [Rob_Janssen]
+ampr-rcmd         459/udp # ampr-rcmd [Rob_Janssen] [Rob_Janssen]
+skronk            460/tcp # skronk [Henry_Strickland] [Henry_Strickland]
+skronk            460/udp # skronk [Henry_Strickland] [Henry_Strickland]
+datasurfsrv       461/tcp # DataRampSrv
+datasurfsrv       461/udp # DataRampSrv
+datasurfsrvsec    462/tcp # DataRampSrvSec [Diane_Downie] [Diane_Downie]
+datasurfsrvsec    462/udp # DataRampSrvSec [Diane_Downie] [Diane_Downie]
+alpes             463/tcp # alpes [Alain_Durand] [Alain_Durand]
+alpes             463/udp # alpes [Alain_Durand] [Alain_Durand]
+kpasswd           464/tcp # kpasswd [Theodore_Ts_o] [Theodore_Ts_o]
+kpasswd           464/udp # kpasswd [Theodore_Ts_o] [Theodore_Ts_o]
+urd               465/tcp # URL Rendesvous Directory for SSM
+igmpv3lite        465/udp # IGMP over UDP for SSM [Toerless_Eckert] [Toerless_Eckert]
+digital-vrc       466/tcp # digital-vrc [Peter_Higginson] [Peter_Higginson]
+digital-vrc       466/udp # digital-vrc [Peter_Higginson] [Peter_Higginson]
+mylex-mapd        467/tcp # mylex-mapd [Gary_Lewis] [Gary_Lewis]
+mylex-mapd        467/udp # mylex-mapd [Gary_Lewis] [Gary_Lewis]
+photuris          468/tcp # proturis [Bill_Simpson_2] [Bill_Simpson_2]
+photuris          468/udp # proturis [Bill_Simpson_2] [Bill_Simpson_2]
+rcp               469/tcp # Radio Control Protocol [Jim_Jennings] [Jim_Jennings]
+rcp               469/udp # Radio Control Protocol [Jim_Jennings] [Jim_Jennings]
+scx-proxy         470/tcp # scx-proxy [Scott_Narveson] [Scott_Narveson]
+scx-proxy         470/udp # scx-proxy [Scott_Narveson] [Scott_Narveson]
+mondex            471/tcp # Mondex [Bill_Reding] [Bill_Reding]
+mondex            471/udp # Mondex [Bill_Reding] [Bill_Reding]
+ljk-login         472/tcp # ljk-login [LJK] [LJK]
+ljk-login         472/udp # ljk-login [LJK] [LJK]
+hybrid-pop        473/tcp # hybrid-pop [Rami_Rubin] [Rami_Rubin]
+hybrid-pop        473/udp # hybrid-pop [Rami_Rubin] [Rami_Rubin]
+tn-tl-w1          474/tcp # tn-tl-w1
+tn-tl-w2          474/udp # tn-tl-w2 [Ed_Kress] [Ed_Kress]
+tcpnethaspsrv     475/tcp # tcpnethaspsrv [Michael_Zunke] [Michael_Zunke] 2010-07-23
+tcpnethaspsrv     475/udp # tcpnethaspsrv [Michael_Zunke] [Michael_Zunke] 2010-07-23
+tn-tl-fd1         476/tcp # tn-tl-fd1 [Ed_Kress] [Ed_Kress]
+tn-tl-fd1         476/udp # tn-tl-fd1 [Ed_Kress] [Ed_Kress]
+ss7ns             477/tcp # ss7ns [Jean_Michel_URSCH] [Jean_Michel_URSCH]
+ss7ns             477/udp # ss7ns [Jean_Michel_URSCH] [Jean_Michel_URSCH]
+spsc              478/tcp # spsc [Mike_Rieker] [Mike_Rieker]
+spsc              478/udp # spsc [Mike_Rieker] [Mike_Rieker]
+iafserver         479/tcp # iafserver
+iafserver         479/udp # iafserver
+iafdbase          480/tcp # iafdbase [Rick_Yazwinski] [Rick_Yazwinski]
+iafdbase          480/udp # iafdbase [Rick_Yazwinski] [Rick_Yazwinski]
+ph                481/tcp # Ph service [Roland_Hedberg] [Roland_Hedberg]
+ph                481/udp # Ph service [Roland_Hedberg] [Roland_Hedberg]
+bgs-nsi           482/tcp # bgs-nsi [Jon_Saperia] [Jon_Saperia]
+bgs-nsi           482/udp # bgs-nsi [Jon_Saperia] [Jon_Saperia]
+ulpnet            483/tcp # ulpnet [Kevin_Mooney] [Kevin_Mooney]
+ulpnet            483/udp # ulpnet [Kevin_Mooney] [Kevin_Mooney]
+integra-sme       484/tcp # Integra Software Management Environment [Randall_Dow] [Randall_Dow]
+integra-sme       484/udp # Integra Software Management Environment [Randall_Dow] [Randall_Dow]
+powerburst        485/tcp # Air Soft Power Burst [gary] [gary]
+powerburst        485/udp # Air Soft Power Burst [gary] [gary]
+avian             486/tcp # avian [Robert_Ullmann_2] [Robert_Ullmann_2]
+avian             486/udp # avian [Robert_Ullmann_2] [Robert_Ullmann_2]
+saft              487/tcp # saft Simple Asynchronous File Transfer [Ulli_Horlacher] [Ulli_Horlacher]
+saft              487/udp # saft Simple Asynchronous File Transfer [Ulli_Horlacher] [Ulli_Horlacher]
+gss-http          488/tcp # gss-http [Doug_Rosenthal] [Doug_Rosenthal]
+gss-http          488/udp # gss-http [Doug_Rosenthal] [Doug_Rosenthal]
+nest-protocol     489/tcp # nest-protocol [Gilles_Gameiro] [Gilles_Gameiro]
+nest-protocol     489/udp # nest-protocol [Gilles_Gameiro] [Gilles_Gameiro]
+micom-pfs         490/tcp # micom-pfs [David_Misunas] [David_Misunas]
+micom-pfs         490/udp # micom-pfs [David_Misunas] [David_Misunas]
+go-login          491/tcp # go-login [Troy_Morrison] [Troy_Morrison]
+go-login          491/udp # go-login [Troy_Morrison] [Troy_Morrison]
+ticf-1            492/tcp # Transport Independent Convergence for FNA
+ticf-1            492/udp # Transport Independent Convergence for FNA
+ticf-2            493/tcp # Transport Independent Convergence for FNA [Mamoru_Ito] [Mamoru_Ito]
+ticf-2            493/udp # Transport Independent Convergence for FNA [Mamoru_Ito] [Mamoru_Ito]
+pov-ray           494/tcp # POV-Ray [POV_Team_Co_ordinato] [POV_Team_Co_ordinato]
+pov-ray           494/udp # POV-Ray [POV_Team_Co_ordinato] [POV_Team_Co_ordinato]
+intecourier       495/tcp # intecourier [Steve_Favor] [Steve_Favor]
+intecourier       495/udp # intecourier [Steve_Favor] [Steve_Favor]
+pim-rp-disc       496/tcp # PIM-RP-DISC [Dino_Farinacci] [Dino_Farinacci]
+pim-rp-disc       496/udp # PIM-RP-DISC [Dino_Farinacci] [Dino_Farinacci]
+retrospect        497/tcp # Retrospect backup and restore service [Retrospect_Inc] [JG_Heithcock] 2012-02-02
+retrospect        497/udp # Retrospect backup and restore service [Retrospect_Inc] [JG_Heithcock] 2012-02-02
+siam              498/tcp # siam [Philippe_Gilbert] [Philippe_Gilbert]
+siam              498/udp # siam [Philippe_Gilbert] [Philippe_Gilbert]
+iso-ill           499/tcp # ISO ILL Protocol [Mark_H_Needleman] [Mark_H_Needleman]
+iso-ill           499/udp # ISO ILL Protocol [Mark_H_Needleman] [Mark_H_Needleman]
+isakmp            500/tcp # isakmp [Mark_Schertler] [Mark_Schertler]
+isakmp            500/udp # isakmp [Mark_Schertler] [Mark_Schertler]
+stmf              501/tcp # STMF [Alan_Ungar] [Alan_Ungar]
+stmf              501/udp # STMF [Alan_Ungar] [Alan_Ungar]
+asa-appl-proto    502/tcp # asa-appl-proto [Dennis_Dube] [Dennis_Dube]
+asa-appl-proto    502/udp # asa-appl-proto [Dennis_Dube] [Dennis_Dube]
+intrinsa          503/tcp # Intrinsa [Robert_Ford] [Robert_Ford]
+intrinsa          503/udp # Intrinsa [Robert_Ford] [Robert_Ford]
+citadel           504/tcp # citadel [Art_Cancro] [Art_Cancro]
+citadel           504/udp # citadel [Art_Cancro] [Art_Cancro]
+mailbox-lm        505/tcp # mailbox-lm [Beverly_Moody] [Beverly_Moody]
+mailbox-lm        505/udp # mailbox-lm [Beverly_Moody] [Beverly_Moody]
+ohimsrv           506/tcp # ohimsrv [Scott_Powell] [Scott_Powell]
+ohimsrv           506/udp # ohimsrv [Scott_Powell] [Scott_Powell]
+crs               507/tcp # crs [Brad_Wright] [Brad_Wright]
+crs               507/udp # crs [Brad_Wright] [Brad_Wright]
+xvttp             508/tcp # xvttp [Keith_J_Alphonso] [Keith_J_Alphonso]
+xvttp             508/udp # xvttp [Keith_J_Alphonso] [Keith_J_Alphonso]
+snare             509/tcp # snare [Dennis_Batchelder] [Dennis_Batchelder]
+snare             509/udp # snare [Dennis_Batchelder] [Dennis_Batchelder]
+fcp               510/tcp # FirstClass Protocol [Mike_Marshburn] [Mike_Marshburn]
+fcp               510/udp # FirstClass Protocol [Mike_Marshburn] [Mike_Marshburn]
+passgo            511/tcp # PassGo [John_Rainford] [John_Rainford]
+passgo            511/udp # PassGo [John_Rainford] [John_Rainford]
+exec              512/tcp # remote process execution; authentication performed using passwords and UNIX login names
+comsat            512/udp # 
+biff              512/udp # used by mail system to notify users of new mail received; currently receives messages only from processes on the same machine
+login             513/tcp # remote login a la telnet; automatic authentication performed based on priviledged port numbers and distributed data bases which identify "authentication domains"
+who               513/udp # maintains data bases showing who's logged in to machines on a local net and the load average of the machine
+shell             514/tcp # cmd like exec, but automatic authentication is performed as for login server
+syslog            514/udp # 
+printer           515/tcp # spooler
+printer           515/udp # spooler
+videotex          516/tcp # videotex [Daniel_Mavrakis] [Daniel_Mavrakis]
+videotex          516/udp # videotex [Daniel_Mavrakis] [Daniel_Mavrakis]
+talk              517/tcp # like tenex link, but across machine - unfortunately, doesn't use link protocol (this is actually just a rendezvous port from which a tcp connection is established)
+talk              517/udp # like tenex link, but across machine - unfortunately, doesn't use link protocol (this is actually just a rendezvous port from which a tcp connection is established)
+ntalk             518/tcp # 
+ntalk             518/udp # 
+utime             519/tcp # unixtime
+utime             519/udp # unixtime
+efs               520/tcp # extended file name server
+router            520/udp # local routing process (on site); uses variant of Xerox NS routing information protocol - RIP
+ripng             521/tcp # ripng [Robert_E_Minnear] [Robert_E_Minnear]
+ripng             521/udp # ripng [Robert_E_Minnear] [Robert_E_Minnear]
+ulp               522/tcp # ULP [Max_Morris] [Max_Morris]
+ulp               522/udp # ULP [Max_Morris] [Max_Morris]
+ibm-db2           523/tcp # IBM-DB2 [Juliana_Hsu] [Juliana_Hsu]
+ibm-db2           523/udp # IBM-DB2 [Juliana_Hsu] [Juliana_Hsu]
+ncp               524/tcp # NCP [Don_Provan_2] [Don_Provan_2]
+ncp               524/udp # NCP [Don_Provan_2] [Don_Provan_2]
+timed             525/tcp # timeserver
+timed             525/udp # timeserver
+tempo             526/tcp # newdate
+tempo             526/udp # newdate
+stx               527/tcp # Stock IXChange [Fraxion_Software] [Ferdi_Ladeira] 2012-03-21
+stx               527/udp # Stock IXChange [Fraxion_Software] [Ferdi_Ladeira] 2012-03-21
+custix            528/tcp # Customer IXChange [Fraxion_Software] [Ferdi_Ladeira] 2012-03-21
+custix            528/udp # Customer IXChange [Fraxion_Software] [Ferdi_Ladeira] 2012-03-21
+irc-serv          529/tcp # IRC-SERV [Brian_Tackett] [Brian_Tackett]
+irc-serv          529/udp # IRC-SERV [Brian_Tackett] [Brian_Tackett]
+courier           530/tcp # rpc
+courier           530/udp # rpc
+conference        531/tcp # chat
+conference        531/udp # chat
+netnews           532/tcp # readnews
+netnews           532/udp # readnews
+netwall           533/tcp # for emergency broadcasts [Andreas_Heidemann] [Andreas_Heidemann]
+netwall           533/udp # for emergency broadcasts [Andreas_Heidemann] [Andreas_Heidemann]
+windream          534/tcp # windream Admin [Uwe_Honermann] [Uwe_Honermann]
+windream          534/udp # windream Admin [Uwe_Honermann] [Uwe_Honermann]
+iiop              535/tcp # iiop [Jeff_M_Michaud] [Jeff_M_Michaud]
+iiop              535/udp # iiop [Jeff_M_Michaud] [Jeff_M_Michaud]
+opalis-rdv        536/tcp # opalis-rdv [Laurent_Domenech] [Laurent_Domenech]
+opalis-rdv        536/udp # opalis-rdv [Laurent_Domenech] [Laurent_Domenech]
+nmsp              537/tcp # Networked Media Streaming Protocol [Paul_Santinelli_Jr] [Paul_Santinelli_Jr]
+nmsp              537/udp # Networked Media Streaming Protocol [Paul_Santinelli_Jr] [Paul_Santinelli_Jr]
+gdomap            538/tcp # gdomap [Richard_Frith_Macdon] [Richard_Frith_Macdon]
+gdomap            538/udp # gdomap [Richard_Frith_Macdon] [Richard_Frith_Macdon]
+apertus-ldp       539/tcp # Apertus Technologies Load Determination
+apertus-ldp       539/udp # Apertus Technologies Load Determination
+uucp              540/tcp # uucpd
+uucp              540/udp # uucpd
+uucp-rlogin       541/tcp # uucp-rlogin [Stuart_Lynne] [Stuart_Lynne]
+uucp-rlogin       541/udp # uucp-rlogin [Stuart_Lynne] [Stuart_Lynne]
+commerce          542/tcp # commerce [Randy_Epstein] [Randy_Epstein]
+commerce          542/udp # commerce [Randy_Epstein] [Randy_Epstein]
+klogin            543/tcp # 
+klogin            543/udp # 
+kshell            544/tcp # krcmd
+kshell            544/udp # krcmd
+appleqtcsrvr      545/tcp # appleqtcsrvr [Murali_Ranganathan] [Murali_Ranganathan]
+appleqtcsrvr      545/udp # appleqtcsrvr [Murali_Ranganathan] [Murali_Ranganathan]
+dhcpv6-client     546/tcp # DHCPv6 Client
+dhcpv6-client     546/udp # DHCPv6 Client
+dhcpv6-server     547/tcp # DHCPv6 Server [Jim_Bound] [Jim_Bound]
+dhcpv6-server     547/udp # DHCPv6 Server [Jim_Bound] [Jim_Bound]
+afpovertcp        548/tcp # AFP over TCP [Leland_Wallace] [Leland_Wallace] Defined TXT keys: u=<username> p=<password> path=<path>
+afpovertcp        548/udp # AFP over TCP [Leland_Wallace] [Leland_Wallace] Defined TXT keys: u=<username> p=<password> path=<path>
+idfp              549/tcp # IDFP [Ramana_Kovi] [Ramana_Kovi]
+idfp              549/udp # IDFP [Ramana_Kovi] [Ramana_Kovi]
+new-rwho          550/tcp # new-who [n/a]
+new-rwho          550/udp # new-who [n/a]
+cybercash         551/tcp # cybercash [Donald_E_Eastlake] [Donald_E_Eastlake] [RFC1898]
+cybercash         551/udp # cybercash [Donald_E_Eastlake] [Donald_E_Eastlake] [RFC1898]
+devshr-nts        552/tcp # DeviceShare [Benjamin_Rosenberg] [Benjamin_Rosenberg]
+devshr-nts        552/udp # DeviceShare [Benjamin_Rosenberg] [Benjamin_Rosenberg]
+pirp              553/tcp # pirp [D_J_Bernstein] [D_J_Bernstein]
+pirp              553/udp # pirp [D_J_Bernstein] [D_J_Bernstein]
+rtsp              554/tcp # Real Time Streaming Protocol (RTSP) [Rob_Lanphier] [Rob_Lanphier]
+rtsp              554/udp # Real Time Streaming Protocol (RTSP) [Rob_Lanphier] [Rob_Lanphier]
+dsf               555/tcp # 
+dsf               555/udp # 
+remotefs          556/tcp # rfs server
+remotefs          556/udp # rfs server
+openvms-sysipc    557/tcp # openvms-sysipc [Alan_Potter] [Alan_Potter]
+openvms-sysipc    557/udp # openvms-sysipc [Alan_Potter] [Alan_Potter]
+sdnskmp           558/tcp # SDNSKMP
+sdnskmp           558/udp # SDNSKMP
+teedtap           559/tcp # TEEDTAP [Charlie_Limoges] [Charlie_Limoges]
+teedtap           559/udp # TEEDTAP [Charlie_Limoges] [Charlie_Limoges]
+rmonitor          560/tcp # rmonitord
+rmonitor          560/udp # rmonitord
+monitor           561/tcp # 
+monitor           561/udp # 
+chshell           562/tcp # chcmd
+chshell           562/udp # chcmd
+nntps             563/tcp # nntp protocol over TLS/SSL (was snntp) [Kipp_E_B_Hickman_2] [Kipp_E_B_Hickman_2]
+nntps             563/udp # nntp protocol over TLS/SSL (was snntp) [Kipp_E_B_Hickman_2] [Kipp_E_B_Hickman_2]
+9pfs              564/tcp # plan 9 file service
+9pfs              564/udp # plan 9 file service
+whoami            565/tcp # whoami
+whoami            565/udp # whoami
+streettalk        566/tcp # streettalk
+streettalk        566/udp # streettalk
+banyan-rpc        567/tcp # banyan-rpc [Tom_Lemaire] [Tom_Lemaire]
+banyan-rpc        567/udp # banyan-rpc [Tom_Lemaire] [Tom_Lemaire]
+ms-shuttle        568/tcp # microsoft shuttle [Rudolph_Balaz] [Rudolph_Balaz]
+ms-shuttle        568/udp # microsoft shuttle [Rudolph_Balaz] [Rudolph_Balaz]
+ms-rome           569/tcp # microsoft rome [Rudolph_Balaz] [Rudolph_Balaz]
+ms-rome           569/udp # microsoft rome [Rudolph_Balaz] [Rudolph_Balaz]
+meter             570/tcp # demon
+meter             570/udp # demon
+meter             571/tcp # udemon
+meter             571/udp # udemon
+sonar             572/tcp # sonar [Keith_Moore] [Keith_Moore]
+sonar             572/udp # sonar [Keith_Moore] [Keith_Moore]
+banyan-vip        573/tcp # banyan-vip [Denis_Leclerc] [Denis_Leclerc]
+banyan-vip        573/udp # banyan-vip [Denis_Leclerc] [Denis_Leclerc]
+ftp-agent         574/tcp # FTP Software Agent System [Michael_S_Greenberg] [Michael_S_Greenberg]
+ftp-agent         574/udp # FTP Software Agent System [Michael_S_Greenberg] [Michael_S_Greenberg]
+vemmi             575/tcp # VEMMI [Daniel_Mavrakis_2] [Daniel_Mavrakis_2]
+vemmi             575/udp # VEMMI [Daniel_Mavrakis_2] [Daniel_Mavrakis_2]
+ipcd              576/tcp # ipcd
+ipcd              576/udp # ipcd
+vnas              577/tcp # vnas
+vnas              577/udp # vnas
+ipdd              578/tcp # ipdd [Jay_Farhat] [Jay_Farhat]
+ipdd              578/udp # ipdd [Jay_Farhat] [Jay_Farhat]
+decbsrv           579/tcp # decbsrv [Rudi_Martin] [Rudi_Martin]
+decbsrv           579/udp # decbsrv [Rudi_Martin] [Rudi_Martin]
+sntp-heartbeat    580/tcp # SNTP HEARTBEAT [Louis_Mamakos_2] [Louis_Mamakos_2]
+sntp-heartbeat    580/udp # SNTP HEARTBEAT [Louis_Mamakos_2] [Louis_Mamakos_2]
+bdp               581/tcp # Bundle Discovery Protocol [Gary_Malkin] [Gary_Malkin]
+bdp               581/udp # Bundle Discovery Protocol [Gary_Malkin] [Gary_Malkin]
+scc-security      582/tcp # SCC Security [Prashant_Dholakia] [Prashant_Dholakia]
+scc-security      582/udp # SCC Security [Prashant_Dholakia] [Prashant_Dholakia]
+philips-vc        583/tcp # Philips Video-Conferencing [Janna_Chang] [Janna_Chang]
+philips-vc        583/udp # Philips Video-Conferencing [Janna_Chang] [Janna_Chang]
+keyserver         584/tcp # Key Server [Gary_Howland] [Gary_Howland]
+keyserver         584/udp # Key Server [Gary_Howland] [Gary_Howland]
+password-chg      586/tcp # Password Change
+password-chg      586/udp # Password Change
+submission        587/tcp # Message Submission 2011-11-17 [RFC6409]
+submission        587/udp # Message Submission 2011-11-17 [RFC6409]
+cal               588/tcp # CAL [Myron_Hattig] [Myron_Hattig]
+cal               588/udp # CAL [Myron_Hattig] [Myron_Hattig]
+eyelink           589/tcp # EyeLink [Dave_Stampe] [Dave_Stampe]
+eyelink           589/udp # EyeLink [Dave_Stampe] [Dave_Stampe]
+tns-cml           590/tcp # TNS CML [Jerome_Albin] [Jerome_Albin]
+tns-cml           590/udp # TNS CML [Jerome_Albin] [Jerome_Albin]
+http-alt          591/tcp # FileMaker, Inc. - HTTP Alternate (see Port 80) [Clay_Maeckel] [Clay_Maeckel]
+http-alt          591/udp # FileMaker, Inc. - HTTP Alternate (see Port 80) [Clay_Maeckel] [Clay_Maeckel]
+eudora-set        592/tcp # Eudora Set [Randall_Gellens] [Randall_Gellens]
+eudora-set        592/udp # Eudora Set [Randall_Gellens] [Randall_Gellens]
+http-rpc-epmap    593/tcp # HTTP RPC Ep Map [Edward_Reus] [Edward_Reus]
+http-rpc-epmap    593/udp # HTTP RPC Ep Map [Edward_Reus] [Edward_Reus]
+tpip              594/tcp # TPIP [Brad_Spear] [Brad_Spear]
+tpip              594/udp # TPIP [Brad_Spear] [Brad_Spear]
+cab-protocol      595/tcp # CAB Protocol [Winston_Hetherington] [Winston_Hetherington]
+cab-protocol      595/udp # CAB Protocol [Winston_Hetherington] [Winston_Hetherington]
+smsd              596/tcp # SMSD [Wayne_Barlow] [Wayne_Barlow]
+smsd              596/udp # SMSD [Wayne_Barlow] [Wayne_Barlow]
+ptcnameservice    597/tcp # PTC Name Service [Yuri_Machkasov] [Yuri_Machkasov]
+ptcnameservice    597/udp # PTC Name Service [Yuri_Machkasov] [Yuri_Machkasov]
+sco-websrvrmg3    598/tcp # SCO Web Server Manager 3 [Simon_Baldwin] [Simon_Baldwin]
+sco-websrvrmg3    598/udp # SCO Web Server Manager 3 [Simon_Baldwin] [Simon_Baldwin]
+acp               599/tcp # Aeolon Core Protocol [Michael_Alyn_Miller] [Michael_Alyn_Miller]
+acp               599/udp # Aeolon Core Protocol [Michael_Alyn_Miller] [Michael_Alyn_Miller]
+ipcserver         600/tcp # Sun IPC server [Bill_Schiefelbein] [Bill_Schiefelbein]
+ipcserver         600/udp # Sun IPC server [Bill_Schiefelbein] [Bill_Schiefelbein]
+syslog-conn       601/tcp # Reliable Syslog Service [RFC3195]
+syslog-conn       601/udp # Reliable Syslog Service [RFC3195]
+xmlrpc-beep       602/tcp # XML-RPC over BEEP [RFC3529]
+xmlrpc-beep       602/udp # XML-RPC over BEEP [RFC3529]
+idxp              603/tcp # IDXP [RFC4767]
+idxp              603/udp # IDXP [RFC4767]
+tunnel            604/tcp # TUNNEL [RFC3620]
+tunnel            604/udp # TUNNEL [RFC3620]
+soap-beep         605/tcp # SOAP over BEEP [RFC4227]
+soap-beep         605/udp # SOAP over BEEP [RFC4227]
+urm               606/tcp # Cray Unified Resource Manager
+urm               606/udp # Cray Unified Resource Manager
+nqs               607/tcp # nqs [Bill_Schiefelbein] [Bill_Schiefelbein]
+nqs               607/udp # nqs [Bill_Schiefelbein] [Bill_Schiefelbein]
+sift-uft          608/tcp # Sender-Initiated/Unsolicited File Transfer [Rick_Troth] [Rick_Troth]
+sift-uft          608/udp # Sender-Initiated/Unsolicited File Transfer [Rick_Troth] [Rick_Troth]
+npmp-trap         609/tcp # npmp-trap
+npmp-trap         609/udp # npmp-trap
+npmp-local        610/tcp # npmp-local
+npmp-local        610/udp # npmp-local
+npmp-gui          611/tcp # npmp-gui [John_Barnes] [John_Barnes]
+npmp-gui          611/udp # npmp-gui [John_Barnes] [John_Barnes]
+hmmp-ind          612/tcp # HMMP Indication
+hmmp-ind          612/udp # HMMP Indication
+hmmp-op           613/tcp # HMMP Operation [Andrew_Sinclair] [Andrew_Sinclair]
+hmmp-op           613/udp # HMMP Operation [Andrew_Sinclair] [Andrew_Sinclair]
+sshell            614/tcp # SSLshell [Simon_J_Gerraty] [Simon_J_Gerraty]
+sshell            614/udp # SSLshell [Simon_J_Gerraty] [Simon_J_Gerraty]
+sco-inetmgr       615/tcp # Internet Configuration Manager
+sco-inetmgr       615/udp # Internet Configuration Manager
+sco-sysmgr        616/tcp # SCO System Administration Server
+sco-sysmgr        616/udp # SCO System Administration Server
+sco-dtmgr         617/tcp # SCO Desktop Administration Server [Christopher_Durham] [Christopher_Durham]
+sco-dtmgr         617/udp # SCO Desktop Administration Server [Christopher_Durham] [Christopher_Durham]
+dei-icda          618/tcp # DEI-ICDA [David_Turner] [David_Turner]
+dei-icda          618/udp # DEI-ICDA [David_Turner] [David_Turner]
+compaq-evm        619/tcp # Compaq EVM [Jem_Treadwell] [Jem_Treadwell]
+compaq-evm        619/udp # Compaq EVM [Jem_Treadwell] [Jem_Treadwell]
+sco-websrvrmgr    620/tcp # SCO WebServer Manager [Christopher_Durham] [Christopher_Durham]
+sco-websrvrmgr    620/udp # SCO WebServer Manager [Christopher_Durham] [Christopher_Durham]
+escp-ip           621/tcp # ESCP [Lai_Zit_Seng] [Lai_Zit_Seng]
+escp-ip           621/udp # ESCP [Lai_Zit_Seng] [Lai_Zit_Seng]
+collaborator      622/tcp # Collaborator [Johnson_Davis] [Johnson_Davis]
+collaborator      622/udp # Collaborator [Johnson_Davis] [Johnson_Davis]
+oob-ws-http       623/tcp # DMTF out-of-band web services management protocol [Jim_Davis] [Jim_Davis] 2007-06
+asf-rmcp          623/udp # ASF Remote Management and Control Protocol [Carl_First] [Carl_First]
+cryptoadmin       624/tcp # Crypto Admin [Tony_Walker] [Tony_Walker]
+cryptoadmin       624/udp # Crypto Admin [Tony_Walker] [Tony_Walker]
+dec-dlm           625/tcp # DEC DLMIANA assigned this well-formed service name as a replacement for "dec_dlm". [Rudi_Martin_2] [Rudi_Martin_2]
+dec_dlm           625/tcp # DEC DLM [Rudi_Martin_2] [Rudi_Martin_2] This entry is an alias to "dec-dlm".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+dec-dlm           625/udp # DEC DLMIANA assigned this well-formed service name as a replacement for "dec_dlm". [Rudi_Martin_2] [Rudi_Martin_2]
+dec_dlm           625/udp # DEC DLM [Rudi_Martin_2] [Rudi_Martin_2] This entry is an alias to "dec-dlm".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+asia              626/tcp # ASIA [Michael_Dasenbrock] [Michael_Dasenbrock]
+asia              626/udp # ASIA [Michael_Dasenbrock] [Michael_Dasenbrock]
+passgo-tivoli     627/tcp # PassGo Tivoli [John_Rainford_2] [John_Rainford_2]
+passgo-tivoli     627/udp # PassGo Tivoli [John_Rainford_2] [John_Rainford_2]
+qmqp              628/tcp # QMQP [Dan_Bernstein_2] [Dan_Bernstein_2]
+qmqp              628/udp # QMQP [Dan_Bernstein_2] [Dan_Bernstein_2]
+3com-amp3         629/tcp # 3Com AMP3 [Prakash_Banthia] [Prakash_Banthia]
+3com-amp3         629/udp # 3Com AMP3 [Prakash_Banthia] [Prakash_Banthia]
+rda               630/tcp # RDA [John_Hadjioannou] [John_Hadjioannou]
+rda               630/udp # RDA [John_Hadjioannou] [John_Hadjioannou]
+ipp               631/tcp # IPP (Internet Printing Protocol) [Carl_Uno_Manros] [Carl_Uno_Manros] Defined TXT keys: See BonjourPrinting.pdf.
+ipp               631/udp # IPP (Internet Printing Protocol) [Carl_Uno_Manros] [Carl_Uno_Manros] Defined TXT keys: See BonjourPrinting.pdf.
+bmpp              632/tcp # bmpp [Troy_Rollo] [Troy_Rollo]
+bmpp              632/udp # bmpp [Troy_Rollo] [Troy_Rollo]
+servstat          633/tcp # Service Status update (Sterling Software) [Greg_Rose] [Greg_Rose]
+servstat          633/udp # Service Status update (Sterling Software) [Greg_Rose] [Greg_Rose]
+ginad             634/tcp # ginad [Mark_Crother] [Mark_Crother]
+ginad             634/udp # ginad [Mark_Crother] [Mark_Crother]
+rlzdbase          635/tcp # RLZ DBase [Michael_Ginn] [Michael_Ginn]
+rlzdbase          635/udp # RLZ DBase [Michael_Ginn] [Michael_Ginn]
+ldaps             636/tcp # ldap protocol over TLS/SSL (was sldap) [Pat_Richard] [Pat_Richard]
+ldaps             636/udp # ldap protocol over TLS/SSL (was sldap) [Pat_Richard] [Pat_Richard]
+lanserver         637/tcp # lanserver [Chris_Larsson] [Chris_Larsson]
+lanserver         637/udp # lanserver [Chris_Larsson] [Chris_Larsson]
+mcns-sec          638/tcp # mcns-sec [Kaz_Ozawa] [Kaz_Ozawa]
+mcns-sec          638/udp # mcns-sec [Kaz_Ozawa] [Kaz_Ozawa]
+msdp              639/tcp # MSDP [Dino_Farinacci] [Dino_Farinacci]
+msdp              639/udp # MSDP [Dino_Farinacci] [Dino_Farinacci]
+entrust-sps       640/tcp # entrust-sps [Marek_Buchler] [Marek_Buchler]
+entrust-sps       640/udp # entrust-sps [Marek_Buchler] [Marek_Buchler]
+repcmd            641/tcp # repcmd [Scott_Dale] [Scott_Dale]
+repcmd            641/udp # repcmd [Scott_Dale] [Scott_Dale]
+esro-emsdp        642/tcp # ESRO-EMSDP V1.3 [Mohsen_Banan_2] [Mohsen_Banan_2]
+esro-emsdp        642/udp # ESRO-EMSDP V1.3 [Mohsen_Banan_2] [Mohsen_Banan_2]
+sanity            643/tcp # SANity [Peter_Viscarola] [Peter_Viscarola]
+sanity            643/udp # SANity [Peter_Viscarola] [Peter_Viscarola]
+dwr               644/tcp # dwr [Bill_Fenner] [Bill_Fenner]
+dwr               644/udp # dwr [Bill_Fenner] [Bill_Fenner]
+pssc              645/tcp # PSSC [Egon_Meier_Engelen] [Egon_Meier_Engelen]
+pssc              645/udp # PSSC [Egon_Meier_Engelen] [Egon_Meier_Engelen]
+ldp               646/tcp # LDP [Bob_Thomas] [Bob_Thomas]
+ldp               646/udp # LDP [Bob_Thomas] [Bob_Thomas]
+dhcp-failover     647/tcp # DHCP Failover [Bernard_Volz] [Bernard_Volz]
+dhcp-failover     647/udp # DHCP Failover [Bernard_Volz] [Bernard_Volz]
+rrp               648/tcp # Registry Registrar Protocol (RRP) [Scott_Hollenbeck] [Scott_Hollenbeck]
+rrp               648/udp # Registry Registrar Protocol (RRP) [Scott_Hollenbeck] [Scott_Hollenbeck]
+cadview-3d        649/tcp # Cadview-3d - streaming 3d models over the internet [David_Cooper] [David_Cooper]
+cadview-3d        649/udp # Cadview-3d - streaming 3d models over the internet [David_Cooper] [David_Cooper]
+obex              650/tcp # OBEX [Jeff_Garbers] [Jeff_Garbers]
+obex              650/udp # OBEX [Jeff_Garbers] [Jeff_Garbers]
+ieee-mms          651/tcp # IEEE MMS [Curtis_Anderson] [Curtis_Anderson]
+ieee-mms          651/udp # IEEE MMS [Curtis_Anderson] [Curtis_Anderson]
+hello-port        652/tcp # HELLO_PORT [Patrick_Cipiere] [Patrick_Cipiere]
+hello-port        652/udp # HELLO_PORT [Patrick_Cipiere] [Patrick_Cipiere]
+repscmd           653/tcp # RepCmd [Scott_Dale_2] [Scott_Dale_2]
+repscmd           653/udp # RepCmd [Scott_Dale_2] [Scott_Dale_2]
+aodv              654/tcp # AODV [Charles_Perkins] [Charles_Perkins]
+aodv              654/udp # AODV [Charles_Perkins] [Charles_Perkins]
+tinc              655/tcp # TINC [Ivo_Timmermans] [Ivo_Timmermans]
+tinc              655/udp # TINC [Ivo_Timmermans] [Ivo_Timmermans]
+spmp              656/tcp # SPMP [Jakob_Kaivo] [Jakob_Kaivo]
+spmp              656/udp # SPMP [Jakob_Kaivo] [Jakob_Kaivo]
+rmc               657/tcp # RMC [Michael_Schmidt] [Michael_Schmidt]
+rmc               657/udp # RMC [Michael_Schmidt] [Michael_Schmidt]
+tenfold           658/tcp # TenFold [Louis_Olszyk] [Louis_Olszyk]
+tenfold           658/udp # TenFold [Louis_Olszyk] [Louis_Olszyk]
+mac-srvr-admin    660/tcp # MacOS Server Admin [Forest_Hill] [Forest_Hill]
+mac-srvr-admin    660/udp # MacOS Server Admin [Forest_Hill] [Forest_Hill]
+hap               661/tcp # HAP [Igor_Plotnikov] [Igor_Plotnikov]
+hap               661/udp # HAP [Igor_Plotnikov] [Igor_Plotnikov]
+pftp              662/tcp # PFTP [Ben_Schluricke] [Ben_Schluricke]
+pftp              662/udp # PFTP [Ben_Schluricke] [Ben_Schluricke]
+purenoise         663/tcp # PureNoise [Sam_Osa] [Sam_Osa]
+purenoise         663/udp # PureNoise [Sam_Osa] [Sam_Osa]
+oob-ws-https      664/tcp # DMTF out-of-band secure web services management protocol [Jim_Davis] [Jim_Davis] 2007-06
+asf-secure-rmcp   664/udp # ASF Secure Remote Management and Control Protocol [Carl_First] [Carl_First]
+sun-dr            665/tcp # Sun DR [Harinder_Bhasin] [Harinder_Bhasin]
+sun-dr            665/udp # Sun DR [Harinder_Bhasin] [Harinder_Bhasin]
+mdqs              666/tcp # 
+mdqs              666/udp # 
+doom              666/tcp # doom Id Software [ddt] [ddt]
+doom              666/udp # doom Id Software [ddt] [ddt]
+disclose          667/tcp # campaign contribution disclosures - SDR Technologies [Jim_Dixon] [Jim_Dixon]
+disclose          667/udp # campaign contribution disclosures - SDR Technologies [Jim_Dixon] [Jim_Dixon]
+mecomm            668/tcp # MeComm
+mecomm            668/udp # MeComm
+meregister        669/tcp # MeRegister [Armin_Sawusch] [Armin_Sawusch]
+meregister        669/udp # MeRegister [Armin_Sawusch] [Armin_Sawusch]
+vacdsm-sws        670/tcp # VACDSM-SWS
+vacdsm-sws        670/udp # VACDSM-SWS
+vacdsm-app        671/tcp # VACDSM-APP
+vacdsm-app        671/udp # VACDSM-APP
+vpps-qua          672/tcp # VPPS-QUA
+vpps-qua          672/udp # VPPS-QUA
+cimplex           673/tcp # CIMPLEX [Ulysses_G_Smith_Jr] [Ulysses_G_Smith_Jr]
+cimplex           673/udp # CIMPLEX [Ulysses_G_Smith_Jr] [Ulysses_G_Smith_Jr]
+acap              674/tcp # ACAP [Chris_Newman] [Chris_Newman] 2010-10-15
+acap              674/udp # ACAP [Chris_Newman] [Chris_Newman] 2010-10-15
+dctp              675/tcp # DCTP [Andre_Kramer] [Andre_Kramer]
+dctp              675/udp # DCTP [Andre_Kramer] [Andre_Kramer]
+vpps-via          676/tcp # VPPS Via [Ulysses_G_Smith_Jr] [Ulysses_G_Smith_Jr]
+vpps-via          676/udp # VPPS Via [Ulysses_G_Smith_Jr] [Ulysses_G_Smith_Jr]
+vpp               677/tcp # Virtual Presence Protocol [Klaus_Wolf] [Klaus_Wolf]
+vpp               677/udp # Virtual Presence Protocol [Klaus_Wolf] [Klaus_Wolf]
+ggf-ncp           678/tcp # GNU Generation Foundation NCP [Noah_Paul] [Noah_Paul]
+ggf-ncp           678/udp # GNU Generation Foundation NCP [Noah_Paul] [Noah_Paul]
+mrm               679/tcp # MRM [Liming_Wei] [Liming_Wei]
+mrm               679/udp # MRM [Liming_Wei] [Liming_Wei]
+entrust-aaas      680/tcp # entrust-aaas
+entrust-aaas      680/udp # entrust-aaas
+entrust-aams      681/tcp # entrust-aams [Adrian_Mancini] [Adrian_Mancini]
+entrust-aams      681/udp # entrust-aams [Adrian_Mancini] [Adrian_Mancini]
+xfr               682/tcp # XFR [Noah_Paul_2] [Noah_Paul_2]
+xfr               682/udp # XFR [Noah_Paul_2] [Noah_Paul_2]
+corba-iiop        683/tcp # CORBA IIOP
+corba-iiop        683/udp # CORBA IIOP
+corba-iiop-ssl    684/tcp # CORBA IIOP SSL [Andrew_Watson] [Andrew_Watson]
+corba-iiop-ssl    684/udp # CORBA IIOP SSL [Andrew_Watson] [Andrew_Watson]
+mdc-portmapper    685/tcp # MDC Port Mapper [Noah_Paul] [Noah_Paul]
+mdc-portmapper    685/udp # MDC Port Mapper [Noah_Paul] [Noah_Paul]
+hcp-wismar        686/tcp # Hardware Control Protocol Wismar [David_Merchant] [David_Merchant]
+hcp-wismar        686/udp # Hardware Control Protocol Wismar [David_Merchant] [David_Merchant]
+asipregistry      687/tcp # asipregistry [Erik_Sea] [Erik_Sea]
+asipregistry      687/udp # asipregistry [Erik_Sea] [Erik_Sea]
+realm-rusd        688/tcp # ApplianceWare managment protocol [Stacy_Kenworthy] [Stacy_Kenworthy]
+realm-rusd        688/udp # ApplianceWare managment protocol [Stacy_Kenworthy] [Stacy_Kenworthy]
+nmap              689/tcp # NMAP [Peter_Dennis_Bartok] [Peter_Dennis_Bartok]
+nmap              689/udp # NMAP [Peter_Dennis_Bartok] [Peter_Dennis_Bartok]
+vatp              690/tcp # Velazquez Application Transfer Protocol [Velneo] [Velneo]
+vatp              690/udp # Velazquez Application Transfer Protocol [Velneo] [Velneo]
+msexch-routing    691/tcp # MS Exchange Routing [David_Lemson] [David_Lemson]
+msexch-routing    691/udp # MS Exchange Routing [David_Lemson] [David_Lemson]
+hyperwave-isp     692/tcp # Hyperwave-ISP [Gerald_Mesaric] [Gerald_Mesaric]
+hyperwave-isp     692/udp # Hyperwave-ISP [Gerald_Mesaric] [Gerald_Mesaric]
+connendp          693/tcp # almanid Connection Endpoint [Ronny_Bremer] [Ronny_Bremer]
+connendp          693/udp # almanid Connection Endpoint [Ronny_Bremer] [Ronny_Bremer]
+ha-cluster        694/tcp # ha-cluster [Alan_Robertson] [Alan_Robertson]
+ha-cluster        694/udp # ha-cluster [Alan_Robertson] [Alan_Robertson]
+ieee-mms-ssl      695/tcp # IEEE-MMS-SSL [Curtis_Anderson_2] [Curtis_Anderson_2]
+ieee-mms-ssl      695/udp # IEEE-MMS-SSL [Curtis_Anderson_2] [Curtis_Anderson_2]
+rushd             696/tcp # RUSHD [Greg_Ercolano] [Greg_Ercolano]
+rushd             696/udp # RUSHD [Greg_Ercolano] [Greg_Ercolano]
+uuidgen           697/tcp # UUIDGEN [James_Falkner] [James_Falkner]
+uuidgen           697/udp # UUIDGEN [James_Falkner] [James_Falkner]
+olsr              698/tcp # OLSR [Thomas_Clausen] [Thomas_Clausen]
+olsr              698/udp # OLSR [Thomas_Clausen] [Thomas_Clausen]
+accessnetwork     699/tcp # Access Network [Yingchun_Xu] [Yingchun_Xu]
+accessnetwork     699/udp # Access Network [Yingchun_Xu] [Yingchun_Xu]
+epp               700/tcp # Extensible Provisioning Protocol [RFC5734]
+epp               700/udp # Extensible Provisioning Protocol [RFC5734]
+lmp               701/tcp # Link Management Protocol (LMP) [RFC4204]
+lmp               701/udp # Link Management Protocol (LMP) [RFC4204]
+iris-beep         702/tcp # IRIS over BEEP [RFC3983]
+iris-beep         702/udp # IRIS over BEEP [RFC3983]
+elcsd             704/tcp # errlog copy/server daemon
+elcsd             704/udp # errlog copy/server daemon
+agentx            705/tcp # AgentX [Bob_Natale] [Bob_Natale]
+agentx            705/udp # AgentX [Bob_Natale] [Bob_Natale]
+silc              706/tcp # SILC [Pekka_Riikonen] [Pekka_Riikonen]
+silc              706/udp # SILC [Pekka_Riikonen] [Pekka_Riikonen]
+borland-dsj       707/tcp # Borland DSJ [Gerg_Cole] [Gerg_Cole]
+borland-dsj       707/udp # Borland DSJ [Gerg_Cole] [Gerg_Cole]
+entrust-kmsh      709/tcp # Entrust Key Management Service Handler
+entrust-kmsh      709/udp # Entrust Key Management Service Handler
+entrust-ash       710/tcp # Entrust Administration Service Handler [Peter_Whittaker] [Peter_Whittaker]
+entrust-ash       710/udp # Entrust Administration Service Handler [Peter_Whittaker] [Peter_Whittaker]
+cisco-tdp         711/tcp # Cisco TDP [Bruce_Davie] [Bruce_Davie]
+cisco-tdp         711/udp # Cisco TDP [Bruce_Davie] [Bruce_Davie]
+tbrpf             712/tcp # TBRPF [RFC3684]
+tbrpf             712/udp # TBRPF [RFC3684]
+iris-xpc          713/tcp # IRIS over XPC
+iris-xpc          713/udp # IRIS over XPC
+iris-xpcs         714/tcp # IRIS over XPCS [RFC4992]
+iris-xpcs         714/udp # IRIS over XPCS [RFC4992]
+iris-lwz          715/tcp # IRIS-LWZ [RFC4993]
+iris-lwz          715/udp # IRIS-LWZ [RFC4993]
+pana              716/udp # PANA Messages [RFC5191]
+netviewdm1        729/tcp # IBM NetView DM/6000 Server/Client
+netviewdm1        729/udp # IBM NetView DM/6000 Server/Client
+netviewdm2        730/tcp # IBM NetView DM/6000 send/tcp
+netviewdm2        730/udp # IBM NetView DM/6000 send/tcp
+netviewdm3        731/tcp # IBM NetView DM/6000 receive/tcp [Philippe_Binet] [Philippe_Binet]
+netviewdm3        731/udp # IBM NetView DM/6000 receive/tcp [Philippe_Binet] [Philippe_Binet]
+netgw             741/tcp # netGW [Oliver_Korfmacher] [Oliver_Korfmacher]
+netgw             741/udp # netGW [Oliver_Korfmacher] [Oliver_Korfmacher]
+netrcs            742/tcp # Network based Rev. Cont. Sys. [Gordon_C_Galligher] [Gordon_C_Galligher]
+netrcs            742/udp # Network based Rev. Cont. Sys. [Gordon_C_Galligher] [Gordon_C_Galligher]
+flexlm            744/tcp # Flexible License Manager [Matt_Christiano] [Matt_Christiano]
+flexlm            744/udp # Flexible License Manager [Matt_Christiano] [Matt_Christiano]
+fujitsu-dev       747/tcp # Fujitsu Device Control
+fujitsu-dev       747/udp # Fujitsu Device Control
+ris-cm            748/tcp # Russell Info Sci Calendar Manager
+ris-cm            748/udp # Russell Info Sci Calendar Manager
+kerberos-adm      749/tcp # kerberos administration
+kerberos-adm      749/udp # kerberos administration
+rfile             750/tcp # 
+loadav            750/udp # 
+kerberos-iv       750/udp # kerberos version iv [Martin_Hamilton] [Martin_Hamilton]
+pump              751/tcp # 
+pump              751/udp # 
+qrh               752/tcp # 
+qrh               752/udp # 
+rrh               753/tcp # 
+rrh               753/udp # 
+tell              754/tcp # send [Josyula_R_Rao] [Josyula_R_Rao]
+tell              754/udp # send [Josyula_R_Rao] [Josyula_R_Rao]
+nlogin            758/tcp # 
+nlogin            758/udp # 
+con               759/tcp # 
+con               759/udp # 
+ns                760/tcp # 
+ns                760/udp # 
+rxe               761/tcp # 
+rxe               761/udp # 
+quotad            762/tcp # 
+quotad            762/udp # 
+cycleserv         763/tcp # 
+cycleserv         763/udp # 
+omserv            764/tcp # 
+omserv            764/udp # 
+webster           765/tcp # [Josyula_R_Rao] [Josyula_R_Rao]
+webster           765/udp # [Josyula_R_Rao] [Josyula_R_Rao]
+phonebook         767/tcp # phone [Josyula_R_Rao] [Josyula_R_Rao]
+phonebook         767/udp # phone [Josyula_R_Rao] [Josyula_R_Rao]
+vid               769/tcp # 
+vid               769/udp # 
+cadlock           770/tcp # 
+cadlock           770/udp # 
+rtip              771/tcp # 
+rtip              771/udp # 
+cycleserv2        772/tcp # 
+cycleserv2        772/udp # 
+submit            773/tcp # 
+notify            773/udp # 
+rpasswd           774/tcp # 
+acmaint-dbd       774/udp # IANA assigned this well-formed service name as a replacement for "acmaint_dbd".
+acmaint_dbd       774/udp # This entry is an alias to "acmaint-dbd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+entomb            775/tcp # 
+acmaint-transd    775/udp # IANA assigned this well-formed service name as a replacement for "acmaint_transd".
+acmaint_transd    775/udp # This entry is an alias to "acmaint-transd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+wpages            776/tcp # [Josyula_R_Rao] [Josyula_R_Rao]
+wpages            776/udp # [Josyula_R_Rao] [Josyula_R_Rao]
+multiling-http    777/tcp # Multiling HTTP [Alejandro_Bonet] [Alejandro_Bonet]
+multiling-http    777/udp # Multiling HTTP [Alejandro_Bonet] [Alejandro_Bonet]
+wpgs              780/tcp # [Josyula_R_Rao] [Josyula_R_Rao]
+wpgs              780/udp # [Josyula_R_Rao] [Josyula_R_Rao]
+mdbs-daemon       800/tcp # IANA assigned this well-formed service name as a replacement for "mdbs_daemon".
+mdbs_daemon       800/tcp # This entry is an alias to "mdbs-daemon".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+mdbs-daemon       800/udp # IANA assigned this well-formed service name as a replacement for "mdbs_daemon".
+mdbs_daemon       800/udp # This entry is an alias to "mdbs-daemon".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+device            801/tcp # 
+device            801/udp # 
+fcp-udp           810/tcp # FCP [Paul_Whittemore] [Paul_Whittemore]
+fcp-udp           810/udp # FCP Datagram [Paul_Whittemore] [Paul_Whittemore]
+itm-mcell-s       828/tcp # itm-mcell-s [Portnoy_Boxman] [Portnoy_Boxman]
+itm-mcell-s       828/udp # itm-mcell-s [Portnoy_Boxman] [Portnoy_Boxman]
+pkix-3-ca-ra      829/tcp # PKIX-3 CA/RA [Carlisle_Adams] [Carlisle_Adams]
+pkix-3-ca-ra      829/udp # PKIX-3 CA/RA [Carlisle_Adams] [Carlisle_Adams]
+netconf-ssh       830/tcp # NETCONF over SSH [RFC6242]
+netconf-ssh       830/udp # NETCONF over SSH [RFC6242]
+netconf-beep      831/tcp # NETCONF over BEEP [RFC4744]
+netconf-beep      831/udp # NETCONF over BEEP [RFC4744]
+netconfsoaphttp   832/tcp # NETCONF for SOAP over HTTPS [RFC4743]
+netconfsoaphttp   832/udp # NETCONF for SOAP over HTTPS [RFC4743]
+netconfsoapbeep   833/tcp # NETCONF for SOAP over BEEP [RFC4743]
+netconfsoapbeep   833/udp # NETCONF for SOAP over BEEP [RFC4743]
+dhcp-failover2    847/tcp # dhcp-failover 2 [Bernard_Volz] [Bernard_Volz]
+dhcp-failover2    847/udp # dhcp-failover 2 [Bernard_Volz] [Bernard_Volz]
+gdoi              848/tcp # GDOI [RFC3547]
+gdoi              848/udp # GDOI [RFC3547]
+iscsi             860/tcp # iSCSI [IESG] [IETF_Chair] 2013-08-27 [RFC-ietf-storm-iscsi-cons-10]
+iscsi             860/udp # iSCSI [IESG] [IETF_Chair] 2013-08-27 [RFC-ietf-storm-iscsi-cons-10]
+owamp-control     861/tcp # OWAMP-Control [RFC4656]
+owamp-control     861/udp # OWAMP-Control [RFC4656]
+twamp-control     862/tcp # Two-way Active Measurement Protocol (TWAMP) Control [RFC5357]
+twamp-control     862/udp # Two-way Active Measurement Protocol (TWAMP) Control [RFC5357]
+rsync             873/tcp # rsync [Andrew_Tridgell] [Andrew_Tridgell]
+rsync             873/udp # rsync [Andrew_Tridgell] [Andrew_Tridgell]
+iclcnet-locate    886/tcp # ICL coNETion locate server [Bob_Lyon] [Bob_Lyon]
+iclcnet-locate    886/udp # ICL coNETion locate server [Bob_Lyon] [Bob_Lyon]
+iclcnet-svinfo    887/tcp # ICL coNETion server infoIANA assigned this well-formed service name as a replacement for "iclcnet_svinfo". [Bob_Lyon] [Bob_Lyon]
+iclcnet_svinfo    887/tcp # ICL coNETion server info [Bob_Lyon] [Bob_Lyon] This entry is an alias to "iclcnet-svinfo".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+iclcnet-svinfo    887/udp # ICL coNETion server infoIANA assigned this well-formed service name as a replacement for "iclcnet_svinfo". [Bob_Lyon] [Bob_Lyon]
+iclcnet_svinfo    887/udp # ICL coNETion server info [Bob_Lyon] [Bob_Lyon] This entry is an alias to "iclcnet-svinfo".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+accessbuilder     888/tcp # AccessBuilder [Steve_Sweeney] [Steve_Sweeney]
+accessbuilder     888/udp # AccessBuilder [Steve_Sweeney] [Steve_Sweeney]
+cddbp             888/tcp # CD Database Protocol [Steve_Scherf] [Steve_Scherf] This entry records an unassigned but widespread use
+omginitialrefs    900/tcp # OMG Initial Refs [Christian_Callsen] [Christian_Callsen]
+omginitialrefs    900/udp # OMG Initial Refs [Christian_Callsen] [Christian_Callsen]
+smpnameres        901/tcp # SMPNAMERES [Leif_Ekblad] [Leif_Ekblad]
+smpnameres        901/udp # SMPNAMERES [Leif_Ekblad] [Leif_Ekblad]
+ideafarm-door     902/tcp # self documenting Telnet Door
+ideafarm-door     902/udp # self documenting Door: send 0x00 for info
+ideafarm-panic    903/tcp # self documenting Telnet Panic Door [Wo_o_Ideafarm] [Wo_o_Ideafarm]
+ideafarm-panic    903/udp # self documenting Panic Door: send 0x00 for info [Wo_o_Ideafarm] [Wo_o_Ideafarm]
+kink              910/tcp # Kerberized Internet Negotiation of Keys (KINK) [RFC4430]
+kink              910/udp # Kerberized Internet Negotiation of Keys (KINK) [RFC4430]
+xact-backup       911/tcp # xact-backup [Bill_Carroll] [Bill_Carroll]
+xact-backup       911/udp # xact-backup [Bill_Carroll] [Bill_Carroll]
+apex-mesh         912/tcp # APEX relay-relay service
+apex-mesh         912/udp # APEX relay-relay service
+apex-edge         913/tcp # APEX endpoint-relay service [RFC3340]
+apex-edge         913/udp # APEX endpoint-relay service [RFC3340]
+ftps-data         989/tcp # ftp protocol, data, over TLS/SSL
+ftps-data         989/udp # ftp protocol, data, over TLS/SSL
+ftps              990/tcp # ftp protocol, control, over TLS/SSL [Christopher_Allen] [Christopher_Allen]
+ftps              990/udp # ftp protocol, control, over TLS/SSL [Christopher_Allen] [Christopher_Allen]
+nas               991/tcp # Netnews Administration System [Vera_Heinau][Heiko_Schlichting] [Vera_Heinau][Heiko_Schlichting]
+nas               991/udp # Netnews Administration System [Vera_Heinau][Heiko_Schlichting] [Vera_Heinau][Heiko_Schlichting]
+telnets           992/tcp # telnet protocol over TLS/SSL
+telnets           992/udp # telnet protocol over TLS/SSL
+imaps             993/tcp # imap4 protocol over TLS/SSL
+imaps             993/udp # imap4 protocol over TLS/SSL
+pop3s             995/tcp # pop3 protocol over TLS/SSL (was spop3) [Gordon_Mangione] [Gordon_Mangione]
+pop3s             995/udp # pop3 protocol over TLS/SSL (was spop3) [Gordon_Mangione] [Gordon_Mangione]
+vsinet            996/tcp # vsinet [Rob_Juergens] [Rob_Juergens]
+vsinet            996/udp # vsinet [Rob_Juergens] [Rob_Juergens]
+maitrd            997/tcp # 
+maitrd            997/udp # 
+busboy            998/tcp # 
+puparp            998/udp # 
+garcon            999/tcp # 
+applix            999/udp # Applix ac
+puprouter         999/tcp # 
+puprouter         999/udp # 
+cadlock2         1000/tcp # 
+cadlock2         1000/udp # 
+surf             1010/tcp # surf [Joseph_Geer] [Joseph_Geer]
+surf             1010/udp # surf [Joseph_Geer] [Joseph_Geer]
+exp1             1021/tcp # RFC3692-style Experiment 1 [IESG] [IETF_Chair] [1][RFC4727][RFC6335]
+exp1             1021/udp # RFC3692-style Experiment 1 [IESG] [IETF_Chair] [1][RFC4727][RFC6335]
+exp1             1021/sctp # RFC3692-style Experiment 1 [IESG] [IETF_Chair] [1][RFC4727][RFC6335]
+exp1             1021/dccp # RFC3692-style Experiment 1 [IESG] [IETF_Chair] [1][RFC4727][RFC6335]
+exp2             1022/tcp # RFC3692-style Experiment 2 [IESG] [IETF_Chair] [1][RFC4727][RFC6335]
+exp2             1022/udp # RFC3692-style Experiment 2 [IESG] [IETF_Chair] [1][RFC4727][RFC6335]
+exp2             1022/sctp # RFC3692-style Experiment 2 [IESG] [IETF_Chair] [1][RFC4727][RFC6335]
+exp2             1022/dccp # RFC3692-style Experiment 2 [IESG] [IETF_Chair] [1][RFC4727][RFC6335]
+blackjack        1025/tcp # network blackjack
+blackjack        1025/udp # network blackjack
+cap              1026/tcp # Calendar Access Protocol [Doug_Royer] [Doug_Royer] 2010-12-09
+cap              1026/udp # Calendar Access Protocol [Doug_Royer] [Doug_Royer] 2010-12-09
+6a44             1027/udp # IPv6 Behind NAT44 CPEs [IESG] [IETF_Chair] 2012-08-02 [RFC6751]
+solid-mux        1029/tcp # Solid Mux Server [Anders_Borg] [Anders_Borg] 2004-11
+solid-mux        1029/udp # Solid Mux Server [Anders_Borg] [Anders_Borg] 2004-11
+netinfo-local    1033/tcp # local netinfo port [Marc_Majka] [Marc_Majka] 2002-08
+netinfo-local    1033/udp # local netinfo port [Marc_Majka] [Marc_Majka] 2002-08
+activesync       1034/tcp # ActiveSync Notifications [Sandra_Vargas] [Sandra_Vargas] 2003-03
+activesync       1034/udp # ActiveSync Notifications [Sandra_Vargas] [Sandra_Vargas] 2003-03
+mxxrlogin        1035/tcp # MX-XR RPC [Arnold_E_Mauer] [Arnold_E_Mauer] 2003-04
+mxxrlogin        1035/udp # MX-XR RPC [Arnold_E_Mauer] [Arnold_E_Mauer] 2003-04
+nsstp            1036/tcp # Nebula Secure Segment Transfer Protocol [Steve_Ravida] [Steve_Ravida]
+nsstp            1036/udp # Nebula Secure Segment Transfer Protocol [Steve_Ravida] [Steve_Ravida]
+ams              1037/tcp # AMS [Ronald_R_Ohmer] [Ronald_R_Ohmer] 2004-02
+ams              1037/udp # AMS [Ronald_R_Ohmer] [Ronald_R_Ohmer] 2004-02
+mtqp             1038/tcp # Message Tracking Query Protocol [RFC3887]
+mtqp             1038/udp # Message Tracking Query Protocol [RFC3887]
+sbl              1039/tcp # Streamlined Blackhole [Jonathan_A_Zdziaras] [Jonathan_A_Zdziaras] 2004-11
+sbl              1039/udp # Streamlined Blackhole [Jonathan_A_Zdziaras] [Jonathan_A_Zdziaras] 2004-11
+netarx           1040/tcp # Netarx Netcare [Sandy_Kronenberg] [Sandy_Kronenberg] 2008-04-03
+netarx           1040/udp # Netarx Netcare [Sandy_Kronenberg] [Sandy_Kronenberg] 2008-04-03
+danf-ak2         1041/tcp # AK2 Product [Karl_Palsson] [Karl_Palsson] 2004-11
+danf-ak2         1041/udp # AK2 Product [Karl_Palsson] [Karl_Palsson] 2004-11
+afrog            1042/tcp # Subnet Roaming [Michael_Chapman] [Michael_Chapman] 2004-11
+afrog            1042/udp # Subnet Roaming [Michael_Chapman] [Michael_Chapman] 2004-11
+boinc-client     1043/tcp # BOINC Client Control [David_Anderson] [David_Anderson] 2004-11
+boinc-client     1043/udp # BOINC Client Control [David_Anderson] [David_Anderson] 2004-11
+dcutility        1044/tcp # Dev Consortium Utility [Chris_Ryland] [Chris_Ryland] 2004-11
+dcutility        1044/udp # Dev Consortium Utility [Chris_Ryland] [Chris_Ryland] 2004-11
+fpitp            1045/tcp # Fingerprint Image Transfer Protocol [Steven_Fields] [Steven_Fields] 2002-02
+fpitp            1045/udp # Fingerprint Image Transfer Protocol [Steven_Fields] [Steven_Fields] 2002-02
+wfremotertm      1046/tcp # WebFilter Remote Monitor [Tim_Morgan] [Tim_Morgan] 2004-11
+wfremotertm      1046/udp # WebFilter Remote Monitor [Tim_Morgan] [Tim_Morgan] 2004-11
+neod1            1047/tcp # Sun's NEO Object Request Broker
+neod1            1047/udp # Sun's NEO Object Request Broker
+neod2            1048/tcp # Sun's NEO Object Request Broker [Rohit_Garg] [Rohit_Garg]
+neod2            1048/udp # Sun's NEO Object Request Broker [Rohit_Garg] [Rohit_Garg]
+td-postman       1049/tcp # Tobit David Postman VPMN [Franz_Josef_Leuders] [Franz_Josef_Leuders]
+td-postman       1049/udp # Tobit David Postman VPMN [Franz_Josef_Leuders] [Franz_Josef_Leuders]
+cma              1050/tcp # CORBA Management Agent [Ramy_Zaarour] [Ramy_Zaarour]
+cma              1050/udp # CORBA Management Agent [Ramy_Zaarour] [Ramy_Zaarour]
+optima-vnet      1051/tcp # Optima VNET [Ralf_Doewich] [Ralf_Doewich]
+optima-vnet      1051/udp # Optima VNET [Ralf_Doewich] [Ralf_Doewich]
+ddt              1052/tcp # Dynamic DNS Tools [Remi_Lefebvre] [Remi_Lefebvre]
+ddt              1052/udp # Dynamic DNS Tools [Remi_Lefebvre] [Remi_Lefebvre]
+remote-as        1053/tcp # Remote Assistant (RA) [Roman_Kriis] [Roman_Kriis] Unauthorized Use Known on port 1053
+remote-as        1053/udp # Remote Assistant (RA) [Roman_Kriis] [Roman_Kriis]
+brvread          1054/tcp # BRVREAD [A_Boninn] [A_Boninn]
+brvread          1054/udp # BRVREAD [A_Boninn] [A_Boninn]
+ansyslmd         1055/tcp # ANSYS - License Manager [Suzanne_Lorrin] [Suzanne_Lorrin]
+ansyslmd         1055/udp # ANSYS - License Manager [Suzanne_Lorrin] [Suzanne_Lorrin]
+vfo              1056/tcp # VFO [Anthony_Gonzalez] [Anthony_Gonzalez]
+vfo              1056/udp # VFO [Anthony_Gonzalez] [Anthony_Gonzalez]
+startron         1057/tcp # STARTRON [Markus_Sabadello] [Markus_Sabadello]
+startron         1057/udp # STARTRON [Markus_Sabadello] [Markus_Sabadello]
+nim              1058/tcp # nim
+nim              1058/udp # nim
+nimreg           1059/tcp # nimreg [Robert_Gordon] [Robert_Gordon]
+nimreg           1059/udp # nimreg [Robert_Gordon] [Robert_Gordon]
+polestar         1060/tcp # POLESTAR [Masakuni_Okada] [Masakuni_Okada]
+polestar         1060/udp # POLESTAR [Masakuni_Okada] [Masakuni_Okada]
+kiosk            1061/tcp # KIOSK [Ken_Ksiazek] [Ken_Ksiazek]
+kiosk            1061/udp # KIOSK [Ken_Ksiazek] [Ken_Ksiazek]
+veracity         1062/tcp # Veracity [Ross_Williams] [Ross_Williams]
+veracity         1062/udp # Veracity [Ross_Williams] [Ross_Williams]
+kyoceranetdev    1063/tcp # KyoceraNetDev [Shigenaka_Kanemitsu] [Shigenaka_Kanemitsu]
+kyoceranetdev    1063/udp # KyoceraNetDev [Shigenaka_Kanemitsu] [Shigenaka_Kanemitsu]
+jstel            1064/tcp # JSTEL [Duane_Kiser] [Duane_Kiser]
+jstel            1064/udp # JSTEL [Duane_Kiser] [Duane_Kiser]
+syscomlan        1065/tcp # SYSCOMLAN [Alexandre_Lechenne] [Alexandre_Lechenne] 2008-12-10
+syscomlan        1065/udp # SYSCOMLAN [Alexandre_Lechenne] [Alexandre_Lechenne] 2008-12-10
+fpo-fns          1066/tcp # FPO-FNS [Jens_Klose] [Jens_Klose]
+fpo-fns          1066/udp # FPO-FNS [Jens_Klose] [Jens_Klose]
+instl-boots      1067/tcp # Installation Bootstrap Proto. Serv.IANA assigned this well-formed service name as a replacement for "instl_boots".
+instl_boots      1067/tcp # Installation Bootstrap Proto. Serv. This entry is an alias to "instl-boots".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+instl-boots      1067/udp # Installation Bootstrap Proto. Serv.IANA assigned this well-formed service name as a replacement for "instl_boots".
+instl_boots      1067/udp # Installation Bootstrap Proto. Serv. This entry is an alias to "instl-boots".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+instl-bootc      1068/tcp # Installation Bootstrap Proto. Cli.IANA assigned this well-formed service name as a replacement for "instl_bootc". [David_Arko] [David_Arko]
+instl_bootc      1068/tcp # Installation Bootstrap Proto. Cli. [David_Arko] [David_Arko] This entry is an alias to "instl-bootc".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+instl-bootc      1068/udp # Installation Bootstrap Proto. Cli.IANA assigned this well-formed service name as a replacement for "instl_bootc". [David_Arko] [David_Arko]
+instl_bootc      1068/udp # Installation Bootstrap Proto. Cli. [David_Arko] [David_Arko] This entry is an alias to "instl-bootc".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+cognex-insight   1069/tcp # COGNEX-INSIGHT [Steve_Olson] [Steve_Olson]
+cognex-insight   1069/udp # COGNEX-INSIGHT [Steve_Olson] [Steve_Olson]
+gmrupdateserv    1070/tcp # GMRUpdateSERV [Steve_Kellogg] [Steve_Kellogg]
+gmrupdateserv    1070/udp # GMRUpdateSERV [Steve_Kellogg] [Steve_Kellogg]
+bsquare-voip     1071/tcp # BSQUARE-VOIP [Yen_Lee] [Yen_Lee]
+bsquare-voip     1071/udp # BSQUARE-VOIP [Yen_Lee] [Yen_Lee]
+cardax           1072/tcp # CARDAX [Charles_Oram] [Charles_Oram]
+cardax           1072/udp # CARDAX [Charles_Oram] [Charles_Oram]
+bridgecontrol    1073/tcp # Bridge Control [Andy_Heron] [Andy_Heron]
+bridgecontrol    1073/udp # Bridge Control [Andy_Heron] [Andy_Heron]
+warmspotMgmt     1074/tcp # Warmspot Management Protocol [Robert_C_Henningsga] [Robert_C_Henningsga]
+warmspotMgmt     1074/udp # Warmspot Management Protocol [Robert_C_Henningsga] [Robert_C_Henningsga]
+rdrmshc          1075/tcp # RDRMSHC [Ericko_Shimada] [Ericko_Shimada]
+rdrmshc          1075/udp # RDRMSHC [Ericko_Shimada] [Ericko_Shimada]
+dab-sti-c        1076/tcp # DAB STI-C [World_DAB] [World_DAB]
+dab-sti-c        1076/udp # DAB STI-C [World_DAB] [World_DAB]
+imgames          1077/tcp # IMGames [Jean_A_Ames] [Jean_A_Ames]
+imgames          1077/udp # IMGames [Jean_A_Ames] [Jean_A_Ames]
+avocent-proxy    1078/tcp # Avocent Proxy Protocol [Steven_W_Clark] [Steven_W_Clark]
+avocent-proxy    1078/udp # Avocent Proxy Protocol [Steven_W_Clark] [Steven_W_Clark]
+asprovatalk      1079/tcp # ASPROVATalk [Chiew_Farn_Chung] [Chiew_Farn_Chung]
+asprovatalk      1079/udp # ASPROVATalk [Chiew_Farn_Chung] [Chiew_Farn_Chung]
+socks            1080/tcp # Socks [Ying_Da_Lee] [Ying_Da_Lee]
+socks            1080/udp # Socks [Ying_Da_Lee] [Ying_Da_Lee]
+pvuniwien        1081/tcp # PVUNIWIEN [Peter_Lipp] [Peter_Lipp]
+pvuniwien        1081/udp # PVUNIWIEN [Peter_Lipp] [Peter_Lipp]
+amt-esd-prot     1082/tcp # AMT-ESD-PROT [AMTEC_S_p_A] [AMTEC_S_p_A]
+amt-esd-prot     1082/udp # AMT-ESD-PROT [AMTEC_S_p_A] [AMTEC_S_p_A]
+ansoft-lm-1      1083/tcp # Anasoft License Manager
+ansoft-lm-1      1083/udp # Anasoft License Manager
+ansoft-lm-2      1084/tcp # Anasoft License Manager
+ansoft-lm-2      1084/udp # Anasoft License Manager
+webobjects       1085/tcp # Web Objects [Andy_Belk] [Andy_Belk]
+webobjects       1085/udp # Web Objects [Andy_Belk] [Andy_Belk]
+cplscrambler-lg  1086/tcp # CPL Scrambler Logging
+cplscrambler-lg  1086/udp # CPL Scrambler Logging
+cplscrambler-in  1087/tcp # CPL Scrambler Internal
+cplscrambler-in  1087/udp # CPL Scrambler Internal
+cplscrambler-al  1088/tcp # CPL Scrambler Alarm Log [Richard_Corn] [Richard_Corn]
+cplscrambler-al  1088/udp # CPL Scrambler Alarm Log [Richard_Corn] [Richard_Corn]
+ff-annunc        1089/tcp # FF Annunciation
+ff-annunc        1089/udp # FF Annunciation
+ff-fms           1090/tcp # FF Fieldbus Message Specification
+ff-fms           1090/udp # FF Fieldbus Message Specification
+ff-sm            1091/tcp # FF System Management [Fieldbus_Foundation] [Fieldbus_Foundation]
+ff-sm            1091/udp # FF System Management [Fieldbus_Foundation] [Fieldbus_Foundation]
+obrpd            1092/tcp # Open Business Reporting Protocol [William_Randolph_Roy] [William_Randolph_Roy]
+obrpd            1092/udp # Open Business Reporting Protocol [William_Randolph_Roy] [William_Randolph_Roy]
+proofd           1093/tcp # PROOFD
+proofd           1093/udp # PROOFD
+rootd            1094/tcp # ROOTD [Fons_Rademakers] [Fons_Rademakers]
+rootd            1094/udp # ROOTD [Fons_Rademakers] [Fons_Rademakers]
+nicelink         1095/tcp # NICELink [Jordi_Lisbona] [Jordi_Lisbona]
+nicelink         1095/udp # NICELink [Jordi_Lisbona] [Jordi_Lisbona]
+cnrprotocol      1096/tcp # Common Name Resolution Protocol [Michael_Mealling] [Michael_Mealling]
+cnrprotocol      1096/udp # Common Name Resolution Protocol [Michael_Mealling] [Michael_Mealling]
+sunclustermgr    1097/tcp # Sun Cluster Manager [Ashit_Patel] [Ashit_Patel]
+sunclustermgr    1097/udp # Sun Cluster Manager [Ashit_Patel] [Ashit_Patel]
+rmiactivation    1098/tcp # RMI Activation
+rmiactivation    1098/udp # RMI Activation
+rmiregistry      1099/tcp # RMI Registry [Mark_Hodapp] [Mark_Hodapp]
+rmiregistry      1099/udp # RMI Registry [Mark_Hodapp] [Mark_Hodapp]
+mctp             1100/tcp # MCTP [Vitaly_Revsin] [Vitaly_Revsin]
+mctp             1100/udp # MCTP [Vitaly_Revsin] [Vitaly_Revsin]
+pt2-discover     1101/tcp # PT2-DISCOVER [Ralph_Kammerlander] [Ralph_Kammerlander]
+pt2-discover     1101/udp # PT2-DISCOVER [Ralph_Kammerlander] [Ralph_Kammerlander]
+adobeserver-1    1102/tcp # ADOBE SERVER 1
+adobeserver-1    1102/udp # ADOBE SERVER 1
+adobeserver-2    1103/tcp # ADOBE SERVER 2 [Frank_Soetebeer] [Frank_Soetebeer]
+adobeserver-2    1103/udp # ADOBE SERVER 2 [Frank_Soetebeer] [Frank_Soetebeer]
+xrl              1104/tcp # XRL [Patrick_Robinson] [Patrick_Robinson]
+xrl              1104/udp # XRL [Patrick_Robinson] [Patrick_Robinson]
+ftranhc          1105/tcp # FTRANHC [Eriko_Shimada] [Eriko_Shimada]
+ftranhc          1105/udp # FTRANHC [Eriko_Shimada] [Eriko_Shimada]
+isoipsigport-1   1106/tcp # ISOIPSIGPORT-1
+isoipsigport-1   1106/udp # ISOIPSIGPORT-1
+isoipsigport-2   1107/tcp # ISOIPSIGPORT-2 [Peter_Egli] [Peter_Egli]
+isoipsigport-2   1107/udp # ISOIPSIGPORT-2 [Peter_Egli] [Peter_Egli]
+ratio-adp        1108/tcp # ratio-adp [Oliver_Thulke] [Oliver_Thulke]
+ratio-adp        1108/udp # ratio-adp [Oliver_Thulke] [Oliver_Thulke]
+webadmstart      1110/tcp # Start web admin server
+nfsd-keepalive   1110/udp # Client status info [Beth_Crespo] [Beth_Crespo]
+lmsocialserver   1111/tcp # LM Social Server [Ron_Lussier] [Ron_Lussier]
+lmsocialserver   1111/udp # LM Social Server [Ron_Lussier] [Ron_Lussier]
+icp              1112/tcp # Intelligent Communication Protocol [Mark_H_David] [Mark_H_David]
+icp              1112/udp # Intelligent Communication Protocol [Mark_H_David] [Mark_H_David]
+ltp-deepspace    1113/tcp # Licklider Transmission Protocol [RFC5326]
+ltp-deepspace    1113/udp # Licklider Transmission Protocol [RFC5326]
+mini-sql         1114/tcp # Mini SQL [David_Hughes] [David_Hughes]
+mini-sql         1114/udp # Mini SQL [David_Hughes] [David_Hughes]
+ardus-trns       1115/tcp # ARDUS Transfer
+ardus-trns       1115/udp # ARDUS Transfer
+ardus-cntl       1116/tcp # ARDUS Control
+ardus-cntl       1116/udp # ARDUS Control
+ardus-mtrns      1117/tcp # ARDUS Multicast Transfer [Shinya_Abe] [Shinya_Abe]
+ardus-mtrns      1117/udp # ARDUS Multicast Transfer [Shinya_Abe] [Shinya_Abe]
+sacred           1118/tcp # SACRED [RFC3767]
+sacred           1118/udp # SACRED [RFC3767]
+bnetgame         1119/tcp # Battle.net Chat/Game Protocol
+bnetgame         1119/udp # Battle.net Chat/Game Protocol
+bnetfile         1120/tcp # Battle.net File Transfer Protocol [Domain_Tech] [Domain_Tech] 2005-04
+bnetfile         1120/udp # Battle.net File Transfer Protocol [Domain_Tech] [Domain_Tech] 2005-04
+rmpp             1121/tcp # Datalode RMPP [Dave_Ruedger] [Dave_Ruedger] 2003-11
+rmpp             1121/udp # Datalode RMPP [Dave_Ruedger] [Dave_Ruedger] 2003-11
+availant-mgr     1122/tcp # availant-mgr [Steven_Pelletier] [Steven_Pelletier]
+availant-mgr     1122/udp # availant-mgr [Steven_Pelletier] [Steven_Pelletier]
+murray           1123/tcp # Murray [Stu_Mark] [Stu_Mark]
+murray           1123/udp # Murray [Stu_Mark] [Stu_Mark]
+hpvmmcontrol     1124/tcp # HP VMM Control
+hpvmmcontrol     1124/udp # HP VMM Control
+hpvmmagent       1125/tcp # HP VMM Agent
+hpvmmagent       1125/udp # HP VMM Agent
+hpvmmdata        1126/tcp # HP VMM Agent [John_Morton] [John_Morton] 2004-11
+hpvmmdata        1126/udp # HP VMM Agent [John_Morton] [John_Morton] 2004-11
+kwdb-commn       1127/tcp # KWDB Remote Communication [Lal_Samuel_Varghese] [Lal_Samuel_Varghese] 2005-08
+kwdb-commn       1127/udp # KWDB Remote Communication [Lal_Samuel_Varghese] [Lal_Samuel_Varghese] 2005-08
+saphostctrl      1128/tcp # SAPHostControl over SOAP/HTTP
+saphostctrl      1128/udp # SAPHostControl over SOAP/HTTP
+saphostctrls     1129/tcp # SAPHostControl over SOAP/HTTPS [Muscarella_Fabrizio] [Muscarella_Fabrizio] 2006-04
+saphostctrls     1129/udp # SAPHostControl over SOAP/HTTPS [Muscarella_Fabrizio] [Muscarella_Fabrizio] 2006-04
+casp             1130/tcp # CAC App Service Protocol
+casp             1130/udp # CAC App Service Protocol
+caspssl          1131/tcp # CAC App Service Protocol Encripted [Enrique_Corujo] [Enrique_Corujo] 2006-02
+caspssl          1131/udp # CAC App Service Protocol Encripted [Enrique_Corujo] [Enrique_Corujo] 2006-02
+kvm-via-ip       1132/tcp # KVM-via-IP Management Service [Ian_Miller] [Ian_Miller] 2006-03
+kvm-via-ip       1132/udp # KVM-via-IP Management Service [Ian_Miller] [Ian_Miller] 2006-03
+dfn              1133/tcp # Data Flow Network [Dmitry_Obuvalin] [Dmitry_Obuvalin] 2006-02
+dfn              1133/udp # Data Flow Network [Dmitry_Obuvalin] [Dmitry_Obuvalin] 2006-02
+aplx             1134/tcp # MicroAPL APLX [Richard_Nabavi] [Richard_Nabavi] 2006-02
+aplx             1134/udp # MicroAPL APLX [Richard_Nabavi] [Richard_Nabavi] 2006-02
+omnivision       1135/tcp # OmniVision Communication Service [Serge_Vacquier] [Serge_Vacquier] 2006-02
+omnivision       1135/udp # OmniVision Communication Service [Serge_Vacquier] [Serge_Vacquier] 2006-02
+hhb-gateway      1136/tcp # HHB Gateway Control [Richard_Harwell] [Richard_Harwell] 2006-02
+hhb-gateway      1136/udp # HHB Gateway Control [Richard_Harwell] [Richard_Harwell] 2006-02
+trim             1137/tcp # TRIM Workgroup Service [Siva_Poobalasingam] [Siva_Poobalasingam] 2006-03
+trim             1137/udp # TRIM Workgroup Service [Siva_Poobalasingam] [Siva_Poobalasingam] 2006-03
+encrypted-admin  1138/tcp # encrypted admin requestsIANA assigned this well-formed service name as a replacement for "encrypted_admin". [Michael_Elizarov] [Michael_Elizarov] 2007-01
+encrypted_admin  1138/tcp # encrypted admin requests [Michael_Elizarov] [Michael_Elizarov] 2007-01 This entry is an alias to "encrypted-admin".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+encrypted-admin  1138/udp # encrypted admin requestsIANA assigned this well-formed service name as a replacement for "encrypted_admin". [Michael_Elizarov] [Michael_Elizarov] 2007-01
+encrypted_admin  1138/udp # encrypted admin requests [Michael_Elizarov] [Michael_Elizarov] 2007-01 This entry is an alias to "encrypted-admin".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+evm              1139/tcp # Enterprise Virtual Manager [Thomas_Hennessy] [Thomas_Hennessy] 2007-10-04
+evm              1139/udp # Enterprise Virtual Manager [Thomas_Hennessy] [Thomas_Hennessy] 2007-10-04
+autonoc          1140/tcp # AutoNOC Network Operations Protocol [Kyle_Lussier] [Kyle_Lussier] 2005-12
+autonoc          1140/udp # AutoNOC Network Operations Protocol [Kyle_Lussier] [Kyle_Lussier] 2005-12
+mxomss           1141/tcp # User Message Service [Chaoyi_Lang] [Chaoyi_Lang] 2006-01
+mxomss           1141/udp # User Message Service [Chaoyi_Lang] [Chaoyi_Lang] 2006-01
+edtools          1142/tcp # User Discovery Service [Lee_Dolson] [Lee_Dolson] 2006-01
+edtools          1142/udp # User Discovery Service [Lee_Dolson] [Lee_Dolson] 2006-01
+imyx             1143/tcp # Infomatryx Exchange [David_Walling] [David_Walling] 2006-03
+imyx             1143/udp # Infomatryx Exchange [David_Walling] [David_Walling] 2006-03
+fuscript         1144/tcp # Fusion Script [Peter_Loveday] [Peter_Loveday] 2006-01
+fuscript         1144/udp # Fusion Script [Peter_Loveday] [Peter_Loveday] 2006-01
+x9-icue          1145/tcp # X9 iCue Show Control [Brandon_Potter] [Brandon_Potter] 2006-01
+x9-icue          1145/udp # X9 iCue Show Control [Brandon_Potter] [Brandon_Potter] 2006-01
+audit-transfer   1146/tcp # audit transfer [Mark_Wahl] [Mark_Wahl] 2005-11
+audit-transfer   1146/udp # audit transfer [Mark_Wahl] [Mark_Wahl] 2005-11
+capioverlan      1147/tcp # CAPIoverLAN [Diego_Friedel] [Diego_Friedel] 2005-11
+capioverlan      1147/udp # CAPIoverLAN [Diego_Friedel] [Diego_Friedel] 2005-11
+elfiq-repl       1148/tcp # Elfiq Replication Service [Frederick_Parent] [Frederick_Parent] 2005-11
+elfiq-repl       1148/udp # Elfiq Replication Service [Frederick_Parent] [Frederick_Parent] 2005-11
+bvtsonar         1149/tcp # BlueView Sonar Service [Teledyne_BlueView_Inc] [Cat_Zimmermann] 2005-11 2012-09-19
+bvtsonar         1149/udp # BlueView Sonar Service [Teledyne_BlueView_Inc] [Cat_Zimmermann] 2005-11 2012-09-19
+blaze            1150/tcp # Blaze File Server [Curt_Schimmel] [Curt_Schimmel] 2005-11
+blaze            1150/udp # Blaze File Server [Curt_Schimmel] [Curt_Schimmel] 2005-11
+unizensus        1151/tcp # Unizensus Login Server [Dirk_Materlik] [Dirk_Materlik] 2005-11
+unizensus        1151/udp # Unizensus Login Server [Dirk_Materlik] [Dirk_Materlik] 2005-11
+winpoplanmess    1152/tcp # Winpopup LAN Messenger [Vitali_Fomine] [Vitali_Fomine] 2005-11
+winpoplanmess    1152/udp # Winpopup LAN Messenger [Vitali_Fomine] [Vitali_Fomine] 2005-11
+c1222-acse       1153/tcp # ANSI C12.22 Port [RFC6142]
+c1222-acse       1153/udp # ANSI C12.22 Port [RFC6142]
+resacommunity    1154/tcp # Community Service [Stephane_MONS] [Stephane_MONS] 2005-09
+resacommunity    1154/udp # Community Service [Stephane_MONS] [Stephane_MONS] 2005-09
+nfa              1155/tcp # Network File Access [James_Powell] [James_Powell]
+nfa              1155/udp # Network File Access [James_Powell] [James_Powell]
+iascontrol-oms   1156/tcp # iasControl OMS [Todd_Guay] [Todd_Guay] 2004-11
+iascontrol-oms   1156/udp # iasControl OMS [Todd_Guay] [Todd_Guay] 2004-11
+iascontrol       1157/tcp # Oracle iASControl [Todd_Guay] [Todd_Guay] 2004-11
+iascontrol       1157/udp # Oracle iASControl [Todd_Guay] [Todd_Guay] 2004-11
+dbcontrol-oms    1158/tcp # dbControl OMS [Todd_Guay] [Todd_Guay] 2004-11
+dbcontrol-oms    1158/udp # dbControl OMS [Todd_Guay] [Todd_Guay] 2004-11
+oracle-oms       1159/tcp # Oracle OMS [Todd_Guay] [Todd_Guay] 2004-11
+oracle-oms       1159/udp # Oracle OMS [Todd_Guay] [Todd_Guay] 2004-11
+olsv             1160/tcp # DB Lite Mult-User Server [Philip_Stephenson] [Philip_Stephenson] 2005-08
+olsv             1160/udp # DB Lite Mult-User Server [Philip_Stephenson] [Philip_Stephenson] 2005-08
+health-polling   1161/tcp # Health Polling
+health-polling   1161/udp # Health Polling
+health-trap      1162/tcp # Health Trap
+health-trap      1162/udp # Health Trap
+sddp             1163/tcp # SmartDialer Data Protocol [Lee_Griffiths] [Lee_Griffiths] 2004-11
+sddp             1163/udp # SmartDialer Data Protocol [Lee_Griffiths] [Lee_Griffiths] 2004-11
+qsm-proxy        1164/tcp # QSM Proxy Service [Norm_Lunde] [Norm_Lunde] 2004-11
+qsm-proxy        1164/udp # QSM Proxy Service [Norm_Lunde] [Norm_Lunde] 2004-11
+qsm-gui          1165/tcp # QSM GUI Service [Norm_Lunde] [Norm_Lunde] 2004-11
+qsm-gui          1165/udp # QSM GUI Service [Norm_Lunde] [Norm_Lunde] 2004-11
+qsm-remote       1166/tcp # QSM RemoteExec [Norm_Lunde] [Norm_Lunde] 2004-11
+qsm-remote       1166/udp # QSM RemoteExec [Norm_Lunde] [Norm_Lunde] 2004-11
+cisco-ipsla      1167/tcp # Cisco IP SLAs Control Protocol [Emmanuel_Tychon] [Emmanuel_Tychon] 2006-03
+cisco-ipsla      1167/udp # Cisco IP SLAs Control Protocol [Emmanuel_Tychon] [Emmanuel_Tychon] 2006-03
+cisco-ipsla      1167/sctp # Cisco IP SLAs Control Protocol [Emmanuel_Tychon] [Emmanuel_Tychon] 2006-03
+vchat            1168/tcp # VChat Conference Service [Andreas_Wetzel] [Andreas_Wetzel] 2002-09
+vchat            1168/udp # VChat Conference Service [Andreas_Wetzel] [Andreas_Wetzel] 2002-09
+tripwire         1169/tcp # TRIPWIRE [Ed_Metcalf][Albert_Holt] [Ed_Metcalf][Albert_Holt]
+tripwire         1169/udp # TRIPWIRE [Ed_Metcalf][Albert_Holt] [Ed_Metcalf][Albert_Holt]
+atc-lm           1170/tcp # AT+C License Manager [Peter_Schafer] [Peter_Schafer] 2004-02
+atc-lm           1170/udp # AT+C License Manager [Peter_Schafer] [Peter_Schafer] 2004-02
+atc-appserver    1171/tcp # AT+C FmiApplicationServer [Peter_Schafer] [Peter_Schafer] 2004-02
+atc-appserver    1171/udp # AT+C FmiApplicationServer [Peter_Schafer] [Peter_Schafer] 2004-02
+dnap             1172/tcp # DNA Protocol [David_McLaughlin] [David_McLaughlin] 2004-11
+dnap             1172/udp # DNA Protocol [David_McLaughlin] [David_McLaughlin] 2004-11
+d-cinema-rrp     1173/tcp # D-Cinema Request-Response [Robert_Baldwin] [Robert_Baldwin] 2004-11
+d-cinema-rrp     1173/udp # D-Cinema Request-Response [Robert_Baldwin] [Robert_Baldwin] 2004-11
+fnet-remote-ui   1174/tcp # FlashNet Remote Admin [Terry_Smyth] [Terry_Smyth] 2004-11
+fnet-remote-ui   1174/udp # FlashNet Remote Admin [Terry_Smyth] [Terry_Smyth] 2004-11
+dossier          1175/tcp # Dossier Server [Rob_Minerick] [Rob_Minerick] 2004-11
+dossier          1175/udp # Dossier Server [Rob_Minerick] [Rob_Minerick] 2004-11
+indigo-server    1176/tcp # Indigo Home Server [Matt_Bendiksen] [Matt_Bendiksen] 2004-11
+indigo-server    1176/udp # Indigo Home Server [Matt_Bendiksen] [Matt_Bendiksen] 2004-11
+dkmessenger      1177/tcp # DKMessenger Protocol [Douglas_Kadlecek] [Douglas_Kadlecek] 2004-11
+dkmessenger      1177/udp # DKMessenger Protocol [Douglas_Kadlecek] [Douglas_Kadlecek] 2004-11
+sgi-storman      1178/tcp # SGI Storage Manager [Greg_Banks] [Greg_Banks] 2004-11
+sgi-storman      1178/udp # SGI Storage Manager [Greg_Banks] [Greg_Banks] 2004-11
+b2n              1179/tcp # Backup To Neighbor [Thomas_Fok] [Thomas_Fok] 2004-11
+b2n              1179/udp # Backup To Neighbor [Thomas_Fok] [Thomas_Fok] 2004-11
+mc-client        1180/tcp # Millicent Client Proxy [Steve_Glassman] [Steve_Glassman]
+mc-client        1180/udp # Millicent Client Proxy [Steve_Glassman] [Steve_Glassman]
+3comnetman       1181/tcp # 3Com Net Management [Peter_White] [Peter_White] 2004-11
+3comnetman       1181/udp # 3Com Net Management [Peter_White] [Peter_White] 2004-11
+accelenet        1182/tcp # AcceleNet Control
+accelenet-data   1182/udp # AcceleNet Data [Peter_Lepeska] [Peter_Lepeska] 2010-09-10
+llsurfup-http    1183/tcp # LL Surfup HTTP
+llsurfup-http    1183/udp # LL Surfup HTTP
+llsurfup-https   1184/tcp # LL Surfup HTTPS [Katy_Lynn_McCullough] [Katy_Lynn_McCullough]
+llsurfup-https   1184/udp # LL Surfup HTTPS [Katy_Lynn_McCullough] [Katy_Lynn_McCullough]
+catchpole        1185/tcp # Catchpole port [Christian_Catchpole] [Christian_Catchpole] 2002-03
+catchpole        1185/udp # Catchpole port [Christian_Catchpole] [Christian_Catchpole] 2002-03
+mysql-cluster    1186/tcp # MySQL Cluster Manager [Arjen_Lentz] [Arjen_Lentz] 2004-11
+mysql-cluster    1186/udp # MySQL Cluster Manager [Arjen_Lentz] [Arjen_Lentz] 2004-11
+alias            1187/tcp # Alias Service [Paul_Tokarchuk] [Paul_Tokarchuk] 2004-11
+alias            1187/udp # Alias Service [Paul_Tokarchuk] [Paul_Tokarchuk] 2004-11
+hp-webadmin      1188/tcp # HP Web Admin [Lance_Kind] [Lance_Kind]
+hp-webadmin      1188/udp # HP Web Admin [Lance_Kind] [Lance_Kind]
+unet             1189/tcp # Unet Connection [Anthony_Stahler] [Anthony_Stahler] 2004-11
+unet             1189/udp # Unet Connection [Anthony_Stahler] [Anthony_Stahler] 2004-11
+commlinx-avl     1190/tcp # CommLinx GPS / AVL System [Peter_Johnson] [Peter_Johnson] 2004-11
+commlinx-avl     1190/udp # CommLinx GPS / AVL System [Peter_Johnson] [Peter_Johnson] 2004-11
+gpfs             1191/tcp # General Parallel File System [Dave_Craft] [Dave_Craft] 2004-11
+gpfs             1191/udp # General Parallel File System [Dave_Craft] [Dave_Craft] 2004-11
+caids-sensor     1192/tcp # caids sensors channel [Gregory_Hostettler] [Gregory_Hostettler] 2004-11
+caids-sensor     1192/udp # caids sensors channel [Gregory_Hostettler] [Gregory_Hostettler] 2004-11
+fiveacross       1193/tcp # Five Across Server [Glenn_Reid] [Glenn_Reid] 2004-11
+fiveacross       1193/udp # Five Across Server [Glenn_Reid] [Glenn_Reid] 2004-11
+openvpn          1194/tcp # OpenVPN [James_Yonan] [James_Yonan] 2004-11
+openvpn          1194/udp # OpenVPN [James_Yonan] [James_Yonan] 2004-11
+rsf-1            1195/tcp # RSF-1 clustering [Dave_Hines] [Dave_Hines] 2004-11
+rsf-1            1195/udp # RSF-1 clustering [Dave_Hines] [Dave_Hines] 2004-11
+netmagic         1196/tcp # Network Magic [Nick_Holt] [Nick_Holt] 2005-08
+netmagic         1196/udp # Network Magic [Nick_Holt] [Nick_Holt] 2005-08
+carrius-rshell   1197/tcp # Carrius Remote Access [Gerry_Dubois] [Gerry_Dubois] 2005-08
+carrius-rshell   1197/udp # Carrius Remote Access [Gerry_Dubois] [Gerry_Dubois] 2005-08
+cajo-discovery   1198/tcp # cajo reference discovery [John_Catherino] [John_Catherino] 2005-08
+cajo-discovery   1198/udp # cajo reference discovery [John_Catherino] [John_Catherino] 2005-08
+dmidi            1199/tcp # DMIDI [Phil_Kerr] [Phil_Kerr] 2002-02
+dmidi            1199/udp # DMIDI [Phil_Kerr] [Phil_Kerr] 2002-02
+scol             1200/tcp # SCOL [Cryo_Networks] [Cryo_Networks]
+scol             1200/udp # SCOL [Cryo_Networks] [Cryo_Networks]
+nucleus-sand     1201/tcp # Nucleus Sand Database Server [James_Marsh] [James_Marsh]
+nucleus-sand     1201/udp # Nucleus Sand Database Server [James_Marsh] [James_Marsh]
+caiccipc         1202/tcp # caiccipc [Vince_Re] [Vince_Re]
+caiccipc         1202/udp # caiccipc [Vince_Re] [Vince_Re]
+ssslic-mgr       1203/tcp # License Validation
+ssslic-mgr       1203/udp # License Validation
+ssslog-mgr       1204/tcp # Log Request Listener [Eric_Bruno] [Eric_Bruno]
+ssslog-mgr       1204/udp # Log Request Listener [Eric_Bruno] [Eric_Bruno]
+accord-mgc       1205/tcp # Accord-MGC [Roni_Even] [Roni_Even]
+accord-mgc       1205/udp # Accord-MGC [Roni_Even] [Roni_Even]
+anthony-data     1206/tcp # Anthony Data [Paul_Dollemore] [Paul_Dollemore]
+anthony-data     1206/udp # Anthony Data [Paul_Dollemore] [Paul_Dollemore]
+metasage         1207/tcp # MetaSage [Peter_Anvelt] [Peter_Anvelt]
+metasage         1207/udp # MetaSage [Peter_Anvelt] [Peter_Anvelt]
+seagull-ais      1208/tcp # SEAGULL AIS [Lee_Breisacher] [Lee_Breisacher]
+seagull-ais      1208/udp # SEAGULL AIS [Lee_Breisacher] [Lee_Breisacher]
+ipcd3            1209/tcp # IPCD3 [Mark_Ciskey] [Mark_Ciskey]
+ipcd3            1209/udp # IPCD3 [Mark_Ciskey] [Mark_Ciskey]
+eoss             1210/tcp # EOSS [Robert_Armes] [Robert_Armes]
+eoss             1210/udp # EOSS [Robert_Armes] [Robert_Armes]
+groove-dpp       1211/tcp # Groove DPP [Ken_Moore] [Ken_Moore]
+groove-dpp       1211/udp # Groove DPP [Ken_Moore] [Ken_Moore]
+lupa             1212/tcp # lupa [Barney_Wolff] [Barney_Wolff]
+lupa             1212/udp # lupa [Barney_Wolff] [Barney_Wolff]
+mpc-lifenet      1213/tcp # MPC LIFENET [Ward_Silver] [Ward_Silver]
+mpc-lifenet      1213/udp # MPC LIFENET [Ward_Silver] [Ward_Silver]
+kazaa            1214/tcp # KAZAA [Ahti_Heinla] [Ahti_Heinla]
+kazaa            1214/udp # KAZAA [Ahti_Heinla] [Ahti_Heinla]
+scanstat-1       1215/tcp # scanSTAT 1.0 [William_Scheding] [William_Scheding]
+scanstat-1       1215/udp # scanSTAT 1.0 [William_Scheding] [William_Scheding]
+etebac5          1216/tcp # ETEBAC 5 [Jean_Louis_Barbut] [Jean_Louis_Barbut]
+etebac5          1216/udp # ETEBAC 5 [Jean_Louis_Barbut] [Jean_Louis_Barbut]
+hpss-ndapi       1217/tcp # HPSS NonDCE Gateway [Michael_Gleicher] [Michael_Gleicher]
+hpss-ndapi       1217/udp # HPSS NonDCE Gateway [Michael_Gleicher] [Michael_Gleicher]
+aeroflight-ads   1218/tcp # AeroFlight-ADs
+aeroflight-ads   1218/udp # AeroFlight-ADs
+aeroflight-ret   1219/tcp # AeroFlight-Ret [Eric_Johnson] [Eric_Johnson]
+aeroflight-ret   1219/udp # AeroFlight-Ret [Eric_Johnson] [Eric_Johnson]
+qt-serveradmin   1220/tcp # QT SERVER ADMIN [Chris_LeCroy] [Chris_LeCroy]
+qt-serveradmin   1220/udp # QT SERVER ADMIN [Chris_LeCroy] [Chris_LeCroy]
+sweetware-apps   1221/tcp # SweetWARE Apps [David_Dunetz] [David_Dunetz]
+sweetware-apps   1221/udp # SweetWARE Apps [David_Dunetz] [David_Dunetz]
+nerv             1222/tcp # SNI R&D network [Martin_Freiss] [Martin_Freiss]
+nerv             1222/udp # SNI R&D network [Martin_Freiss] [Martin_Freiss]
+tgp              1223/tcp # TrulyGlobal Protocol [Gur_Kimchi] [Gur_Kimchi] 2008-05-20
+tgp              1223/udp # TrulyGlobal Protocol [Gur_Kimchi] [Gur_Kimchi] 2008-05-20
+vpnz             1224/tcp # VPNz [Tom_Strack] [Tom_Strack]
+vpnz             1224/udp # VPNz [Tom_Strack] [Tom_Strack]
+slinkysearch     1225/tcp # SLINKYSEARCH [Desmond_Chan] [Desmond_Chan]
+slinkysearch     1225/udp # SLINKYSEARCH [Desmond_Chan] [Desmond_Chan]
+stgxfws          1226/tcp # STGXFWS [Tetsuya_Shioda] [Tetsuya_Shioda]
+stgxfws          1226/udp # STGXFWS [Tetsuya_Shioda] [Tetsuya_Shioda]
+dns2go           1227/tcp # DNS2Go [Mike_Courterier] [Mike_Courterier]
+dns2go           1227/udp # DNS2Go [Mike_Courterier] [Mike_Courterier]
+florence         1228/tcp # FLORENCE [Brian_Trammell] [Brian_Trammell]
+florence         1228/udp # FLORENCE [Brian_Trammell] [Brian_Trammell]
+zented           1229/tcp # ZENworks Tiered Electronic Distribution [Ty_Ellis] [Ty_Ellis]
+zented           1229/udp # ZENworks Tiered Electronic Distribution [Ty_Ellis] [Ty_Ellis]
+periscope        1230/tcp # Periscope [Kevin_Madden] [Kevin_Madden]
+periscope        1230/udp # Periscope [Kevin_Madden] [Kevin_Madden]
+menandmice-lpm   1231/tcp # menandmice-lpm [Sigfus_Magnusson] [Sigfus_Magnusson]
+menandmice-lpm   1231/udp # menandmice-lpm [Sigfus_Magnusson] [Sigfus_Magnusson]
+first-defense    1232/tcp # Remote systems monitoring [Nexum] [Michael_Fread] 2012-09-21 Microsoft (unoffically) using 1232
+first-defense    1232/udp # Remote systems monitoring [Nexum] [Michael_Fread] 2012-09-21 Microsoft (unoffically) using 1232
+univ-appserver   1233/tcp # Universal App Server [Tim_Sent] [Tim_Sent]
+univ-appserver   1233/udp # Universal App Server [Tim_Sent] [Tim_Sent]
+search-agent     1234/tcp # Infoseek Search Agent [Jackie_Wu] [Jackie_Wu]
+search-agent     1234/udp # Infoseek Search Agent [Jackie_Wu] [Jackie_Wu]
+mosaicsyssvc1    1235/tcp # mosaicsyssvc1 [Brian_Matthews] [Brian_Matthews]
+mosaicsyssvc1    1235/udp # mosaicsyssvc1 [Brian_Matthews] [Brian_Matthews]
+bvcontrol        1236/tcp # bvcontrol [Daniel_J_Walsh] [Daniel_J_Walsh]
+bvcontrol        1236/udp # bvcontrol [Daniel_J_Walsh] [Daniel_J_Walsh]
+tsdos390         1237/tcp # tsdos390 [Ben_Pracht] [Ben_Pracht]
+tsdos390         1237/udp # tsdos390 [Ben_Pracht] [Ben_Pracht]
+hacl-qs          1238/tcp # hacl-qs [Farid_Faez] [Farid_Faez]
+hacl-qs          1238/udp # hacl-qs [Farid_Faez] [Farid_Faez]
+nmsd             1239/tcp # NMSD [Yuri_Machkasov] [Yuri_Machkasov]
+nmsd             1239/udp # NMSD [Yuri_Machkasov] [Yuri_Machkasov]
+instantia        1240/tcp # Instantia [Ruth_Slater] [Ruth_Slater]
+instantia        1240/udp # Instantia [Ruth_Slater] [Ruth_Slater]
+nessus           1241/tcp # nessus [Jordan_Hrycaj] [Jordan_Hrycaj]
+nessus           1241/udp # nessus [Jordan_Hrycaj] [Jordan_Hrycaj]
+nmasoverip       1242/tcp # NMAS over IP [Hal_Henderson] [Hal_Henderson]
+nmasoverip       1242/udp # NMAS over IP [Hal_Henderson] [Hal_Henderson]
+serialgateway    1243/tcp # SerialGateway [Stephen_LaValley] [Stephen_LaValley]
+serialgateway    1243/udp # SerialGateway [Stephen_LaValley] [Stephen_LaValley]
+isbconference1   1244/tcp # isbconference1
+isbconference1   1244/udp # isbconference1
+isbconference2   1245/tcp # isbconference2 [Arnold_Dittmann] [Arnold_Dittmann]
+isbconference2   1245/udp # isbconference2 [Arnold_Dittmann] [Arnold_Dittmann]
+payrouter        1246/tcp # payrouter [David_Wilson] [David_Wilson]
+payrouter        1246/udp # payrouter [David_Wilson] [David_Wilson]
+visionpyramid    1247/tcp # VisionPyramid [Gavin_Hutchinson] [Gavin_Hutchinson]
+visionpyramid    1247/udp # VisionPyramid [Gavin_Hutchinson] [Gavin_Hutchinson]
+hermes           1248/tcp # hermes
+hermes           1248/udp # hermes
+mesavistaco      1249/tcp # Mesa Vista Co [Rick_LaBanca] [Rick_LaBanca]
+mesavistaco      1249/udp # Mesa Vista Co [Rick_LaBanca] [Rick_LaBanca]
+swldy-sias       1250/tcp # swldy-sias [Peter_E_Williams] [Peter_E_Williams]
+swldy-sias       1250/udp # swldy-sias [Peter_E_Williams] [Peter_E_Williams]
+servergraph      1251/tcp # servergraph [Lindsay_Morris] [Lindsay_Morris]
+servergraph      1251/udp # servergraph [Lindsay_Morris] [Lindsay_Morris]
+bspne-pcc        1252/tcp # bspne-pcc
+bspne-pcc        1252/udp # bspne-pcc
+q55-pcc          1253/tcp # q55-pcc [Prem_Tirilok] [Prem_Tirilok]
+q55-pcc          1253/udp # q55-pcc [Prem_Tirilok] [Prem_Tirilok]
+de-noc           1254/tcp # de-noc
+de-noc           1254/udp # de-noc
+de-cache-query   1255/tcp # de-cache-query
+de-cache-query   1255/udp # de-cache-query
+de-server        1256/tcp # de-server [Jeff_Burdette] [Jeff_Burdette]
+de-server        1256/udp # de-server [Jeff_Burdette] [Jeff_Burdette]
+shockwave2       1257/tcp # Shockwave 2 [Dave_Simmons] [Dave_Simmons]
+shockwave2       1257/udp # Shockwave 2 [Dave_Simmons] [Dave_Simmons]
+opennl           1258/tcp # Open Network Library
+opennl           1258/udp # Open Network Library
+opennl-voice     1259/tcp # Open Network Library Voice [Phil_Frisbie] [Phil_Frisbie]
+opennl-voice     1259/udp # Open Network Library Voice [Phil_Frisbie] [Phil_Frisbie]
+ibm-ssd          1260/tcp # ibm-ssd [Barry_Whyte] [Barry_Whyte]
+ibm-ssd          1260/udp # ibm-ssd [Barry_Whyte] [Barry_Whyte]
+mpshrsv          1261/tcp # mpshrsv [Makoto_Ikeyama] [Makoto_Ikeyama]
+mpshrsv          1261/udp # mpshrsv [Makoto_Ikeyama] [Makoto_Ikeyama]
+qnts-orb         1262/tcp # QNTS-ORB [Raghurama_Bhat] [Raghurama_Bhat]
+qnts-orb         1262/udp # QNTS-ORB [Raghurama_Bhat] [Raghurama_Bhat]
+dka              1263/tcp # dka [Chris_Griffin] [Chris_Griffin]
+dka              1263/udp # dka [Chris_Griffin] [Chris_Griffin]
+prat             1264/tcp # PRAT [Keith_Wood] [Keith_Wood]
+prat             1264/udp # PRAT [Keith_Wood] [Keith_Wood]
+dssiapi          1265/tcp # DSSIAPI [Jim_Turner] [Jim_Turner]
+dssiapi          1265/udp # DSSIAPI [Jim_Turner] [Jim_Turner]
+dellpwrappks     1266/tcp # DELLPWRAPPKS [David_Troeger] [David_Troeger]
+dellpwrappks     1266/udp # DELLPWRAPPKS [David_Troeger] [David_Troeger]
+epc              1267/tcp # eTrust Policy Compliance [Aaron_Stein] [Aaron_Stein]
+epc              1267/udp # eTrust Policy Compliance [Aaron_Stein] [Aaron_Stein]
+propel-msgsys    1268/tcp # PROPEL-MSGSYS [Bert_Van_der_Linden] [Bert_Van_der_Linden]
+propel-msgsys    1268/udp # PROPEL-MSGSYS [Bert_Van_der_Linden] [Bert_Van_der_Linden]
+watilapp         1269/tcp # WATiLaPP [Frederic_Weymann] [Frederic_Weymann]
+watilapp         1269/udp # WATiLaPP [Frederic_Weymann] [Frederic_Weymann]
+opsmgr           1270/tcp # Microsoft Operations Manager [Ashvin_Sanghvi] [Ashvin_Sanghvi]
+opsmgr           1270/udp # Microsoft Operations Manager [Ashvin_Sanghvi] [Ashvin_Sanghvi]
+excw             1271/tcp # eXcW [Norm_Freedman] [Norm_Freedman]
+excw             1271/udp # eXcW [Norm_Freedman] [Norm_Freedman]
+cspmlockmgr      1272/tcp # CSPMLockMgr [Ibtsam_Mahfouz] [Ibtsam_Mahfouz]
+cspmlockmgr      1272/udp # CSPMLockMgr [Ibtsam_Mahfouz] [Ibtsam_Mahfouz]
+emc-gateway      1273/tcp # EMC-Gateway [Rene_Fontaine] [Rene_Fontaine]
+emc-gateway      1273/udp # EMC-Gateway [Rene_Fontaine] [Rene_Fontaine]
+t1distproc       1274/tcp # t1distproc [Julian_Biddle] [Julian_Biddle]
+t1distproc       1274/udp # t1distproc [Julian_Biddle] [Julian_Biddle]
+ivcollector      1275/tcp # ivcollector
+ivcollector      1275/udp # ivcollector
+ivmanager        1276/tcp # ivmanager [Xavier_Roques] [Xavier_Roques]
+ivmanager        1276/udp # ivmanager [Xavier_Roques] [Xavier_Roques]
+miva-mqs         1277/tcp # mqs [Miva_Corporation] [Miva_Corporation]
+miva-mqs         1277/udp # mqs [Miva_Corporation] [Miva_Corporation]
+dellwebadmin-1   1278/tcp # Dell Web Admin 1
+dellwebadmin-1   1278/udp # Dell Web Admin 1
+dellwebadmin-2   1279/tcp # Dell Web Admin 2 [Bridget_Navoda] [Bridget_Navoda]
+dellwebadmin-2   1279/udp # Dell Web Admin 2 [Bridget_Navoda] [Bridget_Navoda]
+pictrography     1280/tcp # Pictrography [Takashi_Hoshino] [Takashi_Hoshino]
+pictrography     1280/udp # Pictrography [Takashi_Hoshino] [Takashi_Hoshino]
+healthd          1281/tcp # healthd [James_E_Housley] [James_E_Housley]
+healthd          1281/udp # healthd [James_E_Housley] [James_E_Housley]
+emperion         1282/tcp # Emperion [Claus_Thor_Barth] [Claus_Thor_Barth]
+emperion         1282/udp # Emperion [Claus_Thor_Barth] [Claus_Thor_Barth]
+productinfo      1283/tcp # Product Information
+productinfo      1283/udp # Product Information
+iee-qfx          1284/tcp # IEE-QFX [Mehrdad_Ashtiani] [Mehrdad_Ashtiani] 2009-10-19
+iee-qfx          1284/udp # IEE-QFX [Mehrdad_Ashtiani] [Mehrdad_Ashtiani] 2009-10-19
+neoiface         1285/tcp # neoiface [Jason_McManus] [Jason_McManus]
+neoiface         1285/udp # neoiface [Jason_McManus] [Jason_McManus]
+netuitive        1286/tcp # netuitive [JF_Huard] [JF_Huard]
+netuitive        1286/udp # netuitive [JF_Huard] [JF_Huard]
+routematch       1287/tcp # RouteMatch Com [Jeff_Jones] [Jeff_Jones] 2005-11
+routematch       1287/udp # RouteMatch Com [Jeff_Jones] [Jeff_Jones] 2005-11
+navbuddy         1288/tcp # NavBuddy [Eric_Hackman] [Eric_Hackman]
+navbuddy         1288/udp # NavBuddy [Eric_Hackman] [Eric_Hackman]
+jwalkserver      1289/tcp # JWalkServer
+jwalkserver      1289/udp # JWalkServer
+winjaserver      1290/tcp # WinJaServer
+winjaserver      1290/udp # WinJaServer
+seagulllms       1291/tcp # SEAGULLLMS [Lee_Breisacher] [Lee_Breisacher]
+seagulllms       1291/udp # SEAGULLLMS [Lee_Breisacher] [Lee_Breisacher]
+dsdn             1292/tcp # dsdn [Stanislaw_Skowronek] [Stanislaw_Skowronek]
+dsdn             1292/udp # dsdn [Stanislaw_Skowronek] [Stanislaw_Skowronek]
+pkt-krb-ipsec    1293/tcp # PKT-KRB-IPSec [Nancy_Davoust] [Nancy_Davoust]
+pkt-krb-ipsec    1293/udp # PKT-KRB-IPSec [Nancy_Davoust] [Nancy_Davoust]
+cmmdriver        1294/tcp # CMMdriver [Lutz_Karras] [Lutz_Karras]
+cmmdriver        1294/udp # CMMdriver [Lutz_Karras] [Lutz_Karras]
+ehtp             1295/tcp # End-by-Hop Transmission Protocol [Alexander_Bogdanov] [Alexander_Bogdanov]
+ehtp             1295/udp # End-by-Hop Transmission Protocol [Alexander_Bogdanov] [Alexander_Bogdanov]
+dproxy           1296/tcp # dproxy
+dproxy           1296/udp # dproxy
+sdproxy          1297/tcp # sdproxy [Raimond_Diederik] [Raimond_Diederik]
+sdproxy          1297/udp # sdproxy [Raimond_Diederik] [Raimond_Diederik]
+lpcp             1298/tcp # lpcp [Christian_Stredicke] [Christian_Stredicke]
+lpcp             1298/udp # lpcp [Christian_Stredicke] [Christian_Stredicke]
+hp-sci           1299/tcp # hp-sci [Kim_Scott] [Kim_Scott]
+hp-sci           1299/udp # hp-sci [Kim_Scott] [Kim_Scott]
+h323hostcallsc   1300/tcp # H.323 Secure Call Control Signalling [ITU-T] [ITU-T_TSB] 2013-01-31
+h323hostcallsc   1300/udp # H.323 Secure Call Control Signalling [ITU-T] [ITU-T_TSB] 2013-01-31
+ci3-software-1   1301/tcp # CI3-Software-1
+ci3-software-1   1301/udp # CI3-Software-1
+ci3-software-2   1302/tcp # CI3-Software-2 [Kelli_Watson] [Kelli_Watson]
+ci3-software-2   1302/udp # CI3-Software-2 [Kelli_Watson] [Kelli_Watson]
+sftsrv           1303/tcp # sftsrv [Robert_Frazier] [Robert_Frazier]
+sftsrv           1303/udp # sftsrv [Robert_Frazier] [Robert_Frazier]
+boomerang        1304/tcp # Boomerang [Bruce_Lueckenhoff] [Bruce_Lueckenhoff]
+boomerang        1304/udp # Boomerang [Bruce_Lueckenhoff] [Bruce_Lueckenhoff]
+pe-mike          1305/tcp # pe-mike [Stephen_Hemminger] [Stephen_Hemminger]
+pe-mike          1305/udp # pe-mike [Stephen_Hemminger] [Stephen_Hemminger]
+re-conn-proto    1306/tcp # RE-Conn-Proto [Sandeep_Singhal] [Sandeep_Singhal]
+re-conn-proto    1306/udp # RE-Conn-Proto [Sandeep_Singhal] [Sandeep_Singhal]
+pacmand          1307/tcp # Pacmand [Edward_T_O_Shea] [Edward_T_O_Shea]
+pacmand          1307/udp # Pacmand [Edward_T_O_Shea] [Edward_T_O_Shea]
+odsi             1308/tcp # Optical Domain Service Interconnect (ODSI) [K_Arvind] [K_Arvind]
+odsi             1308/udp # Optical Domain Service Interconnect (ODSI) [K_Arvind] [K_Arvind]
+jtag-server      1309/tcp # JTAG server [Andrew_Draper] [Andrew_Draper]
+jtag-server      1309/udp # JTAG server [Andrew_Draper] [Andrew_Draper]
+husky            1310/tcp # Husky [Mark_Zang] [Mark_Zang]
+husky            1310/udp # Husky [Mark_Zang] [Mark_Zang]
+rxmon            1311/tcp # RxMon [Javier_Jiminez] [Javier_Jiminez]
+rxmon            1311/udp # RxMon [Javier_Jiminez] [Javier_Jiminez]
+sti-envision     1312/tcp # STI Envision [Don_Stedman] [Don_Stedman]
+sti-envision     1312/udp # STI Envision [Don_Stedman] [Don_Stedman]
+bmc-patroldb     1313/tcp # BMC_PATROLDBIANA assigned this well-formed service name as a replacement for "bmc_patroldb". [Portnoy_Boxman] [Portnoy_Boxman]
+bmc_patroldb     1313/tcp # BMC_PATROLDB [Portnoy_Boxman] [Portnoy_Boxman] This entry is an alias to "bmc-patroldb".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+bmc-patroldb     1313/udp # BMC_PATROLDBIANA assigned this well-formed service name as a replacement for "bmc_patroldb". [Portnoy_Boxman] [Portnoy_Boxman]
+bmc_patroldb     1313/udp # BMC_PATROLDB [Portnoy_Boxman] [Portnoy_Boxman] This entry is an alias to "bmc-patroldb".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+pdps             1314/tcp # Photoscript Distributed Printing System [Les_Klein] [Les_Klein]
+pdps             1314/udp # Photoscript Distributed Printing System [Les_Klein] [Les_Klein]
+els              1315/tcp # E.L.S., Event Listener Service [Jim_Cleppe] [Jim_Cleppe]
+els              1315/udp # E.L.S., Event Listener Service [Jim_Cleppe] [Jim_Cleppe]
+exbit-escp       1316/tcp # Exbit-ESCP [Morten_Christensen] [Morten_Christensen]
+exbit-escp       1316/udp # Exbit-ESCP [Morten_Christensen] [Morten_Christensen]
+vrts-ipcserver   1317/tcp # vrts-ipcserver [Bruce_Hestand] [Bruce_Hestand]
+vrts-ipcserver   1317/udp # vrts-ipcserver [Bruce_Hestand] [Bruce_Hestand]
+krb5gatekeeper   1318/tcp # krb5gatekeeper [Patrick_Moore] [Patrick_Moore]
+krb5gatekeeper   1318/udp # krb5gatekeeper [Patrick_Moore] [Patrick_Moore]
+amx-icsp         1319/tcp # AMX-ICSP [Jeff_Burch] [Jeff_Burch]
+amx-icsp         1319/udp # AMX-ICSP [Jeff_Burch] [Jeff_Burch]
+amx-axbnet       1320/tcp # AMX-AXBNET [Jeff_Burch] [Jeff_Burch]
+amx-axbnet       1320/udp # AMX-AXBNET [Jeff_Burch] [Jeff_Burch]
+pip              1321/tcp # PIP [Gordon_Mohr] [Gordon_Mohr]
+pip              1321/udp # PIP [Gordon_Mohr] [Gordon_Mohr]
+novation         1322/tcp # Novation [Alan_Dano] [Alan_Dano]
+novation         1322/udp # Novation [Alan_Dano] [Alan_Dano]
+brcd             1323/tcp # brcd [Todd_Picquelle] [Todd_Picquelle]
+brcd             1323/udp # brcd [Todd_Picquelle] [Todd_Picquelle]
+delta-mcp        1324/tcp # delta-mcp [Quinton_Tormanen] [Quinton_Tormanen]
+delta-mcp        1324/udp # delta-mcp [Quinton_Tormanen] [Quinton_Tormanen]
+dx-instrument    1325/tcp # DX-Instrument [Walt_Modic] [Walt_Modic]
+dx-instrument    1325/udp # DX-Instrument [Walt_Modic] [Walt_Modic]
+wimsic           1326/tcp # WIMSIC [James_Brown] [James_Brown]
+wimsic           1326/udp # WIMSIC [James_Brown] [James_Brown]
+ultrex           1327/tcp # Ultrex [Tim_Walsh] [Tim_Walsh]
+ultrex           1327/udp # Ultrex [Tim_Walsh] [Tim_Walsh]
+ewall            1328/tcp # EWALL [Jeff_Busma] [Jeff_Busma]
+ewall            1328/udp # EWALL [Jeff_Busma] [Jeff_Busma]
+netdb-export     1329/tcp # netdb-export [Konstantinos_Kostis] [Konstantinos_Kostis]
+netdb-export     1329/udp # netdb-export [Konstantinos_Kostis] [Konstantinos_Kostis]
+streetperfect    1330/tcp # StreetPerfect [Michael_R_Young] [Michael_R_Young]
+streetperfect    1330/udp # StreetPerfect [Michael_R_Young] [Michael_R_Young]
+intersan         1331/tcp # intersan [Barry_H_Feild] [Barry_H_Feild]
+intersan         1331/udp # intersan [Barry_H_Feild] [Barry_H_Feild]
+pcia-rxp-b       1332/tcp # PCIA RXP-B [James_Dabbs] [James_Dabbs]
+pcia-rxp-b       1332/udp # PCIA RXP-B [James_Dabbs] [James_Dabbs]
+passwrd-policy   1333/tcp # Password Policy [Tonio_Pirotta] [Tonio_Pirotta]
+passwrd-policy   1333/udp # Password Policy [Tonio_Pirotta] [Tonio_Pirotta]
+writesrv         1334/tcp # writesrv [Marvin_Toungate] [Marvin_Toungate]
+writesrv         1334/udp # writesrv [Marvin_Toungate] [Marvin_Toungate]
+digital-notary   1335/tcp # Digital Notary Protocol [Wes_Doonan] [Wes_Doonan]
+digital-notary   1335/udp # Digital Notary Protocol [Wes_Doonan] [Wes_Doonan]
+ischat           1336/tcp # Instant Service Chat [Mike_Clise] [Mike_Clise]
+ischat           1336/udp # Instant Service Chat [Mike_Clise] [Mike_Clise]
+menandmice-dns   1337/tcp # menandmice DNS [Sigfus_Magnusson] [Sigfus_Magnusson]
+menandmice-dns   1337/udp # menandmice DNS [Sigfus_Magnusson] [Sigfus_Magnusson]
+wmc-log-svc      1338/tcp # WMC-log-svr [Scott_Anderson] [Scott_Anderson]
+wmc-log-svc      1338/udp # WMC-log-svr [Scott_Anderson] [Scott_Anderson]
+kjtsiteserver    1339/tcp # kjtsiteserver [Jason_Aubain] [Jason_Aubain]
+kjtsiteserver    1339/udp # kjtsiteserver [Jason_Aubain] [Jason_Aubain]
+naap             1340/tcp # NAAP [Henry_Haverinen] [Henry_Haverinen]
+naap             1340/udp # NAAP [Henry_Haverinen] [Henry_Haverinen]
+qubes            1341/tcp # QuBES [Eric_Grange] [Eric_Grange]
+qubes            1341/udp # QuBES [Eric_Grange] [Eric_Grange]
+esbroker         1342/tcp # ESBroker [Alexander_Medvinsky] [Alexander_Medvinsky]
+esbroker         1342/udp # ESBroker [Alexander_Medvinsky] [Alexander_Medvinsky]
+re101            1343/tcp # re101 [Doriano_Blengino] [Doriano_Blengino]
+re101            1343/udp # re101 [Doriano_Blengino] [Doriano_Blengino]
+icap             1344/tcp # ICAP [Jeremy_Elson] [Jeremy_Elson]
+icap             1344/udp # ICAP [Jeremy_Elson] [Jeremy_Elson]
+vpjp             1345/tcp # VPJP [Michael_Collins] [Michael_Collins]
+vpjp             1345/udp # VPJP [Michael_Collins] [Michael_Collins]
+alta-ana-lm      1346/tcp # Alta Analytics License Manager
+alta-ana-lm      1346/udp # Alta Analytics License Manager
+bbn-mmc          1347/tcp # multi media conferencing
+bbn-mmc          1347/udp # multi media conferencing
+bbn-mmx          1348/tcp # multi media conferencing
+bbn-mmx          1348/udp # multi media conferencing
+sbook            1349/tcp # Registration Network Protocol
+sbook            1349/udp # Registration Network Protocol
+editbench        1350/tcp # Registration Network Protocol [Simson_L_Garfinkel] [Simson_L_Garfinkel]
+editbench        1350/udp # Registration Network Protocol [Simson_L_Garfinkel] [Simson_L_Garfinkel]
+equationbuilder  1351/tcp # Digital Tool Works (MIT) [Terrence_J_Talbot] [Terrence_J_Talbot]
+equationbuilder  1351/udp # Digital Tool Works (MIT) [Terrence_J_Talbot] [Terrence_J_Talbot]
+lotusnote        1352/tcp # Lotus Note [Greg_Pflaum] [Greg_Pflaum] 1992-07
+lotusnote        1352/udp # Lotus Note [Greg_Pflaum] [Greg_Pflaum] 1992-07
+relief           1353/tcp # Relief Consulting [John_Feiler] [John_Feiler]
+relief           1353/udp # Relief Consulting [John_Feiler] [John_Feiler]
+XSIP-network     1354/tcp # Five Across XSIP Network [Glenn_Reid] [Glenn_Reid]
+XSIP-network     1354/udp # Five Across XSIP Network [Glenn_Reid] [Glenn_Reid]
+intuitive-edge   1355/tcp # Intuitive Edge [Montgomery_Zukowski] [Montgomery_Zukowski]
+intuitive-edge   1355/udp # Intuitive Edge [Montgomery_Zukowski] [Montgomery_Zukowski]
+cuillamartin     1356/tcp # CuillaMartin Company
+cuillamartin     1356/udp # CuillaMartin Company
+pegboard         1357/tcp # Electronic PegBoard [Chris_Cuilla] [Chris_Cuilla]
+pegboard         1357/udp # Electronic PegBoard [Chris_Cuilla] [Chris_Cuilla]
+connlcli         1358/tcp # CONNLCLI
+connlcli         1358/udp # CONNLCLI
+ftsrv            1359/tcp # FTSRV [Ines_Homem_de_Melo] [Ines_Homem_de_Melo]
+ftsrv            1359/udp # FTSRV [Ines_Homem_de_Melo] [Ines_Homem_de_Melo]
+mimer            1360/tcp # MIMER [Per_Schroeder] [Per_Schroeder]
+mimer            1360/udp # MIMER [Per_Schroeder] [Per_Schroeder]
+linx             1361/tcp # LinX [Steffen_Schilke] [Steffen_Schilke]
+linx             1361/udp # LinX [Steffen_Schilke] [Steffen_Schilke]
+timeflies        1362/tcp # TimeFlies [Doug_Kent] [Doug_Kent]
+timeflies        1362/udp # TimeFlies [Doug_Kent] [Doug_Kent]
+ndm-requester    1363/tcp # Network DataMover Requester
+ndm-requester    1363/udp # Network DataMover Requester
+ndm-server       1364/tcp # Network DataMover Server [Toshio_Watanabe] [Toshio_Watanabe]
+ndm-server       1364/udp # Network DataMover Server [Toshio_Watanabe] [Toshio_Watanabe]
+adapt-sna        1365/tcp # Network Software Associates [Jeffery_Chiao] [Jeffery_Chiao]
+adapt-sna        1365/udp # Network Software Associates [Jeffery_Chiao] [Jeffery_Chiao]
+netware-csp      1366/tcp # Novell NetWare Comm Service Platform [Laurie_Lindsey] [Laurie_Lindsey]
+netware-csp      1366/udp # Novell NetWare Comm Service Platform [Laurie_Lindsey] [Laurie_Lindsey]
+dcs              1367/tcp # DCS [Stefan_Siebert] [Stefan_Siebert]
+dcs              1367/udp # DCS [Stefan_Siebert] [Stefan_Siebert]
+screencast       1368/tcp # ScreenCast [Bill_Tschumy] [Bill_Tschumy]
+screencast       1368/udp # ScreenCast [Bill_Tschumy] [Bill_Tschumy]
+gv-us            1369/tcp # GlobalView to Unix Shell
+gv-us            1369/udp # GlobalView to Unix Shell
+us-gv            1370/tcp # Unix Shell to GlobalView [Makoto_Mita] [Makoto_Mita]
+us-gv            1370/udp # Unix Shell to GlobalView [Makoto_Mita] [Makoto_Mita]
+fc-cli           1371/tcp # Fujitsu Config Protocol
+fc-cli           1371/udp # Fujitsu Config Protocol
+fc-ser           1372/tcp # Fujitsu Config Protocol [Ryuichi_Horie] [Ryuichi_Horie]
+fc-ser           1372/udp # Fujitsu Config Protocol [Ryuichi_Horie] [Ryuichi_Horie]
+chromagrafx      1373/tcp # Chromagrafx [Mike_Barthelemy] [Mike_Barthelemy]
+chromagrafx      1373/udp # Chromagrafx [Mike_Barthelemy] [Mike_Barthelemy]
+molly            1374/tcp # EPI Software Systems [Jim_Vlcek] [Jim_Vlcek]
+molly            1374/udp # EPI Software Systems [Jim_Vlcek] [Jim_Vlcek]
+bytex            1375/tcp # Bytex [Mary_Ann_Burt] [Mary_Ann_Burt]
+bytex            1375/udp # Bytex [Mary_Ann_Burt] [Mary_Ann_Burt]
+ibm-pps          1376/tcp # IBM Person to Person Software [Simon_Phipps] [Simon_Phipps]
+ibm-pps          1376/udp # IBM Person to Person Software [Simon_Phipps] [Simon_Phipps]
+cichlid          1377/tcp # Cichlid License Manager [Andy_Burgess] [Andy_Burgess]
+cichlid          1377/udp # Cichlid License Manager [Andy_Burgess] [Andy_Burgess]
+elan             1378/tcp # Elan License Manager [Ken_Greer] [Ken_Greer]
+elan             1378/udp # Elan License Manager [Ken_Greer] [Ken_Greer]
+dbreporter       1379/tcp # Integrity Solutions [Tim_Dawson] [Tim_Dawson]
+dbreporter       1379/udp # Integrity Solutions [Tim_Dawson] [Tim_Dawson]
+telesis-licman   1380/tcp # Telesis Network License Manager [Karl_Schendel_Jr] [Karl_Schendel_Jr]
+telesis-licman   1380/udp # Telesis Network License Manager [Karl_Schendel_Jr] [Karl_Schendel_Jr]
+apple-licman     1381/tcp # Apple Network License Manager [Earl_Wallace] [Earl_Wallace]
+apple-licman     1381/udp # Apple Network License Manager [Earl_Wallace] [Earl_Wallace]
+udt-os           1382/tcp # udt_osIANA assigned this well-formed service name as a replacement for "udt_os".
+udt_os           1382/tcp # udt_os This entry is an alias to "udt-os".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+udt-os           1382/udp # udt_osIANA assigned this well-formed service name as a replacement for "udt_os".
+udt_os           1382/udp # udt_os This entry is an alias to "udt-os".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+gwha             1383/tcp # GW Hannaway Network License Manager [J_Gabriel_Foster] [J_Gabriel_Foster]
+gwha             1383/udp # GW Hannaway Network License Manager [J_Gabriel_Foster] [J_Gabriel_Foster]
+os-licman        1384/tcp # Objective Solutions License Manager [Donald_Cornwell] [Donald_Cornwell]
+os-licman        1384/udp # Objective Solutions License Manager [Donald_Cornwell] [Donald_Cornwell]
+atex-elmd        1385/tcp # Atex Publishing License ManagerIANA assigned this well-formed service name as a replacement for "atex_elmd". [Brett_Sorenson] [Brett_Sorenson]
+atex_elmd        1385/tcp # Atex Publishing License Manager [Brett_Sorenson] [Brett_Sorenson] This entry is an alias to "atex-elmd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+atex-elmd        1385/udp # Atex Publishing License ManagerIANA assigned this well-formed service name as a replacement for "atex_elmd". [Brett_Sorenson] [Brett_Sorenson]
+atex_elmd        1385/udp # Atex Publishing License Manager [Brett_Sorenson] [Brett_Sorenson] This entry is an alias to "atex-elmd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+checksum         1386/tcp # CheckSum License Manager [Andreas_Glocker] [Andreas_Glocker]
+checksum         1386/udp # CheckSum License Manager [Andreas_Glocker] [Andreas_Glocker]
+cadsi-lm         1387/tcp # Computer Aided Design Software Inc LM [Sulistio_Muljadi] [Sulistio_Muljadi]
+cadsi-lm         1387/udp # Computer Aided Design Software Inc LM [Sulistio_Muljadi] [Sulistio_Muljadi]
+objective-dbc    1388/tcp # Objective Solutions DataBase Cache [Donald_Cornwell_2] [Donald_Cornwell_2]
+objective-dbc    1388/udp # Objective Solutions DataBase Cache [Donald_Cornwell_2] [Donald_Cornwell_2]
+iclpv-dm         1389/tcp # Document Manager
+iclpv-dm         1389/udp # Document Manager
+iclpv-sc         1390/tcp # Storage Controller
+iclpv-sc         1390/udp # Storage Controller
+iclpv-sas        1391/tcp # Storage Access Server
+iclpv-sas        1391/udp # Storage Access Server
+iclpv-pm         1392/tcp # Print Manager
+iclpv-pm         1392/udp # Print Manager
+iclpv-nls        1393/tcp # Network Log Server
+iclpv-nls        1393/udp # Network Log Server
+iclpv-nlc        1394/tcp # Network Log Client
+iclpv-nlc        1394/udp # Network Log Client
+iclpv-wsm        1395/tcp # PC Workstation Manager software [A_P_Hobson] [A_P_Hobson]
+iclpv-wsm        1395/udp # PC Workstation Manager software [A_P_Hobson] [A_P_Hobson]
+dvl-activemail   1396/tcp # DVL Active Mail
+dvl-activemail   1396/udp # DVL Active Mail
+audio-activmail  1397/tcp # Audio Active Mail
+audio-activmail  1397/udp # Audio Active Mail
+video-activmail  1398/tcp # Video Active Mail [Avshalom_Houri] [Avshalom_Houri]
+video-activmail  1398/udp # Video Active Mail [Avshalom_Houri] [Avshalom_Houri]
+cadkey-licman    1399/tcp # Cadkey License Manager
+cadkey-licman    1399/udp # Cadkey License Manager
+cadkey-tablet    1400/tcp # Cadkey Tablet Daemon [Joe_McCollough] [Joe_McCollough]
+cadkey-tablet    1400/udp # Cadkey Tablet Daemon [Joe_McCollough] [Joe_McCollough]
+goldleaf-licman  1401/tcp # Goldleaf License Manager [John_Fox] [John_Fox]
+goldleaf-licman  1401/udp # Goldleaf License Manager [John_Fox] [John_Fox]
+prm-sm-np        1402/tcp # Prospero Resource Manager
+prm-sm-np        1402/udp # Prospero Resource Manager
+prm-nm-np        1403/tcp # Prospero Resource Manager [B_Clifford_Neuman] [B_Clifford_Neuman]
+prm-nm-np        1403/udp # Prospero Resource Manager [B_Clifford_Neuman] [B_Clifford_Neuman]
+igi-lm           1404/tcp # Infinite Graphics License Manager
+igi-lm           1404/udp # Infinite Graphics License Manager
+ibm-res          1405/tcp # IBM Remote Execution Starter
+ibm-res          1405/udp # IBM Remote Execution Starter
+netlabs-lm       1406/tcp # NetLabs License Manager
+netlabs-lm       1406/udp # NetLabs License Manager
+dbsa-lm          1407/tcp # DBSA License Manager [Scott_Shattuck] [Scott_Shattuck]
+dbsa-lm          1407/udp # DBSA License Manager [Scott_Shattuck] [Scott_Shattuck]
+sophia-lm        1408/tcp # Sophia License Manager [Eric_Brown] [Eric_Brown]
+sophia-lm        1408/udp # Sophia License Manager [Eric_Brown] [Eric_Brown]
+here-lm          1409/tcp # Here License Manager [David_Ison] [David_Ison]
+here-lm          1409/udp # Here License Manager [David_Ison] [David_Ison]
+hiq              1410/tcp # HiQ License Manager [Rick_Pugh] [Rick_Pugh]
+hiq              1410/udp # HiQ License Manager [Rick_Pugh] [Rick_Pugh]
+af               1411/tcp # AudioFile [Jim_Gettys] [Jim_Gettys]
+af               1411/udp # AudioFile [Jim_Gettys] [Jim_Gettys]
+innosys          1412/tcp # InnoSys
+innosys          1412/udp # InnoSys
+innosys-acl      1413/tcp # Innosys-ACL [Eric_Welch] [Eric_Welch]
+innosys-acl      1413/udp # Innosys-ACL [Eric_Welch] [Eric_Welch]
+ibm-mqseries     1414/tcp # IBM MQSeries [Roger_Meli] [Roger_Meli]
+ibm-mqseries     1414/udp # IBM MQSeries [Roger_Meli] [Roger_Meli]
+dbstar           1415/tcp # DBStar [Jeffrey_Millman] [Jeffrey_Millman]
+dbstar           1415/udp # DBStar [Jeffrey_Millman] [Jeffrey_Millman]
+novell-lu6-2     1416/tcp # Novell LU6.2IANA assigned this well-formed service name as a replacement for "novell-lu6.2". [Peter_Liu] [Peter_Liu]
+novell-lu6.2     1416/tcp # Novell LU6.2 [Peter_Liu] [Peter_Liu] This entry is an alias to "novell-lu6-2".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+novell-lu6-2     1416/udp # Novell LU6.2IANA assigned this well-formed service name as a replacement for "novell-lu6.2". [Peter_Liu] [Peter_Liu]
+novell-lu6.2     1416/udp # Novell LU6.2 [Peter_Liu] [Peter_Liu] This entry is an alias to "novell-lu6-2".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+timbuktu-srv1    1417/tcp # Timbuktu Service 1 Port
+timbuktu-srv1    1417/udp # Timbuktu Service 1 Port
+timbuktu-srv2    1418/tcp # Timbuktu Service 2 Port
+timbuktu-srv2    1418/udp # Timbuktu Service 2 Port
+timbuktu-srv3    1419/tcp # Timbuktu Service 3 Port
+timbuktu-srv3    1419/udp # Timbuktu Service 3 Port
+timbuktu-srv4    1420/tcp # Timbuktu Service 4 Port [Marc_Epard] [Marc_Epard]
+timbuktu-srv4    1420/udp # Timbuktu Service 4 Port [Marc_Epard] [Marc_Epard]
+gandalf-lm       1421/tcp # Gandalf License Manager [gilmer] [gilmer]
+gandalf-lm       1421/udp # Gandalf License Manager [gilmer] [gilmer]
+autodesk-lm      1422/tcp # Autodesk License Manager [David_Ko] [David_Ko]
+autodesk-lm      1422/udp # Autodesk License Manager [David_Ko] [David_Ko]
+essbase          1423/tcp # Essbase Arbor Software
+essbase          1423/udp # Essbase Arbor Software
+hybrid           1424/tcp # Hybrid Encryption Protocol [Howard_Hart] [Howard_Hart]
+hybrid           1424/udp # Hybrid Encryption Protocol [Howard_Hart] [Howard_Hart]
+zion-lm          1425/tcp # Zion Software License Manager [David_Ferrero] [David_Ferrero]
+zion-lm          1425/udp # Zion Software License Manager [David_Ferrero] [David_Ferrero]
+sais             1426/tcp # Satellite-data Acquisition System 1 [Bill_Taylor] [Bill_Taylor]
+sais             1426/udp # Satellite-data Acquisition System 1 [Bill_Taylor] [Bill_Taylor]
+mloadd           1427/tcp # mloadd monitoring tool [Bob_Braden_2] [Bob_Braden_2]
+mloadd           1427/udp # mloadd monitoring tool [Bob_Braden_2] [Bob_Braden_2]
+informatik-lm    1428/tcp # Informatik License Manager [Harald_Schlangmann] [Harald_Schlangmann]
+informatik-lm    1428/udp # Informatik License Manager [Harald_Schlangmann] [Harald_Schlangmann]
+nms              1429/tcp # Hypercom NMS
+nms              1429/udp # Hypercom NMS
+tpdu             1430/tcp # Hypercom TPDU [Noor_Chowdhury] [Noor_Chowdhury]
+tpdu             1430/udp # Hypercom TPDU [Noor_Chowdhury] [Noor_Chowdhury]
+rgtp             1431/tcp # Reverse Gossip Transport [Ian_Jackson] [Ian_Jackson]
+rgtp             1431/udp # Reverse Gossip Transport [Ian_Jackson] [Ian_Jackson]
+blueberry-lm     1432/tcp # Blueberry Software License Manager [Steve_Beigel] [Steve_Beigel]
+blueberry-lm     1432/udp # Blueberry Software License Manager [Steve_Beigel] [Steve_Beigel]
+ms-sql-s         1433/tcp # Microsoft-SQL-Server
+ms-sql-s         1433/udp # Microsoft-SQL-Server
+ms-sql-m         1434/tcp # Microsoft-SQL-Monitor [Peter_Hussey] [Peter_Hussey]
+ms-sql-m         1434/udp # Microsoft-SQL-Monitor [Peter_Hussey] [Peter_Hussey]
+ibm-cics         1435/tcp # IBM CICS [Geoff_Meacock] [Geoff_Meacock]
+ibm-cics         1435/udp # IBM CICS [Geoff_Meacock] [Geoff_Meacock]
+saism            1436/tcp # Satellite-data Acquisition System 2 [Bill_Taylor] [Bill_Taylor]
+saism            1436/udp # Satellite-data Acquisition System 2 [Bill_Taylor] [Bill_Taylor]
+tabula           1437/tcp # Tabula [Marcelo_Einhorn] [Marcelo_Einhorn]
+tabula           1437/udp # Tabula [Marcelo_Einhorn] [Marcelo_Einhorn]
+eicon-server     1438/tcp # Eicon Security Agent/Server
+eicon-server     1438/udp # Eicon Security Agent/Server
+eicon-x25        1439/tcp # Eicon X25/SNA Gateway
+eicon-x25        1439/udp # Eicon X25/SNA Gateway
+eicon-slp        1440/tcp # Eicon Service Location Protocol [Pat_Calhoun] [Pat_Calhoun]
+eicon-slp        1440/udp # Eicon Service Location Protocol [Pat_Calhoun] [Pat_Calhoun]
+cadis-1          1441/tcp # Cadis License Management
+cadis-1          1441/udp # Cadis License Management
+cadis-2          1442/tcp # Cadis License Management [Todd_Wichers] [Todd_Wichers]
+cadis-2          1442/udp # Cadis License Management [Todd_Wichers] [Todd_Wichers]
+ies-lm           1443/tcp # Integrated Engineering Software [David_Tong] [David_Tong]
+ies-lm           1443/udp # Integrated Engineering Software [David_Tong] [David_Tong]
+marcam-lm        1444/tcp # Marcam  License Management [Therese_Hunt] [Therese_Hunt]
+marcam-lm        1444/udp # Marcam  License Management [Therese_Hunt] [Therese_Hunt]
+proxima-lm       1445/tcp # Proxima License Manager
+proxima-lm       1445/udp # Proxima License Manager
+ora-lm           1446/tcp # Optical Research Associates License Manager
+ora-lm           1446/udp # Optical Research Associates License Manager
+apri-lm          1447/tcp # Applied Parallel Research LM [Jim_Dillon] [Jim_Dillon]
+apri-lm          1447/udp # Applied Parallel Research LM [Jim_Dillon] [Jim_Dillon]
+oc-lm            1448/tcp # OpenConnect License Manager [Sue_Barnhill] [Sue_Barnhill]
+oc-lm            1448/udp # OpenConnect License Manager [Sue_Barnhill] [Sue_Barnhill]
+peport           1449/tcp # PEport [Qentin_Neill] [Qentin_Neill]
+peport           1449/udp # PEport [Qentin_Neill] [Qentin_Neill]
+dwf              1450/tcp # Tandem Distributed Workbench Facility [Mike_Bert] [Mike_Bert]
+dwf              1450/udp # Tandem Distributed Workbench Facility [Mike_Bert] [Mike_Bert]
+infoman          1451/tcp # IBM Information Management [Karen_Burns] [Karen_Burns]
+infoman          1451/udp # IBM Information Management [Karen_Burns] [Karen_Burns]
+gtegsc-lm        1452/tcp # GTE Government Systems License Man [Mike_Gregory] [Mike_Gregory]
+gtegsc-lm        1452/udp # GTE Government Systems License Man [Mike_Gregory] [Mike_Gregory]
+genie-lm         1453/tcp # Genie License Manager [Paul_Applegate] [Paul_Applegate]
+genie-lm         1453/udp # Genie License Manager [Paul_Applegate] [Paul_Applegate]
+interhdl-elmd    1454/tcp # interHDL License ManagerIANA assigned this well-formed service name as a replacement for "interhdl_elmd". [Eli_Sternheim] [Eli_Sternheim]
+interhdl_elmd    1454/tcp # interHDL License Manager [Eli_Sternheim] [Eli_Sternheim] This entry is an alias to "interhdl-elmd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+interhdl-elmd    1454/udp # interHDL License ManagerIANA assigned this well-formed service name as a replacement for "interhdl_elmd". [Eli_Sternheim] [Eli_Sternheim]
+interhdl_elmd    1454/udp # interHDL License Manager [Eli_Sternheim] [Eli_Sternheim] This entry is an alias to "interhdl-elmd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+esl-lm           1455/tcp # ESL License Manager [Abel_Chou] [Abel_Chou]
+esl-lm           1455/udp # ESL License Manager [Abel_Chou] [Abel_Chou]
+dca              1456/tcp # DCA [Jeff_Garbers_2] [Jeff_Garbers_2]
+dca              1456/udp # DCA [Jeff_Garbers_2] [Jeff_Garbers_2]
+valisys-lm       1457/tcp # Valisys License Manager [Leslie_Lincoln] [Leslie_Lincoln]
+valisys-lm       1457/udp # Valisys License Manager [Leslie_Lincoln] [Leslie_Lincoln]
+nrcabq-lm        1458/tcp # Nichols Research Corp. [Howard_Cole] [Howard_Cole]
+nrcabq-lm        1458/udp # Nichols Research Corp. [Howard_Cole] [Howard_Cole]
+proshare1        1459/tcp # Proshare Notebook Application
+proshare1        1459/udp # Proshare Notebook Application
+proshare2        1460/tcp # Proshare Notebook Application [Robin_Kar] [Robin_Kar]
+proshare2        1460/udp # Proshare Notebook Application [Robin_Kar] [Robin_Kar]
+ibm-wrless-lan   1461/tcp # IBM Wireless LANIANA assigned this well-formed service name as a replacement for "ibm_wrless_lan". [flanne] [flanne]
+ibm_wrless_lan   1461/tcp # IBM Wireless LAN [flanne] [flanne] This entry is an alias to "ibm-wrless-lan".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+ibm-wrless-lan   1461/udp # IBM Wireless LANIANA assigned this well-formed service name as a replacement for "ibm_wrless_lan". [flanne] [flanne]
+ibm_wrless_lan   1461/udp # IBM Wireless LAN [flanne] [flanne] This entry is an alias to "ibm-wrless-lan".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+world-lm         1462/tcp # World License Manager [Michael_S_Amirault] [Michael_S_Amirault]
+world-lm         1462/udp # World License Manager [Michael_S_Amirault] [Michael_S_Amirault]
+nucleus          1463/tcp # Nucleus [Venky_Nagar] [Venky_Nagar]
+nucleus          1463/udp # Nucleus [Venky_Nagar] [Venky_Nagar]
+msl-lmd          1464/tcp # MSL License ManagerIANA assigned this well-formed service name as a replacement for "msl_lmd". [Matt_Timmermans] [Matt_Timmermans]
+msl_lmd          1464/tcp # MSL License Manager [Matt_Timmermans] [Matt_Timmermans] This entry is an alias to "msl-lmd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+msl-lmd          1464/udp # MSL License ManagerIANA assigned this well-formed service name as a replacement for "msl_lmd". [Matt_Timmermans] [Matt_Timmermans]
+msl_lmd          1464/udp # MSL License Manager [Matt_Timmermans] [Matt_Timmermans] This entry is an alias to "msl-lmd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+pipes            1465/tcp # Pipes Platform [Mark_Farlin] [Mark_Farlin]
+pipes            1465/udp # Pipes Platform [Mark_Farlin] [Mark_Farlin]
+oceansoft-lm     1466/tcp # Ocean Software License Manager [Randy_Leonard] [Randy_Leonard]
+oceansoft-lm     1466/udp # Ocean Software License Manager [Randy_Leonard] [Randy_Leonard]
+csdmbase         1467/tcp # CSDMBASE
+csdmbase         1467/udp # CSDMBASE
+csdm             1468/tcp # CSDM [Robert_Stabl] [Robert_Stabl]
+csdm             1468/udp # CSDM [Robert_Stabl] [Robert_Stabl]
+aal-lm           1469/tcp # Active Analysis Limited License Manager [David_Snocken] [David_Snocken]
+aal-lm           1469/udp # Active Analysis Limited License Manager [David_Snocken] [David_Snocken]
+uaiact           1470/tcp # Universal Analytics [Mark_R_Ludwig] [Mark_R_Ludwig]
+uaiact           1470/udp # Universal Analytics [Mark_R_Ludwig] [Mark_R_Ludwig]
+csdmbase         1471/tcp # csdmbase
+csdmbase         1471/udp # csdmbase
+csdm             1472/tcp # csdm [Robert_Stabl] [Robert_Stabl]
+csdm             1472/udp # csdm [Robert_Stabl] [Robert_Stabl]
+openmath         1473/tcp # OpenMath [Garth_Mayville] [Garth_Mayville]
+openmath         1473/udp # OpenMath [Garth_Mayville] [Garth_Mayville]
+telefinder       1474/tcp # Telefinder [Jim_White] [Jim_White]
+telefinder       1474/udp # Telefinder [Jim_White] [Jim_White]
+taligent-lm      1475/tcp # Taligent License Manager [Mark_Sapsford] [Mark_Sapsford]
+taligent-lm      1475/udp # Taligent License Manager [Mark_Sapsford] [Mark_Sapsford]
+clvm-cfg         1476/tcp # clvm-cfg [Eric_Soderberg] [Eric_Soderberg]
+clvm-cfg         1476/udp # clvm-cfg [Eric_Soderberg] [Eric_Soderberg]
+ms-sna-server    1477/tcp # ms-sna-server
+ms-sna-server    1477/udp # ms-sna-server
+ms-sna-base      1478/tcp # ms-sna-base [Gordon_Mangione] [Gordon_Mangione]
+ms-sna-base      1478/udp # ms-sna-base [Gordon_Mangione] [Gordon_Mangione]
+dberegister      1479/tcp # dberegister [Brian_Griswold] [Brian_Griswold]
+dberegister      1479/udp # dberegister [Brian_Griswold] [Brian_Griswold]
+pacerforum       1480/tcp # PacerForum [Peter_Caswell] [Peter_Caswell]
+pacerforum       1480/udp # PacerForum [Peter_Caswell] [Peter_Caswell]
+airs             1481/tcp # AIRS [Bruce_Wilson] [Bruce_Wilson]
+airs             1481/udp # AIRS [Bruce_Wilson] [Bruce_Wilson]
+miteksys-lm      1482/tcp # Miteksys License Manager [Shane_McRoberts] [Shane_McRoberts]
+miteksys-lm      1482/udp # Miteksys License Manager [Shane_McRoberts] [Shane_McRoberts]
+afs              1483/tcp # AFS License Manager [Michael_R_Pizolato] [Michael_R_Pizolato]
+afs              1483/udp # AFS License Manager [Michael_R_Pizolato] [Michael_R_Pizolato]
+confluent        1484/tcp # Confluent License Manager [James_Greenfiel] [James_Greenfiel]
+confluent        1484/udp # Confluent License Manager [James_Greenfiel] [James_Greenfiel]
+lansource        1485/tcp # LANSource [Christopher_Wells] [Christopher_Wells]
+lansource        1485/udp # LANSource [Christopher_Wells] [Christopher_Wells]
+nms-topo-serv    1486/tcp # nms_topo_servIANA assigned this well-formed service name as a replacement for "nms_topo_serv". [Sylvia_Siu] [Sylvia_Siu]
+nms_topo_serv    1486/tcp # nms_topo_serv [Sylvia_Siu] [Sylvia_Siu] This entry is an alias to "nms-topo-serv".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+nms-topo-serv    1486/udp # nms_topo_servIANA assigned this well-formed service name as a replacement for "nms_topo_serv". [Sylvia_Siu] [Sylvia_Siu]
+nms_topo_serv    1486/udp # nms_topo_serv [Sylvia_Siu] [Sylvia_Siu] This entry is an alias to "nms-topo-serv".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+localinfosrvr    1487/tcp # LocalInfoSrvr [Brian_Matthews_2] [Brian_Matthews_2]
+localinfosrvr    1487/udp # LocalInfoSrvr [Brian_Matthews_2] [Brian_Matthews_2]
+docstor          1488/tcp # DocStor [Brian_Spears] [Brian_Spears]
+docstor          1488/udp # DocStor [Brian_Spears] [Brian_Spears]
+dmdocbroker      1489/tcp # dmdocbroker [Razmik_Abnous] [Razmik_Abnous]
+dmdocbroker      1489/udp # dmdocbroker [Razmik_Abnous] [Razmik_Abnous]
+insitu-conf      1490/tcp # insitu-conf [Paul_Blacknell] [Paul_Blacknell]
+insitu-conf      1490/udp # insitu-conf [Paul_Blacknell] [Paul_Blacknell]
+stone-design-1   1492/tcp # stone-design-1 [Andrew_Stone] [Andrew_Stone]
+stone-design-1   1492/udp # stone-design-1 [Andrew_Stone] [Andrew_Stone]
+netmap-lm        1493/tcp # netmap_lmIANA assigned this well-formed service name as a replacement for "netmap_lm". [Phillip_Magson] [Phillip_Magson]
+netmap_lm        1493/tcp # netmap_lm [Phillip_Magson] [Phillip_Magson] This entry is an alias to "netmap-lm".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+netmap-lm        1493/udp # netmap_lmIANA assigned this well-formed service name as a replacement for "netmap_lm". [Phillip_Magson] [Phillip_Magson]
+netmap_lm        1493/udp # netmap_lm [Phillip_Magson] [Phillip_Magson] This entry is an alias to "netmap-lm".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+ica              1494/tcp # ica [John_Richardson] [John_Richardson]
+ica              1494/udp # ica [John_Richardson] [John_Richardson]
+cvc              1495/tcp # cvc [Bill_Davidson] [Bill_Davidson]
+cvc              1495/udp # cvc [Bill_Davidson] [Bill_Davidson]
+liberty-lm       1496/tcp # liberty-lm [Jim_Rogers] [Jim_Rogers]
+liberty-lm       1496/udp # liberty-lm [Jim_Rogers] [Jim_Rogers]
+rfx-lm           1497/tcp # rfx-lm [Bill_Bishop] [Bill_Bishop]
+rfx-lm           1497/udp # rfx-lm [Bill_Bishop] [Bill_Bishop]
+sybase-sqlany    1498/tcp # Sybase SQL Any [Dave_Neudoerffer] [Dave_Neudoerffer]
+sybase-sqlany    1498/udp # Sybase SQL Any [Dave_Neudoerffer] [Dave_Neudoerffer]
+fhc              1499/tcp # Federico Heinz Consultora [Federico_Heinz] [Federico_Heinz]
+fhc              1499/udp # Federico Heinz Consultora [Federico_Heinz] [Federico_Heinz]
+vlsi-lm          1500/tcp # VLSI License Manager [Shue_Lin_Kuo] [Shue_Lin_Kuo]
+vlsi-lm          1500/udp # VLSI License Manager [Shue_Lin_Kuo] [Shue_Lin_Kuo]
+saiscm           1501/tcp # Satellite-data Acquisition System 3 [Bill_Taylor] [Bill_Taylor]
+saiscm           1501/udp # Satellite-data Acquisition System 3 [Bill_Taylor] [Bill_Taylor]
+shivadiscovery   1502/tcp # Shiva [Jonathan_Wenocur] [Jonathan_Wenocur]
+shivadiscovery   1502/udp # Shiva [Jonathan_Wenocur] [Jonathan_Wenocur]
+imtc-mcs         1503/tcp # Databeam [Jim_Johnston] [Jim_Johnston]
+imtc-mcs         1503/udp # Databeam [Jim_Johnston] [Jim_Johnston]
+evb-elm          1504/tcp # EVB Software Engineering License Manager [B_G_Mahesh] [B_G_Mahesh]
+evb-elm          1504/udp # EVB Software Engineering License Manager [B_G_Mahesh] [B_G_Mahesh]
+funkproxy        1505/tcp # Funk Software, Inc. [Robert_D_Vincent] [Robert_D_Vincent]
+funkproxy        1505/udp # Funk Software, Inc. [Robert_D_Vincent] [Robert_D_Vincent]
+utcd             1506/tcp # Universal Time daemon (utcd) [Walter_Poxon] [Walter_Poxon]
+utcd             1506/udp # Universal Time daemon (utcd) [Walter_Poxon] [Walter_Poxon]
+symplex          1507/tcp # symplex [Mike_Turley] [Mike_Turley]
+symplex          1507/udp # symplex [Mike_Turley] [Mike_Turley]
+diagmond         1508/tcp # diagmond [Pete_Moscatelli] [Pete_Moscatelli]
+diagmond         1508/udp # diagmond [Pete_Moscatelli] [Pete_Moscatelli]
+robcad-lm        1509/tcp # Robcad, Ltd. License Manager [Hindin_Joseph] [Hindin_Joseph]
+robcad-lm        1509/udp # Robcad, Ltd. License Manager [Hindin_Joseph] [Hindin_Joseph]
+mvx-lm           1510/tcp # Midland Valley Exploration Ltd. Lic. Man. [Neil_Salter] [Neil_Salter]
+mvx-lm           1510/udp # Midland Valley Exploration Ltd. Lic. Man. [Neil_Salter] [Neil_Salter]
+3l-l1            1511/tcp # 3l-l1 [Ian_A_Young] [Ian_A_Young]
+3l-l1            1511/udp # 3l-l1 [Ian_A_Young] [Ian_A_Young]
+wins             1512/tcp # Microsoft's Windows Internet Name Service [Pradeep_Bahl] [Pradeep_Bahl]
+wins             1512/udp # Microsoft's Windows Internet Name Service [Pradeep_Bahl] [Pradeep_Bahl]
+fujitsu-dtc      1513/tcp # Fujitsu Systems Business of America, Inc
+fujitsu-dtc      1513/udp # Fujitsu Systems Business of America, Inc
+fujitsu-dtcns    1514/tcp # Fujitsu Systems Business of America, Inc [Charles_A_Higgins] [Charles_A_Higgins]
+fujitsu-dtcns    1514/udp # Fujitsu Systems Business of America, Inc [Charles_A_Higgins] [Charles_A_Higgins]
+ifor-protocol    1515/tcp # ifor-protocol [Dr_R_P_Alston] [Dr_R_P_Alston]
+ifor-protocol    1515/udp # ifor-protocol [Dr_R_P_Alston] [Dr_R_P_Alston]
+vpad             1516/tcp # Virtual Places Audio data
+vpad             1516/udp # Virtual Places Audio data
+vpac             1517/tcp # Virtual Places Audio control
+vpac             1517/udp # Virtual Places Audio control
+vpvd             1518/tcp # Virtual Places Video data
+vpvd             1518/udp # Virtual Places Video data
+vpvc             1519/tcp # Virtual Places Video control [Avshalom_Houri] [Avshalom_Houri]
+vpvc             1519/udp # Virtual Places Video control [Avshalom_Houri] [Avshalom_Houri]
+atm-zip-office   1520/tcp # atm zip office [Wilson_Kwan] [Wilson_Kwan]
+atm-zip-office   1520/udp # atm zip office [Wilson_Kwan] [Wilson_Kwan]
+ncube-lm         1521/tcp # nCube License Manager [Maxine_Yuen] [Maxine_Yuen]
+ncube-lm         1521/udp # nCube License Manager [Maxine_Yuen] [Maxine_Yuen]
+ricardo-lm       1522/tcp # Ricardo North America License Manager [Mike_Flemming] [Mike_Flemming]
+ricardo-lm       1522/udp # Ricardo North America License Manager [Mike_Flemming] [Mike_Flemming]
+cichild-lm       1523/tcp # cichild [Andy_Burgess] [Andy_Burgess]
+cichild-lm       1523/udp # cichild [Andy_Burgess] [Andy_Burgess]
+ingreslock       1524/tcp # ingres
+ingreslock       1524/udp # ingres
+orasrv           1525/tcp # oracle
+orasrv           1525/udp # oracle
+prospero-np      1525/tcp # Prospero Directory Service non-priv
+prospero-np      1525/udp # Prospero Directory Service non-priv
+pdap-np          1526/tcp # Prospero Data Access Prot non-priv [B_Clifford_Neuman] [B_Clifford_Neuman]
+pdap-np          1526/udp # Prospero Data Access Prot non-priv [B_Clifford_Neuman] [B_Clifford_Neuman]
+tlisrv           1527/tcp # oracle
+tlisrv           1527/udp # oracle
+coauthor         1529/tcp # oracle
+coauthor         1529/udp # oracle
+rap-service      1530/tcp # rap-service
+rap-service      1530/udp # rap-service
+rap-listen       1531/tcp # rap-listen [Phil_Servita] [Phil_Servita]
+rap-listen       1531/udp # rap-listen [Phil_Servita] [Phil_Servita]
+miroconnect      1532/tcp # miroconnect [Michael_Fischer_2] [Michael_Fischer_2]
+miroconnect      1532/udp # miroconnect [Michael_Fischer_2] [Michael_Fischer_2]
+virtual-places   1533/tcp # Virtual Places Software [Avshalom_Houri] [Avshalom_Houri]
+virtual-places   1533/udp # Virtual Places Software [Avshalom_Houri] [Avshalom_Houri]
+micromuse-lm     1534/tcp # micromuse-lm [Adam_Kerrison] [Adam_Kerrison]
+micromuse-lm     1534/udp # micromuse-lm [Adam_Kerrison] [Adam_Kerrison]
+ampr-info        1535/tcp # ampr-info
+ampr-info        1535/udp # ampr-info
+ampr-inter       1536/tcp # ampr-inter [Rob_Janssen] [Rob_Janssen]
+ampr-inter       1536/udp # ampr-inter [Rob_Janssen] [Rob_Janssen]
+sdsc-lm          1537/tcp # isi-lm [Len_Wanger] [Len_Wanger]
+sdsc-lm          1537/udp # isi-lm [Len_Wanger] [Len_Wanger]
+3ds-lm           1538/tcp # 3ds-lm [Keith_Trummel] [Keith_Trummel]
+3ds-lm           1538/udp # 3ds-lm [Keith_Trummel] [Keith_Trummel]
+intellistor-lm   1539/tcp # Intellistor License Manager [Ron_Vaughn] [Ron_Vaughn]
+intellistor-lm   1539/udp # Intellistor License Manager [Ron_Vaughn] [Ron_Vaughn]
+rds              1540/tcp # rds
+rds              1540/udp # rds
+rds2             1541/tcp # rds2 [Sudhakar_Rajamannar] [Sudhakar_Rajamannar]
+rds2             1541/udp # rds2 [Sudhakar_Rajamannar] [Sudhakar_Rajamannar]
+gridgen-elmd     1542/tcp # gridgen-elmd [John_R_Chawner] [John_R_Chawner]
+gridgen-elmd     1542/udp # gridgen-elmd [John_R_Chawner] [John_R_Chawner]
+simba-cs         1543/tcp # simba-cs [Betsy_Alexander] [Betsy_Alexander]
+simba-cs         1543/udp # simba-cs [Betsy_Alexander] [Betsy_Alexander]
+aspeclmd         1544/tcp # aspeclmd [V_Balaji] [V_Balaji]
+aspeclmd         1544/udp # aspeclmd [V_Balaji] [V_Balaji]
+vistium-share    1545/tcp # vistium-share [Allison_Carleton] [Allison_Carleton]
+vistium-share    1545/udp # vistium-share [Allison_Carleton] [Allison_Carleton]
+abbaccuray       1546/tcp # abbaccuray [John_Wendt] [John_Wendt]
+abbaccuray       1546/udp # abbaccuray [John_Wendt] [John_Wendt]
+laplink          1547/tcp # laplink [Michael_Crawford] [Michael_Crawford]
+laplink          1547/udp # laplink [Michael_Crawford] [Michael_Crawford]
+axon-lm          1548/tcp # Axon License Manager [Mark_Pearce] [Mark_Pearce]
+axon-lm          1548/udp # Axon License Manager [Mark_Pearce] [Mark_Pearce]
+shivahose        1549/tcp # Shiva Hose
+shivasound       1549/udp # Shiva Sound [Kin_Chan] [Kin_Chan]
+3m-image-lm      1550/tcp # Image Storage license manager 3M Company [J_C_Canessa] [J_C_Canessa]
+3m-image-lm      1550/udp # Image Storage license manager 3M Company [J_C_Canessa] [J_C_Canessa]
+hecmtl-db        1551/tcp # HECMTL-DB [Maxime_Belanger] [Maxime_Belanger]
+hecmtl-db        1551/udp # HECMTL-DB [Maxime_Belanger] [Maxime_Belanger]
+pciarray         1552/tcp # pciarray [Ron_Folk] [Ron_Folk]
+pciarray         1552/udp # pciarray [Ron_Folk] [Ron_Folk]
+sna-cs           1553/tcp # sna-cs [Tony_Sowter] [Tony_Sowter]
+sna-cs           1553/udp # sna-cs [Tony_Sowter] [Tony_Sowter]
+caci-lm          1554/tcp # CACI Products Company License Manager [Erik_Blume] [Erik_Blume]
+caci-lm          1554/udp # CACI Products Company License Manager [Erik_Blume] [Erik_Blume]
+livelan          1555/tcp # livelan [Kaynam_Hedayat] [Kaynam_Hedayat]
+livelan          1555/udp # livelan [Kaynam_Hedayat] [Kaynam_Hedayat]
+veritas-pbx      1556/tcp # VERITAS Private Branch ExchangeIANA assigned this well-formed service name as a replacement for "veritas_pbx". [Stefan_Winkel] [Stefan_Winkel] 2004-04
+veritas_pbx      1556/tcp # VERITAS Private Branch Exchange [Stefan_Winkel] [Stefan_Winkel] 2004-04 This entry is an alias to "veritas-pbx".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+veritas-pbx      1556/udp # VERITAS Private Branch ExchangeIANA assigned this well-formed service name as a replacement for "veritas_pbx". [Stefan_Winkel] [Stefan_Winkel] 2004-04
+veritas_pbx      1556/udp # VERITAS Private Branch Exchange [Stefan_Winkel] [Stefan_Winkel] 2004-04 This entry is an alias to "veritas-pbx".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+arbortext-lm     1557/tcp # ArborText License Manager [David_J_Wilson] [David_J_Wilson]
+arbortext-lm     1557/udp # ArborText License Manager [David_J_Wilson] [David_J_Wilson]
+xingmpeg         1558/tcp # xingmpeg [Howard_Gordon] [Howard_Gordon]
+xingmpeg         1558/udp # xingmpeg [Howard_Gordon] [Howard_Gordon]
+web2host         1559/tcp # web2host [Stephen_Johnson] [Stephen_Johnson]
+web2host         1559/udp # web2host [Stephen_Johnson] [Stephen_Johnson]
+asci-val         1560/tcp # ASCI-RemoteSHADOW [Benjamin_Rosenberg] [Benjamin_Rosenberg]
+asci-val         1560/udp # ASCI-RemoteSHADOW [Benjamin_Rosenberg] [Benjamin_Rosenberg]
+facilityview     1561/tcp # facilityview [Ed_Green] [Ed_Green]
+facilityview     1561/udp # facilityview [Ed_Green] [Ed_Green]
+pconnectmgr      1562/tcp # pconnectmgr [Bob_Kaiser] [Bob_Kaiser]
+pconnectmgr      1562/udp # pconnectmgr [Bob_Kaiser] [Bob_Kaiser]
+cadabra-lm       1563/tcp # Cadabra License Manager [Arthur_Castonguay] [Arthur_Castonguay]
+cadabra-lm       1563/udp # Cadabra License Manager [Arthur_Castonguay] [Arthur_Castonguay]
+pay-per-view     1564/tcp # Pay-Per-View [Brian_Tung] [Brian_Tung]
+pay-per-view     1564/udp # Pay-Per-View [Brian_Tung] [Brian_Tung]
+winddlb          1565/tcp # WinDD [Kelly_Sims] [Kelly_Sims]
+winddlb          1565/udp # WinDD [Kelly_Sims] [Kelly_Sims]
+corelvideo       1566/tcp # CORELVIDEO [Ming_Poon] [Ming_Poon]
+corelvideo       1566/udp # CORELVIDEO [Ming_Poon] [Ming_Poon]
+jlicelmd         1567/tcp # jlicelmd [Christian_Schormann] [Christian_Schormann]
+jlicelmd         1567/udp # jlicelmd [Christian_Schormann] [Christian_Schormann]
+tsspmap          1568/tcp # tsspmap [Paul_W_Nelson] [Paul_W_Nelson]
+tsspmap          1568/udp # tsspmap [Paul_W_Nelson] [Paul_W_Nelson]
+ets              1569/tcp # ets [Carstein_Seeberg] [Carstein_Seeberg]
+ets              1569/udp # ets [Carstein_Seeberg] [Carstein_Seeberg]
+orbixd           1570/tcp # orbixd [Bridget_Walsh] [Bridget_Walsh]
+orbixd           1570/udp # orbixd [Bridget_Walsh] [Bridget_Walsh]
+rdb-dbs-disp     1571/tcp # Oracle Remote Data Base [mackin] [mackin]
+rdb-dbs-disp     1571/udp # Oracle Remote Data Base [mackin] [mackin]
+chip-lm          1572/tcp # Chipcom License Manager
+chip-lm          1572/udp # Chipcom License Manager
+itscomm-ns       1573/tcp # itscomm-ns [Rich_Thompson] [Rich_Thompson]
+itscomm-ns       1573/udp # itscomm-ns [Rich_Thompson] [Rich_Thompson]
+mvel-lm          1574/tcp # mvel-lm [David_Bisset] [David_Bisset]
+mvel-lm          1574/udp # mvel-lm [David_Bisset] [David_Bisset]
+oraclenames      1575/tcp # oraclenames [P_V_Shivkumar] [P_V_Shivkumar]
+oraclenames      1575/udp # oraclenames [P_V_Shivkumar] [P_V_Shivkumar]
+moldflow-lm      1576/tcp # Moldflow License Manager [Lech_Laskowski] [Lech_Laskowski]
+moldflow-lm      1576/udp # Moldflow License Manager [Lech_Laskowski] [Lech_Laskowski]
+hypercube-lm     1577/tcp # hypercube-lm [Christopher_McLendon] [Christopher_McLendon]
+hypercube-lm     1577/udp # hypercube-lm [Christopher_McLendon] [Christopher_McLendon]
+jacobus-lm       1578/tcp # Jacobus License Manager [Tony_Cleveland] [Tony_Cleveland]
+jacobus-lm       1578/udp # Jacobus License Manager [Tony_Cleveland] [Tony_Cleveland]
+ioc-sea-lm       1579/tcp # ioc-sea-lm [Paul_Nelson] [Paul_Nelson]
+ioc-sea-lm       1579/udp # ioc-sea-lm [Paul_Nelson] [Paul_Nelson]
+tn-tl-r1         1580/tcp # tn-tl-r1
+tn-tl-r2         1580/udp # tn-tl-r2 [Ed_Kress] [Ed_Kress]
+mil-2045-47001   1581/tcp # MIL-2045-47001 [Eric_Whitehill] [Eric_Whitehill]
+mil-2045-47001   1581/udp # MIL-2045-47001 [Eric_Whitehill] [Eric_Whitehill]
+msims            1582/tcp # MSIMS [Glenn_Olander] [Glenn_Olander]
+msims            1582/udp # MSIMS [Glenn_Olander] [Glenn_Olander]
+simbaexpress     1583/tcp # simbaexpress [Betsy_Alexander] [Betsy_Alexander]
+simbaexpress     1583/udp # simbaexpress [Betsy_Alexander] [Betsy_Alexander]
+tn-tl-fd2        1584/tcp # tn-tl-fd2 [Ed_Kress] [Ed_Kress]
+tn-tl-fd2        1584/udp # tn-tl-fd2 [Ed_Kress] [Ed_Kress]
+intv             1585/tcp # intv [Dermot_Tynand] [Dermot_Tynand]
+intv             1585/udp # intv [Dermot_Tynand] [Dermot_Tynand]
+ibm-abtact       1586/tcp # ibm-abtact [Sandeep_K_Singhal] [Sandeep_K_Singhal]
+ibm-abtact       1586/udp # ibm-abtact [Sandeep_K_Singhal] [Sandeep_K_Singhal]
+pra-elmd         1587/tcp # pra_elmdIANA assigned this well-formed service name as a replacement for "pra_elmd". [Dennis_Mastin] [Dennis_Mastin]
+pra_elmd         1587/tcp # pra_elmd [Dennis_Mastin] [Dennis_Mastin] This entry is an alias to "pra-elmd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+pra-elmd         1587/udp # pra_elmdIANA assigned this well-formed service name as a replacement for "pra_elmd". [Dennis_Mastin] [Dennis_Mastin]
+pra_elmd         1587/udp # pra_elmd [Dennis_Mastin] [Dennis_Mastin] This entry is an alias to "pra-elmd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+triquest-lm      1588/tcp # triquest-lm [Nand_Kumar] [Nand_Kumar]
+triquest-lm      1588/udp # triquest-lm [Nand_Kumar] [Nand_Kumar]
+vqp              1589/tcp # VQP [Keith_McCloghrie] [Keith_McCloghrie]
+vqp              1589/udp # VQP [Keith_McCloghrie] [Keith_McCloghrie]
+gemini-lm        1590/tcp # gemini-lm [Tony_Sawyer] [Tony_Sawyer]
+gemini-lm        1590/udp # gemini-lm [Tony_Sawyer] [Tony_Sawyer]
+ncpm-pm          1591/tcp # ncpm-pm [Ted_Power] [Ted_Power]
+ncpm-pm          1591/udp # ncpm-pm [Ted_Power] [Ted_Power]
+commonspace      1592/tcp # commonspace [Rob_Chandhok_2] [Rob_Chandhok_2]
+commonspace      1592/udp # commonspace [Rob_Chandhok_2] [Rob_Chandhok_2]
+mainsoft-lm      1593/tcp # mainsoft-lm [Anand_Gangadharan] [Anand_Gangadharan]
+mainsoft-lm      1593/udp # mainsoft-lm [Anand_Gangadharan] [Anand_Gangadharan]
+sixtrak          1594/tcp # sixtrak [Bob_Rennie] [Bob_Rennie]
+sixtrak          1594/udp # sixtrak [Bob_Rennie] [Bob_Rennie]
+radio            1595/tcp # radio
+radio            1595/udp # radio
+radio-sm         1596/tcp # radio-sm
+radio-bc         1596/udp # radio-bc [Ken_Chapman] [Ken_Chapman]
+orbplus-iiop     1597/tcp # orbplus-iiop [Robert_A_Kukura] [Robert_A_Kukura]
+orbplus-iiop     1597/udp # orbplus-iiop [Robert_A_Kukura] [Robert_A_Kukura]
+picknfs          1598/tcp # picknfs [John_Lombardo] [John_Lombardo]
+picknfs          1598/udp # picknfs [John_Lombardo] [John_Lombardo]
+simbaservices    1599/tcp # simbaservices [Betsy_Alexander] [Betsy_Alexander]
+simbaservices    1599/udp # simbaservices [Betsy_Alexander] [Betsy_Alexander]
+issd             1600/tcp # issd
+issd             1600/udp # issd
+aas              1601/tcp # aas [Bob_Beard] [Bob_Beard]
+aas              1601/udp # aas [Bob_Beard] [Bob_Beard]
+inspect          1602/tcp # inspect [Frank_O_Neill] [Frank_O_Neill]
+inspect          1602/udp # inspect [Frank_O_Neill] [Frank_O_Neill]
+picodbc          1603/tcp # pickodbc [John_Lombardo] [John_Lombardo]
+picodbc          1603/udp # pickodbc [John_Lombardo] [John_Lombardo]
+icabrowser       1604/tcp # icabrowser [Brad_Pedersen] [Brad_Pedersen]
+icabrowser       1604/udp # icabrowser [Brad_Pedersen] [Brad_Pedersen]
+slp              1605/tcp # Salutation Manager (Salutation Protocol)
+slp              1605/udp # Salutation Manager (Salutation Protocol)
+slm-api          1606/tcp # Salutation Manager (SLM-API) [Tohru_Mori] [Tohru_Mori]
+slm-api          1606/udp # Salutation Manager (SLM-API) [Tohru_Mori] [Tohru_Mori]
+stt              1607/tcp # stt [Ryan_Bolz] [Ryan_Bolz]
+stt              1607/udp # stt [Ryan_Bolz] [Ryan_Bolz]
+smart-lm         1608/tcp # Smart Corp. License Manager [Connie_Qiu] [Connie_Qiu]
+smart-lm         1608/udp # Smart Corp. License Manager [Connie_Qiu] [Connie_Qiu]
+isysg-lm         1609/tcp # isysg-lm [Adam_Curtin] [Adam_Curtin]
+isysg-lm         1609/udp # isysg-lm [Adam_Curtin] [Adam_Curtin]
+taurus-wh        1610/tcp # taurus-wh [Jeff_Moffatt] [Jeff_Moffatt]
+taurus-wh        1610/udp # taurus-wh [Jeff_Moffatt] [Jeff_Moffatt]
+ill              1611/tcp # Inter Library Loan [Niall_Murphy] [Niall_Murphy]
+ill              1611/udp # Inter Library Loan [Niall_Murphy] [Niall_Murphy]
+netbill-trans    1612/tcp # NetBill Transaction Server
+netbill-trans    1612/udp # NetBill Transaction Server
+netbill-keyrep   1613/tcp # NetBill Key Repository
+netbill-keyrep   1613/udp # NetBill Key Repository
+netbill-cred     1614/tcp # NetBill Credential Server
+netbill-cred     1614/udp # NetBill Credential Server
+netbill-auth     1615/tcp # NetBill Authorization Server
+netbill-auth     1615/udp # NetBill Authorization Server
+netbill-prod     1616/tcp # NetBill Product Server [Marvin_Sirbu] [Marvin_Sirbu]
+netbill-prod     1616/udp # NetBill Product Server [Marvin_Sirbu] [Marvin_Sirbu]
+nimrod-agent     1617/tcp # Nimrod Inter-Agent Communication [Charles_Lynn] [Charles_Lynn]
+nimrod-agent     1617/udp # Nimrod Inter-Agent Communication [Charles_Lynn] [Charles_Lynn]
+skytelnet        1618/tcp # skytelnet [Byron_Jones] [Byron_Jones]
+skytelnet        1618/udp # skytelnet [Byron_Jones] [Byron_Jones]
+xs-openstorage   1619/tcp # xs-openstorage [XuiS_Software_Ltd] [XuiS_Software_Ltd]
+xs-openstorage   1619/udp # xs-openstorage [XuiS_Software_Ltd] [XuiS_Software_Ltd]
+faxportwinport   1620/tcp # faxportwinport [Chris_Wells] [Chris_Wells]
+faxportwinport   1620/udp # faxportwinport [Chris_Wells] [Chris_Wells]
+softdataphone    1621/tcp # softdataphone [Dror_Gill] [Dror_Gill]
+softdataphone    1621/udp # softdataphone [Dror_Gill] [Dror_Gill]
+ontime           1622/tcp # ontime [Keith_Rhodes] [Keith_Rhodes]
+ontime           1622/udp # ontime [Keith_Rhodes] [Keith_Rhodes]
+jaleosnd         1623/tcp # jaleosnd [Christian_Schormann] [Christian_Schormann]
+jaleosnd         1623/udp # jaleosnd [Christian_Schormann] [Christian_Schormann]
+udp-sr-port      1624/tcp # udp-sr-port [Herb_Jensen] [Herb_Jensen]
+udp-sr-port      1624/udp # udp-sr-port [Herb_Jensen] [Herb_Jensen]
+svs-omagent      1625/tcp # svs-omagent [Alberto_Berlen] [Alberto_Berlen]
+svs-omagent      1625/udp # svs-omagent [Alberto_Berlen] [Alberto_Berlen]
+shockwave        1626/tcp # Shockwave [Sarah_Allen] [Sarah_Allen]
+shockwave        1626/udp # Shockwave [Sarah_Allen] [Sarah_Allen]
+t128-gateway     1627/tcp # T.128 Gateway [Phil_May] [Phil_May]
+t128-gateway     1627/udp # T.128 Gateway [Phil_May] [Phil_May]
+lontalk-norm     1628/tcp # LonTalk normal
+lontalk-norm     1628/udp # LonTalk normal
+lontalk-urgnt    1629/tcp # LonTalk urgent [Bob_Dolin] [Bob_Dolin] 2008-04-10
+lontalk-urgnt    1629/udp # LonTalk urgent [Bob_Dolin] [Bob_Dolin] 2008-04-10
+oraclenet8cman   1630/tcp # Oracle Net8 Cman [Tong_Ming_Lee] [Tong_Ming_Lee]
+oraclenet8cman   1630/udp # Oracle Net8 Cman [Tong_Ming_Lee] [Tong_Ming_Lee]
+visitview        1631/tcp # Visit view [Tom_Whittaker] [Tom_Whittaker]
+visitview        1631/udp # Visit view [Tom_Whittaker] [Tom_Whittaker]
+pammratc         1632/tcp # PAMMRATC
+pammratc         1632/udp # PAMMRATC
+pammrpc          1633/tcp # PAMMRPC [John_Britton] [John_Britton]
+pammrpc          1633/udp # PAMMRPC [John_Britton] [John_Britton]
+loaprobe         1634/tcp # Log On America Probe [James_Tavares] [James_Tavares]
+loaprobe         1634/udp # Log On America Probe [James_Tavares] [James_Tavares]
+edb-server1      1635/tcp # EDB Server 1 [Carlos_Portela] [Carlos_Portela]
+edb-server1      1635/udp # EDB Server 1 [Carlos_Portela] [Carlos_Portela]
+isdc             1636/tcp # ISP shared public data control
+isdc             1636/udp # ISP shared public data control
+islc             1637/tcp # ISP shared local data control
+islc             1637/udp # ISP shared local data control
+ismc             1638/tcp # ISP shared management control [Nick_Austin] [Nick_Austin]
+ismc             1638/udp # ISP shared management control [Nick_Austin] [Nick_Austin]
+cert-initiator   1639/tcp # cert-initiator
+cert-initiator   1639/udp # cert-initiator
+cert-responder   1640/tcp # cert-responder [Tom_Markson] [Tom_Markson]
+cert-responder   1640/udp # cert-responder [Tom_Markson] [Tom_Markson]
+invision         1641/tcp # InVision [Christopher_Davey] [Christopher_Davey]
+invision         1641/udp # InVision [Christopher_Davey] [Christopher_Davey]
+isis-am          1642/tcp # isis-am
+isis-am          1642/udp # isis-am
+isis-ambc        1643/tcp # isis-ambc [Ken_Chapman] [Ken_Chapman]
+isis-ambc        1643/udp # isis-ambc [Ken_Chapman] [Ken_Chapman]
+saiseh           1644/tcp # Satellite-data Acquisition System 4 [Bill_Taylor] [Bill_Taylor]
+saiseh           1644/udp # Satellite-data Acquisition System 4 [Bill_Taylor] [Bill_Taylor]
+sightline        1645/tcp # SightLine [admin] [admin]
+sightline        1645/udp # SightLine [admin] [admin]
+sa-msg-port      1646/tcp # sa-msg-port [Eric_Whitehill] [Eric_Whitehill]
+sa-msg-port      1646/udp # sa-msg-port [Eric_Whitehill] [Eric_Whitehill]
+rsap             1647/tcp # rsap [Holger_Reif] [Holger_Reif]
+rsap             1647/udp # rsap [Holger_Reif] [Holger_Reif]
+concurrent-lm    1648/tcp # concurrent-lm [Maggie_Brinsford] [Maggie_Brinsford]
+concurrent-lm    1648/udp # concurrent-lm [Maggie_Brinsford] [Maggie_Brinsford]
+kermit           1649/tcp # kermit [Frank_da_Cruz] [Frank_da_Cruz]
+kermit           1649/udp # kermit [Frank_da_Cruz] [Frank_da_Cruz]
+nkd              1650/tcp # nkdn
+nkd              1650/udp # nkd
+shiva-confsrvr   1651/tcp # shiva_confsrvrIANA assigned this well-formed service name as a replacement for "shiva_confsrvr". [Mike_Horowitz] [Mike_Horowitz]
+shiva_confsrvr   1651/tcp # shiva_confsrvr [Mike_Horowitz] [Mike_Horowitz] This entry is an alias to "shiva-confsrvr".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+shiva-confsrvr   1651/udp # shiva_confsrvrIANA assigned this well-formed service name as a replacement for "shiva_confsrvr". [Mike_Horowitz] [Mike_Horowitz]
+shiva_confsrvr   1651/udp # shiva_confsrvr [Mike_Horowitz] [Mike_Horowitz] This entry is an alias to "shiva-confsrvr".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+xnmp             1652/tcp # xnmp [Ali_Saleh] [Ali_Saleh]
+xnmp             1652/udp # xnmp [Ali_Saleh] [Ali_Saleh]
+alphatech-lm     1653/tcp # alphatech-lm [Joseph_Hauk] [Joseph_Hauk]
+alphatech-lm     1653/udp # alphatech-lm [Joseph_Hauk] [Joseph_Hauk]
+stargatealerts   1654/tcp # stargatealerts [Tim_Coppernoll] [Tim_Coppernoll]
+stargatealerts   1654/udp # stargatealerts [Tim_Coppernoll] [Tim_Coppernoll]
+dec-mbadmin      1655/tcp # dec-mbadmin
+dec-mbadmin      1655/udp # dec-mbadmin
+dec-mbadmin-h    1656/tcp # dec-mbadmin-h [Nick_Shipman] [Nick_Shipman]
+dec-mbadmin-h    1656/udp # dec-mbadmin-h [Nick_Shipman] [Nick_Shipman]
+fujitsu-mmpdc    1657/tcp # fujitsu-mmpdc [Katsumi_Oomuro] [Katsumi_Oomuro]
+fujitsu-mmpdc    1657/udp # fujitsu-mmpdc [Katsumi_Oomuro] [Katsumi_Oomuro]
+sixnetudr        1658/tcp # sixnetudr [Bob_Rennie] [Bob_Rennie]
+sixnetudr        1658/udp # sixnetudr [Bob_Rennie] [Bob_Rennie]
+sg-lm            1659/tcp # Silicon Grail License Manager [William_R_Bishop] [William_R_Bishop]
+sg-lm            1659/udp # Silicon Grail License Manager [William_R_Bishop] [William_R_Bishop]
+skip-mc-gikreq   1660/tcp # skip-mc-gikreq [Tom_Markson] [Tom_Markson]
+skip-mc-gikreq   1660/udp # skip-mc-gikreq [Tom_Markson] [Tom_Markson]
+netview-aix-1    1661/tcp # netview-aix-1
+netview-aix-1    1661/udp # netview-aix-1
+netview-aix-2    1662/tcp # netview-aix-2
+netview-aix-2    1662/udp # netview-aix-2
+netview-aix-3    1663/tcp # netview-aix-3
+netview-aix-3    1663/udp # netview-aix-3
+netview-aix-4    1664/tcp # netview-aix-4
+netview-aix-4    1664/udp # netview-aix-4
+netview-aix-5    1665/tcp # netview-aix-5
+netview-aix-5    1665/udp # netview-aix-5
+netview-aix-6    1666/tcp # netview-aix-6
+netview-aix-6    1666/udp # netview-aix-6
+netview-aix-7    1667/tcp # netview-aix-7
+netview-aix-7    1667/udp # netview-aix-7
+netview-aix-8    1668/tcp # netview-aix-8
+netview-aix-8    1668/udp # netview-aix-8
+netview-aix-9    1669/tcp # netview-aix-9
+netview-aix-9    1669/udp # netview-aix-9
+netview-aix-10   1670/tcp # netview-aix-10
+netview-aix-10   1670/udp # netview-aix-10
+netview-aix-11   1671/tcp # netview-aix-11
+netview-aix-11   1671/udp # netview-aix-11
+netview-aix-12   1672/tcp # netview-aix-12 [Martha_Crisson] [Martha_Crisson]
+netview-aix-12   1672/udp # netview-aix-12 [Martha_Crisson] [Martha_Crisson]
+proshare-mc-1    1673/tcp # Intel Proshare Multicast
+proshare-mc-1    1673/udp # Intel Proshare Multicast
+proshare-mc-2    1674/tcp # Intel Proshare Multicast [Mark_Lewis] [Mark_Lewis]
+proshare-mc-2    1674/udp # Intel Proshare Multicast [Mark_Lewis] [Mark_Lewis]
+pdp              1675/tcp # Pacific Data Products [Gary_Morton] [Gary_Morton]
+pdp              1675/udp # Pacific Data Products [Gary_Morton] [Gary_Morton]
+netcomm1         1676/tcp # netcomm1
+netcomm2         1676/udp # netcomm2 [Bulent_Kasman] [Bulent_Kasman]
+groupwise        1677/tcp # groupwise [Brent_Bradshaw] [Brent_Bradshaw]
+groupwise        1677/udp # groupwise [Brent_Bradshaw] [Brent_Bradshaw]
+prolink          1678/tcp # prolink [Brian_Abramson] [Brian_Abramson]
+prolink          1678/udp # prolink [Brian_Abramson] [Brian_Abramson]
+darcorp-lm       1679/tcp # darcorp-lm [DARcorp] [DARcorp]
+darcorp-lm       1679/udp # darcorp-lm [DARcorp] [DARcorp]
+microcom-sbp     1680/tcp # microcom-sbp [Boris_B_Maiden] [Boris_B_Maiden]
+microcom-sbp     1680/udp # microcom-sbp [Boris_B_Maiden] [Boris_B_Maiden]
+sd-elmd          1681/tcp # sd-elmd [Bryan_Otey] [Bryan_Otey]
+sd-elmd          1681/udp # sd-elmd [Bryan_Otey] [Bryan_Otey]
+lanyon-lantern   1682/tcp # lanyon-lantern [Robin_Lewis] [Robin_Lewis]
+lanyon-lantern   1682/udp # lanyon-lantern [Robin_Lewis] [Robin_Lewis]
+ncpm-hip         1683/tcp # ncpm-hip [Ken_Hearn] [Ken_Hearn]
+ncpm-hip         1683/udp # ncpm-hip [Ken_Hearn] [Ken_Hearn]
+snaresecure      1684/tcp # SnareSecure [Marty_Batchelder] [Marty_Batchelder]
+snaresecure      1684/udp # SnareSecure [Marty_Batchelder] [Marty_Batchelder]
+n2nremote        1685/tcp # n2nremote [Kin_Chan_2] [Kin_Chan_2]
+n2nremote        1685/udp # n2nremote [Kin_Chan_2] [Kin_Chan_2]
+cvmon            1686/tcp # cvmon [Carol_Ann_Krug] [Carol_Ann_Krug]
+cvmon            1686/udp # cvmon [Carol_Ann_Krug] [Carol_Ann_Krug]
+nsjtp-ctrl       1687/tcp # nsjtp-ctrl
+nsjtp-ctrl       1687/udp # nsjtp-ctrl
+nsjtp-data       1688/tcp # nsjtp-data [Orazio_Granato] [Orazio_Granato]
+nsjtp-data       1688/udp # nsjtp-data [Orazio_Granato] [Orazio_Granato]
+firefox          1689/tcp # firefox [Mark_S_Edwards] [Mark_S_Edwards]
+firefox          1689/udp # firefox [Mark_S_Edwards] [Mark_S_Edwards]
+ng-umds          1690/tcp # ng-umds [Louis_E_Simard] [Louis_E_Simard]
+ng-umds          1690/udp # ng-umds [Louis_E_Simard] [Louis_E_Simard]
+empire-empuma    1691/tcp # empire-empuma [Bobby_Krupczak] [Bobby_Krupczak]
+empire-empuma    1691/udp # empire-empuma [Bobby_Krupczak] [Bobby_Krupczak]
+sstsys-lm        1692/tcp # sstsys-lm [Yih_Wu_Wang] [Yih_Wu_Wang]
+sstsys-lm        1692/udp # sstsys-lm [Yih_Wu_Wang] [Yih_Wu_Wang]
+rrirtr           1693/tcp # rrirtr
+rrirtr           1693/udp # rrirtr
+rrimwm           1694/tcp # rrimwm
+rrimwm           1694/udp # rrimwm
+rrilwm           1695/tcp # rrilwm
+rrilwm           1695/udp # rrilwm
+rrifmm           1696/tcp # rrifmm
+rrifmm           1696/udp # rrifmm
+rrisat           1697/tcp # rrisat [Allen_Briggs] [Allen_Briggs]
+rrisat           1697/udp # rrisat [Allen_Briggs] [Allen_Briggs]
+rsvp-encap-1     1698/tcp # RSVP-ENCAPSULATION-1
+rsvp-encap-1     1698/udp # RSVP-ENCAPSULATION-1
+rsvp-encap-2     1699/tcp # RSVP-ENCAPSULATION-2 [Bob_Braden_2] [Bob_Braden_2]
+rsvp-encap-2     1699/udp # RSVP-ENCAPSULATION-2 [Bob_Braden_2] [Bob_Braden_2]
+mps-raft         1700/tcp # mps-raft [Jason_Leupen] [Jason_Leupen]
+mps-raft         1700/udp # mps-raft [Jason_Leupen] [Jason_Leupen]
+l2f              1701/tcp # l2f
+l2f              1701/udp # l2f
+l2tp             1701/tcp # l2tp [Andy_Valencia] [Andy_Valencia]
+l2tp             1701/udp # l2tp [Andy_Valencia] [Andy_Valencia]
+deskshare        1702/tcp # deskshare [Sarah_Thompson] [Sarah_Thompson]
+deskshare        1702/udp # deskshare [Sarah_Thompson] [Sarah_Thompson]
+hb-engine        1703/tcp # hb-engine [Charles_C_L_Chou] [Charles_C_L_Chou]
+hb-engine        1703/udp # hb-engine [Charles_C_L_Chou] [Charles_C_L_Chou]
+bcs-broker       1704/tcp # bcs-broker [Andy_Warner] [Andy_Warner]
+bcs-broker       1704/udp # bcs-broker [Andy_Warner] [Andy_Warner]
+slingshot        1705/tcp # slingshot [Paul_Groarke] [Paul_Groarke]
+slingshot        1705/udp # slingshot [Paul_Groarke] [Paul_Groarke]
+jetform          1706/tcp # jetform [gdeinsta] [gdeinsta]
+jetform          1706/udp # jetform [gdeinsta] [gdeinsta]
+vdmplay          1707/tcp # vdmplay [David_Thielen] [David_Thielen]
+vdmplay          1707/udp # vdmplay [David_Thielen] [David_Thielen]
+gat-lmd          1708/tcp # gat-lmd [Igor_Zaoutine] [Igor_Zaoutine]
+gat-lmd          1708/udp # gat-lmd [Igor_Zaoutine] [Igor_Zaoutine]
+centra           1709/tcp # centra [Drew_Wolff] [Drew_Wolff]
+centra           1709/udp # centra [Drew_Wolff] [Drew_Wolff]
+impera           1710/tcp # impera [Stepehen_Campbell] [Stepehen_Campbell]
+impera           1710/udp # impera [Stepehen_Campbell] [Stepehen_Campbell]
+pptconference    1711/tcp # pptconference [John_Tafoya] [John_Tafoya]
+pptconference    1711/udp # pptconference [John_Tafoya] [John_Tafoya]
+registrar        1712/tcp # resource monitoring service [Ron_Lawson] [Ron_Lawson]
+registrar        1712/udp # resource monitoring service [Ron_Lawson] [Ron_Lawson]
+conferencetalk   1713/tcp # ConferenceTalk [George_Kajos] [George_Kajos]
+conferencetalk   1713/udp # ConferenceTalk [George_Kajos] [George_Kajos]
+sesi-lm          1714/tcp # sesi-lm
+sesi-lm          1714/udp # sesi-lm
+houdini-lm       1715/tcp # houdini-lm [Paul_Breslin] [Paul_Breslin]
+houdini-lm       1715/udp # houdini-lm [Paul_Breslin] [Paul_Breslin]
+xmsg             1716/tcp # xmsg [Mark_E_Fogle] [Mark_E_Fogle]
+xmsg             1716/udp # xmsg [Mark_E_Fogle] [Mark_E_Fogle]
+fj-hdnet         1717/tcp # fj-hdnet [Manabu_Makino] [Manabu_Makino]
+fj-hdnet         1717/udp # fj-hdnet [Manabu_Makino] [Manabu_Makino]
+h323gatedisc     1718/tcp # H.323 Multicast Gatekeeper Discover [ITU-T] [ITU-T_TSB] 2013-01-31
+h323gatedisc     1718/udp # H.323 Multicast Gatekeeper Discover [ITU-T] [ITU-T_TSB] 2013-01-31
+h323gatestat     1719/tcp # H.323 Unicast Gatekeeper Signaling [ITU-T] [ITU-T_TSB] 2013-01-31
+h323gatestat     1719/udp # H.323 Unicast Gatekeeper Signaling [ITU-T] [ITU-T_TSB] 2013-01-31
+h323hostcall     1720/tcp # H.323 Call Control Signalling [ITU-T] [ITU-T_TSB] 2013-01-31
+h323hostcall     1720/udp # H.323 Call Control Signalling [ITU-T] [ITU-T_TSB] 2013-01-31
+caicci           1721/tcp # caicci [Sylvia_Scheuren] [Sylvia_Scheuren]
+caicci           1721/udp # caicci [Sylvia_Scheuren] [Sylvia_Scheuren]
+hks-lm           1722/tcp # HKS License Manager [Michael_Wood] [Michael_Wood]
+hks-lm           1722/udp # HKS License Manager [Michael_Wood] [Michael_Wood]
+pptp             1723/tcp # pptp [Ken_Crocker] [Ken_Crocker]
+pptp             1723/udp # pptp [Ken_Crocker] [Ken_Crocker]
+csbphonemaster   1724/tcp # csbphonemaster [Hans_Peter_Heffels] [Hans_Peter_Heffels]
+csbphonemaster   1724/udp # csbphonemaster [Hans_Peter_Heffels] [Hans_Peter_Heffels]
+iden-ralp        1725/tcp # iden-ralp [Chris_Stanaway] [Chris_Stanaway]
+iden-ralp        1725/udp # iden-ralp [Chris_Stanaway] [Chris_Stanaway]
+iberiagames      1726/tcp # IBERIAGAMES [Jose_Luis] [Jose_Luis]
+iberiagames      1726/udp # IBERIAGAMES [Jose_Luis] [Jose_Luis]
+winddx           1727/tcp # winddx [Bill_Andrews] [Bill_Andrews]
+winddx           1727/udp # winddx [Bill_Andrews] [Bill_Andrews]
+telindus         1728/tcp # TELINDUS [Paul_Pyck] [Paul_Pyck]
+telindus         1728/udp # TELINDUS [Paul_Pyck] [Paul_Pyck]
+citynl           1729/tcp # CityNL License Management [CityDisc] [CityDisc]
+citynl           1729/udp # CityNL License Management [CityDisc] [CityDisc]
+roketz           1730/tcp # roketz [Ahti_Heinla] [Ahti_Heinla]
+roketz           1730/udp # roketz [Ahti_Heinla] [Ahti_Heinla]
+msiccp           1731/tcp # MSICCP [Max_Morris] [Max_Morris]
+msiccp           1731/udp # MSICCP [Max_Morris] [Max_Morris]
+proxim           1732/tcp # proxim [Srinivas_N_Mogalapa] [Srinivas_N_Mogalapa]
+proxim           1732/udp # proxim [Srinivas_N_Mogalapa] [Srinivas_N_Mogalapa]
+siipat           1733/tcp # SIMS - SIIPAT Protocol for Alarm Transmission [Steve_Ryckman] [Steve_Ryckman]
+siipat           1733/udp # SIMS - SIIPAT Protocol for Alarm Transmission [Steve_Ryckman] [Steve_Ryckman]
+cambertx-lm      1734/tcp # Camber Corporation License Management [Jeannie_Burleson] [Jeannie_Burleson]
+cambertx-lm      1734/udp # Camber Corporation License Management [Jeannie_Burleson] [Jeannie_Burleson]
+privatechat      1735/tcp # PrivateChat [Louis_E_Simard] [Louis_E_Simard]
+privatechat      1735/udp # PrivateChat [Louis_E_Simard] [Louis_E_Simard]
+street-stream    1736/tcp # street-stream [Glenn_Levitt] [Glenn_Levitt]
+street-stream    1736/udp # street-stream [Glenn_Levitt] [Glenn_Levitt]
+ultimad          1737/tcp # ultimad [Michael_Lanzetta] [Michael_Lanzetta]
+ultimad          1737/udp # ultimad [Michael_Lanzetta] [Michael_Lanzetta]
+gamegen1         1738/tcp # GameGen1 [Glen_Pearson] [Glen_Pearson]
+gamegen1         1738/udp # GameGen1 [Glen_Pearson] [Glen_Pearson]
+webaccess        1739/tcp # webaccess [Christian_Saether] [Christian_Saether]
+webaccess        1739/udp # webaccess [Christian_Saether] [Christian_Saether]
+encore           1740/tcp # encore [Stuart_Button] [Stuart_Button]
+encore           1740/udp # encore [Stuart_Button] [Stuart_Button]
+cisco-net-mgmt   1741/tcp # cisco-net-mgmt [John_McCormack] [John_McCormack]
+cisco-net-mgmt   1741/udp # cisco-net-mgmt [John_McCormack] [John_McCormack]
+3Com-nsd         1742/tcp # 3Com-nsd [Nitza_Steinberg] [Nitza_Steinberg]
+3Com-nsd         1742/udp # 3Com-nsd [Nitza_Steinberg] [Nitza_Steinberg]
+cinegrfx-lm      1743/tcp # Cinema Graphics License Manager [Rodney_Iwashina] [Rodney_Iwashina]
+cinegrfx-lm      1743/udp # Cinema Graphics License Manager [Rodney_Iwashina] [Rodney_Iwashina]
+ncpm-ft          1744/tcp # ncpm-ft [Ken_Hearn] [Ken_Hearn]
+ncpm-ft          1744/udp # ncpm-ft [Ken_Hearn] [Ken_Hearn]
+remote-winsock   1745/tcp # remote-winsock [Avi_Nathan] [Avi_Nathan]
+remote-winsock   1745/udp # remote-winsock [Avi_Nathan] [Avi_Nathan]
+ftrapid-1        1746/tcp # ftrapid-1
+ftrapid-1        1746/udp # ftrapid-1
+ftrapid-2        1747/tcp # ftrapid-2 [Richard_J_Williams] [Richard_J_Williams]
+ftrapid-2        1747/udp # ftrapid-2 [Richard_J_Williams] [Richard_J_Williams]
+oracle-em1       1748/tcp # oracle-em1 [Bob_Purvy] [Bob_Purvy]
+oracle-em1       1748/udp # oracle-em1 [Bob_Purvy] [Bob_Purvy]
+aspen-services   1749/tcp # aspen-services [Mark_B_Hurst] [Mark_B_Hurst]
+aspen-services   1749/udp # aspen-services [Mark_B_Hurst] [Mark_B_Hurst]
+sslp             1750/tcp # Simple Socket Library's PortMaster [Dr_Charles_E_Campb] [Dr_Charles_E_Campb]
+sslp             1750/udp # Simple Socket Library's PortMaster [Dr_Charles_E_Campb] [Dr_Charles_E_Campb]
+swiftnet         1751/tcp # SwiftNet [Terry_Lim] [Terry_Lim]
+swiftnet         1751/udp # SwiftNet [Terry_Lim] [Terry_Lim]
+lofr-lm          1752/tcp # Leap of Faith Research License Manager
+lofr-lm          1752/udp # Leap of Faith Research License Manager
+predatar-comms   1753/tcp # Predatar Comms Service [Silverstring_Ltd] [Ronnie_De_Giorgio] 2011-09-15
+oracle-em2       1754/tcp # oracle-em2 [Bob_Purvy] [Bob_Purvy]
+oracle-em2       1754/udp # oracle-em2 [Bob_Purvy] [Bob_Purvy]
+ms-streaming     1755/tcp # ms-streaming [Bret_O_Rourke] [Bret_O_Rourke]
+ms-streaming     1755/udp # ms-streaming [Bret_O_Rourke] [Bret_O_Rourke]
+capfast-lmd      1756/tcp # capfast-lmd [Chuck_Neal] [Chuck_Neal]
+capfast-lmd      1756/udp # capfast-lmd [Chuck_Neal] [Chuck_Neal]
+cnhrp            1757/tcp # cnhrp [William_Stoye] [William_Stoye]
+cnhrp            1757/udp # cnhrp [William_Stoye] [William_Stoye]
+tftp-mcast       1758/tcp # tftp-mcast [Tom_Emberson] [Tom_Emberson]
+tftp-mcast       1758/udp # tftp-mcast [Tom_Emberson] [Tom_Emberson]
+spss-lm          1759/tcp # SPSS License Manager [Tex_Hull] [Tex_Hull]
+spss-lm          1759/udp # SPSS License Manager [Tex_Hull] [Tex_Hull]
+www-ldap-gw      1760/tcp # www-ldap-gw [Nick_Emery] [Nick_Emery]
+www-ldap-gw      1760/udp # www-ldap-gw [Nick_Emery] [Nick_Emery]
+cft-0            1761/tcp # cft-0 [Martine_Marchand] [Martine_Marchand]
+cft-0            1761/udp # cft-0 [Martine_Marchand] [Martine_Marchand]
+cft-1            1762/tcp # cft-1 [Martine_Marchand] [Martine_Marchand]
+cft-1            1762/udp # cft-1 [Martine_Marchand] [Martine_Marchand]
+cft-2            1763/tcp # cft-2 [Martine_Marchand] [Martine_Marchand]
+cft-2            1763/udp # cft-2 [Martine_Marchand] [Martine_Marchand]
+cft-3            1764/tcp # cft-3 [Martine_Marchand] [Martine_Marchand]
+cft-3            1764/udp # cft-3 [Martine_Marchand] [Martine_Marchand]
+cft-4            1765/tcp # cft-4 [Martine_Marchand] [Martine_Marchand]
+cft-4            1765/udp # cft-4 [Martine_Marchand] [Martine_Marchand]
+cft-5            1766/tcp # cft-5 [Martine_Marchand] [Martine_Marchand]
+cft-5            1766/udp # cft-5 [Martine_Marchand] [Martine_Marchand]
+cft-6            1767/tcp # cft-6 [Martine_Marchand] [Martine_Marchand]
+cft-6            1767/udp # cft-6 [Martine_Marchand] [Martine_Marchand]
+cft-7            1768/tcp # cft-7 [Martine_Marchand] [Martine_Marchand]
+cft-7            1768/udp # cft-7 [Martine_Marchand] [Martine_Marchand]
+bmc-net-adm      1769/tcp # bmc-net-adm [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-net-adm      1769/udp # bmc-net-adm [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-net-svc      1770/tcp # bmc-net-svc [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-net-svc      1770/udp # bmc-net-svc [Portnoy_Boxman] [Portnoy_Boxman]
+vaultbase        1771/tcp # vaultbase [Jose_A_Sesin] [Jose_A_Sesin]
+vaultbase        1771/udp # vaultbase [Jose_A_Sesin] [Jose_A_Sesin]
+essweb-gw        1772/tcp # EssWeb Gateway [Bob_Nattenberg] [Bob_Nattenberg]
+essweb-gw        1772/udp # EssWeb Gateway [Bob_Nattenberg] [Bob_Nattenberg]
+kmscontrol       1773/tcp # KMSControl [Roy_Chastain] [Roy_Chastain]
+kmscontrol       1773/udp # KMSControl [Roy_Chastain] [Roy_Chastain]
+global-dtserv    1774/tcp # global-dtserv [Nicholas_Davies] [Nicholas_Davies]
+global-dtserv    1774/udp # global-dtserv [Nicholas_Davies] [Nicholas_Davies]
+femis            1776/tcp # Federal Emergency Management Information System [Larry_Gerhardstein] [Larry_Gerhardstein]
+femis            1776/udp # Federal Emergency Management Information System [Larry_Gerhardstein] [Larry_Gerhardstein]
+powerguardian    1777/tcp # powerguardian [Charles_Bennett] [Charles_Bennett] 2008-08-29
+powerguardian    1777/udp # powerguardian [Charles_Bennett] [Charles_Bennett] 2008-08-29
+prodigy-intrnet  1778/tcp # prodigy-internet [Bob_Dedrick] [Bob_Dedrick]
+prodigy-intrnet  1778/udp # prodigy-internet [Bob_Dedrick] [Bob_Dedrick]
+pharmasoft       1779/tcp # pharmasoft [Ola_Strandberg] [Ola_Strandberg]
+pharmasoft       1779/udp # pharmasoft [Ola_Strandberg] [Ola_Strandberg]
+dpkeyserv        1780/tcp # dpkeyserv [Yasunari_Gon_Yamasit] [Yasunari_Gon_Yamasit]
+dpkeyserv        1780/udp # dpkeyserv [Yasunari_Gon_Yamasit] [Yasunari_Gon_Yamasit]
+answersoft-lm    1781/tcp # answersoft-lm [James_A_Brewster] [James_A_Brewster]
+answersoft-lm    1781/udp # answersoft-lm [James_A_Brewster] [James_A_Brewster]
+hp-hcip          1782/tcp # hp-hcip [Allen_Baker] [Allen_Baker]
+hp-hcip          1782/udp # hp-hcip [Allen_Baker] [Allen_Baker]
+finle-lm         1784/tcp # Finle License Manager [Dongling_Wang] [Dongling_Wang]
+finle-lm         1784/udp # Finle License Manager [Dongling_Wang] [Dongling_Wang]
+windlm           1785/tcp # Wind River Systems License Manager [Will_Dere] [Will_Dere]
+windlm           1785/udp # Wind River Systems License Manager [Will_Dere] [Will_Dere]
+funk-logger      1786/tcp # funk-logger
+funk-logger      1786/udp # funk-logger
+funk-license     1787/tcp # funk-license [Cimarron_Boozer][Eric_Wilde] [Cimarron_Boozer][Eric_Wilde]
+funk-license     1787/udp # funk-license [Cimarron_Boozer][Eric_Wilde] [Cimarron_Boozer][Eric_Wilde]
+psmond           1788/tcp # psmond [Will_Golson] [Will_Golson]
+psmond           1788/udp # psmond [Will_Golson] [Will_Golson]
+hello            1789/tcp # hello [D_J_Bernstein_2] [D_J_Bernstein_2]
+hello            1789/udp # hello [D_J_Bernstein_2] [D_J_Bernstein_2]
+nmsp             1790/tcp # Narrative Media Streaming Protocol [Paul_Santinelli_Jr] [Paul_Santinelli_Jr]
+nmsp             1790/udp # Narrative Media Streaming Protocol [Paul_Santinelli_Jr] [Paul_Santinelli_Jr]
+ea1              1791/tcp # EA1 [Kirk_MacLean] [Kirk_MacLean]
+ea1              1791/udp # EA1 [Kirk_MacLean] [Kirk_MacLean]
+ibm-dt-2         1792/tcp # ibm-dt-2 [Sam_Borman] [Sam_Borman]
+ibm-dt-2         1792/udp # ibm-dt-2 [Sam_Borman] [Sam_Borman]
+rsc-robot        1793/tcp # rsc-robot [Andrew_Jay_Schneider] [Andrew_Jay_Schneider]
+rsc-robot        1793/udp # rsc-robot [Andrew_Jay_Schneider] [Andrew_Jay_Schneider]
+cera-bcm         1794/tcp # cera-bcm [Leo_Moesgaard] [Leo_Moesgaard]
+cera-bcm         1794/udp # cera-bcm [Leo_Moesgaard] [Leo_Moesgaard]
+dpi-proxy        1795/tcp # dpi-proxy [Charles_Gordon] [Charles_Gordon]
+dpi-proxy        1795/udp # dpi-proxy [Charles_Gordon] [Charles_Gordon]
+vocaltec-admin   1796/tcp # Vocaltec Server Administration [Scott_Petrack] [Scott_Petrack]
+vocaltec-admin   1796/udp # Vocaltec Server Administration [Scott_Petrack] [Scott_Petrack]
+uma              1797/tcp # UMA [Martin_Kirk] [Martin_Kirk]
+uma              1797/udp # UMA [Martin_Kirk] [Martin_Kirk]
+etp              1798/tcp # Event Transfer Protocol [Mike_Wray] [Mike_Wray]
+etp              1798/udp # Event Transfer Protocol [Mike_Wray] [Mike_Wray]
+netrisk          1799/tcp # NETRISK [Kevin_Green] [Kevin_Green]
+netrisk          1799/udp # NETRISK [Kevin_Green] [Kevin_Green]
+ansys-lm         1800/tcp # ANSYS-License manager [Suzanne_Lorrin_2] [Suzanne_Lorrin_2]
+ansys-lm         1800/udp # ANSYS-License manager [Suzanne_Lorrin_2] [Suzanne_Lorrin_2]
+msmq             1801/tcp # Microsoft Message Que [Amnon_Horowitz] [Amnon_Horowitz]
+msmq             1801/udp # Microsoft Message Que [Amnon_Horowitz] [Amnon_Horowitz]
+concomp1         1802/tcp # ConComp1 [Ed_Vincent] [Ed_Vincent]
+concomp1         1802/udp # ConComp1 [Ed_Vincent] [Ed_Vincent]
+hp-hcip-gwy      1803/tcp # HP-HCIP-GWY [Allen_Baker] [Allen_Baker]
+hp-hcip-gwy      1803/udp # HP-HCIP-GWY [Allen_Baker] [Allen_Baker]
+enl              1804/tcp # ENL [Brian_Olson] [Brian_Olson]
+enl              1804/udp # ENL [Brian_Olson] [Brian_Olson]
+enl-name         1805/tcp # ENL-Name [Brian_Olson] [Brian_Olson]
+enl-name         1805/udp # ENL-Name [Brian_Olson] [Brian_Olson]
+musiconline      1806/tcp # Musiconline [Craig_Weeks] [Craig_Weeks]
+musiconline      1806/udp # Musiconline [Craig_Weeks] [Craig_Weeks]
+fhsp             1807/tcp # Fujitsu Hot Standby Protocol [Eiki_Iwata] [Eiki_Iwata]
+fhsp             1807/udp # Fujitsu Hot Standby Protocol [Eiki_Iwata] [Eiki_Iwata]
+oracle-vp2       1808/tcp # Oracle-VP2 [Craig_Fowler] [Craig_Fowler]
+oracle-vp2       1808/udp # Oracle-VP2 [Craig_Fowler] [Craig_Fowler]
+oracle-vp1       1809/tcp # Oracle-VP1 [Craig_Fowler] [Craig_Fowler]
+oracle-vp1       1809/udp # Oracle-VP1 [Craig_Fowler] [Craig_Fowler]
+jerand-lm        1810/tcp # Jerand License Manager [Robert_Monat] [Robert_Monat]
+jerand-lm        1810/udp # Jerand License Manager [Robert_Monat] [Robert_Monat]
+scientia-sdb     1811/tcp # Scientia-SDB [SYSTEMS_MANAGER] [SYSTEMS_MANAGER]
+scientia-sdb     1811/udp # Scientia-SDB [SYSTEMS_MANAGER] [SYSTEMS_MANAGER]
+radius           1812/tcp # RADIUS [RFC2865]
+radius           1812/udp # RADIUS [RFC2865]
+radius-acct      1813/tcp # RADIUS Accounting [RFC2866]
+radius-acct      1813/udp # RADIUS Accounting [RFC2866]
+tdp-suite        1814/tcp # TDP Suite [Rob_Lockhart] [Rob_Lockhart]
+tdp-suite        1814/udp # TDP Suite [Rob_Lockhart] [Rob_Lockhart]
+mmpft            1815/tcp # MMPFT [Ralf_Muckenhirn] [Ralf_Muckenhirn]
+mmpft            1815/udp # MMPFT [Ralf_Muckenhirn] [Ralf_Muckenhirn]
+harp             1816/tcp # HARP [Bjorn_Chambless] [Bjorn_Chambless]
+harp             1816/udp # HARP [Bjorn_Chambless] [Bjorn_Chambless]
+rkb-oscs         1817/tcp # RKB-OSCS [Robert_Kevin_Breton] [Robert_Kevin_Breton]
+rkb-oscs         1817/udp # RKB-OSCS [Robert_Kevin_Breton] [Robert_Kevin_Breton]
+etftp            1818/tcp # Enhanced Trivial File Transfer Protocol [William_Polites] [William_Polites]
+etftp            1818/udp # Enhanced Trivial File Transfer Protocol [William_Polites] [William_Polites]
+plato-lm         1819/tcp # Plato License Manager [Mark_Morris] [Mark_Morris]
+plato-lm         1819/udp # Plato License Manager [Mark_Morris] [Mark_Morris]
+mcagent          1820/tcp # mcagent [Ryoichi_Shinohara] [Ryoichi_Shinohara]
+mcagent          1820/udp # mcagent [Ryoichi_Shinohara] [Ryoichi_Shinohara]
+donnyworld       1821/tcp # donnyworld [Don_Oliver] [Don_Oliver]
+donnyworld       1821/udp # donnyworld [Don_Oliver] [Don_Oliver]
+es-elmd          1822/tcp # es-elmd [David_Duncan] [David_Duncan]
+es-elmd          1822/udp # es-elmd [David_Duncan] [David_Duncan]
+unisys-lm        1823/tcp # Unisys Natural Language License Manager [Raymond_A_Diedrichs] [Raymond_A_Diedrichs]
+unisys-lm        1823/udp # Unisys Natural Language License Manager [Raymond_A_Diedrichs] [Raymond_A_Diedrichs]
+metrics-pas      1824/tcp # metrics-pas [Tom_Haapanen] [Tom_Haapanen]
+metrics-pas      1824/udp # metrics-pas [Tom_Haapanen] [Tom_Haapanen]
+direcpc-video    1825/tcp # DirecPC Video [Chris_Kerrigan] [Chris_Kerrigan]
+direcpc-video    1825/udp # DirecPC Video [Chris_Kerrigan] [Chris_Kerrigan]
+ardt             1826/tcp # ARDT [Mike_Goddard] [Mike_Goddard]
+ardt             1826/udp # ARDT [Mike_Goddard] [Mike_Goddard]
+asi              1827/tcp # ASI [Bob_Tournoux] [Bob_Tournoux]
+asi              1827/udp # ASI [Bob_Tournoux] [Bob_Tournoux]
+itm-mcell-u      1828/tcp # itm-mcell-u [Portnoy_Boxman] [Portnoy_Boxman]
+itm-mcell-u      1828/udp # itm-mcell-u [Portnoy_Boxman] [Portnoy_Boxman]
+optika-emedia    1829/tcp # Optika eMedia [Daryle_DeBalski] [Daryle_DeBalski]
+optika-emedia    1829/udp # Optika eMedia [Daryle_DeBalski] [Daryle_DeBalski]
+net8-cman        1830/tcp # Oracle Net8 CMan Admin [Shuvayu_Kanjilal] [Shuvayu_Kanjilal]
+net8-cman        1830/udp # Oracle Net8 CMan Admin [Shuvayu_Kanjilal] [Shuvayu_Kanjilal]
+myrtle           1831/tcp # Myrtle [Ron_Achin] [Ron_Achin]
+myrtle           1831/udp # Myrtle [Ron_Achin] [Ron_Achin]
+tht-treasure     1832/tcp # ThoughtTreasure [Erik_Mueller] [Erik_Mueller]
+tht-treasure     1832/udp # ThoughtTreasure [Erik_Mueller] [Erik_Mueller]
+udpradio         1833/tcp # udpradio [Guus_Sliepen] [Guus_Sliepen]
+udpradio         1833/udp # udpradio [Guus_Sliepen] [Guus_Sliepen]
+ardusuni         1834/tcp # ARDUS Unicast
+ardusuni         1834/udp # ARDUS Unicast
+ardusmul         1835/tcp # ARDUS Multicast [Toshikatsu_Ito] [Toshikatsu_Ito]
+ardusmul         1835/udp # ARDUS Multicast [Toshikatsu_Ito] [Toshikatsu_Ito]
+ste-smsc         1836/tcp # ste-smsc [Tom_Snauwaert] [Tom_Snauwaert]
+ste-smsc         1836/udp # ste-smsc [Tom_Snauwaert] [Tom_Snauwaert]
+csoft1           1837/tcp # csoft1 [John_Coll] [John_Coll]
+csoft1           1837/udp # csoft1 [John_Coll] [John_Coll]
+talnet           1838/tcp # TALNET [Aaron_Lav] [Aaron_Lav]
+talnet           1838/udp # TALNET [Aaron_Lav] [Aaron_Lav]
+netopia-vo1      1839/tcp # netopia-vo1
+netopia-vo1      1839/udp # netopia-vo1
+netopia-vo2      1840/tcp # netopia-vo2
+netopia-vo2      1840/udp # netopia-vo2
+netopia-vo3      1841/tcp # netopia-vo3
+netopia-vo3      1841/udp # netopia-vo3
+netopia-vo4      1842/tcp # netopia-vo4
+netopia-vo4      1842/udp # netopia-vo4
+netopia-vo5      1843/tcp # netopia-vo5 [Marc_Epard] [Marc_Epard]
+netopia-vo5      1843/udp # netopia-vo5 [Marc_Epard] [Marc_Epard]
+direcpc-dll      1844/tcp # DirecPC-DLL [Chris_Kerrigan] [Chris_Kerrigan]
+direcpc-dll      1844/udp # DirecPC-DLL [Chris_Kerrigan] [Chris_Kerrigan]
+altalink         1845/tcp # altalink [Alberto_Raydan] [Alberto_Raydan]
+altalink         1845/udp # altalink [Alberto_Raydan] [Alberto_Raydan]
+tunstall-pnc     1846/tcp # Tunstall PNC [Robert_M_Moore] [Robert_M_Moore]
+tunstall-pnc     1846/udp # Tunstall PNC [Robert_M_Moore] [Robert_M_Moore]
+slp-notify       1847/tcp # SLP Notification [RFC3082]
+slp-notify       1847/udp # SLP Notification [RFC3082]
+fjdocdist        1848/tcp # fjdocdist [Yuichi_Ohiwa] [Yuichi_Ohiwa]
+fjdocdist        1848/udp # fjdocdist [Yuichi_Ohiwa] [Yuichi_Ohiwa]
+alpha-sms        1849/tcp # ALPHA-SMS [Benjamin_Grimm] [Benjamin_Grimm]
+alpha-sms        1849/udp # ALPHA-SMS [Benjamin_Grimm] [Benjamin_Grimm]
+gsi              1850/tcp # GSI [William_Mullaney] [William_Mullaney]
+gsi              1850/udp # GSI [William_Mullaney] [William_Mullaney]
+ctcd             1851/tcp # ctcd [John_Ryan] [John_Ryan]
+ctcd             1851/udp # ctcd [John_Ryan] [John_Ryan]
+virtual-time     1852/tcp # Virtual Time [Angie_S_Morner] [Angie_S_Morner]
+virtual-time     1852/udp # Virtual Time [Angie_S_Morner] [Angie_S_Morner]
+vids-avtp        1853/tcp # VIDS-AVTP [Sascha_Kuemmel] [Sascha_Kuemmel]
+vids-avtp        1853/udp # VIDS-AVTP [Sascha_Kuemmel] [Sascha_Kuemmel]
+buddy-draw       1854/tcp # Buddy Draw [Marvin_Shin] [Marvin_Shin]
+buddy-draw       1854/udp # Buddy Draw [Marvin_Shin] [Marvin_Shin]
+fiorano-rtrsvc   1855/tcp # Fiorano RtrSvc
+fiorano-rtrsvc   1855/udp # Fiorano RtrSvc
+fiorano-msgsvc   1856/tcp # Fiorano MsgSvc [Albert_Holt_2] [Albert_Holt_2]
+fiorano-msgsvc   1856/udp # Fiorano MsgSvc [Albert_Holt_2] [Albert_Holt_2]
+datacaptor       1857/tcp # DataCaptor [Steven_M_Forrester] [Steven_M_Forrester]
+datacaptor       1857/udp # DataCaptor [Steven_M_Forrester] [Steven_M_Forrester]
+privateark       1858/tcp # PrivateArk [Ronen_Zoran] [Ronen_Zoran]
+privateark       1858/udp # PrivateArk [Ronen_Zoran] [Ronen_Zoran]
+gammafetchsvr    1859/tcp # Gamma Fetcher Server [Cnaan_Aviv] [Cnaan_Aviv]
+gammafetchsvr    1859/udp # Gamma Fetcher Server [Cnaan_Aviv] [Cnaan_Aviv]
+sunscalar-svc    1860/tcp # SunSCALAR Services [Sanjay_Radia] [Sanjay_Radia]
+sunscalar-svc    1860/udp # SunSCALAR Services [Sanjay_Radia] [Sanjay_Radia]
+lecroy-vicp      1861/tcp # LeCroy VICP [Anthony_Cake] [Anthony_Cake]
+lecroy-vicp      1861/udp # LeCroy VICP [Anthony_Cake] [Anthony_Cake]
+mysql-cm-agent   1862/tcp # MySQL Cluster Manager Agent [Andrew_Morgan] [Andrew_Morgan] 2009-12-08
+mysql-cm-agent   1862/udp # MySQL Cluster Manager Agent [Andrew_Morgan] [Andrew_Morgan] 2009-12-08
+msnp             1863/tcp # MSNP [William_Lai] [William_Lai]
+msnp             1863/udp # MSNP [William_Lai] [William_Lai]
+paradym-31port   1864/tcp # Paradym 31 Port [David_Wooden] [David_Wooden]
+paradym-31port   1864/udp # Paradym 31 Port [David_Wooden] [David_Wooden]
+entp             1865/tcp # ENTP [Seiko_Epson] [Seiko_Epson]
+entp             1865/udp # ENTP [Seiko_Epson] [Seiko_Epson]
+swrmi            1866/tcp # swrmi [Jun_Yoshii] [Jun_Yoshii]
+swrmi            1866/udp # swrmi [Jun_Yoshii] [Jun_Yoshii]
+udrive           1867/tcp # UDRIVE [Robby_Walker] [Robby_Walker]
+udrive           1867/udp # UDRIVE [Robby_Walker] [Robby_Walker]
+viziblebrowser   1868/tcp # VizibleBrowser [Jimmy_Talbot] [Jimmy_Talbot]
+viziblebrowser   1868/udp # VizibleBrowser [Jimmy_Talbot] [Jimmy_Talbot]
+transact         1869/tcp # TransAct [TransAct_Futures_Dev] [TransAct_Futures_Dev]
+transact         1869/udp # TransAct [TransAct_Futures_Dev] [TransAct_Futures_Dev]
+sunscalar-dns    1870/tcp # SunSCALAR DNS Service [Sanjay_Radia] [Sanjay_Radia]
+sunscalar-dns    1870/udp # SunSCALAR DNS Service [Sanjay_Radia] [Sanjay_Radia]
+canocentral0     1871/tcp # Cano Central 0
+canocentral0     1871/udp # Cano Central 0
+canocentral1     1872/tcp # Cano Central 1 [Mark_McNamara] [Mark_McNamara]
+canocentral1     1872/udp # Cano Central 1 [Mark_McNamara] [Mark_McNamara]
+fjmpjps          1873/tcp # Fjmpjps
+fjmpjps          1873/udp # Fjmpjps
+fjswapsnp        1874/tcp # Fjswapsnp [Y_Ohiwa] [Y_Ohiwa]
+fjswapsnp        1874/udp # Fjswapsnp [Y_Ohiwa] [Y_Ohiwa]
+westell-stats    1875/tcp # westell stats [Thomas_McCabe] [Thomas_McCabe]
+westell-stats    1875/udp # westell stats [Thomas_McCabe] [Thomas_McCabe]
+ewcappsrv        1876/tcp # ewcappsrv [Howard_Yin] [Howard_Yin]
+ewcappsrv        1876/udp # ewcappsrv [Howard_Yin] [Howard_Yin]
+hp-webqosdb      1877/tcp # hp-webqosdb [Kim_Scott] [Kim_Scott]
+hp-webqosdb      1877/udp # hp-webqosdb [Kim_Scott] [Kim_Scott]
+drmsmc           1878/tcp # drmsmc [Katsuhiko_Abe] [Katsuhiko_Abe]
+drmsmc           1878/udp # drmsmc [Katsuhiko_Abe] [Katsuhiko_Abe]
+nettgain-nms     1879/tcp # NettGain NMS [Dr_Yair_Shapira] [Dr_Yair_Shapira]
+nettgain-nms     1879/udp # NettGain NMS [Dr_Yair_Shapira] [Dr_Yair_Shapira]
+vsat-control     1880/tcp # Gilat VSAT Control [Yariv_Kaplan] [Yariv_Kaplan]
+vsat-control     1880/udp # Gilat VSAT Control [Yariv_Kaplan] [Yariv_Kaplan]
+ibm-mqseries2    1881/tcp # IBM WebSphere MQ Everyplace [Jane_Porter] [Jane_Porter]
+ibm-mqseries2    1881/udp # IBM WebSphere MQ Everyplace [Jane_Porter] [Jane_Porter]
+ecsqdmn          1882/tcp # CA eTrust Common Services [Paul_Wissmiller] [Paul_Wissmiller]
+ecsqdmn          1882/udp # CA eTrust Common Services [Paul_Wissmiller] [Paul_Wissmiller]
+ibm-mqisdp       1883/tcp # IBM MQSeries SCADA [Andy_Stanford_Clark] [Andy_Stanford_Clark]
+ibm-mqisdp       1883/udp # IBM MQSeries SCADA [Andy_Stanford_Clark] [Andy_Stanford_Clark]
+idmaps           1884/tcp # Internet Distance Map Svc [Sugih_Jamim] [Sugih_Jamim]
+idmaps           1884/udp # Internet Distance Map Svc [Sugih_Jamim] [Sugih_Jamim]
+vrtstrapserver   1885/tcp # Veritas Trap Server [Russell_Thrasher] [Russell_Thrasher]
+vrtstrapserver   1885/udp # Veritas Trap Server [Russell_Thrasher] [Russell_Thrasher]
+leoip            1886/tcp # Leonardo over IP [Dietmar_Finkler] [Dietmar_Finkler]
+leoip            1886/udp # Leonardo over IP [Dietmar_Finkler] [Dietmar_Finkler]
+filex-lport      1887/tcp # FileX Listening Port [Megan_Woods] [Megan_Woods]
+filex-lport      1887/udp # FileX Listening Port [Megan_Woods] [Megan_Woods]
+ncconfig         1888/tcp # NC Config Port [Simon_Parker] [Simon_Parker]
+ncconfig         1888/udp # NC Config Port [Simon_Parker] [Simon_Parker]
+unify-adapter    1889/tcp # Unify Web Adapter Service [Daegis_Inc] [Chris_Anderson] 2012-07-31
+unify-adapter    1889/udp # Unify Web Adapter Service [Daegis_Inc] [Chris_Anderson] 2012-07-31
+wilkenlistener   1890/tcp # wilkenListener [Wilken_GmbH] [Wilken_GmbH]
+wilkenlistener   1890/udp # wilkenListener [Wilken_GmbH] [Wilken_GmbH]
+childkey-notif   1891/tcp # ChildKey Notification
+childkey-notif   1891/udp # ChildKey Notification
+childkey-ctrl    1892/tcp # ChildKey Control [Ivan_Berardinelli] [Ivan_Berardinelli]
+childkey-ctrl    1892/udp # ChildKey Control [Ivan_Berardinelli] [Ivan_Berardinelli]
+elad             1893/tcp # ELAD Protocol [Franco_Milan] [Franco_Milan]
+elad             1893/udp # ELAD Protocol [Franco_Milan] [Franco_Milan]
+o2server-port    1894/tcp # O2Server Port [Tim_Howard] [Tim_Howard]
+o2server-port    1894/udp # O2Server Port [Tim_Howard] [Tim_Howard]
+b-novative-ls    1896/tcp # b-novative license server [Matthias_Riese] [Matthias_Riese]
+b-novative-ls    1896/udp # b-novative license server [Matthias_Riese] [Matthias_Riese]
+metaagent        1897/tcp # MetaAgent [Marie_France_Dubreui] [Marie_France_Dubreui]
+metaagent        1897/udp # MetaAgent [Marie_France_Dubreui] [Marie_France_Dubreui]
+cymtec-port      1898/tcp # Cymtec secure management [Michael_Mester] [Michael_Mester]
+cymtec-port      1898/udp # Cymtec secure management [Michael_Mester] [Michael_Mester]
+mc2studios       1899/tcp # MC2Studios [Michael_Coon] [Michael_Coon]
+mc2studios       1899/udp # MC2Studios [Michael_Coon] [Michael_Coon]
+ssdp             1900/tcp # SSDP [UPnP_Forum] [UPnP_Forum]
+ssdp             1900/udp # SSDP [UPnP_Forum] [UPnP_Forum]
+fjicl-tep-a      1901/tcp # Fujitsu ICL Terminal Emulator Program A [Bob_Lyon] [Bob_Lyon]
+fjicl-tep-a      1901/udp # Fujitsu ICL Terminal Emulator Program A [Bob_Lyon] [Bob_Lyon]
+fjicl-tep-b      1902/tcp # Fujitsu ICL Terminal Emulator Program B [Bob_Lyon] [Bob_Lyon]
+fjicl-tep-b      1902/udp # Fujitsu ICL Terminal Emulator Program B [Bob_Lyon] [Bob_Lyon]
+linkname         1903/tcp # Local Link Name Resolution [Dan_Harrington] [Dan_Harrington]
+linkname         1903/udp # Local Link Name Resolution [Dan_Harrington] [Dan_Harrington]
+fjicl-tep-c      1904/tcp # Fujitsu ICL Terminal Emulator Program C [Bob_Lyon] [Bob_Lyon]
+fjicl-tep-c      1904/udp # Fujitsu ICL Terminal Emulator Program C [Bob_Lyon] [Bob_Lyon]
+sugp             1905/tcp # Secure UP.Link Gateway Protocol [Peter_King] [Peter_King]
+sugp             1905/udp # Secure UP.Link Gateway Protocol [Peter_King] [Peter_King]
+tpmd             1906/tcp # TPortMapperReq [Sheila_Devins] [Sheila_Devins]
+tpmd             1906/udp # TPortMapperReq [Sheila_Devins] [Sheila_Devins]
+intrastar        1907/tcp # IntraSTAR [Peter_Schoenberger] [Peter_Schoenberger]
+intrastar        1907/udp # IntraSTAR [Peter_Schoenberger] [Peter_Schoenberger]
+dawn             1908/tcp # Dawn [Michael_Crawford_2] [Michael_Crawford_2]
+dawn             1908/udp # Dawn [Michael_Crawford_2] [Michael_Crawford_2]
+global-wlink     1909/tcp # Global World Link [Nicholas_Davies] [Nicholas_Davies]
+global-wlink     1909/udp # Global World Link [Nicholas_Davies] [Nicholas_Davies]
+ultrabac         1910/tcp # UltraBac Software communications port [Paul_Bunn] [Paul_Bunn]
+ultrabac         1910/udp # UltraBac Software communications port [Paul_Bunn] [Paul_Bunn]
+mtp              1911/tcp # Starlight Networks Multimedia Transport Protocol [Bruce_Lieberman] [Bruce_Lieberman]
+mtp              1911/udp # Starlight Networks Multimedia Transport Protocol [Bruce_Lieberman] [Bruce_Lieberman]
+rhp-iibp         1912/tcp # rhp-iibp [George_Nachman][Tom_Lake] [George_Nachman][Tom_Lake]
+rhp-iibp         1912/udp # rhp-iibp [George_Nachman][Tom_Lake] [George_Nachman][Tom_Lake]
+armadp           1913/tcp # armadp [Kevin_Welton] [Kevin_Welton]
+armadp           1913/udp # armadp [Kevin_Welton] [Kevin_Welton]
+elm-momentum     1914/tcp # Elm-Momentum [Willie_Wu] [Willie_Wu]
+elm-momentum     1914/udp # Elm-Momentum [Willie_Wu] [Willie_Wu]
+facelink         1915/tcp # FACELINK [J_H_Hermans] [J_H_Hermans]
+facelink         1915/udp # FACELINK [J_H_Hermans] [J_H_Hermans]
+persona          1916/tcp # Persoft Persona [Tom_Spidell] [Tom_Spidell]
+persona          1916/udp # Persoft Persona [Tom_Spidell] [Tom_Spidell]
+noagent          1917/tcp # nOAgent [Martin_Bestmann] [Martin_Bestmann]
+noagent          1917/udp # nOAgent [Martin_Bestmann] [Martin_Bestmann]
+can-nds          1918/tcp # IBM Tivole Directory Service - NDS
+can-nds          1918/udp # IBM Tivole Directory Service - NDS
+can-dch          1919/tcp # IBM Tivoli Directory Service - DCH
+can-dch          1919/udp # IBM Tivoli Directory Service - DCH
+can-ferret       1920/tcp # IBM Tivoli Directory Service - FERRET [Nic_Catrambone] [Nic_Catrambone]
+can-ferret       1920/udp # IBM Tivoli Directory Service - FERRET [Nic_Catrambone] [Nic_Catrambone]
+noadmin          1921/tcp # NoAdmin [Martin_Bestmann] [Martin_Bestmann]
+noadmin          1921/udp # NoAdmin [Martin_Bestmann] [Martin_Bestmann]
+tapestry         1922/tcp # Tapestry [Ken_Oliver] [Ken_Oliver]
+tapestry         1922/udp # Tapestry [Ken_Oliver] [Ken_Oliver]
+spice            1923/tcp # SPICE [Nicholas_Chua] [Nicholas_Chua]
+spice            1923/udp # SPICE [Nicholas_Chua] [Nicholas_Chua]
+xiip             1924/tcp # XIIP [Alain_Robert_2] [Alain_Robert_2]
+xiip             1924/udp # XIIP [Alain_Robert_2] [Alain_Robert_2]
+discovery-port   1925/tcp # Surrogate Discovery Port [Keith_Thompson] [Keith_Thompson]
+discovery-port   1925/udp # Surrogate Discovery Port [Keith_Thompson] [Keith_Thompson]
+egs              1926/tcp # Evolution Game Server [Simon_Butcher] [Simon_Butcher]
+egs              1926/udp # Evolution Game Server [Simon_Butcher] [Simon_Butcher]
+videte-cipc      1927/tcp # Videte CIPC Port [Videte_IT] [Videte_IT]
+videte-cipc      1927/udp # Videte CIPC Port [Videte_IT] [Videte_IT]
+emsd-port        1928/tcp # Expnd Maui Srvr Dscovr [Edo_Yahav] [Edo_Yahav]
+emsd-port        1928/udp # Expnd Maui Srvr Dscovr [Edo_Yahav] [Edo_Yahav]
+bandwiz-system   1929/tcp # Bandwiz System - Server [Joseph_Weihs] [Joseph_Weihs]
+bandwiz-system   1929/udp # Bandwiz System - Server [Joseph_Weihs] [Joseph_Weihs]
+driveappserver   1930/tcp # Drive AppServer [Andrew_Johnson] [Andrew_Johnson]
+driveappserver   1930/udp # Drive AppServer [Andrew_Johnson] [Andrew_Johnson]
+amdsched         1931/tcp # AMD SCHED [Michael_Walsh] [Michael_Walsh]
+amdsched         1931/udp # AMD SCHED [Michael_Walsh] [Michael_Walsh]
+ctt-broker       1932/tcp # CTT Broker [Jens_Edlund] [Jens_Edlund]
+ctt-broker       1932/udp # CTT Broker [Jens_Edlund] [Jens_Edlund]
+xmapi            1933/tcp # IBM LM MT Agent
+xmapi            1933/udp # IBM LM MT Agent
+xaapi            1934/tcp # IBM LM Appl Agent [Helga_Wolin] [Helga_Wolin]
+xaapi            1934/udp # IBM LM Appl Agent [Helga_Wolin] [Helga_Wolin]
+macromedia-fcs   1935/tcp # Macromedia Flash Communications Server MX [Pritham_Shetty] [Pritham_Shetty]
+macromedia-fcs   1935/udp # Macromedia Flash Communications server MX [Pritham_Shetty] [Pritham_Shetty]
+jetcmeserver     1936/tcp # JetCmeServer Server Port
+jetcmeserver     1936/udp # JetCmeServer Server Port
+jwserver         1937/tcp # JetVWay Server Port
+jwserver         1937/udp # JetVWay Server Port
+jwclient         1938/tcp # JetVWay Client Port
+jwclient         1938/udp # JetVWay Client Port
+jvserver         1939/tcp # JetVision Server Port
+jvserver         1939/udp # JetVision Server Port
+jvclient         1940/tcp # JetVision Client Port [Stephen_Tsun] [Stephen_Tsun]
+jvclient         1940/udp # JetVision Client Port [Stephen_Tsun] [Stephen_Tsun]
+dic-aida         1941/tcp # DIC-Aida [Frans_S_C_Witte] [Frans_S_C_Witte]
+dic-aida         1941/udp # DIC-Aida [Frans_S_C_Witte] [Frans_S_C_Witte]
+res              1942/tcp # Real Enterprise Service [Bob_Janssen] [Bob_Janssen]
+res              1942/udp # Real Enterprise Service [Bob_Janssen] [Bob_Janssen]
+beeyond-media    1943/tcp # Beeyond Media [Bob_Deblier] [Bob_Deblier]
+beeyond-media    1943/udp # Beeyond Media [Bob_Deblier] [Bob_Deblier]
+close-combat     1944/tcp # close-combat [David_Hua] [David_Hua]
+close-combat     1944/udp # close-combat [David_Hua] [David_Hua]
+dialogic-elmd    1945/tcp # dialogic-elmd [Roger_Kay] [Roger_Kay]
+dialogic-elmd    1945/udp # dialogic-elmd [Roger_Kay] [Roger_Kay]
+tekpls           1946/tcp # tekpls [Brian_Abramson_2] [Brian_Abramson_2]
+tekpls           1946/udp # tekpls [Brian_Abramson_2] [Brian_Abramson_2]
+sentinelsrm      1947/tcp # SentinelSRM [Michael_Zunke_2] [Michael_Zunke_2] 2010-07-23
+sentinelsrm      1947/udp # SentinelSRM [Michael_Zunke_2] [Michael_Zunke_2] 2010-07-23
+eye2eye          1948/tcp # eye2eye [Trevor_Bell] [Trevor_Bell]
+eye2eye          1948/udp # eye2eye [Trevor_Bell] [Trevor_Bell]
+ismaeasdaqlive   1949/tcp # ISMA Easdaq Live [Stephen_Dunne] [Stephen_Dunne]
+ismaeasdaqlive   1949/udp # ISMA Easdaq Live [Stephen_Dunne] [Stephen_Dunne]
+ismaeasdaqtest   1950/tcp # ISMA Easdaq Test [Stephen_Dunne] [Stephen_Dunne]
+ismaeasdaqtest   1950/udp # ISMA Easdaq Test [Stephen_Dunne] [Stephen_Dunne]
+bcs-lmserver     1951/tcp # bcs-lmserver [Andy_Warner] [Andy_Warner]
+bcs-lmserver     1951/udp # bcs-lmserver [Andy_Warner] [Andy_Warner]
+mpnjsc           1952/tcp # mpnjsc [Takenori_Miyahara] [Takenori_Miyahara]
+mpnjsc           1952/udp # mpnjsc [Takenori_Miyahara] [Takenori_Miyahara]
+rapidbase        1953/tcp # Rapid Base [Antoni_Wolski] [Antoni_Wolski]
+rapidbase        1953/udp # Rapid Base [Antoni_Wolski] [Antoni_Wolski]
+abr-api          1954/tcp # ABR-API (diskbridge)
+abr-api          1954/udp # ABR-API (diskbridge)
+abr-secure       1955/tcp # ABR-Secure Data (diskbridge) [Graham_Wooden] [Graham_Wooden]
+abr-secure       1955/udp # ABR-Secure Data (diskbridge) [Graham_Wooden] [Graham_Wooden]
+vrtl-vmf-ds      1956/tcp # Vertel VMF DS [Alan_Akahoshi] [Alan_Akahoshi]
+vrtl-vmf-ds      1956/udp # Vertel VMF DS [Alan_Akahoshi] [Alan_Akahoshi]
+unix-status      1957/tcp # unix-status [Thomas_Erskine] [Thomas_Erskine]
+unix-status      1957/udp # unix-status [Thomas_Erskine] [Thomas_Erskine]
+dxadmind         1958/tcp # CA Administration Daemon [John_Birrell] [John_Birrell]
+dxadmind         1958/udp # CA Administration Daemon [John_Birrell] [John_Birrell]
+simp-all         1959/tcp # SIMP Channel [Tim_Hunnewell] [Tim_Hunnewell]
+simp-all         1959/udp # SIMP Channel [Tim_Hunnewell] [Tim_Hunnewell]
+nasmanager       1960/tcp # Merit DAC NASmanager [Richard_S_Conto] [Richard_S_Conto]
+nasmanager       1960/udp # Merit DAC NASmanager [Richard_S_Conto] [Richard_S_Conto]
+bts-appserver    1961/tcp # BTS APPSERVER [Carl_Obsorn] [Carl_Obsorn]
+bts-appserver    1961/udp # BTS APPSERVER [Carl_Obsorn] [Carl_Obsorn]
+biap-mp          1962/tcp # BIAP-MP [Louis_Slothouber] [Louis_Slothouber]
+biap-mp          1962/udp # BIAP-MP [Louis_Slothouber] [Louis_Slothouber]
+webmachine       1963/tcp # WebMachine [Tim_Jowers] [Tim_Jowers]
+webmachine       1963/udp # WebMachine [Tim_Jowers] [Tim_Jowers]
+solid-e-engine   1964/tcp # SOLID E ENGINE [Ari_Valtanen] [Ari_Valtanen]
+solid-e-engine   1964/udp # SOLID E ENGINE [Ari_Valtanen] [Ari_Valtanen]
+tivoli-npm       1965/tcp # Tivoli NPM [Ivana_Cuozzo] [Ivana_Cuozzo]
+tivoli-npm       1965/udp # Tivoli NPM [Ivana_Cuozzo] [Ivana_Cuozzo]
+slush            1966/tcp # Slush [Damien_Miller] [Damien_Miller]
+slush            1966/udp # Slush [Damien_Miller] [Damien_Miller]
+sns-quote        1967/tcp # SNS Quote [Robert_Ellman] [Robert_Ellman]
+sns-quote        1967/udp # SNS Quote [Robert_Ellman] [Robert_Ellman]
+lipsinc          1968/tcp # LIPSinc
+lipsinc          1968/udp # LIPSinc
+lipsinc1         1969/tcp # LIPSinc 1 [Robert_Armington] [Robert_Armington]
+lipsinc1         1969/udp # LIPSinc 1 [Robert_Armington] [Robert_Armington]
+netop-rc         1970/tcp # NetOp Remote Control
+netop-rc         1970/udp # NetOp Remote Control
+netop-school     1971/tcp # NetOp School [NetOp_Technical_Supp] [NetOp_Technical_Supp]
+netop-school     1971/udp # NetOp School [NetOp_Technical_Supp] [NetOp_Technical_Supp]
+intersys-cache   1972/tcp # Cache [Mark_Hanson] [Mark_Hanson]
+intersys-cache   1972/udp # Cache [Mark_Hanson] [Mark_Hanson]
+dlsrap           1973/tcp # Data Link Switching Remote Access Protocol [Steve_T_Chiang] [Steve_T_Chiang]
+dlsrap           1973/udp # Data Link Switching Remote Access Protocol [Steve_T_Chiang] [Steve_T_Chiang]
+drp              1974/tcp # DRP [Richard_Alan_Johnson] [Richard_Alan_Johnson]
+drp              1974/udp # DRP [Richard_Alan_Johnson] [Richard_Alan_Johnson]
+tcoflashagent    1975/tcp # TCO Flash Agent
+tcoflashagent    1975/udp # TCO Flash Agent
+tcoregagent      1976/tcp # TCO Reg Agent
+tcoregagent      1976/udp # TCO Reg Agent
+tcoaddressbook   1977/tcp # TCO Address Book [Allan_Panitch] [Allan_Panitch]
+tcoaddressbook   1977/udp # TCO Address Book [Allan_Panitch] [Allan_Panitch]
+unisql           1978/tcp # UniSQL
+unisql           1978/udp # UniSQL
+unisql-java      1979/tcp # UniSQL Java [Keith_Yarbrough] [Keith_Yarbrough]
+unisql-java      1979/udp # UniSQL Java [Keith_Yarbrough] [Keith_Yarbrough]
+pearldoc-xact    1980/tcp # PearlDoc XACT [Chris_Vertonghen] [Chris_Vertonghen]
+pearldoc-xact    1980/udp # PearlDoc XACT [Chris_Vertonghen] [Chris_Vertonghen]
+p2pq             1981/tcp # p2pQ [Warren_Alexander] [Warren_Alexander]
+p2pq             1981/udp # p2pQ [Warren_Alexander] [Warren_Alexander]
+estamp           1982/tcp # Evidentiary Timestamp [Todd_Glassey] [Todd_Glassey]
+estamp           1982/udp # Evidentiary Timestamp [Todd_Glassey] [Todd_Glassey]
+lhtp             1983/tcp # Loophole Test Protocol [Kade_Hansson] [Kade_Hansson]
+lhtp             1983/udp # Loophole Test Protocol [Kade_Hansson] [Kade_Hansson]
+bb               1984/tcp # BB [Sean_MacGuire] [Sean_MacGuire]
+bb               1984/udp # BB [Sean_MacGuire] [Sean_MacGuire]
+hsrp             1985/tcp # Hot Standby Router Protocol [RFC2281]
+hsrp             1985/udp # Hot Standby Router Protocol [RFC2281]
+licensedaemon    1986/tcp # cisco license management
+licensedaemon    1986/udp # cisco license management
+tr-rsrb-p1       1987/tcp # cisco RSRB Priority 1 port
+tr-rsrb-p1       1987/udp # cisco RSRB Priority 1 port
+tr-rsrb-p2       1988/tcp # cisco RSRB Priority 2 port
+tr-rsrb-p2       1988/udp # cisco RSRB Priority 2 port
+tr-rsrb-p3       1989/tcp # cisco RSRB Priority 3 port
+tr-rsrb-p3       1989/udp # cisco RSRB Priority 3 port
+mshnet           1989/tcp # MHSnet system [Bob_Kummerfeld] [Bob_Kummerfeld] This entry records an unassigned but widespread use
+mshnet           1989/udp # MHSnet system [Bob_Kummerfeld] [Bob_Kummerfeld] This entry records an unassigned but widespread use
+stun-p1          1990/tcp # cisco STUN Priority 1 port
+stun-p1          1990/udp # cisco STUN Priority 1 port
+stun-p2          1991/tcp # cisco STUN Priority 2 port
+stun-p2          1991/udp # cisco STUN Priority 2 port
+stun-p3          1992/tcp # cisco STUN Priority 3 port
+stun-p3          1992/udp # cisco STUN Priority 3 port
+ipsendmsg        1992/tcp # IPsendmsg [Bob_Kummerfeld] [Bob_Kummerfeld] This entry records an unassigned but widespread use
+ipsendmsg        1992/udp # IPsendmsg [Bob_Kummerfeld] [Bob_Kummerfeld] This entry records an unassigned but widespread use
+snmp-tcp-port    1993/tcp # cisco SNMP TCP port
+snmp-tcp-port    1993/udp # cisco SNMP TCP port
+stun-port        1994/tcp # cisco serial tunnel port
+stun-port        1994/udp # cisco serial tunnel port
+perf-port        1995/tcp # cisco perf port
+perf-port        1995/udp # cisco perf port
+tr-rsrb-port     1996/tcp # cisco Remote SRB port
+tr-rsrb-port     1996/udp # cisco Remote SRB port
+gdp-port         1997/tcp # cisco Gateway Discovery Protocol
+gdp-port         1997/udp # cisco Gateway Discovery Protocol
+x25-svc-port     1998/tcp # cisco X.25 service (XOT)
+x25-svc-port     1998/udp # cisco X.25 service (XOT)
+tcp-id-port      1999/tcp # cisco identification port
+tcp-id-port      1999/udp # cisco identification port
+cisco-sccp       2000/tcp # Cisco SCCP [Dan_Wing] [Dan_Wing] 2003-11
+cisco-sccp       2000/udp # Cisco SCCp [Dan_Wing] [Dan_Wing] 2003-11
+dc               2001/tcp # 
+wizard           2001/udp # curry
+globe            2002/tcp # 
+globe            2002/udp # 
+brutus           2003/tcp # Brutus Server [Johannes_Skov_Frands] [Johannes_Skov_Frands] 2008-02-28
+brutus           2003/udp # Brutus Server [Johannes_Skov_Frands] [Johannes_Skov_Frands] 2008-02-28
+mailbox          2004/tcp # 
+emce             2004/udp # CCWS mm conf
+berknet          2005/tcp # 
+oracle           2005/udp # 
+invokator        2006/tcp # 
+raid-cd          2006/udp # raid
+dectalk          2007/tcp # 
+raid-am          2007/udp # 
+conf             2008/tcp # 
+terminaldb       2008/udp # 
+news             2009/tcp # 
+whosockami       2009/udp # 
+search           2010/tcp # 
+pipe-server      2010/udp # IANA assigned this well-formed service name as a replacement for "pipe_server".
+pipe_server      2010/udp # This entry is an alias to "pipe-server".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+raid-cc          2011/tcp # raid
+servserv         2011/udp # 
+ttyinfo          2012/tcp # 
+raid-ac          2012/udp # 
+raid-am          2013/tcp # 
+raid-cd          2013/udp # 
+troff            2014/tcp # 
+raid-sf          2014/udp # 
+cypress          2015/tcp # 
+raid-cs          2015/udp # 
+bootserver       2016/tcp # 
+bootserver       2016/udp # 
+cypress-stat     2017/tcp # 
+bootclient       2017/udp # 
+terminaldb       2018/tcp # 
+rellpack         2018/udp # 
+whosockami       2019/tcp # 
+about            2019/udp # 
+xinupageserver   2020/tcp # 
+xinupageserver   2020/udp # 
+servexec         2021/tcp # 
+xinuexpansion1   2021/udp # 
+down             2022/tcp # 
+xinuexpansion2   2022/udp # 
+xinuexpansion3   2023/tcp # 
+xinuexpansion3   2023/udp # 
+xinuexpansion4   2024/tcp # 
+xinuexpansion4   2024/udp # 
+ellpack          2025/tcp # 
+xribs            2025/udp # 
+scrabble         2026/tcp # 
+scrabble         2026/udp # 
+shadowserver     2027/tcp # 
+shadowserver     2027/udp # 
+submitserver     2028/tcp # 
+submitserver     2028/udp # 
+hsrpv6           2029/tcp # Hot Standby Router Protocol IPv6 [Ian_Wilson] [Ian_Wilson] 2004-11
+hsrpv6           2029/udp # Hot Standby Router Protocol IPv6 [Ian_Wilson] [Ian_Wilson] 2004-11
+device2          2030/tcp # 
+device2          2030/udp # 
+mobrien-chat     2031/tcp # mobrien-chat [Mike_O_Brien] [Mike_O_Brien] 2004-11
+mobrien-chat     2031/udp # mobrien-chat [Mike_O_Brien] [Mike_O_Brien] 2004-11
+blackboard       2032/tcp # 
+blackboard       2032/udp # 
+glogger          2033/tcp # 
+glogger          2033/udp # 
+scoremgr         2034/tcp # 
+scoremgr         2034/udp # 
+imsldoc          2035/tcp # 
+imsldoc          2035/udp # 
+e-dpnet          2036/tcp # Ethernet WS DP network [Peter_Kaever] [Peter_Kaever] 2005-08
+e-dpnet          2036/udp # Ethernet WS DP network [Peter_Kaever] [Peter_Kaever] 2005-08
+applus           2037/tcp # APplus Application Server [Thomas_Boerkel] [Thomas_Boerkel] 2008-06-06 Formerly was P2plus Application Server
+applus           2037/udp # APplus Application Server [Thomas_Boerkel] [Thomas_Boerkel] 2008-06-06 Formerly was P2plus Application Server
+objectmanager    2038/tcp # 
+objectmanager    2038/udp # 
+prizma           2039/tcp # Prizma Monitoring Service [Dotan_Ofek] [Dotan_Ofek] 2005-12
+prizma           2039/udp # Prizma Monitoring Service [Dotan_Ofek] [Dotan_Ofek] 2005-12
+lam              2040/tcp # 
+lam              2040/udp # 
+interbase        2041/tcp # 
+interbase        2041/udp # 
+isis             2042/tcp # isis
+isis             2042/udp # isis
+isis-bcast       2043/tcp # isis-bcast [Ken_Chapman] [Ken_Chapman]
+isis-bcast       2043/udp # isis-bcast [Ken_Chapman] [Ken_Chapman]
+rimsl            2044/tcp # 
+rimsl            2044/udp # 
+cdfunc           2045/tcp # 
+cdfunc           2045/udp # 
+sdfunc           2046/tcp # 
+sdfunc           2046/udp # 
+dls              2047/tcp # 
+dls              2047/udp # 
+dls-monitor      2048/tcp # 
+dls-monitor      2048/udp # 
+nfs              2049/tcp # Network File System - Sun Microsystems [Brent_Callaghan] [Brent_Callaghan] Defined TXT keys: path=<path to mount point>
+nfs              2049/udp # Network File System - Sun Microsystems [Brent_Callaghan] [Brent_Callaghan] Defined TXT keys: path=<path to mount point>
+nfs              2049/sctp # Network File System [RFC5665] Defined TXT keys: path=<path to mount point>
+av-emb-config    2050/tcp # Avaya EMB Config Port [John_Yeager] [John_Yeager]
+av-emb-config    2050/udp # Avaya EMB Config Port [John_Yeager] [John_Yeager]
+epnsdp           2051/tcp # EPNSDP [Hiroyasu_Ogata] [Hiroyasu_Ogata]
+epnsdp           2051/udp # EPNSDP [Hiroyasu_Ogata] [Hiroyasu_Ogata]
+clearvisn        2052/tcp # clearVisn Services Port [Dave_Lyons] [Dave_Lyons]
+clearvisn        2052/udp # clearVisn Services Port [Dave_Lyons] [Dave_Lyons]
+lot105-ds-upd    2053/tcp # Lot105 DSuper Updates [Piers_Scannell] [Piers_Scannell]
+lot105-ds-upd    2053/udp # Lot105 DSuper Updates [Piers_Scannell] [Piers_Scannell]
+weblogin         2054/tcp # Weblogin Port [Diego_Saravia] [Diego_Saravia]
+weblogin         2054/udp # Weblogin Port [Diego_Saravia] [Diego_Saravia]
+iop              2055/tcp # Iliad-Odyssey Protocol [Bruce_Lueckenhoff] [Bruce_Lueckenhoff]
+iop              2055/udp # Iliad-Odyssey Protocol [Bruce_Lueckenhoff] [Bruce_Lueckenhoff]
+omnisky          2056/tcp # OmniSky Port [Oren_Hurvitz] [Oren_Hurvitz]
+omnisky          2056/udp # OmniSky Port [Oren_Hurvitz] [Oren_Hurvitz]
+rich-cp          2057/tcp # Rich Content Protocol [Ronen_Vainish] [Ronen_Vainish]
+rich-cp          2057/udp # Rich Content Protocol [Ronen_Vainish] [Ronen_Vainish]
+newwavesearch    2058/tcp # NewWaveSearchables RMI [Thomas_Kerkau] [Thomas_Kerkau]
+newwavesearch    2058/udp # NewWaveSearchables RMI [Thomas_Kerkau] [Thomas_Kerkau]
+bmc-messaging    2059/tcp # BMC Messaging Service [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-messaging    2059/udp # BMC Messaging Service [Portnoy_Boxman] [Portnoy_Boxman]
+teleniumdaemon   2060/tcp # Telenium Daemon IF [Nick_Woronuk] [Nick_Woronuk]
+teleniumdaemon   2060/udp # Telenium Daemon IF [Nick_Woronuk] [Nick_Woronuk]
+netmount         2061/tcp # NetMount [Alex_Oberlander] [Alex_Oberlander]
+netmount         2061/udp # NetMount [Alex_Oberlander] [Alex_Oberlander]
+icg-swp          2062/tcp # ICG SWP Port
+icg-swp          2062/udp # ICG SWP Port
+icg-bridge       2063/tcp # ICG Bridge Port
+icg-bridge       2063/udp # ICG Bridge Port
+icg-iprelay      2064/tcp # ICG IP Relay Port [Steve_Quintana] [Steve_Quintana]
+icg-iprelay      2064/udp # ICG IP Relay Port [Steve_Quintana] [Steve_Quintana]
+dlsrpn           2065/tcp # Data Link Switch Read Port Number [Amir_Peless] [Amir_Peless]
+dlsrpn           2065/udp # Data Link Switch Read Port Number [Amir_Peless] [Amir_Peless]
+aura             2066/tcp # AVM USB Remote Architecture [Diego_Friedel] [Diego_Friedel] 2006-03
+aura             2066/udp # AVM USB Remote Architecture [Diego_Friedel] [Diego_Friedel] 2006-03
+dlswpn           2067/tcp # Data Link Switch Write Port Number [Amir_Peless] [Amir_Peless]
+dlswpn           2067/udp # Data Link Switch Write Port Number [Amir_Peless] [Amir_Peless]
+avauthsrvprtcl   2068/tcp # Avocent AuthSrv Protocol [Steven_W_Clark_2] [Steven_W_Clark_2]
+avauthsrvprtcl   2068/udp # Avocent AuthSrv Protocol [Steven_W_Clark_2] [Steven_W_Clark_2]
+event-port       2069/tcp # HTTP Event Port [Larry_Emlich] [Larry_Emlich]
+event-port       2069/udp # HTTP Event Port [Larry_Emlich] [Larry_Emlich]
+ah-esp-encap     2070/tcp # AH and ESP Encapsulated in UDP packet [Amy_Weaver] [Amy_Weaver]
+ah-esp-encap     2070/udp # AH and ESP Encapsulated in UDP packet [Amy_Weaver] [Amy_Weaver]
+acp-port         2071/tcp # Axon Control Protocol [Christiaan_Simons] [Christiaan_Simons]
+acp-port         2071/udp # Axon Control Protocol [Christiaan_Simons] [Christiaan_Simons]
+msync            2072/tcp # GlobeCast mSync [Piers_Scannell_2] [Piers_Scannell_2]
+msync            2072/udp # GlobeCast mSync [Piers_Scannell_2] [Piers_Scannell_2]
+gxs-data-port    2073/tcp # DataReel Database Socket [Douglas_M_Gaer] [Douglas_M_Gaer]
+gxs-data-port    2073/udp # DataReel Database Socket [Douglas_M_Gaer] [Douglas_M_Gaer]
+vrtl-vmf-sa      2074/tcp # Vertel VMF SA [Alan_Akahoshi] [Alan_Akahoshi]
+vrtl-vmf-sa      2074/udp # Vertel VMF SA [Alan_Akahoshi] [Alan_Akahoshi]
+newlixengine     2075/tcp # Newlix ServerWare Engine
+newlixengine     2075/udp # Newlix ServerWare Engine
+newlixconfig     2076/tcp # Newlix JSPConfig [Jean_Serge_Gagnon] [Jean_Serge_Gagnon]
+newlixconfig     2076/udp # Newlix JSPConfig [Jean_Serge_Gagnon] [Jean_Serge_Gagnon]
+tsrmagt          2077/tcp # Old Tivoli Storage Manager
+tsrmagt          2077/udp # Old Tivoli Storage Manager
+tpcsrvr          2078/tcp # IBM Total Productivity Center Server [Justin_R_Bendich] [Justin_R_Bendich]
+tpcsrvr          2078/udp # IBM Total Productivity Center Server [Justin_R_Bendich] [Justin_R_Bendich]
+idware-router    2079/tcp # IDWARE Router Port [Zdenek_Kolba] [Zdenek_Kolba]
+idware-router    2079/udp # IDWARE Router Port [Zdenek_Kolba] [Zdenek_Kolba]
+autodesk-nlm     2080/tcp # Autodesk NLM (FLEXlm) [Greg_Suppes] [Greg_Suppes]
+autodesk-nlm     2080/udp # Autodesk NLM (FLEXlm) [Greg_Suppes] [Greg_Suppes]
+kme-trap-port    2081/tcp # KME PRINTER TRAP PORT [Masakatsu_Matsuo] [Masakatsu_Matsuo]
+kme-trap-port    2081/udp # KME PRINTER TRAP PORT [Masakatsu_Matsuo] [Masakatsu_Matsuo]
+infowave         2082/tcp # Infowave Mobility Server [Kaz_Kylheku] [Kaz_Kylheku]
+infowave         2082/udp # Infowave Mobility Server [Kaz_Kylheku] [Kaz_Kylheku]
+radsec           2083/tcp # Secure Radius Service [IESG] [IETF_Chair] 2005-05 [RFC6614] The TCP port 2083 was already      previously assigned by IANA for "RadSec", an early implementation      of RADIUS/TLS, prior to issuance of this RFC.  This early      implementation can be configured to be compatible to RADIUS/TLS as      specified by the IETF.  See [RFC6614],      Appendix A for details.
+radsec           2083/udp # Secure Radius Service [Mike_McCauley] [Mike_McCauley] 2005-05
+sunclustergeo    2084/tcp # SunCluster Geographic [Oracle_2] [Steve_McKinty] 2005-11 2013-08-14
+sunclustergeo    2084/udp # SunCluster Geographic [Oracle_2] [Steve_McKinty] 2005-11 2013-08-14
+ada-cip          2085/tcp # ADA Control [Eugene_Frenkel] [Eugene_Frenkel] 2005-11
+ada-cip          2085/udp # ADA Control [Eugene_Frenkel] [Eugene_Frenkel] 2005-11
+gnunet           2086/tcp # GNUnet [Christian_Grothoff] [Christian_Grothoff] 2002-10
+gnunet           2086/udp # GNUnet [Christian_Grothoff] [Christian_Grothoff] 2002-10
+eli              2087/tcp # ELI - Event Logging Integration [Maya_Zimerman] [Maya_Zimerman]
+eli              2087/udp # ELI - Event Logging Integration [Maya_Zimerman] [Maya_Zimerman]
+ip-blf           2088/tcp # IP Busy Lamp Field [Jeffrey_Szczepanski] [Jeffrey_Szczepanski] 2005-02
+ip-blf           2088/udp # IP Busy Lamp Field [Jeffrey_Szczepanski] [Jeffrey_Szczepanski] 2005-02
+sep              2089/tcp # Security Encapsulation Protocol - SEP [Maya_Zimerman] [Maya_Zimerman]
+sep              2089/udp # Security Encapsulation Protocol - SEP [Maya_Zimerman] [Maya_Zimerman]
+lrp              2090/tcp # Load Report Protocol [Amir_Peless] [Amir_Peless]
+lrp              2090/udp # Load Report Protocol [Amir_Peless] [Amir_Peless]
+prp              2091/tcp # PRP [Amir_Peless] [Amir_Peless]
+prp              2091/udp # PRP [Amir_Peless] [Amir_Peless]
+descent3         2092/tcp # Descent 3 [Kevin_Bentley] [Kevin_Bentley]
+descent3         2092/udp # Descent 3 [Kevin_Bentley] [Kevin_Bentley]
+nbx-cc           2093/tcp # NBX CC
+nbx-cc           2093/udp # NBX CC
+nbx-au           2094/tcp # NBX AU
+nbx-au           2094/udp # NBX AU
+nbx-ser          2095/tcp # NBX SER
+nbx-ser          2095/udp # NBX SER
+nbx-dir          2096/tcp # NBX DIR [Henry_Houh] [Henry_Houh]
+nbx-dir          2096/udp # NBX DIR [Henry_Houh] [Henry_Houh]
+jetformpreview   2097/tcp # Jet Form Preview [Zygmunt_Wiercioch] [Zygmunt_Wiercioch]
+jetformpreview   2097/udp # Jet Form Preview [Zygmunt_Wiercioch] [Zygmunt_Wiercioch]
+dialog-port      2098/tcp # Dialog Port [Joseph_Mathew] [Joseph_Mathew]
+dialog-port      2098/udp # Dialog Port [Joseph_Mathew] [Joseph_Mathew]
+h2250-annex-g    2099/tcp # H.225.0 Annex G Signalling [ITU-T] [ITU-T_TSB] 2013-01-31
+h2250-annex-g    2099/udp # H.225.0 Annex G Signalling [ITU-T] [ITU-T_TSB] 2013-01-31
+amiganetfs       2100/tcp # Amiga Network Filesystem [Rudi_Chiarito] [Rudi_Chiarito]
+amiganetfs       2100/udp # Amiga Network Filesystem [Rudi_Chiarito] [Rudi_Chiarito]
+rtcm-sc104       2101/tcp # rtcm-sc104 [Wolfgang_Rupprecht] [Wolfgang_Rupprecht]
+rtcm-sc104       2101/udp # rtcm-sc104 [Wolfgang_Rupprecht] [Wolfgang_Rupprecht]
+zephyr-srv       2102/tcp # Zephyr server
+zephyr-srv       2102/udp # Zephyr server
+zephyr-clt       2103/tcp # Zephyr serv-hm connection
+zephyr-clt       2103/udp # Zephyr serv-hm connection
+zephyr-hm        2104/tcp # Zephyr hostmanager [Greg_Hudson] [Greg_Hudson]
+zephyr-hm        2104/udp # Zephyr hostmanager [Greg_Hudson] [Greg_Hudson]
+minipay          2105/tcp # MiniPay [Amir_Herzberg] [Amir_Herzberg]
+minipay          2105/udp # MiniPay [Amir_Herzberg] [Amir_Herzberg]
+mzap             2106/tcp # MZAP [Dave_Thaler_2] [Dave_Thaler_2]
+mzap             2106/udp # MZAP [Dave_Thaler_2] [Dave_Thaler_2]
+bintec-admin     2107/tcp # BinTec Admin [Thomas_Schmidt] [Thomas_Schmidt]
+bintec-admin     2107/udp # BinTec Admin [Thomas_Schmidt] [Thomas_Schmidt]
+comcam           2108/tcp # Comcam [Don_Gilbreath] [Don_Gilbreath]
+comcam           2108/udp # Comcam [Don_Gilbreath] [Don_Gilbreath]
+ergolight        2109/tcp # Ergolight [Jindra_Ryvola] [Jindra_Ryvola]
+ergolight        2109/udp # Ergolight [Jindra_Ryvola] [Jindra_Ryvola]
+umsp             2110/tcp # UMSP [Alexander_Bogdanov_2] [Alexander_Bogdanov_2]
+umsp             2110/udp # UMSP [Alexander_Bogdanov_2] [Alexander_Bogdanov_2]
+dsatp            2111/tcp # OPNET Dynamic Sampling Agent Transaction Protocol [OPNET_Technologies_Inc] [Edward_Macomber] 2011-09-21
+dsatp            2111/udp # OPNET Dynamic Sampling Agent Transaction Protocol [OPNET_Technologies_Inc] [Edward_Macomber] 2011-09-21
+idonix-metanet   2112/tcp # Idonix MetaNet [Paul_Harrison] [Paul_Harrison]
+idonix-metanet   2112/udp # Idonix MetaNet [Paul_Harrison] [Paul_Harrison]
+hsl-storm        2113/tcp # HSL StoRM [Jost_Faganel] [Jost_Faganel]
+hsl-storm        2113/udp # HSL StoRM [Jost_Faganel] [Jost_Faganel]
+newheights       2114/tcp # NEWHEIGHTS [Michael_Levy] [Michael_Levy]
+newheights       2114/udp # NEWHEIGHTS [Michael_Levy] [Michael_Levy]
+kdm              2115/tcp # Key Distribution Manager [Mike_Little] [Mike_Little]
+kdm              2115/udp # Key Distribution Manager [Mike_Little] [Mike_Little]
+ccowcmr          2116/tcp # CCOWCMR [Mark_Morwood] [Mark_Morwood]
+ccowcmr          2116/udp # CCOWCMR [Mark_Morwood] [Mark_Morwood]
+mentaclient      2117/tcp # MENTACLIENT
+mentaclient      2117/udp # MENTACLIENT
+mentaserver      2118/tcp # MENTASERVER [Ilan_Shlosberg] [Ilan_Shlosberg]
+mentaserver      2118/udp # MENTASERVER [Ilan_Shlosberg] [Ilan_Shlosberg]
+gsigatekeeper    2119/tcp # GSIGATEKEEPER [Steve_Tuecke] [Steve_Tuecke]
+gsigatekeeper    2119/udp # GSIGATEKEEPER [Steve_Tuecke] [Steve_Tuecke]
+qencp            2120/tcp # Quick Eagle Networks CP [Santa_Dasu] [Santa_Dasu]
+qencp            2120/udp # Quick Eagle Networks CP [Santa_Dasu] [Santa_Dasu]
+scientia-ssdb    2121/tcp # SCIENTIA-SSDB [SYSTEMS_MANAGER] [SYSTEMS_MANAGER]
+scientia-ssdb    2121/udp # SCIENTIA-SSDB [SYSTEMS_MANAGER] [SYSTEMS_MANAGER]
+caupc-remote     2122/tcp # CauPC Remote Control [Environics_Oy] [Environics_Oy]
+caupc-remote     2122/udp # CauPC Remote Control [Environics_Oy] [Environics_Oy]
+gtp-control      2123/tcp # GTP-Control Plane (3GPP) [Alessio_Casati] [Alessio_Casati]
+gtp-control      2123/udp # GTP-Control Plane (3GPP) [Alessio_Casati] [Alessio_Casati]
+elatelink        2124/tcp # ELATELINK [Tim_Lawrence] [Tim_Lawrence]
+elatelink        2124/udp # ELATELINK [Tim_Lawrence] [Tim_Lawrence]
+lockstep         2125/tcp # LOCKSTEP [Karl_Forster] [Karl_Forster]
+lockstep         2125/udp # LOCKSTEP [Karl_Forster] [Karl_Forster]
+pktcable-cops    2126/tcp # PktCable-COPS [Glenn_Russell] [Glenn_Russell]
+pktcable-cops    2126/udp # PktCable-COPS [Glenn_Russell] [Glenn_Russell]
+index-pc-wb      2127/tcp # INDEX-PC-WB [James_David_Fisher] [James_David_Fisher]
+index-pc-wb      2127/udp # INDEX-PC-WB [James_David_Fisher] [James_David_Fisher]
+net-steward      2128/tcp # Net Steward Control [Martin_Norman] [Martin_Norman]
+net-steward      2128/udp # Net Steward Control [Martin_Norman] [Martin_Norman]
+cs-live          2129/tcp # cs-live.com [Matt_Lachance] [Matt_Lachance]
+cs-live          2129/udp # cs-live.com [Matt_Lachance] [Matt_Lachance]
+xds              2130/tcp # XDS [Peter_Zurich] [Peter_Zurich]
+xds              2130/udp # XDS [Peter_Zurich] [Peter_Zurich]
+avantageb2b      2131/tcp # Avantageb2b [Avi_Software] [Avi_Software]
+avantageb2b      2131/udp # Avantageb2b [Avi_Software] [Avi_Software]
+solera-epmap     2132/tcp # SoleraTec End Point Map [Mark_Armstrong] [Mark_Armstrong]
+solera-epmap     2132/udp # SoleraTec End Point Map [Mark_Armstrong] [Mark_Armstrong]
+zymed-zpp        2133/tcp # ZYMED-ZPP [Gregg_Welker] [Gregg_Welker]
+zymed-zpp        2133/udp # ZYMED-ZPP [Gregg_Welker] [Gregg_Welker]
+avenue           2134/tcp # AVENUE [Jason_Cater] [Jason_Cater]
+avenue           2134/udp # AVENUE [Jason_Cater] [Jason_Cater]
+gris             2135/tcp # Grid Resource Information Server [Steve_Tuecke] [Steve_Tuecke]
+gris             2135/udp # Grid Resource Information Server [Steve_Tuecke] [Steve_Tuecke]
+appworxsrv       2136/tcp # APPWORXSRV [Fred_McLain] [Fred_McLain]
+appworxsrv       2136/udp # APPWORXSRV [Fred_McLain] [Fred_McLain]
+connect          2137/tcp # CONNECT [Reid_Ligon] [Reid_Ligon]
+connect          2137/udp # CONNECT [Reid_Ligon] [Reid_Ligon]
+unbind-cluster   2138/tcp # UNBIND-CLUSTER [Francois_Harvey] [Francois_Harvey]
+unbind-cluster   2138/udp # UNBIND-CLUSTER [Francois_Harvey] [Francois_Harvey]
+ias-auth         2139/tcp # IAS-AUTH
+ias-auth         2139/udp # IAS-AUTH
+ias-reg          2140/tcp # IAS-REG
+ias-reg          2140/udp # IAS-REG
+ias-admind       2141/tcp # IAS-ADMIND [Baiju_V_Patel] [Baiju_V_Patel]
+ias-admind       2141/udp # IAS-ADMIND [Baiju_V_Patel] [Baiju_V_Patel]
+tdmoip           2142/tcp # TDM OVER IP [RFC5087]
+tdmoip           2142/udp # TDM OVER IP [RFC5087]
+lv-jc            2143/tcp # Live Vault Job Control
+lv-jc            2143/udp # Live Vault Job Control
+lv-ffx           2144/tcp # Live Vault Fast Object Transfer
+lv-ffx           2144/udp # Live Vault Fast Object Transfer
+lv-pici          2145/tcp # Live Vault Remote Diagnostic Console Support
+lv-pici          2145/udp # Live Vault Remote Diagnostic Console Support
+lv-not           2146/tcp # Live Vault Admin Event Notification
+lv-not           2146/udp # Live Vault Admin Event Notification
+lv-auth          2147/tcp # Live Vault Authentication [Ted_Hess] [Ted_Hess]
+lv-auth          2147/udp # Live Vault Authentication [Ted_Hess] [Ted_Hess]
+veritas-ucl      2148/tcp # VERITAS UNIVERSAL COMMUNICATION LAYER [Songlin_Ren] [Songlin_Ren]
+veritas-ucl      2148/udp # VERITAS UNIVERSAL COMMUNICATION LAYER [Songlin_Ren] [Songlin_Ren]
+acptsys          2149/tcp # ACPTSYS [Michael_Lekias] [Michael_Lekias]
+acptsys          2149/udp # ACPTSYS [Michael_Lekias] [Michael_Lekias]
+dynamic3d        2150/tcp # DYNAMIC3D [Tobias_Wegner] [Tobias_Wegner]
+dynamic3d        2150/udp # DYNAMIC3D [Tobias_Wegner] [Tobias_Wegner]
+docent           2151/tcp # DOCENT [Hali_Lindbloom] [Hali_Lindbloom]
+docent           2151/udp # DOCENT [Hali_Lindbloom] [Hali_Lindbloom]
+gtp-user         2152/tcp # GTP-User Plane (3GPP) [Alessio_Casati] [Alessio_Casati]
+gtp-user         2152/udp # GTP-User Plane (3GPP) [Alessio_Casati] [Alessio_Casati]
+ctlptc           2153/tcp # Control Protocol
+ctlptc           2153/udp # Control Protocol
+stdptc           2154/tcp # Standard Protocol
+stdptc           2154/udp # Standard Protocol
+brdptc           2155/tcp # Bridge Protocol [Hideki_Hatta] [Hideki_Hatta] 2007-09-27
+brdptc           2155/udp # Bridge Protocol [Hideki_Hatta] [Hideki_Hatta] 2007-09-27
+trp              2156/tcp # Talari Reliable Protocol [John_E_Dickey] [John_E_Dickey] 2007-09-27
+trp              2156/udp # Talari Reliable Protocol [John_E_Dickey] [John_E_Dickey] 2007-09-27
+xnds             2157/tcp # Xerox Network Document Scan Protocol [William_R_Lear] [William_R_Lear] 2008-03-06
+xnds             2157/udp # Xerox Network Document Scan Protocol [William_R_Lear] [William_R_Lear] 2008-03-06
+touchnetplus     2158/tcp # TouchNetPlus Service [Brian_Toothill] [Brian_Toothill] 2008-03-06
+touchnetplus     2158/udp # TouchNetPlus Service [Brian_Toothill] [Brian_Toothill] 2008-03-06
+gdbremote        2159/tcp # GDB Remote Debug Port [Nigel_Stephens] [Nigel_Stephens]
+gdbremote        2159/udp # GDB Remote Debug Port [Nigel_Stephens] [Nigel_Stephens]
+apc-2160         2160/tcp # APC 2160 [American_Power_Conve] [American_Power_Conve]
+apc-2160         2160/udp # APC 2160 [American_Power_Conve] [American_Power_Conve]
+apc-2161         2161/tcp # APC 2161 [American_Power_Conve] [American_Power_Conve]
+apc-2161         2161/udp # APC 2161 [American_Power_Conve] [American_Power_Conve]
+navisphere       2162/tcp # Navisphere
+navisphere       2162/udp # Navisphere
+navisphere-sec   2163/tcp # Navisphere Secure [Andreas_Bauer] [Andreas_Bauer]
+navisphere-sec   2163/udp # Navisphere Secure [Andreas_Bauer] [Andreas_Bauer]
+ddns-v3          2164/tcp # Dynamic DNS Version 3 [Alan_Yates] [Alan_Yates]
+ddns-v3          2164/udp # Dynamic DNS Version 3 [Alan_Yates] [Alan_Yates]
+x-bone-api       2165/tcp # X-Bone API [Joe_Touch] [Joe_Touch]
+x-bone-api       2165/udp # X-Bone API [Joe_Touch] [Joe_Touch]
+iwserver         2166/tcp # iwserver [Fred_Surr] [Fred_Surr]
+iwserver         2166/udp # iwserver [Fred_Surr] [Fred_Surr]
+raw-serial       2167/tcp # Raw Async Serial Link [Benjamin_Green] [Benjamin_Green]
+raw-serial       2167/udp # Raw Async Serial Link [Benjamin_Green] [Benjamin_Green]
+easy-soft-mux    2168/tcp # easy-soft Multiplexer [Norbert_Kintzler] [Norbert_Kintzler] 2004-11
+easy-soft-mux    2168/udp # easy-soft Multiplexer [Norbert_Kintzler] [Norbert_Kintzler] 2004-11
+brain            2169/tcp # Backbone for Academic Information Notification (BRAIN) [Archishmat_Gore] [Archishmat_Gore] 2004-11
+brain            2169/udp # Backbone for Academic Information Notification (BRAIN) [Archishmat_Gore] [Archishmat_Gore] 2004-11
+eyetv            2170/tcp # EyeTV Server Port [Elgato_Systems] [Elgato_Systems] 2004-11
+eyetv            2170/udp # EyeTV Server Port [Elgato_Systems] [Elgato_Systems] 2004-11
+msfw-storage     2171/tcp # MS Firewall Storage
+msfw-storage     2171/udp # MS Firewall Storage
+msfw-s-storage   2172/tcp # MS Firewall SecureStorage
+msfw-s-storage   2172/udp # MS Firewall SecureStorage
+msfw-replica     2173/tcp # MS Firewall Replication
+msfw-replica     2173/udp # MS Firewall Replication
+msfw-array       2174/tcp # MS Firewall Intra Array [Itai_Greenberg] [Itai_Greenberg] 2004-11
+msfw-array       2174/udp # MS Firewall Intra Array [Itai_Greenberg] [Itai_Greenberg] 2004-11
+airsync          2175/tcp # Microsoft Desktop AirSync Protocol
+airsync          2175/udp # Microsoft Desktop AirSync Protocol
+rapi             2176/tcp # Microsoft ActiveSync Remote API [Jon_Xu] [Jon_Xu] 2005-08
+rapi             2176/udp # Microsoft ActiveSync Remote API [Jon_Xu] [Jon_Xu] 2005-08
+qwave            2177/tcp # qWAVE Bandwidth Estimate [Gabe_Frost] [Gabe_Frost] 2005-08
+qwave            2177/udp # qWAVE Bandwidth Estimate [Gabe_Frost] [Gabe_Frost] 2005-08
+bitspeer         2178/tcp # Peer Services for BITS [Jeff_Roberts] [Jeff_Roberts] 2005-11
+bitspeer         2178/udp # Peer Services for BITS [Jeff_Roberts] [Jeff_Roberts] 2005-11
+vmrdp            2179/tcp # Microsoft RDP for virtual machines [Brian_Henry] [Brian_Henry] 2007-03
+vmrdp            2179/udp # Microsoft RDP for virtual machines [Brian_Henry] [Brian_Henry] 2007-03
+mc-gt-srv        2180/tcp # Millicent Vendor Gateway Server [Steve_Glassman] [Steve_Glassman]
+mc-gt-srv        2180/udp # Millicent Vendor Gateway Server [Steve_Glassman] [Steve_Glassman]
+eforward         2181/tcp # eforward [Greg_Pringle] [Greg_Pringle]
+eforward         2181/udp # eforward [Greg_Pringle] [Greg_Pringle]
+cgn-stat         2182/tcp # CGN status
+cgn-stat         2182/udp # CGN status
+cgn-config       2183/tcp # Code Green configuration [Chris_Michaelson] [Chris_Michaelson] 2005-08
+cgn-config       2183/udp # Code Green configuration [Chris_Michaelson] [Chris_Michaelson] 2005-08
+nvd              2184/tcp # NVD User [Yves_Gattegno] [Yves_Gattegno] 2004-12
+nvd              2184/udp # NVD User [Yves_Gattegno] [Yves_Gattegno] 2004-12
+onbase-dds       2185/tcp # OnBase Distributed Disk Services [Paul_Tam] [Paul_Tam] 2004-12
+onbase-dds       2185/udp # OnBase Distributed Disk Services [Paul_Tam] [Paul_Tam] 2004-12
+gtaua            2186/tcp # Guy-Tek Automated Update Applications [Daniel_Story] [Daniel_Story] 2008-01-25
+gtaua            2186/udp # Guy-Tek Automated Update Applications [Daniel_Story] [Daniel_Story] 2008-01-25
+ssmc             2187/tcp # Sepehr System Management Control
+ssmd             2187/udp # Sepehr System Management Data [Shahriar_Pourazin] [Shahriar_Pourazin] 2008-12-02
+radware-rpm      2188/tcp # Radware Resource Pool Manager [Radware_LTD] [Samuel_Bercovici] 2011-08-05
+radware-rpm-s    2189/tcp # Secure Radware Resource Pool Manager [Radware_LTD] [Samuel_Bercovici] 2011-08-05
+tivoconnect      2190/tcp # TiVoConnect Beacon [Jeffrey_J_Peters] [Jeffrey_J_Peters] 2002-08
+tivoconnect      2190/udp # TiVoConnect Beacon [Jeffrey_J_Peters] [Jeffrey_J_Peters] 2002-08
+tvbus            2191/tcp # TvBus Messaging [Brian_W_Beach] [Brian_W_Beach] 2003-01
+tvbus            2191/udp # TvBus Messaging [Brian_W_Beach] [Brian_W_Beach] 2003-01
+asdis            2192/tcp # ASDIS software management [ASDIS_Support] [ASDIS_Support] 2005-08
+asdis            2192/udp # ASDIS software management [ASDIS_Support] [ASDIS_Support] 2005-08
+drwcs            2193/tcp # Dr.Web Enterprise Management Service [Eugeny_Gladkih] [Eugeny_Gladkih] 2008-01-31
+drwcs            2193/udp # Dr.Web Enterprise Management Service [Eugeny_Gladkih] [Eugeny_Gladkih] 2008-01-31
+mnp-exchange     2197/tcp # MNP data exchange [Peter_Pramberger] [Peter_Pramberger] 2004-11
+mnp-exchange     2197/udp # MNP data exchange [Peter_Pramberger] [Peter_Pramberger] 2004-11
+onehome-remote   2198/tcp # OneHome Remote Access
+onehome-remote   2198/udp # OneHome Remote Access
+onehome-help     2199/tcp # OneHome Service Port [Jim_Herman] [Jim_Herman] 2005-08
+onehome-help     2199/udp # OneHome Service Port [Jim_Herman] [Jim_Herman] 2005-08
+ici              2200/tcp # ICI [Brent_Hines] [Brent_Hines]
+ici              2200/udp # ICI [Brent_Hines] [Brent_Hines]
+ats              2201/tcp # Advanced Training System Program
+ats              2201/udp # Advanced Training System Program
+imtc-map         2202/tcp # Int. Multimedia Teleconferencing Cosortium [Pat_Galvin] [Pat_Galvin]
+imtc-map         2202/udp # Int. Multimedia Teleconferencing Cosortium [Pat_Galvin] [Pat_Galvin]
+b2-runtime       2203/tcp # b2 Runtime Protocol
+b2-runtime       2203/udp # b2 Runtime Protocol
+b2-license       2204/tcp # b2 License Server [Helge_Frank_Zimpel] [Helge_Frank_Zimpel] 2006-01
+b2-license       2204/udp # b2 License Server [Helge_Frank_Zimpel] [Helge_Frank_Zimpel] 2006-01
+jps              2205/tcp # Java Presentation Server [Leif_Jakob] [Leif_Jakob] 2006-01
+jps              2205/udp # Java Presentation Server [Leif_Jakob] [Leif_Jakob] 2006-01
+hpocbus          2206/tcp # HP OpenCall bus [Jerome_Forissier] [Jerome_Forissier] 2005-12
+hpocbus          2206/udp # HP OpenCall bus [Jerome_Forissier] [Jerome_Forissier] 2005-12
+hpssd            2207/tcp # HP Status and Services [Donald_Welch] [Donald_Welch] 2006-05
+hpssd            2207/udp # HP Status and Services [Donald_Welch] [Donald_Welch] 2006-05
+hpiod            2208/tcp # HP I/O Backend [David_Suffield] [David_Suffield] 2006-05
+hpiod            2208/udp # HP I/O Backend [David_Suffield] [David_Suffield] 2006-05
+rimf-ps          2209/tcp # HP RIM for Files Portal Service [Patty_Ho] [Patty_Ho] 2007-05
+rimf-ps          2209/udp # HP RIM for Files Portal Service [Patty_Ho] [Patty_Ho] 2007-05
+noaaport         2210/tcp # NOAAPORT Broadcast Network
+noaaport         2210/udp # NOAAPORT Broadcast Network
+emwin            2211/tcp # EMWIN [Antonio_Querubin] [Antonio_Querubin] 2008-03-10
+emwin            2211/udp # EMWIN [Antonio_Querubin] [Antonio_Querubin] 2008-03-10
+leecoposserver   2212/tcp # LeeCO POS Server Service [Patrick_Lee] [Patrick_Lee] 2008-03-10
+leecoposserver   2212/udp # LeeCO POS Server Service [Patrick_Lee] [Patrick_Lee] 2008-03-10
+kali             2213/tcp # Kali [Jay_Cotton] [Jay_Cotton]
+kali             2213/udp # Kali [Jay_Cotton] [Jay_Cotton]
+rpi              2214/tcp # RDQ Protocol Interface [Les_Mather] [Les_Mather] 2005-12
+rpi              2214/udp # RDQ Protocol Interface [Les_Mather] [Les_Mather] 2005-12
+ipcore           2215/tcp # IPCore.co.za GPRS [Administrator] [Administrator] 2005-12
+ipcore           2215/udp # IPCore.co.za GPRS [Administrator] [Administrator] 2005-12
+vtu-comms        2216/tcp # VTU data service [David_Barrass] [David_Barrass] 2006-01
+vtu-comms        2216/udp # VTU data service [David_Barrass] [David_Barrass] 2006-01
+gotodevice       2217/tcp # GoToDevice Device Management [John_Lisek] [John_Lisek] 2006-01
+gotodevice       2217/udp # GoToDevice Device Management [John_Lisek] [John_Lisek] 2006-01
+bounzza          2218/tcp # Bounzza IRC Proxy [Danko_Alexeyev] [Danko_Alexeyev] 2006-02
+bounzza          2218/udp # Bounzza IRC Proxy [Danko_Alexeyev] [Danko_Alexeyev] 2006-02
+netiq-ncap       2219/tcp # NetIQ NCAP Protocol [Roger_Huebner] [Roger_Huebner] 2010-08-25
+netiq-ncap       2219/udp # NetIQ NCAP Protocol [Roger_Huebner] [Roger_Huebner] 2010-08-25
+netiq            2220/tcp # NetIQ End2End [Michael_Sharpe] [Michael_Sharpe] 2010-09-14
+netiq            2220/udp # NetIQ End2End [Michael_Sharpe] [Michael_Sharpe] 2010-09-14
+rockwell-csp1    2221/tcp # Rockwell CSP1 [Brian_Batke] [Brian_Batke]
+rockwell-csp1    2221/udp # Rockwell CSP1 [Brian_Batke] [Brian_Batke]
+EtherNet-IP-1    2222/tcp # EtherNet/IP I/OIANA assigned this well-formed service name as a replacement for "EtherNet/IP-1". [Brian_Batke_2] [Brian_Batke_2] New contact added for port 2222 on 2008-02-01
+EtherNet/IP-1    2222/tcp # EtherNet/IP I/O [Brian_Batke_2] [Brian_Batke_2] New contact added for port 2222 on 2008-02-01This entry is an alias to "EtherNet-IP-1".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+EtherNet-IP-1    2222/udp # EtherNet/IP I/OIANA assigned this well-formed service name as a replacement for "EtherNet/IP-1". [Brian_Batke_2] [Brian_Batke_2] New contact added for port 2222 on 2008-02-01
+EtherNet/IP-1    2222/udp # EtherNet/IP I/O [Brian_Batke_2] [Brian_Batke_2] New contact added for port 2222 on 2008-02-01This entry is an alias to "EtherNet-IP-1".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+rockwell-csp2    2223/tcp # Rockwell CSP2 [Brian_Batke] [Brian_Batke]
+rockwell-csp2    2223/udp # Rockwell CSP2 [Brian_Batke] [Brian_Batke]
+efi-mg           2224/tcp # Easy Flexible Internet/Multiplayer Games [Thomas_Efer] [Thomas_Efer] 2006-03
+efi-mg           2224/udp # Easy Flexible Internet/Multiplayer Games [Thomas_Efer] [Thomas_Efer] 2006-03
+rcip-itu         2225/tcp # Resource Connection Initiation Protocol [ITU_TSB] [ITU_TSB]
+rcip-itu         2225/sctp # Resource Connection Initiation Protocol [ITU_TSB] [ITU_TSB]
+di-drm           2226/tcp # Digital Instinct DRM
+di-drm           2226/udp # Digital Instinct DRM
+di-msg           2227/tcp # DI Messaging Service [Sean_Ni] [Sean_Ni] 2006-02
+di-msg           2227/udp # DI Messaging Service [Sean_Ni] [Sean_Ni] 2006-02
+ehome-ms         2228/tcp # eHome Message Server [Peter_Gabriel] [Peter_Gabriel] 2006-01
+ehome-ms         2228/udp # eHome Message Server [Peter_Gabriel] [Peter_Gabriel] 2006-01
+datalens         2229/tcp # DataLens Service [Christopher_Bidwell] [Christopher_Bidwell] 2006-02
+datalens         2229/udp # DataLens Service [Christopher_Bidwell] [Christopher_Bidwell] 2006-02
+queueadm         2230/tcp # MetaSoft Job Queue Administration Service [Ilya_Melamed] [Ilya_Melamed] 2006-06
+queueadm         2230/udp # MetaSoft Job Queue Administration Service [Ilya_Melamed] [Ilya_Melamed] 2006-06
+wimaxasncp       2231/tcp # WiMAX ASN Control Plane Protocol [Prakash_Iyer] [Prakash_Iyer] 2006-06
+wimaxasncp       2231/udp # WiMAX ASN Control Plane Protocol [Prakash_Iyer] [Prakash_Iyer] 2006-06
+ivs-video        2232/tcp # IVS Video default [Thierry_Turletti] [Thierry_Turletti]
+ivs-video        2232/udp # IVS Video default [Thierry_Turletti] [Thierry_Turletti]
+infocrypt        2233/tcp # INFOCRYPT [Erica_Liu] [Erica_Liu]
+infocrypt        2233/udp # INFOCRYPT [Erica_Liu] [Erica_Liu]
+directplay       2234/tcp # DirectPlay [Ajay_Jindal] [Ajay_Jindal]
+directplay       2234/udp # DirectPlay [Ajay_Jindal] [Ajay_Jindal]
+sercomm-wlink    2235/tcp # Sercomm-WLink [Melinda_Tsao] [Melinda_Tsao]
+sercomm-wlink    2235/udp # Sercomm-WLink [Melinda_Tsao] [Melinda_Tsao]
+nani             2236/tcp # Nani [Steve_Benoit] [Steve_Benoit]
+nani             2236/udp # Nani [Steve_Benoit] [Steve_Benoit]
+optech-port1-lm  2237/tcp # Optech Port1 License Manager [Gerard_Cannie] [Gerard_Cannie]
+optech-port1-lm  2237/udp # Optech Port1 License Manager [Gerard_Cannie] [Gerard_Cannie]
+aviva-sna        2238/tcp # AVIVA SNA SERVER [Vick_Keshishian] [Vick_Keshishian]
+aviva-sna        2238/udp # AVIVA SNA SERVER [Vick_Keshishian] [Vick_Keshishian]
+imagequery       2239/tcp # Image Query [Charles_Jacobs] [Charles_Jacobs]
+imagequery       2239/udp # Image Query [Charles_Jacobs] [Charles_Jacobs]
+recipe           2240/tcp # RECIPe [Charlie_Limoges] [Charlie_Limoges] 1997-12-16
+recipe           2240/udp # RECIPe [Charlie_Limoges] [Charlie_Limoges] 1997-12-16
+ivsd             2241/tcp # IVS Daemon [Thierry_Turletti] [Thierry_Turletti]
+ivsd             2241/udp # IVS Daemon [Thierry_Turletti] [Thierry_Turletti]
+foliocorp        2242/tcp # Folio Remote Server [Pat_Mcgowan] [Pat_Mcgowan]
+foliocorp        2242/udp # Folio Remote Server [Pat_Mcgowan] [Pat_Mcgowan]
+magicom          2243/tcp # Magicom Protocol [Yossi_Appleboum] [Yossi_Appleboum]
+magicom          2243/udp # Magicom Protocol [Yossi_Appleboum] [Yossi_Appleboum]
+nmsserver        2244/tcp # NMS Server [Dmitry_Krasnonosenki] [Dmitry_Krasnonosenki]
+nmsserver        2244/udp # NMS Server [Dmitry_Krasnonosenki] [Dmitry_Krasnonosenki]
+hao              2245/tcp # HaO [Panic_Ride] [Panic_Ride]
+hao              2245/udp # HaO [Panic_Ride] [Panic_Ride]
+pc-mta-addrmap   2246/tcp # PacketCable MTA Addr Map [Dave_Maxwell] [Dave_Maxwell]
+pc-mta-addrmap   2246/udp # PacketCable MTA Addr Map [Dave_Maxwell] [Dave_Maxwell]
+antidotemgrsvr   2247/tcp # Antidote Deployment Manager Service [Rod_Waltermann] [Rod_Waltermann] 2006-02
+antidotemgrsvr   2247/udp # Antidote Deployment Manager Service [Rod_Waltermann] [Rod_Waltermann] 2006-02
+ums              2248/tcp # User Management Service [Andrew_Crockford] [Andrew_Crockford]
+ums              2248/udp # User Management Service [Andrew_Crockford] [Andrew_Crockford]
+rfmp             2249/tcp # RISO File Manager Protocol [Shinji_Yamanaka] [Shinji_Yamanaka]
+rfmp             2249/udp # RISO File Manager Protocol [Shinji_Yamanaka] [Shinji_Yamanaka]
+remote-collab    2250/tcp # remote-collab [Richard_Walters] [Richard_Walters]
+remote-collab    2250/udp # remote-collab [Richard_Walters] [Richard_Walters]
+dif-port         2251/tcp # Distributed Framework Port [Sebastien_Lambla] [Sebastien_Lambla]
+dif-port         2251/udp # Distributed Framework Port [Sebastien_Lambla] [Sebastien_Lambla]
+njenet-ssl       2252/tcp # NJENET using SSL [Hans_U_Schmidt] [Hans_U_Schmidt]
+njenet-ssl       2252/udp # NJENET using SSL [Hans_U_Schmidt] [Hans_U_Schmidt]
+dtv-chan-req     2253/tcp # DTV Channel Request [Richard_Hodges] [Richard_Hodges]
+dtv-chan-req     2253/udp # DTV Channel Request [Richard_Hodges] [Richard_Hodges]
+seispoc          2254/tcp # Seismic P.O.C. Port [Robert_Reimiller] [Robert_Reimiller]
+seispoc          2254/udp # Seismic P.O.C. Port [Robert_Reimiller] [Robert_Reimiller]
+vrtp             2255/tcp # VRTP - ViRtue Transfer Protocol [Max_Fudim] [Max_Fudim]
+vrtp             2255/udp # VRTP - ViRtue Transfer Protocol [Max_Fudim] [Max_Fudim]
+pcc-mfp          2256/tcp # PCC MFP [Kunihiko_Morota] [Kunihiko_Morota] 2005-08
+pcc-mfp          2256/udp # PCC MFP [Kunihiko_Morota] [Kunihiko_Morota] 2005-08
+simple-tx-rx     2257/tcp # simple text/file transfer [Daniel_Kilsdonk] [Daniel_Kilsdonk] 2006-08
+simple-tx-rx     2257/udp # simple text/file transfer [Daniel_Kilsdonk] [Daniel_Kilsdonk] 2006-08
+rcts             2258/tcp # Rotorcraft Communications Test System [Terry_Eldridge] [Terry_Eldridge] 2006-08
+rcts             2258/udp # Rotorcraft Communications Test System [Terry_Eldridge] [Terry_Eldridge] 2006-08
+apc-2260         2260/tcp # APC 2260 [American_Power_Conve] [American_Power_Conve] 2002-02
+apc-2260         2260/udp # APC 2260 [American_Power_Conve] [American_Power_Conve] 2002-02
+comotionmaster   2261/tcp # CoMotion Master Server
+comotionmaster   2261/udp # CoMotion Master Server
+comotionback     2262/tcp # CoMotion Backup Server [Friedman_Wagner_Dobl] [Friedman_Wagner_Dobl] 2005-09
+comotionback     2262/udp # CoMotion Backup Server [Friedman_Wagner_Dobl] [Friedman_Wagner_Dobl] 2005-09
+ecwcfg           2263/tcp # ECweb Configuration Service [Anders_Hjelm] [Anders_Hjelm] 2006-03
+ecwcfg           2263/udp # ECweb Configuration Service [Anders_Hjelm] [Anders_Hjelm] 2006-03
+apx500api-1      2264/tcp # Audio Precision Apx500 API Port 1
+apx500api-1      2264/udp # Audio Precision Apx500 API Port 1
+apx500api-2      2265/tcp # Audio Precision Apx500 API Port 2 [Robert_Wright] [Robert_Wright]
+apx500api-2      2265/udp # Audio Precision Apx500 API Port 2 [Robert_Wright] [Robert_Wright]
+mfserver         2266/tcp # M-Files Server [Samppa_Lahtinen] [Samppa_Lahtinen] 2004-06
+mfserver         2266/udp # M-files Server [Samppa_Lahtinen] [Samppa_Lahtinen] 2004-06
+ontobroker       2267/tcp # OntoBroker [Dr_Michael_Erdmann] [Dr_Michael_Erdmann] 2004-12
+ontobroker       2267/udp # OntoBroker [Dr_Michael_Erdmann] [Dr_Michael_Erdmann] 2004-12
+amt              2268/tcp # AMT [Tom_Pusateri] [Tom_Pusateri] 2004-12
+amt              2268/udp # AMT [Tom_Pusateri] [Tom_Pusateri] 2004-12
+mikey            2269/tcp # MIKEY [Karl_Norrman] [Karl_Norrman] 2004-12
+mikey            2269/udp # MIKEY [Karl_Norrman] [Karl_Norrman] 2004-12
+starschool       2270/tcp # starSchool [Adam_Ernst] [Adam_Ernst] 2004-12
+starschool       2270/udp # starSchool [Adam_Ernst] [Adam_Ernst] 2004-12
+mmcals           2271/tcp # Secure Meeting Maker Scheduling
+mmcals           2271/udp # Secure Meeting Maker Scheduling
+mmcal            2272/tcp # Meeting Maker Scheduling [Andrew_H_Derbyshire] [Andrew_H_Derbyshire] 2004-12
+mmcal            2272/udp # Meeting Maker Scheduling [Andrew_H_Derbyshire] [Andrew_H_Derbyshire] 2004-12
+mysql-im         2273/tcp # MySQL Instance Manager [Petr_Chardin] [Petr_Chardin] 2004-12
+mysql-im         2273/udp # MySQL Instance Manager [Petr_Chardin] [Petr_Chardin] 2004-12
+pcttunnell       2274/tcp # PCTTunneller [ProControl_Technolog] [ProControl_Technolog] 2004-12
+pcttunnell       2274/udp # PCTTunneller [ProControl_Technolog] [ProControl_Technolog] 2004-12
+ibridge-data     2275/tcp # iBridge Conferencing
+ibridge-data     2275/udp # iBridge Conferencing
+ibridge-mgmt     2276/tcp # iBridge Management [Patrick_Fisher] [Patrick_Fisher] 2004-12
+ibridge-mgmt     2276/udp # iBridge Management [Patrick_Fisher] [Patrick_Fisher] 2004-12
+bluectrlproxy    2277/tcp # Bt device control proxy [Mark_de_Rooi] [Mark_de_Rooi] 2004-12
+bluectrlproxy    2277/udp # Bt device control proxy [Mark_de_Rooi] [Mark_de_Rooi] 2004-12
+s3db             2278/tcp # Simple Stacked Sequences Database [David_Brandon] [David_Brandon] 2006-08
+s3db             2278/udp # Simple Stacked Sequences Database [David_Brandon] [David_Brandon] 2006-08
+xmquery          2279/tcp # xmquery [Niels_Christiansen] [Niels_Christiansen]
+xmquery          2279/udp # xmquery [Niels_Christiansen] [Niels_Christiansen]
+lnvpoller        2280/tcp # LNVPOLLER
+lnvpoller        2280/udp # LNVPOLLER
+lnvconsole       2281/tcp # LNVCONSOLE
+lnvconsole       2281/udp # LNVCONSOLE
+lnvalarm         2282/tcp # LNVALARM
+lnvalarm         2282/udp # LNVALARM
+lnvstatus        2283/tcp # LNVSTATUS
+lnvstatus        2283/udp # LNVSTATUS
+lnvmaps          2284/tcp # LNVMAPS
+lnvmaps          2284/udp # LNVMAPS
+lnvmailmon       2285/tcp # LNVMAILMON [John_Payne] [John_Payne]
+lnvmailmon       2285/udp # LNVMAILMON [John_Payne] [John_Payne]
+nas-metering     2286/tcp # NAS-Metering [Steven_Sawkins] [Steven_Sawkins]
+nas-metering     2286/udp # NAS-Metering [Steven_Sawkins] [Steven_Sawkins]
+dna              2287/tcp # DNA [Tung_Nguyen] [Tung_Nguyen]
+dna              2287/udp # DNA [Tung_Nguyen] [Tung_Nguyen]
+netml            2288/tcp # NETML [Jochen_Hansmeyer] [Jochen_Hansmeyer]
+netml            2288/udp # NETML [Jochen_Hansmeyer] [Jochen_Hansmeyer]
+dict-lookup      2289/tcp # Lookup dict server [William_Fernando_Mat] [William_Fernando_Mat] 2005-01
+dict-lookup      2289/udp # Lookup dict server [William_Fernando_Mat] [William_Fernando_Mat] 2005-01
+sonus-logging    2290/tcp # Sonus Logging Services [Adwait_Sathe] [Adwait_Sathe] 2005-08
+sonus-logging    2290/udp # Sonus Logging Services [Adwait_Sathe] [Adwait_Sathe] 2005-08
+eapsp            2291/tcp # EPSON Advanced Printer Share Protocol [SEIKO_EPSON] [SEIKO_EPSON] 2006-06
+eapsp            2291/udp # EPSON Advanced Printer Share Protocol [SEIKO_EPSON] [SEIKO_EPSON] 2006-06
+mib-streaming    2292/tcp # Sonus Element Management Services [Linda_Lin] [Linda_Lin] 2006-08
+mib-streaming    2292/udp # Sonus Element Management Services [Linda_Lin] [Linda_Lin] 2006-08
+npdbgmngr        2293/tcp # Network Platform Debug Manager [Robert_Byrne] [Robert_Byrne] 2006-09
+npdbgmngr        2293/udp # Network Platform Debug Manager [Robert_Byrne] [Robert_Byrne] 2006-09
+konshus-lm       2294/tcp # Konshus License Manager (FLEX) [Francois_Painchaud] [Francois_Painchaud]
+konshus-lm       2294/udp # Konshus License Manager (FLEX) [Francois_Painchaud] [Francois_Painchaud]
+advant-lm        2295/tcp # Advant License Manager [Lars_Goran_Magnusson] [Lars_Goran_Magnusson]
+advant-lm        2295/udp # Advant License Manager [Lars_Goran_Magnusson] [Lars_Goran_Magnusson]
+theta-lm         2296/tcp # Theta License Manager (Rainbow) [David_Thompson] [David_Thompson]
+theta-lm         2296/udp # Theta License Manager (Rainbow) [David_Thompson] [David_Thompson]
+d2k-datamover1   2297/tcp # D2K DataMover 1
+d2k-datamover1   2297/udp # D2K DataMover 1
+d2k-datamover2   2298/tcp # D2K DataMover 2 [Eric_Lan] [Eric_Lan]
+d2k-datamover2   2298/udp # D2K DataMover 2 [Eric_Lan] [Eric_Lan]
+pc-telecommute   2299/tcp # PC Telecommute [John_Daniel_Bonamico] [John_Daniel_Bonamico]
+pc-telecommute   2299/udp # PC Telecommute [John_Daniel_Bonamico] [John_Daniel_Bonamico]
+cvmmon           2300/tcp # CVMMON [Roger_Kumpf] [Roger_Kumpf]
+cvmmon           2300/udp # CVMMON [Roger_Kumpf] [Roger_Kumpf]
+cpq-wbem         2301/tcp # Compaq HTTP [Scott_Shaffer] [Scott_Shaffer]
+cpq-wbem         2301/udp # Compaq HTTP [Scott_Shaffer] [Scott_Shaffer]
+binderysupport   2302/tcp # Bindery Support [Narasimha_Rao_N] [Narasimha_Rao_N]
+binderysupport   2302/udp # Bindery Support [Narasimha_Rao_N] [Narasimha_Rao_N]
+proxy-gateway    2303/tcp # Proxy Gateway [Paul_Funk] [Paul_Funk]
+proxy-gateway    2303/udp # Proxy Gateway [Paul_Funk] [Paul_Funk]
+attachmate-uts   2304/tcp # Attachmate UTS [George_Gianelos] [George_Gianelos]
+attachmate-uts   2304/udp # Attachmate UTS [George_Gianelos] [George_Gianelos]
+mt-scaleserver   2305/tcp # MT ScaleServer [Paul_Glaubitz] [Paul_Glaubitz]
+mt-scaleserver   2305/udp # MT ScaleServer [Paul_Glaubitz] [Paul_Glaubitz]
+tappi-boxnet     2306/tcp # TAPPI BoxNet [Richard_Spartz] [Richard_Spartz]
+tappi-boxnet     2306/udp # TAPPI BoxNet [Richard_Spartz] [Richard_Spartz]
+pehelp           2307/tcp # pehelp [Jens_Kilian] [Jens_Kilian]
+pehelp           2307/udp # pehelp [Jens_Kilian] [Jens_Kilian]
+sdhelp           2308/tcp # sdhelp [Annette_Klecha] [Annette_Klecha]
+sdhelp           2308/udp # sdhelp [Annette_Klecha] [Annette_Klecha]
+sdserver         2309/tcp # SD Server
+sdserver         2309/udp # SD Server
+sdclient         2310/tcp # SD Client [Jeurgen_Broesamle] [Jeurgen_Broesamle]
+sdclient         2310/udp # SD Client [Jeurgen_Broesamle] [Jeurgen_Broesamle]
+messageservice   2311/tcp # Message Service
+messageservice   2311/udp # Message Service
+wanscaler        2312/tcp # WANScaler Communication Service [Allen_Samuels] [Allen_Samuels] 2006-11
+wanscaler        2312/udp # WANScaler Communication Service [Allen_Samuels] [Allen_Samuels] 2006-11
+iapp             2313/tcp # IAPP (Inter Access Point Protocol) [Henri_Moelard] [Henri_Moelard]
+iapp             2313/udp # IAPP (Inter Access Point Protocol) [Henri_Moelard] [Henri_Moelard]
+cr-websystems    2314/tcp # CR WebSystems [Robin_Giese] [Robin_Giese]
+cr-websystems    2314/udp # CR WebSystems [Robin_Giese] [Robin_Giese]
+precise-sft      2315/tcp # Precise Sft. [Michael_Landwehr] [Michael_Landwehr]
+precise-sft      2315/udp # Precise Sft. [Michael_Landwehr] [Michael_Landwehr]
+sent-lm          2316/tcp # SENT License Manager [Pisharath_Krishnan] [Pisharath_Krishnan]
+sent-lm          2316/udp # SENT License Manager [Pisharath_Krishnan] [Pisharath_Krishnan]
+attachmate-g32   2317/tcp # Attachmate G32 [Bryce_Bhatnagar] [Bryce_Bhatnagar]
+attachmate-g32   2317/udp # Attachmate G32 [Bryce_Bhatnagar] [Bryce_Bhatnagar]
+cadencecontrol   2318/tcp # Cadence Control [Buck_Caldwell] [Buck_Caldwell]
+cadencecontrol   2318/udp # Cadence Control [Buck_Caldwell] [Buck_Caldwell]
+infolibria       2319/tcp # InfoLibria [Chris_Chiotasso] [Chris_Chiotasso]
+infolibria       2319/udp # InfoLibria [Chris_Chiotasso] [Chris_Chiotasso]
+siebel-ns        2320/tcp # Siebel NS [Gilberto_Arnaiz] [Gilberto_Arnaiz]
+siebel-ns        2320/udp # Siebel NS [Gilberto_Arnaiz] [Gilberto_Arnaiz]
+rdlap            2321/tcp # RDLAP [Robert_Wiebe] [Robert_Wiebe]
+rdlap            2321/udp # RDLAP [Robert_Wiebe] [Robert_Wiebe]
+ofsd             2322/tcp # ofsd
+ofsd             2322/udp # ofsd
+3d-nfsd          2323/tcp # 3d-nfsd [Mike_Sherrill] [Mike_Sherrill]
+3d-nfsd          2323/udp # 3d-nfsd [Mike_Sherrill] [Mike_Sherrill]
+cosmocall        2324/tcp # Cosmocall [Steve_Dellutri] [Steve_Dellutri]
+cosmocall        2324/udp # Cosmocall [Steve_Dellutri] [Steve_Dellutri]
+ansysli          2325/tcp # ANSYS Licensing Interconnect [Suzanne_Lorrin] [Suzanne_Lorrin] Modified: 27 October 2008
+ansysli          2325/udp # ANSYS Licensing Interconnect [Suzanne_Lorrin] [Suzanne_Lorrin] Modified: 27 October 2008
+idcp             2326/tcp # IDCP [Keisokugiken_Corp] [Keisokugiken_Corp]
+idcp             2326/udp # IDCP [Keisokugiken_Corp] [Keisokugiken_Corp]
+xingcsm          2327/tcp # xingcsm [Dave_Spencer] [Dave_Spencer]
+xingcsm          2327/udp # xingcsm [Dave_Spencer] [Dave_Spencer]
+netrix-sftm      2328/tcp # Netrix SFTM [Garrett_Herschleb] [Garrett_Herschleb]
+netrix-sftm      2328/udp # Netrix SFTM [Garrett_Herschleb] [Garrett_Herschleb]
+nvd              2329/tcp # NVD [Peter_Weyman] [Peter_Weyman]
+nvd              2329/udp # NVD [Peter_Weyman] [Peter_Weyman]
+tscchat          2330/tcp # TSCCHAT [Mike_Jackson] [Mike_Jackson]
+tscchat          2330/udp # TSCCHAT [Mike_Jackson] [Mike_Jackson]
+agentview        2331/tcp # AGENTVIEW [Ram_Iyer] [Ram_Iyer]
+agentview        2331/udp # AGENTVIEW [Ram_Iyer] [Ram_Iyer]
+rcc-host         2332/tcp # RCC Host [Martin_Shoemaker] [Martin_Shoemaker]
+rcc-host         2332/udp # RCC Host [Martin_Shoemaker] [Martin_Shoemaker]
+snapp            2333/tcp # SNAPP [Dan_Burrows] [Dan_Burrows] 2009-09-25
+snapp            2333/udp # SNAPP [Dan_Burrows] [Dan_Burrows] 2009-09-25
+ace-client       2334/tcp # ACE Client Auth
+ace-client       2334/udp # ACE Client Auth
+ace-proxy        2335/tcp # ACE Proxy [Riaz_Zolfonoon] [Riaz_Zolfonoon]
+ace-proxy        2335/udp # ACE Proxy [Riaz_Zolfonoon] [Riaz_Zolfonoon]
+appleugcontrol   2336/tcp # Apple UG Control [Gene_Tyacke] [Gene_Tyacke]
+appleugcontrol   2336/udp # Apple UG Control [Gene_Tyacke] [Gene_Tyacke]
+ideesrv          2337/tcp # ideesrv [Marazzi] [Marazzi]
+ideesrv          2337/udp # ideesrv [Marazzi] [Marazzi]
+norton-lambert   2338/tcp # Norton Lambert [Richard_de_Mornay] [Richard_de_Mornay]
+norton-lambert   2338/udp # Norton Lambert [Richard_de_Mornay] [Richard_de_Mornay]
+3com-webview     2339/tcp # 3Com WebView [Jennifer_Grace] [Jennifer_Grace]
+3com-webview     2339/udp # 3Com WebView [Jennifer_Grace] [Jennifer_Grace]
+wrs-registry     2340/tcp # WRS RegistryIANA assigned this well-formed service name as a replacement for "wrs_registry". [Christophe_Cleraux] [Christophe_Cleraux]
+wrs_registry     2340/tcp # WRS Registry [Christophe_Cleraux] [Christophe_Cleraux] This entry is an alias to "wrs-registry".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+wrs-registry     2340/udp # WRS RegistryIANA assigned this well-formed service name as a replacement for "wrs_registry". [Christophe_Cleraux] [Christophe_Cleraux]
+wrs_registry     2340/udp # WRS Registry [Christophe_Cleraux] [Christophe_Cleraux] This entry is an alias to "wrs-registry".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+xiostatus        2341/tcp # XIO Status [Randy_Maas] [Randy_Maas]
+xiostatus        2341/udp # XIO Status [Randy_Maas] [Randy_Maas]
+manage-exec      2342/tcp # Seagate Manage Exec [Jim_Flaherty] [Jim_Flaherty]
+manage-exec      2342/udp # Seagate Manage Exec [Jim_Flaherty] [Jim_Flaherty]
+nati-logos       2343/tcp # nati logos [James_Juhasz] [James_Juhasz]
+nati-logos       2343/udp # nati logos [James_Juhasz] [James_Juhasz]
+fcmsys           2344/tcp # fcmsys
+fcmsys           2344/udp # fcmsys
+dbm              2345/tcp # dbm [Dean_Robson] [Dean_Robson]
+dbm              2345/udp # dbm [Dean_Robson] [Dean_Robson]
+redstorm-join    2346/tcp # Game Connection PortIANA assigned this well-formed service name as a replacement for "redstorm_join".
+redstorm_join    2346/tcp # Game Connection Port This entry is an alias to "redstorm-join".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+redstorm-join    2346/udp # Game Connection PortIANA assigned this well-formed service name as a replacement for "redstorm_join".
+redstorm_join    2346/udp # Game Connection Port This entry is an alias to "redstorm-join".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+redstorm-find    2347/tcp # Game Announcement and LocationIANA assigned this well-formed service name as a replacement for "redstorm_find".
+redstorm_find    2347/tcp # Game Announcement and Location This entry is an alias to "redstorm-find".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+redstorm-find    2347/udp # Game Announcement and LocationIANA assigned this well-formed service name as a replacement for "redstorm_find".
+redstorm_find    2347/udp # Game Announcement and Location This entry is an alias to "redstorm-find".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+redstorm-info    2348/tcp # Information to query for game statusIANA assigned this well-formed service name as a replacement for "redstorm_info".
+redstorm_info    2348/tcp # Information to query for game status This entry is an alias to "redstorm-info".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+redstorm-info    2348/udp # Information to query for game statusIANA assigned this well-formed service name as a replacement for "redstorm_info".
+redstorm_info    2348/udp # Information to query for game status This entry is an alias to "redstorm-info".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+redstorm-diag    2349/tcp # Diagnostics PortIANA assigned this well-formed service name as a replacement for "redstorm_diag". [David_Weinstein] [David_Weinstein]
+redstorm_diag    2349/tcp # Diagnostics Port [David_Weinstein] [David_Weinstein] This entry is an alias to "redstorm-diag".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+redstorm-diag    2349/udp # Diagnostics PortIANA assigned this well-formed service name as a replacement for "redstorm_diag". [David_Weinstein] [David_Weinstein]
+redstorm_diag    2349/udp # Diagnostics Port [David_Weinstein] [David_Weinstein] This entry is an alias to "redstorm-diag".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+psbserver        2350/tcp # Pharos Booking Server
+psbserver        2350/udp # Pharos Booking Server
+psrserver        2351/tcp # psrserver
+psrserver        2351/udp # psrserver
+pslserver        2352/tcp # pslserver
+pslserver        2352/udp # pslserver
+pspserver        2353/tcp # pspserver
+pspserver        2353/udp # pspserver
+psprserver       2354/tcp # psprserver
+psprserver       2354/udp # psprserver
+psdbserver       2355/tcp # psdbserver [Paul_Reddy] [Paul_Reddy]
+psdbserver       2355/udp # psdbserver [Paul_Reddy] [Paul_Reddy]
+gxtelmd          2356/tcp # GXT License Managemant [Robert_Hodgson] [Robert_Hodgson]
+gxtelmd          2356/udp # GXT License Managemant [Robert_Hodgson] [Robert_Hodgson]
+unihub-server    2357/tcp # UniHub Server [Tim_Kenyon] [Tim_Kenyon]
+unihub-server    2357/udp # UniHub Server [Tim_Kenyon] [Tim_Kenyon]
+futrix           2358/tcp # Futrix [Peter_Frankenberg] [Peter_Frankenberg]
+futrix           2358/udp # Futrix [Peter_Frankenberg] [Peter_Frankenberg]
+flukeserver      2359/tcp # FlukeServer [Bill_Marbaker] [Bill_Marbaker]
+flukeserver      2359/udp # FlukeServer [Bill_Marbaker] [Bill_Marbaker]
+nexstorindltd    2360/tcp # NexstorIndLtd [NexStor_India_Limite] [NexStor_India_Limite]
+nexstorindltd    2360/udp # NexstorIndLtd [NexStor_India_Limite] [NexStor_India_Limite]
+tl1              2361/tcp # TL1 [Charles_Scott_Robers] [Charles_Scott_Robers]
+tl1              2361/udp # TL1 [Charles_Scott_Robers] [Charles_Scott_Robers]
+digiman          2362/tcp # digiman [Aaron_S_Kurland] [Aaron_S_Kurland]
+digiman          2362/udp # digiman [Aaron_S_Kurland] [Aaron_S_Kurland]
+mediacntrlnfsd   2363/tcp # Media Central NFSD [Shivakumar_S_Govind] [Shivakumar_S_Govind]
+mediacntrlnfsd   2363/udp # Media Central NFSD [Shivakumar_S_Govind] [Shivakumar_S_Govind]
+oi-2000          2364/tcp # OI-2000 [Software_Horizons_In] [Software_Horizons_In]
+oi-2000          2364/udp # OI-2000 [Software_Horizons_In] [Software_Horizons_In]
+dbref            2365/tcp # dbref [Yoshihiro_Yamazaki] [Yoshihiro_Yamazaki]
+dbref            2365/udp # dbref [Yoshihiro_Yamazaki] [Yoshihiro_Yamazaki]
+qip-login        2366/tcp # qip-login [Mike_Morgan] [Mike_Morgan]
+qip-login        2366/udp # qip-login [Mike_Morgan] [Mike_Morgan]
+service-ctrl     2367/tcp # Service Control [Humberto_Sanchez] [Humberto_Sanchez]
+service-ctrl     2367/udp # Service Control [Humberto_Sanchez] [Humberto_Sanchez]
+opentable        2368/tcp # OpenTable [Brett_Goldstein] [Brett_Goldstein]
+opentable        2368/udp # OpenTable [Brett_Goldstein] [Brett_Goldstein]
+l3-hbmon         2370/tcp # L3-HBMon [Dolores_Scott] [Dolores_Scott] Port 2370 Unofficially used by Compaq
+l3-hbmon         2370/udp # L3-HBMon [Dolores_Scott] [Dolores_Scott] Port 2370 Unofficially used by Compaq
+worldwire        2371/tcp # Compaq WorldWire Port [Michael_Spratte] [Michael_Spratte]
+worldwire        2371/udp # Compaq WorldWire Port [Michael_Spratte] [Michael_Spratte]
+lanmessenger     2372/tcp # LanMessenger [Garrett_Padera] [Garrett_Padera] 2008-02-01
+lanmessenger     2372/udp # LanMessenger [Garrett_Padera] [Garrett_Padera] 2008-02-01
+remographlm      2373/tcp # Remograph License Manager [Per_Fahlberg] [Per_Fahlberg] 2009-01-21
+hydra            2374/tcp # Hydra RPC [Jacob_Feisley] [Jacob_Feisley] 2009-01-21
+compaq-https     2381/tcp # Compaq HTTPS [Scott_Shaffer] [Scott_Shaffer]
+compaq-https     2381/udp # Compaq HTTPS [Scott_Shaffer] [Scott_Shaffer]
+ms-olap3         2382/tcp # Microsoft OLAP
+ms-olap3         2382/udp # Microsoft OLAP
+ms-olap4         2383/tcp # Microsoft OLAP [Mosha_Pasumansky] [Mosha_Pasumansky]
+ms-olap4         2383/udp # Microsoft OLAP [Mosha_Pasumansky] [Mosha_Pasumansky]
+sd-request       2384/tcp # SD-REQUEST
+sd-capacity      2384/udp # SD-CAPACITY [Jason_McManus_2] [Jason_McManus_2]
+sd-data          2385/tcp # SD-DATA [Jason_McManus_2] [Jason_McManus_2]
+sd-data          2385/udp # SD-DATA [Jason_McManus_2] [Jason_McManus_2]
+virtualtape      2386/tcp # Virtual Tape
+virtualtape      2386/udp # Virtual Tape
+vsamredirector   2387/tcp # VSAM Redirector [Ingo_Franzki] [Ingo_Franzki]
+vsamredirector   2387/udp # VSAM Redirector [Ingo_Franzki] [Ingo_Franzki]
+mynahautostart   2388/tcp # MYNAH AutoStart [Thomas_J_Klehr] [Thomas_J_Klehr]
+mynahautostart   2388/udp # MYNAH AutoStart [Thomas_J_Klehr] [Thomas_J_Klehr]
+ovsessionmgr     2389/tcp # OpenView Session Mgr [Eric_Pulsipher] [Eric_Pulsipher]
+ovsessionmgr     2389/udp # OpenView Session Mgr [Eric_Pulsipher] [Eric_Pulsipher]
+rsmtp            2390/tcp # RSMTP [Geoff_Collyer] [Geoff_Collyer]
+rsmtp            2390/udp # RSMTP [Geoff_Collyer] [Geoff_Collyer]
+3com-net-mgmt    2391/tcp # 3COM Net Management [Prathibha_Nagvar] [Prathibha_Nagvar]
+3com-net-mgmt    2391/udp # 3COM Net Management [Prathibha_Nagvar] [Prathibha_Nagvar]
+tacticalauth     2392/tcp # Tactical Auth [David_Yon] [David_Yon]
+tacticalauth     2392/udp # Tactical Auth [David_Yon] [David_Yon]
+ms-olap1         2393/tcp # MS OLAP 1
+ms-olap1         2393/udp # MS OLAP 1
+ms-olap2         2394/tcp # MS OLAP 2 [Mosha_Pasumansky] [Mosha_Pasumansky]
+ms-olap2         2394/udp # MS OLAP 2 [Mosha_Pasumansky] [Mosha_Pasumansky]
+lan900-remote    2395/tcp # LAN900 RemoteIANA assigned this well-formed service name as a replacement for "lan900_remote". [Tom_Quinlan] [Tom_Quinlan]
+lan900_remote    2395/tcp # LAN900 Remote [Tom_Quinlan] [Tom_Quinlan] This entry is an alias to "lan900-remote".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+lan900-remote    2395/udp # LAN900 RemoteIANA assigned this well-formed service name as a replacement for "lan900_remote". [Tom_Quinlan] [Tom_Quinlan]
+lan900_remote    2395/udp # LAN900 Remote [Tom_Quinlan] [Tom_Quinlan] This entry is an alias to "lan900-remote".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+wusage           2396/tcp # Wusage [Thomas_Boutell] [Thomas_Boutell]
+wusage           2396/udp # Wusage [Thomas_Boutell] [Thomas_Boutell]
+ncl              2397/tcp # NCL [Robert_Wiebe] [Robert_Wiebe]
+ncl              2397/udp # NCL [Robert_Wiebe] [Robert_Wiebe]
+orbiter          2398/tcp # Orbiter [David_Goldberg] [David_Goldberg]
+orbiter          2398/udp # Orbiter [David_Goldberg] [David_Goldberg]
+fmpro-fdal       2399/tcp # FileMaker, Inc. - Data Access Layer [Clay_Maeckal] [Clay_Maeckal]
+fmpro-fdal       2399/udp # FileMaker, Inc. - Data Access Layer [Clay_Maeckal] [Clay_Maeckal]
+opequus-server   2400/tcp # OpEquus Server [Gavin_Hutchinson_2] [Gavin_Hutchinson_2]
+opequus-server   2400/udp # OpEquus Server [Gavin_Hutchinson_2] [Gavin_Hutchinson_2]
+cvspserver       2401/tcp # cvspserver [Jim_Kingdon] [Jim_Kingdon]
+cvspserver       2401/udp # cvspserver [Jim_Kingdon] [Jim_Kingdon]
+taskmaster2000   2402/tcp # TaskMaster 2000 Server
+taskmaster2000   2402/udp # TaskMaster 2000 Server
+taskmaster2000   2403/tcp # TaskMaster 2000 Web [Ed_Odjaghian] [Ed_Odjaghian]
+taskmaster2000   2403/udp # TaskMaster 2000 Web [Ed_Odjaghian] [Ed_Odjaghian]
+iec-104          2404/tcp # IEC 60870-5-104 process control over IP [Walter_K_Eichelburg] [Walter_K_Eichelburg]
+iec-104          2404/udp # IEC 60870-5-104 process control over IP [Walter_K_Eichelburg] [Walter_K_Eichelburg]
+trc-netpoll      2405/tcp # TRC Netpoll [Bizhan_Ghavami] [Bizhan_Ghavami]
+trc-netpoll      2405/udp # TRC Netpoll [Bizhan_Ghavami] [Bizhan_Ghavami]
+jediserver       2406/tcp # JediServer [Paul_McEntire] [Paul_McEntire]
+jediserver       2406/udp # JediServer [Paul_McEntire] [Paul_McEntire]
+orion            2407/tcp # Orion [Matthew_Horoschun] [Matthew_Horoschun]
+orion            2407/udp # Orion [Matthew_Horoschun] [Matthew_Horoschun]
+railgun-webaccl  2408/tcp # CloudFlare Railgun Web Acceleration Protocol [CloudFlare] [John_Graham_Cumming] 2012-03-09
+sns-protocol     2409/tcp # SNS Protocol [Amir_Blich] [Amir_Blich]
+sns-protocol     2409/udp # SNS Protocol [Amir_Blich] [Amir_Blich]
+vrts-registry    2410/tcp # VRTS Registry [Pranay_Varma] [Pranay_Varma]
+vrts-registry    2410/udp # VRTS Registry [Pranay_Varma] [Pranay_Varma]
+netwave-ap-mgmt  2411/tcp # Netwave AP Management [Johnny_Zweig] [Johnny_Zweig]
+netwave-ap-mgmt  2411/udp # Netwave AP Management [Johnny_Zweig] [Johnny_Zweig]
+cdn              2412/tcp # CDN [Alan_Noble] [Alan_Noble]
+cdn              2412/udp # CDN [Alan_Noble] [Alan_Noble]
+orion-rmi-reg    2413/tcp # orion-rmi-reg [J_S_Greenfield_2] [J_S_Greenfield_2]
+orion-rmi-reg    2413/udp # orion-rmi-reg [J_S_Greenfield_2] [J_S_Greenfield_2]
+beeyond          2414/tcp # Beeyond [Bob_Deblier] [Bob_Deblier]
+beeyond          2414/udp # Beeyond [Bob_Deblier] [Bob_Deblier]
+codima-rtp       2415/tcp # Codima Remote Transaction Protocol [Sylvia_Ross] [Sylvia_Ross]
+codima-rtp       2415/udp # Codima Remote Transaction Protocol [Sylvia_Ross] [Sylvia_Ross]
+rmtserver        2416/tcp # RMT Server [Yvon_Marineau] [Yvon_Marineau]
+rmtserver        2416/udp # RMT Server [Yvon_Marineau] [Yvon_Marineau]
+composit-server  2417/tcp # Composit Server [Katsuaki_Naoi] [Katsuaki_Naoi]
+composit-server  2417/udp # Composit Server [Katsuaki_Naoi] [Katsuaki_Naoi]
+cas              2418/tcp # cas [Akiyoshi_Ochi] [Akiyoshi_Ochi]
+cas              2418/udp # cas [Akiyoshi_Ochi] [Akiyoshi_Ochi]
+attachmate-s2s   2419/tcp # Attachmate S2S [Chris_Rominski] [Chris_Rominski]
+attachmate-s2s   2419/udp # Attachmate S2S [Chris_Rominski] [Chris_Rominski]
+dslremote-mgmt   2420/tcp # DSL Remote Management [Westell] [Westell]
+dslremote-mgmt   2420/udp # DSL Remote Management [Westell] [Westell]
+g-talk           2421/tcp # G-Talk [Matt_Hammond] [Matt_Hammond]
+g-talk           2421/udp # G-Talk [Matt_Hammond] [Matt_Hammond]
+crmsbits         2422/tcp # CRMSBITS [Rod_Ward] [Rod_Ward]
+crmsbits         2422/udp # CRMSBITS [Rod_Ward] [Rod_Ward]
+rnrp             2423/tcp # RNRP [Per_Sahlqvist] [Per_Sahlqvist]
+rnrp             2423/udp # RNRP [Per_Sahlqvist] [Per_Sahlqvist]
+kofax-svr        2424/tcp # KOFAX-SVR [Steven_Kilby] [Steven_Kilby] 2011-04-25
+kofax-svr        2424/udp # KOFAX-SVR [Steven_Kilby] [Steven_Kilby] 2011-04-25
+fjitsuappmgr     2425/tcp # Fujitsu App Manager [Hiroyuki_Kawabuchi] [Hiroyuki_Kawabuchi]
+fjitsuappmgr     2425/udp # Fujitsu App Manager [Hiroyuki_Kawabuchi] [Hiroyuki_Kawabuchi]
+mgcp-gateway     2427/tcp # Media Gateway Control Protocol Gateway [Christian_Huitema] [Christian_Huitema]
+mgcp-gateway     2427/udp # Media Gateway Control Protocol Gateway [Christian_Huitema] [Christian_Huitema]
+ott              2428/tcp # One Way Trip Time [Greg_Troxel] [Greg_Troxel]
+ott              2428/udp # One Way Trip Time [Greg_Troxel] [Greg_Troxel]
+ft-role          2429/tcp # FT-ROLE [Doug_Boone] [Doug_Boone]
+ft-role          2429/udp # FT-ROLE [Doug_Boone] [Doug_Boone]
+venus            2430/tcp # venus
+venus            2430/udp # venus
+venus-se         2431/tcp # venus-se
+venus-se         2431/udp # venus-se
+codasrv          2432/tcp # codasrv
+codasrv          2432/udp # codasrv
+codasrv-se       2433/tcp # codasrv-se [Robert_Watson] [Robert_Watson]
+codasrv-se       2433/udp # codasrv-se [Robert_Watson] [Robert_Watson]
+pxc-epmap        2434/tcp # pxc-epmap [Jun_Nakamura] [Jun_Nakamura]
+pxc-epmap        2434/udp # pxc-epmap [Jun_Nakamura] [Jun_Nakamura]
+optilogic        2435/tcp # OptiLogic [Clark_Williams] [Clark_Williams]
+optilogic        2435/udp # OptiLogic [Clark_Williams] [Clark_Williams]
+topx             2436/tcp # TOP/X [Dragos_Pop] [Dragos_Pop]
+topx             2436/udp # TOP/X [Dragos_Pop] [Dragos_Pop]
+unicontrol       2437/tcp # UniControl [Ing_Markus_Huemer] [Ing_Markus_Huemer]
+unicontrol       2437/udp # UniControl [Ing_Markus_Huemer] [Ing_Markus_Huemer]
+msp              2438/tcp # MSP [Evan_Caves] [Evan_Caves]
+msp              2438/udp # MSP [Evan_Caves] [Evan_Caves]
+sybasedbsynch    2439/tcp # SybaseDBSynch [Dave_Neudoerffer] [Dave_Neudoerffer]
+sybasedbsynch    2439/udp # SybaseDBSynch [Dave_Neudoerffer] [Dave_Neudoerffer]
+spearway         2440/tcp # Spearway Lockers [Pierre_Frisch] [Pierre_Frisch]
+spearway         2440/udp # Spearway Lockers [Pierre_Frisch] [Pierre_Frisch]
+pvsw-inet        2441/tcp # Pervasive I*net Data Server [Chuck_Talk] [Chuck_Talk]
+pvsw-inet        2441/udp # Pervasive I*net Data Server [Chuck_Talk] [Chuck_Talk]
+netangel         2442/tcp # Netangel [Ladislav_Baranyay] [Ladislav_Baranyay]
+netangel         2442/udp # Netangel [Ladislav_Baranyay] [Ladislav_Baranyay]
+powerclientcsf   2443/tcp # PowerClient Central Storage Facility [Brian_Klassen] [Brian_Klassen]
+powerclientcsf   2443/udp # PowerClient Central Storage Facility [Brian_Klassen] [Brian_Klassen]
+btpp2sectrans    2444/tcp # BT PP2 Sectrans [Ian_Daniels] [Ian_Daniels]
+btpp2sectrans    2444/udp # BT PP2 Sectrans [Ian_Daniels] [Ian_Daniels]
+dtn1             2445/tcp # DTN1 [Bob_Gaddie] [Bob_Gaddie]
+dtn1             2445/udp # DTN1 [Bob_Gaddie] [Bob_Gaddie]
+bues-service     2446/tcp # bues_serviceIANA assigned this well-formed service name as a replacement for "bues_service". [Leonhard_Diekmann] [Leonhard_Diekmann]
+bues_service     2446/tcp # bues_service [Leonhard_Diekmann] [Leonhard_Diekmann] This entry is an alias to "bues-service".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+bues-service     2446/udp # bues_serviceIANA assigned this well-formed service name as a replacement for "bues_service". [Leonhard_Diekmann] [Leonhard_Diekmann]
+bues_service     2446/udp # bues_service [Leonhard_Diekmann] [Leonhard_Diekmann] This entry is an alias to "bues-service".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+ovwdb            2447/tcp # OpenView NNM daemon [Eric_Pulsipher_2] [Eric_Pulsipher_2]
+ovwdb            2447/udp # OpenView NNM daemon [Eric_Pulsipher_2] [Eric_Pulsipher_2]
+hpppssvr         2448/tcp # hpppsvr [Bridgette_Landers] [Bridgette_Landers]
+hpppssvr         2448/udp # hpppsvr [Bridgette_Landers] [Bridgette_Landers]
+ratl             2449/tcp # RATL [Paul_Greenfield] [Paul_Greenfield]
+ratl             2449/udp # RATL [Paul_Greenfield] [Paul_Greenfield]
+netadmin         2450/tcp # netadmin
+netadmin         2450/udp # netadmin
+netchat          2451/tcp # netchat [Julian_Mehnle] [Julian_Mehnle]
+netchat          2451/udp # netchat [Julian_Mehnle] [Julian_Mehnle]
+snifferclient    2452/tcp # SnifferClient [Amy_Weaver_2] [Amy_Weaver_2]
+snifferclient    2452/udp # SnifferClient [Amy_Weaver_2] [Amy_Weaver_2]
+madge-ltd        2453/tcp # madge ltd [Mark_Lyall] [Mark_Lyall]
+madge-ltd        2453/udp # madge ltd [Mark_Lyall] [Mark_Lyall]
+indx-dds         2454/tcp # IndX-DDS [Paul_Carmichael] [Paul_Carmichael]
+indx-dds         2454/udp # IndX-DDS [Paul_Carmichael] [Paul_Carmichael]
+wago-io-system   2455/tcp # WAGO-IO-SYSTEM [Jorg_Hoffmann] [Jorg_Hoffmann]
+wago-io-system   2455/udp # WAGO-IO-SYSTEM [Jorg_Hoffmann] [Jorg_Hoffmann]
+altav-remmgt     2456/tcp # altav-remmgt [Gary_M_Allen] [Gary_M_Allen]
+altav-remmgt     2456/udp # altav-remmgt [Gary_M_Allen] [Gary_M_Allen]
+rapido-ip        2457/tcp # Rapido_IP [Man_Shuen_Cheung] [Man_Shuen_Cheung]
+rapido-ip        2457/udp # Rapido_IP [Man_Shuen_Cheung] [Man_Shuen_Cheung]
+griffin          2458/tcp # griffin [Tom_Taylor] [Tom_Taylor]
+griffin          2458/udp # griffin [Tom_Taylor] [Tom_Taylor]
+community        2459/tcp # Community [David_Schwartz] [David_Schwartz]
+community        2459/udp # Community [David_Schwartz] [David_Schwartz]
+ms-theater       2460/tcp # ms-theater [Anton_Kucer] [Anton_Kucer]
+ms-theater       2460/udp # ms-theater [Anton_Kucer] [Anton_Kucer]
+qadmifoper       2461/tcp # qadmifoper
+qadmifoper       2461/udp # qadmifoper
+qadmifevent      2462/tcp # qadmifevent [Pekka_Takaranta] [Pekka_Takaranta]
+qadmifevent      2462/udp # qadmifevent [Pekka_Takaranta] [Pekka_Takaranta]
+lsi-raid-mgmt    2463/tcp # LSI RAID Management [Kevin_Copas] [Kevin_Copas] 2008-02-07
+lsi-raid-mgmt    2463/udp # LSI RAID Management [Kevin_Copas] [Kevin_Copas] 2008-02-07
+direcpc-si       2464/tcp # DirecPC SI [Doug_Dillon] [Doug_Dillon]
+direcpc-si       2464/udp # DirecPC SI [Doug_Dillon] [Doug_Dillon]
+lbm              2465/tcp # Load Balance Management
+lbm              2465/udp # Load Balance Management
+lbf              2466/tcp # Load Balance Forwarding [Kazuhiro_Koide] [Kazuhiro_Koide]
+lbf              2466/udp # Load Balance Forwarding [Kazuhiro_Koide] [Kazuhiro_Koide]
+high-criteria    2467/tcp # High Criteria [Konstantin_Iavid] [Konstantin_Iavid]
+high-criteria    2467/udp # High Criteria [Konstantin_Iavid] [Konstantin_Iavid]
+qip-msgd         2468/tcp # qip_msgd [Mike_Morgan] [Mike_Morgan]
+qip-msgd         2468/udp # qip_msgd [Mike_Morgan] [Mike_Morgan]
+mti-tcs-comm     2469/tcp # MTI-TCS-COMM [Mario_Bonin] [Mario_Bonin]
+mti-tcs-comm     2469/udp # MTI-TCS-COMM [Mario_Bonin] [Mario_Bonin]
+taskman-port     2470/tcp # taskman port [Boris_Panteleev] [Boris_Panteleev]
+taskman-port     2470/udp # taskman port [Boris_Panteleev] [Boris_Panteleev]
+seaodbc          2471/tcp # SeaODBC [Adrian_Hornby] [Adrian_Hornby]
+seaodbc          2471/udp # SeaODBC [Adrian_Hornby] [Adrian_Hornby]
+c3               2472/tcp # C3 [Eckhard_Grieger] [Eckhard_Grieger]
+c3               2472/udp # C3 [Eckhard_Grieger] [Eckhard_Grieger]
+aker-cdp         2473/tcp # Aker-cdp [Rodrigo_Ormonde] [Rodrigo_Ormonde]
+aker-cdp         2473/udp # Aker-cdp [Rodrigo_Ormonde] [Rodrigo_Ormonde]
+vitalanalysis    2474/tcp # Vital Analysis [Srinivas_Reddy] [Srinivas_Reddy]
+vitalanalysis    2474/udp # Vital Analysis [Srinivas_Reddy] [Srinivas_Reddy]
+ace-server       2475/tcp # ACE Server
+ace-server       2475/udp # ACE Server
+ace-svr-prop     2476/tcp # ACE Server Propagation
+ace-svr-prop     2476/udp # ACE Server Propagation
+ssm-cvs          2477/tcp # SecurSight Certificate Valifation Service
+ssm-cvs          2477/udp # SecurSight Certificate Valifation Service
+ssm-cssps        2478/tcp # SecurSight Authentication Server (SSL)
+ssm-cssps        2478/udp # SecurSight Authentication Server (SSL)
+ssm-els          2479/tcp # SecurSight Event Logging Server (SSL) [John_Linn] [John_Linn]
+ssm-els          2479/udp # SecurSight Event Logging Server (SSL) [John_Linn] [John_Linn]
+powerexchange    2480/tcp # Informatica PowerExchange Listener [Dale_Norman] [Dale_Norman]
+powerexchange    2480/udp # Informatica PowerExchange Listener [Dale_Norman] [Dale_Norman]
+giop             2481/tcp # Oracle GIOP
+giop             2481/udp # Oracle GIOP
+giop-ssl         2482/tcp # Oracle GIOP SSL
+giop-ssl         2482/udp # Oracle GIOP SSL
+ttc              2483/tcp # Oracle TTC
+ttc              2483/udp # Oracle TTC
+ttc-ssl          2484/tcp # Oracle TTC SSL [Chandar_Venkataraman] [Chandar_Venkataraman]
+ttc-ssl          2484/udp # Oracle TTC SSL [Chandar_Venkataraman] [Chandar_Venkataraman]
+netobjects1      2485/tcp # Net Objects1
+netobjects1      2485/udp # Net Objects1
+netobjects2      2486/tcp # Net Objects2 [Francois_Granade] [Francois_Granade]
+netobjects2      2486/udp # Net Objects2 [Francois_Granade] [Francois_Granade]
+pns              2487/tcp # Policy Notice Service [Akiyoshi_Ochi] [Akiyoshi_Ochi]
+pns              2487/udp # Policy Notice Service [Akiyoshi_Ochi] [Akiyoshi_Ochi]
+moy-corp         2488/tcp # Moy Corporation [Gang_Gong_Moy] [Gang_Gong_Moy]
+moy-corp         2488/udp # Moy Corporation [Gang_Gong_Moy] [Gang_Gong_Moy]
+tsilb            2489/tcp # TSILB [James_Irwin] [James_Irwin]
+tsilb            2489/udp # TSILB [James_Irwin] [James_Irwin]
+qip-qdhcp        2490/tcp # qip_qdhcp [Mike_Morgan] [Mike_Morgan]
+qip-qdhcp        2490/udp # qip_qdhcp [Mike_Morgan] [Mike_Morgan]
+conclave-cpp     2491/tcp # Conclave CPP [Larry_Lipstone] [Larry_Lipstone]
+conclave-cpp     2491/udp # Conclave CPP [Larry_Lipstone] [Larry_Lipstone]
+groove           2492/tcp # GROOVE [Ray_Ozzie] [Ray_Ozzie]
+groove           2492/udp # GROOVE [Ray_Ozzie] [Ray_Ozzie]
+talarian-mqs     2493/tcp # Talarian MQS [Jim_Stabile] [Jim_Stabile]
+talarian-mqs     2493/udp # Talarian MQS [Jim_Stabile] [Jim_Stabile]
+bmc-ar           2494/tcp # BMC AR [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-ar           2494/udp # BMC AR [Portnoy_Boxman] [Portnoy_Boxman]
+fast-rem-serv    2495/tcp # Fast Remote Services [Scott_St_Clair] [Scott_St_Clair]
+fast-rem-serv    2495/udp # Fast Remote Services [Scott_St_Clair] [Scott_St_Clair]
+dirgis           2496/tcp # DIRGIS [Deutschland_Informat] [Deutschland_Informat]
+dirgis           2496/udp # DIRGIS [Deutschland_Informat] [Deutschland_Informat]
+quaddb           2497/tcp # Quad DB [Jeff_Rosenthal] [Jeff_Rosenthal]
+quaddb           2497/udp # Quad DB [Jeff_Rosenthal] [Jeff_Rosenthal]
+odn-castraq      2498/tcp # ODN-CasTraq [Richard_Hodges_2] [Richard_Hodges_2]
+odn-castraq      2498/udp # ODN-CasTraq [Richard_Hodges_2] [Richard_Hodges_2]
+unicontrol       2499/tcp # UniControl [Ing_Markus_Huemer] [Ing_Markus_Huemer]
+unicontrol       2499/udp # UniControl [Ing_Markus_Huemer] [Ing_Markus_Huemer]
+rtsserv          2500/tcp # Resource Tracking system server
+rtsserv          2500/udp # Resource Tracking system server
+rtsclient        2501/tcp # Resource Tracking system client [Aubrey_Turner] [Aubrey_Turner]
+rtsclient        2501/udp # Resource Tracking system client [Aubrey_Turner] [Aubrey_Turner]
+kentrox-prot     2502/tcp # Kentrox Protocol [Anil_Lakhwara] [Anil_Lakhwara]
+kentrox-prot     2502/udp # Kentrox Protocol [Anil_Lakhwara] [Anil_Lakhwara]
+nms-dpnss        2503/tcp # NMS-DPNSS [Jean_Christophe_Desi] [Jean_Christophe_Desi]
+nms-dpnss        2503/udp # NMS-DPNSS [Jean_Christophe_Desi] [Jean_Christophe_Desi]
+wlbs             2504/tcp # WLBS [William_Bain] [William_Bain]
+wlbs             2504/udp # WLBS [William_Bain] [William_Bain]
+ppcontrol        2505/tcp # PowerPlay Control [Max_Magliaro] [Max_Magliaro] 2004-11
+ppcontrol        2505/udp # PowerPlay Control [Max_Magliaro] [Max_Magliaro] 2004-11
+jbroker          2506/tcp # jbroker [Rohit_Garg_2] [Rohit_Garg_2]
+jbroker          2506/udp # jbroker [Rohit_Garg_2] [Rohit_Garg_2]
+spock            2507/tcp # spock [Jon_A_Christopher] [Jon_A_Christopher]
+spock            2507/udp # spock [Jon_A_Christopher] [Jon_A_Christopher]
+jdatastore       2508/tcp # JDataStore [Tod_Landis] [Tod_Landis]
+jdatastore       2508/udp # JDataStore [Tod_Landis] [Tod_Landis]
+fjmpss           2509/tcp # fjmpss [Makoto_Watanabe] [Makoto_Watanabe]
+fjmpss           2509/udp # fjmpss [Makoto_Watanabe] [Makoto_Watanabe]
+fjappmgrbulk     2510/tcp # fjappmgrbulk [Hiroyuki_Kawabuchi] [Hiroyuki_Kawabuchi]
+fjappmgrbulk     2510/udp # fjappmgrbulk [Hiroyuki_Kawabuchi] [Hiroyuki_Kawabuchi]
+metastorm        2511/tcp # Metastorm [Eric_Isom] [Eric_Isom]
+metastorm        2511/udp # Metastorm [Eric_Isom] [Eric_Isom]
+citrixima        2512/tcp # Citrix IMA
+citrixima        2512/udp # Citrix IMA
+citrixadmin      2513/tcp # Citrix ADMIN [Myk_Willis] [Myk_Willis]
+citrixadmin      2513/udp # Citrix ADMIN [Myk_Willis] [Myk_Willis]
+facsys-ntp       2514/tcp # Facsys NTP
+facsys-ntp       2514/udp # Facsys NTP
+facsys-router    2515/tcp # Facsys Router [Jeff_Hoffman] [Jeff_Hoffman]
+facsys-router    2515/udp # Facsys Router [Jeff_Hoffman] [Jeff_Hoffman]
+maincontrol      2516/tcp # Main Control [Nathan_Sadia] [Nathan_Sadia]
+maincontrol      2516/udp # Main Control [Nathan_Sadia] [Nathan_Sadia]
+call-sig-trans   2517/tcp # H.323 Annex E Call Control Signalling Transport [ITU-T] [ITU-T_TSB] 2013-01-31
+call-sig-trans   2517/udp # H.323 Annex E Call Control Signalling Transport [ITU-T] [ITU-T_TSB] 2013-01-31
+willy            2518/tcp # Willy [Carl_Johan_Wik] [Carl_Johan_Wik]
+willy            2518/udp # Willy [Carl_Johan_Wik] [Carl_Johan_Wik]
+globmsgsvc       2519/tcp # globmsgsvc [David_Wiltz] [David_Wiltz]
+globmsgsvc       2519/udp # globmsgsvc [David_Wiltz] [David_Wiltz]
+pvsw             2520/tcp # Pervasive Listener [Chuck_Talk] [Chuck_Talk]
+pvsw             2520/udp # Pervasive Listener [Chuck_Talk] [Chuck_Talk]
+adaptecmgr       2521/tcp # Adaptec Manager [Mark_Parenti] [Mark_Parenti]
+adaptecmgr       2521/udp # Adaptec Manager [Mark_Parenti] [Mark_Parenti]
+windb            2522/tcp # WinDb [Larry_Traylor] [Larry_Traylor]
+windb            2522/udp # WinDb [Larry_Traylor] [Larry_Traylor]
+qke-llc-v3       2523/tcp # Qke LLC V.3 [Joerg_Niehoff] [Joerg_Niehoff]
+qke-llc-v3       2523/udp # Qke LLC V.3 [Joerg_Niehoff] [Joerg_Niehoff]
+optiwave-lm      2524/tcp # Optiwave License Management [Slawomir_Krzesinski] [Slawomir_Krzesinski]
+optiwave-lm      2524/udp # Optiwave License Management [Slawomir_Krzesinski] [Slawomir_Krzesinski]
+ms-v-worlds      2525/tcp # MS V-Worlds [Pete_Wong] [Pete_Wong]
+ms-v-worlds      2525/udp # MS V-Worlds [Pete_Wong] [Pete_Wong]
+ema-sent-lm      2526/tcp # EMA License Manager [Thaddeus_Perala] [Thaddeus_Perala]
+ema-sent-lm      2526/udp # EMA License Manager [Thaddeus_Perala] [Thaddeus_Perala]
+iqserver         2527/tcp # IQ Server [Nick_Straguzzi] [Nick_Straguzzi]
+iqserver         2527/udp # IQ Server [Nick_Straguzzi] [Nick_Straguzzi]
+ncr-ccl          2528/tcp # NCR CCLIANA assigned this well-formed service name as a replacement for "ncr_ccl". [Amitava_Dutta] [Amitava_Dutta]
+ncr_ccl          2528/tcp # NCR CCL [Amitava_Dutta] [Amitava_Dutta] This entry is an alias to "ncr-ccl".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+ncr-ccl          2528/udp # NCR CCLIANA assigned this well-formed service name as a replacement for "ncr_ccl". [Amitava_Dutta] [Amitava_Dutta]
+ncr_ccl          2528/udp # NCR CCL [Amitava_Dutta] [Amitava_Dutta] This entry is an alias to "ncr-ccl".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+utsftp           2529/tcp # UTS FTP [David_Moore] [David_Moore]
+utsftp           2529/udp # UTS FTP [David_Moore] [David_Moore]
+vrcommerce       2530/tcp # VR Commerce [Yosi_Mass] [Yosi_Mass]
+vrcommerce       2530/udp # VR Commerce [Yosi_Mass] [Yosi_Mass]
+ito-e-gui        2531/tcp # ITO-E GUI [Michael_Haeuptle] [Michael_Haeuptle]
+ito-e-gui        2531/udp # ITO-E GUI [Michael_Haeuptle] [Michael_Haeuptle]
+ovtopmd          2532/tcp # OVTOPMD [Eric_Pulsipher] [Eric_Pulsipher]
+ovtopmd          2532/udp # OVTOPMD [Eric_Pulsipher] [Eric_Pulsipher]
+snifferserver    2533/tcp # SnifferServer [Amy_Weaver_3] [Amy_Weaver_3]
+snifferserver    2533/udp # SnifferServer [Amy_Weaver_3] [Amy_Weaver_3]
+combox-web-acc   2534/tcp # Combox Web Access [Yochai_Cohen] [Yochai_Cohen]
+combox-web-acc   2534/udp # Combox Web Access [Yochai_Cohen] [Yochai_Cohen]
+madcap           2535/tcp # MADCAP [Stephen_Hanna_2] [Stephen_Hanna_2]
+madcap           2535/udp # MADCAP [Stephen_Hanna_2] [Stephen_Hanna_2]
+btpp2audctr1     2536/tcp # btpp2audctr1 [Ian_Daniels] [Ian_Daniels]
+btpp2audctr1     2536/udp # btpp2audctr1 [Ian_Daniels] [Ian_Daniels]
+upgrade          2537/tcp # Upgrade Protocol [Breck_Auten] [Breck_Auten]
+upgrade          2537/udp # Upgrade Protocol [Breck_Auten] [Breck_Auten]
+vnwk-prapi       2538/tcp # vnwk-prapi [John_Hasselkus] [John_Hasselkus]
+vnwk-prapi       2538/udp # vnwk-prapi [John_Hasselkus] [John_Hasselkus]
+vsiadmin         2539/tcp # VSI Admin [Rob_Juergens] [Rob_Juergens]
+vsiadmin         2539/udp # VSI Admin [Rob_Juergens] [Rob_Juergens]
+lonworks         2540/tcp # LonWorks
+lonworks         2540/udp # LonWorks
+lonworks2        2541/tcp # LonWorks2 [Gary_Bartlett] [Gary_Bartlett]
+lonworks2        2541/udp # LonWorks2 [Gary_Bartlett] [Gary_Bartlett]
+udrawgraph       2542/tcp # uDraw(Graph) [Bremen] [Bremen]
+udrawgraph       2542/udp # uDraw(Graph) [Bremen] [Bremen]
+reftek           2543/tcp # REFTEK [Phil_Davidson] [Phil_Davidson]
+reftek           2543/udp # REFTEK [Phil_Davidson] [Phil_Davidson]
+novell-zen       2544/tcp # Management Daemon Refresh [Ty_Ellis] [Ty_Ellis]
+novell-zen       2544/udp # Management Daemon Refresh [Ty_Ellis] [Ty_Ellis]
+sis-emt          2545/tcp # sis-emt [Bill_Crawford] [Bill_Crawford]
+sis-emt          2545/udp # sis-emt [Bill_Crawford] [Bill_Crawford]
+vytalvaultbrtp   2546/tcp # vytalvaultbrtp
+vytalvaultbrtp   2546/udp # vytalvaultbrtp
+vytalvaultvsmp   2547/tcp # vytalvaultvsmp
+vytalvaultvsmp   2547/udp # vytalvaultvsmp
+vytalvaultpipe   2548/tcp # vytalvaultpipe [Tim_Boldt] [Tim_Boldt]
+vytalvaultpipe   2548/udp # vytalvaultpipe [Tim_Boldt] [Tim_Boldt]
+ipass            2549/tcp # IPASS [Michael_Fischer] [Michael_Fischer]
+ipass            2549/udp # IPASS [Michael_Fischer] [Michael_Fischer]
+ads              2550/tcp # ADS [Michael_O_Connor] [Michael_O_Connor]
+ads              2550/udp # ADS [Michael_O_Connor] [Michael_O_Connor]
+isg-uda-server   2551/tcp # ISG UDA Server [Dror_Harari] [Dror_Harari]
+isg-uda-server   2551/udp # ISG UDA Server [Dror_Harari] [Dror_Harari]
+call-logging     2552/tcp # Call Logging [Dean_Webb] [Dean_Webb]
+call-logging     2552/udp # Call Logging [Dean_Webb] [Dean_Webb]
+efidiningport    2553/tcp # efidiningport [Lynn_Carter] [Lynn_Carter]
+efidiningport    2553/udp # efidiningport [Lynn_Carter] [Lynn_Carter]
+vcnet-link-v10   2554/tcp # VCnet-Link v10 [Csaba_Mate] [Csaba_Mate]
+vcnet-link-v10   2554/udp # VCnet-Link v10 [Csaba_Mate] [Csaba_Mate]
+compaq-wcp       2555/tcp # Compaq WCP [Ferruccio_Barletta] [Ferruccio_Barletta]
+compaq-wcp       2555/udp # Compaq WCP [Ferruccio_Barletta] [Ferruccio_Barletta]
+nicetec-nmsvc    2556/tcp # nicetec-nmsvc
+nicetec-nmsvc    2556/udp # nicetec-nmsvc
+nicetec-mgmt     2557/tcp # nicetec-mgmt [Joerg_Paulus] [Joerg_Paulus]
+nicetec-mgmt     2557/udp # nicetec-mgmt [Joerg_Paulus] [Joerg_Paulus]
+pclemultimedia   2558/tcp # PCLE Multi Media [Jacob_Gsoedl] [Jacob_Gsoedl]
+pclemultimedia   2558/udp # PCLE Multi Media [Jacob_Gsoedl] [Jacob_Gsoedl]
+lstp             2559/tcp # LSTP [Waiki_Wright] [Waiki_Wright]
+lstp             2559/udp # LSTP [Waiki_Wright] [Waiki_Wright]
+labrat           2560/tcp # labrat [John_Harvey] [John_Harvey]
+labrat           2560/udp # labrat [John_Harvey] [John_Harvey]
+mosaixcc         2561/tcp # MosaixCC [Steven_Frare] [Steven_Frare]
+mosaixcc         2561/udp # MosaixCC [Steven_Frare] [Steven_Frare]
+delibo           2562/tcp # Delibo [NovaWiz_LTD] [NovaWiz_LTD]
+delibo           2562/udp # Delibo [NovaWiz_LTD] [NovaWiz_LTD]
+cti-redwood      2563/tcp # CTI Redwood [Songwon_Chi] [Songwon_Chi]
+cti-redwood      2563/udp # CTI Redwood [Songwon_Chi] [Songwon_Chi]
+hp-3000-telnet   2564/tcp # HP 3000 NS/VT block mode telnet
+hp-3000-telnet   2564/udp # HP 3000 NS/VT block mode telnet
+coord-svr        2565/tcp # Coordinator Server [Richard_Steiger] [Richard_Steiger]
+coord-svr        2565/udp # Coordinator Server [Richard_Steiger] [Richard_Steiger]
+pcs-pcw          2566/tcp # pcs-pcw [W_Jordan_Fitzhugh] [W_Jordan_Fitzhugh]
+pcs-pcw          2566/udp # pcs-pcw [W_Jordan_Fitzhugh] [W_Jordan_Fitzhugh]
+clp              2567/tcp # Cisco Line Protocol [Susan_Hinrichs] [Susan_Hinrichs]
+clp              2567/udp # Cisco Line Protocol [Susan_Hinrichs] [Susan_Hinrichs]
+spamtrap         2568/tcp # SPAM TRAP [Charles_Bennett] [Charles_Bennett] 2008-08-29
+spamtrap         2568/udp # SPAM TRAP [Charles_Bennett] [Charles_Bennett] 2008-08-29
+sonuscallsig     2569/tcp # Sonus Call Signal [Mark_Garti] [Mark_Garti]
+sonuscallsig     2569/udp # Sonus Call Signal [Mark_Garti] [Mark_Garti]
+hs-port          2570/tcp # HS Port [Uri_Doron] [Uri_Doron]
+hs-port          2570/udp # HS Port [Uri_Doron] [Uri_Doron]
+cecsvc           2571/tcp # CECSVC [Roger_Pao] [Roger_Pao]
+cecsvc           2571/udp # CECSVC [Roger_Pao] [Roger_Pao]
+ibp              2572/tcp # IBP [Jonathan_Downes] [Jonathan_Downes]
+ibp              2572/udp # IBP [Jonathan_Downes] [Jonathan_Downes]
+trustestablish   2573/tcp # Trust Establish [Yosi_Mass] [Yosi_Mass]
+trustestablish   2573/udp # Trust Establish [Yosi_Mass] [Yosi_Mass]
+blockade-bpsp    2574/tcp # Blockade BPSP [Blockade] [Blockade]
+blockade-bpsp    2574/udp # Blockade BPSP [Blockade] [Blockade]
+hl7              2575/tcp # HL7 [Tim_Jacobs] [Tim_Jacobs]
+hl7              2575/udp # HL7 [Tim_Jacobs] [Tim_Jacobs]
+tclprodebugger   2576/tcp # TCL Pro Debugger
+tclprodebugger   2576/udp # TCL Pro Debugger
+scipticslsrvr    2577/tcp # Scriptics Lsrvr [Brent_Welch] [Brent_Welch]
+scipticslsrvr    2577/udp # Scriptics Lsrvr [Brent_Welch] [Brent_Welch]
+rvs-isdn-dcp     2578/tcp # RVS ISDN DCP [Michael_Zirpel] [Michael_Zirpel]
+rvs-isdn-dcp     2578/udp # RVS ISDN DCP [Michael_Zirpel] [Michael_Zirpel]
+mpfoncl          2579/tcp # mpfoncl [Itaru_Kimura] [Itaru_Kimura]
+mpfoncl          2579/udp # mpfoncl [Itaru_Kimura] [Itaru_Kimura]
+tributary        2580/tcp # Tributary [Louis_Lu] [Louis_Lu]
+tributary        2580/udp # Tributary [Louis_Lu] [Louis_Lu]
+argis-te         2581/tcp # ARGIS TE
+argis-te         2581/udp # ARGIS TE
+argis-ds         2582/tcp # ARGIS DS [John_Legh_Page] [John_Legh_Page]
+argis-ds         2582/udp # ARGIS DS [John_Legh_Page] [John_Legh_Page]
+mon              2583/tcp # MON [Jim_Trocki] [Jim_Trocki]
+mon              2583/udp # MON [Jim_Trocki] [Jim_Trocki]
+cyaserv          2584/tcp # cyaserv [Morgan_Jones] [Morgan_Jones]
+cyaserv          2584/udp # cyaserv [Morgan_Jones] [Morgan_Jones]
+netx-server      2585/tcp # NETX Server
+netx-server      2585/udp # NETX Server
+netx-agent       2586/tcp # NETX Agent [Brett_Dolecheck] [Brett_Dolecheck]
+netx-agent       2586/udp # NETX Agent [Brett_Dolecheck] [Brett_Dolecheck]
+masc             2587/tcp # MASC [Pavlin_Ivanov_Radosl] [Pavlin_Ivanov_Radosl]
+masc             2587/udp # MASC [Pavlin_Ivanov_Radosl] [Pavlin_Ivanov_Radosl]
+privilege        2588/tcp # Privilege [Gil_Hecht] [Gil_Hecht]
+privilege        2588/udp # Privilege [Gil_Hecht] [Gil_Hecht]
+quartus-tcl      2589/tcp # quartus tcl [Subroto_Datta] [Subroto_Datta]
+quartus-tcl      2589/udp # quartus tcl [Subroto_Datta] [Subroto_Datta]
+idotdist         2590/tcp # idotdist [Jason_Hunter] [Jason_Hunter]
+idotdist         2590/udp # idotdist [Jason_Hunter] [Jason_Hunter]
+maytagshuffle    2591/tcp # Maytag Shuffle [Ken_Ksiazek] [Ken_Ksiazek]
+maytagshuffle    2591/udp # Maytag Shuffle [Ken_Ksiazek] [Ken_Ksiazek]
+netrek           2592/tcp # netrek [Al_Guetzlaff] [Al_Guetzlaff]
+netrek           2592/udp # netrek [Al_Guetzlaff] [Al_Guetzlaff]
+mns-mail         2593/tcp # MNS Mail Notice Service [Rumiko_Kikuta] [Rumiko_Kikuta]
+mns-mail         2593/udp # MNS Mail Notice Service [Rumiko_Kikuta] [Rumiko_Kikuta]
+dts              2594/tcp # Data Base Server [Andreas_Roene] [Andreas_Roene]
+dts              2594/udp # Data Base Server [Andreas_Roene] [Andreas_Roene]
+worldfusion1     2595/tcp # World Fusion 1
+worldfusion1     2595/udp # World Fusion 1
+worldfusion2     2596/tcp # World Fusion 2 [World_Fusion] [World_Fusion]
+worldfusion2     2596/udp # World Fusion 2 [World_Fusion] [World_Fusion]
+homesteadglory   2597/tcp # Homestead Glory [John_Tokash] [John_Tokash]
+homesteadglory   2597/udp # Homestead Glory [John_Tokash] [John_Tokash]
+citriximaclient  2598/tcp # Citrix MA Client [Myk_Willis] [Myk_Willis]
+citriximaclient  2598/udp # Citrix MA Client [Myk_Willis] [Myk_Willis]
+snapd            2599/tcp # Snap Discovery [Kevin_Osborn] [Kevin_Osborn]
+snapd            2599/udp # Snap Discovery [Kevin_Osborn] [Kevin_Osborn]
+hpstgmgr         2600/tcp # HPSTGMGR [Kevin_Collins] [Kevin_Collins]
+hpstgmgr         2600/udp # HPSTGMGR [Kevin_Collins] [Kevin_Collins]
+discp-client     2601/tcp # discp client
+discp-client     2601/udp # discp client
+discp-server     2602/tcp # discp server [Peter_White] [Peter_White]
+discp-server     2602/udp # discp server [Peter_White] [Peter_White]
+servicemeter     2603/tcp # Service Meter [Duncan_Hare] [Duncan_Hare]
+servicemeter     2603/udp # Service Meter [Duncan_Hare] [Duncan_Hare]
+nsc-ccs          2604/tcp # NSC CCS
+nsc-ccs          2604/udp # NSC CCS
+nsc-posa         2605/tcp # NSC POSA [Tom_Findley] [Tom_Findley]
+nsc-posa         2605/udp # NSC POSA [Tom_Findley] [Tom_Findley]
+netmon           2606/tcp # Dell Netmon
+netmon           2606/udp # Dell Netmon
+connection       2607/tcp # Dell Connection [Sudhir_Shetty] [Sudhir_Shetty]
+connection       2607/udp # Dell Connection [Sudhir_Shetty] [Sudhir_Shetty]
+wag-service      2608/tcp # Wag Service [Gilles_Bourquard] [Gilles_Bourquard]
+wag-service      2608/udp # Wag Service [Gilles_Bourquard] [Gilles_Bourquard]
+system-monitor   2609/tcp # System Monitor [Greg_Robson_Garth] [Greg_Robson_Garth]
+system-monitor   2609/udp # System Monitor [Greg_Robson_Garth] [Greg_Robson_Garth]
+versa-tek        2610/tcp # VersaTek [James_Kou] [James_Kou]
+versa-tek        2610/udp # VersaTek [James_Kou] [James_Kou]
+lionhead         2611/tcp # LIONHEAD [Tim_Rance] [Tim_Rance]
+lionhead         2611/udp # LIONHEAD [Tim_Rance] [Tim_Rance]
+qpasa-agent      2612/tcp # Qpasa Agent [Craig_Ching] [Craig_Ching]
+qpasa-agent      2612/udp # Qpasa Agent [Craig_Ching] [Craig_Ching]
+smntubootstrap   2613/tcp # SMNTUBootstrap [Matt_Cecile] [Matt_Cecile]
+smntubootstrap   2613/udp # SMNTUBootstrap [Matt_Cecile] [Matt_Cecile]
+neveroffline     2614/tcp # Never Offline [Dustin_Brand] [Dustin_Brand]
+neveroffline     2614/udp # Never Offline [Dustin_Brand] [Dustin_Brand]
+firepower        2615/tcp # firepower [Jason_Volk] [Jason_Volk]
+firepower        2615/udp # firepower [Jason_Volk] [Jason_Volk]
+appswitch-emp    2616/tcp # appswitch-emp [Ted_Ross] [Ted_Ross]
+appswitch-emp    2616/udp # appswitch-emp [Ted_Ross] [Ted_Ross]
+cmadmin          2617/tcp # Clinical Context Managers [Mark_Morwood] [Mark_Morwood]
+cmadmin          2617/udp # Clinical Context Managers [Mark_Morwood] [Mark_Morwood]
+priority-e-com   2618/tcp # Priority E-Com [Marcelo_Einhorn_2] [Marcelo_Einhorn_2]
+priority-e-com   2618/udp # Priority E-Com [Marcelo_Einhorn_2] [Marcelo_Einhorn_2]
+bruce            2619/tcp # bruce [Alec_Muffett] [Alec_Muffett]
+bruce            2619/udp # bruce [Alec_Muffett] [Alec_Muffett]
+lpsrecommender   2620/tcp # LPSRecommender [Pritham_Shetty_2] [Pritham_Shetty_2]
+lpsrecommender   2620/udp # LPSRecommender [Pritham_Shetty_2] [Pritham_Shetty_2]
+miles-apart      2621/tcp # Miles Apart Jukebox Server [Michael_Rathmann] [Michael_Rathmann]
+miles-apart      2621/udp # Miles Apart Jukebox Server [Michael_Rathmann] [Michael_Rathmann]
+metricadbc       2622/tcp # MetricaDBC [Russ_Olivant] [Russ_Olivant]
+metricadbc       2622/udp # MetricaDBC [Russ_Olivant] [Russ_Olivant]
+lmdp             2623/tcp # LMDP [Ken_Bailey] [Ken_Bailey]
+lmdp             2623/udp # LMDP [Ken_Bailey] [Ken_Bailey]
+aria             2624/tcp # Aria [Logan_Bruns] [Logan_Bruns]
+aria             2624/udp # Aria [Logan_Bruns] [Logan_Bruns]
+blwnkl-port      2625/tcp # Blwnkl Port [Weng_Chin_Yung] [Weng_Chin_Yung]
+blwnkl-port      2625/udp # Blwnkl Port [Weng_Chin_Yung] [Weng_Chin_Yung]
+gbjd816          2626/tcp # gbjd816 [George_Balesta] [George_Balesta]
+gbjd816          2626/udp # gbjd816 [George_Balesta] [George_Balesta]
+moshebeeri       2627/tcp # Moshe Beeri [Moshe_Beeri] [Moshe_Beeri]
+moshebeeri       2627/udp # Moshe Beeri [Moshe_Beeri] [Moshe_Beeri]
+dict             2628/tcp # DICT [Rik_Faith] [Rik_Faith]
+dict             2628/udp # DICT [Rik_Faith] [Rik_Faith]
+sitaraserver     2629/tcp # Sitara Server
+sitaraserver     2629/udp # Sitara Server
+sitaramgmt       2630/tcp # Sitara Management
+sitaramgmt       2630/udp # Sitara Management
+sitaradir        2631/tcp # Sitara Dir [Manickam_R_Sridhar] [Manickam_R_Sridhar]
+sitaradir        2631/udp # Sitara Dir [Manickam_R_Sridhar] [Manickam_R_Sridhar]
+irdg-post        2632/tcp # IRdg Post [IRdg] [IRdg]
+irdg-post        2632/udp # IRdg Post [IRdg] [IRdg]
+interintelli     2633/tcp # InterIntelli [Mike_Gagle] [Mike_Gagle]
+interintelli     2633/udp # InterIntelli [Mike_Gagle] [Mike_Gagle]
+pk-electronics   2634/tcp # PK Electronics [Seb_Ibis] [Seb_Ibis]
+pk-electronics   2634/udp # PK Electronics [Seb_Ibis] [Seb_Ibis]
+backburner       2635/tcp # Back Burner [Kevin_Teiskoetter] [Kevin_Teiskoetter]
+backburner       2635/udp # Back Burner [Kevin_Teiskoetter] [Kevin_Teiskoetter]
+solve            2636/tcp # Solve [Peter_Morrison] [Peter_Morrison]
+solve            2636/udp # Solve [Peter_Morrison] [Peter_Morrison]
+imdocsvc         2637/tcp # Import Document Service [Zia_Bhatti] [Zia_Bhatti]
+imdocsvc         2637/udp # Import Document Service [Zia_Bhatti] [Zia_Bhatti]
+sybaseanywhere   2638/tcp # Sybase Anywhere [Dave_Neudoerffer] [Dave_Neudoerffer]
+sybaseanywhere   2638/udp # Sybase Anywhere [Dave_Neudoerffer] [Dave_Neudoerffer]
+aminet           2639/tcp # AMInet [Alcorn_McBride_Inc] [Alcorn_McBride_Inc]
+aminet           2639/udp # AMInet [Alcorn_McBride_Inc] [Alcorn_McBride_Inc]
+sai-sentlm       2640/tcp # Sabbagh Associates Licence ManagerIANA assigned this well-formed service name as a replacement for "sai_sentlm". [Elias_Sabbagh] [Elias_Sabbagh]
+sai_sentlm       2640/tcp # Sabbagh Associates Licence Manager [Elias_Sabbagh] [Elias_Sabbagh] This entry is an alias to "sai-sentlm".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+sai-sentlm       2640/udp # Sabbagh Associates Licence ManagerIANA assigned this well-formed service name as a replacement for "sai_sentlm". [Elias_Sabbagh] [Elias_Sabbagh]
+sai_sentlm       2640/udp # Sabbagh Associates Licence Manager [Elias_Sabbagh] [Elias_Sabbagh] This entry is an alias to "sai-sentlm".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+hdl-srv          2641/tcp # HDL Server [David_Ely] [David_Ely]
+hdl-srv          2641/udp # HDL Server [David_Ely] [David_Ely]
+tragic           2642/tcp # Tragic [Stu_Mark] [Stu_Mark]
+tragic           2642/udp # Tragic [Stu_Mark] [Stu_Mark]
+gte-samp         2643/tcp # GTE-SAMP [Asher_Altman] [Asher_Altman]
+gte-samp         2643/udp # GTE-SAMP [Asher_Altman] [Asher_Altman]
+travsoft-ipx-t   2644/tcp # Travsoft IPX Tunnel [Jack_Wilson] [Jack_Wilson]
+travsoft-ipx-t   2644/udp # Travsoft IPX Tunnel [Jack_Wilson] [Jack_Wilson]
+novell-ipx-cmd   2645/tcp # Novell IPX CMD [Juan_Carlos_Luciani] [Juan_Carlos_Luciani]
+novell-ipx-cmd   2645/udp # Novell IPX CMD [Juan_Carlos_Luciani] [Juan_Carlos_Luciani]
+and-lm           2646/tcp # AND License Manager [Dick_van_der_Sijs] [Dick_van_der_Sijs]
+and-lm           2646/udp # AND License Manager [Dick_van_der_Sijs] [Dick_van_der_Sijs]
+syncserver       2647/tcp # SyncServer [Shawn_Casey] [Shawn_Casey]
+syncserver       2647/udp # SyncServer [Shawn_Casey] [Shawn_Casey]
+upsnotifyprot    2648/tcp # Upsnotifyprot [Mario_Leboute] [Mario_Leboute]
+upsnotifyprot    2648/udp # Upsnotifyprot [Mario_Leboute] [Mario_Leboute]
+vpsipport        2649/tcp # VPSIPPORT [Joon_Radley] [Joon_Radley]
+vpsipport        2649/udp # VPSIPPORT [Joon_Radley] [Joon_Radley]
+eristwoguns      2650/tcp # eristwoguns [Jason_Lockett][Melanie_Kacerek] [Jason_Lockett][Melanie_Kacerek] 2008-12-16
+eristwoguns      2650/udp # eristwoguns [Jason_Lockett][Melanie_Kacerek] [Jason_Lockett][Melanie_Kacerek] 2008-12-16
+ebinsite         2651/tcp # EBInSite [Lefteris_Kalamaras] [Lefteris_Kalamaras]
+ebinsite         2651/udp # EBInSite [Lefteris_Kalamaras] [Lefteris_Kalamaras]
+interpathpanel   2652/tcp # InterPathPanel [Stephen_Misel] [Stephen_Misel]
+interpathpanel   2652/udp # InterPathPanel [Stephen_Misel] [Stephen_Misel]
+sonus            2653/tcp # Sonus [Mark_Garti] [Mark_Garti]
+sonus            2653/udp # Sonus [Mark_Garti] [Mark_Garti]
+corel-vncadmin   2654/tcp # Corel VNC AdminIANA assigned this well-formed service name as a replacement for "corel_vncadmin". [Oleg_Noskov] [Oleg_Noskov]
+corel_vncadmin   2654/tcp # Corel VNC Admin [Oleg_Noskov] [Oleg_Noskov] This entry is an alias to "corel-vncadmin".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+corel-vncadmin   2654/udp # Corel VNC AdminIANA assigned this well-formed service name as a replacement for "corel_vncadmin". [Oleg_Noskov] [Oleg_Noskov]
+corel_vncadmin   2654/udp # Corel VNC Admin [Oleg_Noskov] [Oleg_Noskov] This entry is an alias to "corel-vncadmin".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+unglue           2655/tcp # UNIX Nt Glue [Peter_Santoro] [Peter_Santoro]
+unglue           2655/udp # UNIX Nt Glue [Peter_Santoro] [Peter_Santoro]
+kana             2656/tcp # Kana [Colin_Goldstein] [Colin_Goldstein]
+kana             2656/udp # Kana [Colin_Goldstein] [Colin_Goldstein]
+sns-dispatcher   2657/tcp # SNS Dispatcher
+sns-dispatcher   2657/udp # SNS Dispatcher
+sns-admin        2658/tcp # SNS Admin
+sns-admin        2658/udp # SNS Admin
+sns-query        2659/tcp # SNS Query [Mary_Holstege] [Mary_Holstege]
+sns-query        2659/udp # SNS Query [Mary_Holstege] [Mary_Holstege]
+gcmonitor        2660/tcp # GC Monitor [Gustavo_Rodriguez_Ri] [Gustavo_Rodriguez_Ri]
+gcmonitor        2660/udp # GC Monitor [Gustavo_Rodriguez_Ri] [Gustavo_Rodriguez_Ri]
+olhost           2661/tcp # OLHOST [Robert_Ripberger] [Robert_Ripberger]
+olhost           2661/udp # OLHOST [Robert_Ripberger] [Robert_Ripberger]
+bintec-capi      2662/tcp # BinTec-CAPI Unauthorized Use Known on port 2662
+bintec-capi      2662/udp # BinTec-CAPI Unauthorized Use Known on port 2662
+bintec-tapi      2663/tcp # BinTec-TAPI
+bintec-tapi      2663/udp # BinTec-TAPI
+patrol-mq-gm     2664/tcp # Patrol for MQ GM
+patrol-mq-gm     2664/udp # Patrol for MQ GM
+patrol-mq-nm     2665/tcp # Patrol for MQ NM [Portnoy_Boxman] [Portnoy_Boxman]
+patrol-mq-nm     2665/udp # Patrol for MQ NM [Portnoy_Boxman] [Portnoy_Boxman]
+extensis         2666/tcp # extensis [Milton_Sagen] [Milton_Sagen]
+extensis         2666/udp # extensis [Milton_Sagen] [Milton_Sagen]
+alarm-clock-s    2667/tcp # Alarm Clock Server
+alarm-clock-s    2667/udp # Alarm Clock Server
+alarm-clock-c    2668/tcp # Alarm Clock Client
+alarm-clock-c    2668/udp # Alarm Clock Client
+toad             2669/tcp # TOAD [Michael_Marking] [Michael_Marking]
+toad             2669/udp # TOAD [Michael_Marking] [Michael_Marking]
+tve-announce     2670/tcp # TVE Announce [Dean_Blackketter] [Dean_Blackketter]
+tve-announce     2670/udp # TVE Announce [Dean_Blackketter] [Dean_Blackketter]
+newlixreg        2671/tcp # newlixreg [Jean_Serge_Gagnon_2] [Jean_Serge_Gagnon_2]
+newlixreg        2671/udp # newlixreg [Jean_Serge_Gagnon_2] [Jean_Serge_Gagnon_2]
+nhserver         2672/tcp # nhserver [Adrian_Hornby] [Adrian_Hornby]
+nhserver         2672/udp # nhserver [Adrian_Hornby] [Adrian_Hornby]
+firstcall42      2673/tcp # First Call 42 [Luke_Bowen] [Luke_Bowen]
+firstcall42      2673/udp # First Call 42 [Luke_Bowen] [Luke_Bowen]
+ewnn             2674/tcp # ewnn [Yasunari_Yamashita] [Yasunari_Yamashita]
+ewnn             2674/udp # ewnn [Yasunari_Yamashita] [Yasunari_Yamashita]
+ttc-etap         2675/tcp # TTC ETAP [Daniel_Becker] [Daniel_Becker]
+ttc-etap         2675/udp # TTC ETAP [Daniel_Becker] [Daniel_Becker]
+simslink         2676/tcp # SIMSLink [Steve_Ryckman] [Steve_Ryckman]
+simslink         2676/udp # SIMSLink [Steve_Ryckman] [Steve_Ryckman]
+gadgetgate1way   2677/tcp # Gadget Gate 1 Way
+gadgetgate1way   2677/udp # Gadget Gate 1 Way
+gadgetgate2way   2678/tcp # Gadget Gate 2 Way [Matt_Rollins] [Matt_Rollins]
+gadgetgate2way   2678/udp # Gadget Gate 2 Way [Matt_Rollins] [Matt_Rollins]
+syncserverssl    2679/tcp # Sync Server SSL [Shawn_Casey] [Shawn_Casey]
+syncserverssl    2679/udp # Sync Server SSL [Shawn_Casey] [Shawn_Casey]
+pxc-sapxom       2680/tcp # pxc-sapxom [Hideki_Kiriyama] [Hideki_Kiriyama]
+pxc-sapxom       2680/udp # pxc-sapxom [Hideki_Kiriyama] [Hideki_Kiriyama]
+mpnjsomb         2681/tcp # mpnjsomb [Takenori_Miyahara] [Takenori_Miyahara]
+mpnjsomb         2681/udp # mpnjsomb [Takenori_Miyahara] [Takenori_Miyahara]
+ncdloadbalance   2683/tcp # NCDLoadBalance [Tim_Stevenson] [Tim_Stevenson]
+ncdloadbalance   2683/udp # NCDLoadBalance [Tim_Stevenson] [Tim_Stevenson]
+mpnjsosv         2684/tcp # mpnjsosv
+mpnjsosv         2684/udp # mpnjsosv
+mpnjsocl         2685/tcp # mpnjsocl
+mpnjsocl         2685/udp # mpnjsocl
+mpnjsomg         2686/tcp # mpnjsomg [Takenori_Miyahara] [Takenori_Miyahara]
+mpnjsomg         2686/udp # mpnjsomg [Takenori_Miyahara] [Takenori_Miyahara]
+pq-lic-mgmt      2687/tcp # pq-lic-mgmt [Bob_Sledge] [Bob_Sledge]
+pq-lic-mgmt      2687/udp # pq-lic-mgmt [Bob_Sledge] [Bob_Sledge]
+md-cg-http       2688/tcp # md-cf-http [Lyndon_Nerenberg] [Lyndon_Nerenberg]
+md-cg-http       2688/udp # md-cf-http [Lyndon_Nerenberg] [Lyndon_Nerenberg]
+fastlynx         2689/tcp # FastLynx [Dave_Sewell] [Dave_Sewell]
+fastlynx         2689/udp # FastLynx [Dave_Sewell] [Dave_Sewell]
+hp-nnm-data      2690/tcp # HP NNM Embedded Database [Chris_Das] [Chris_Das]
+hp-nnm-data      2690/udp # HP NNM Embedded Database [Chris_Das] [Chris_Das]
+itinternet       2691/tcp # ITInternet ISM Server [Ron_Ehli] [Ron_Ehli]
+itinternet       2691/udp # ITInternet ISM Server [Ron_Ehli] [Ron_Ehli]
+admins-lms       2692/tcp # Admins LMS [Dagfinn_Saether] [Dagfinn_Saether]
+admins-lms       2692/udp # Admins LMS [Dagfinn_Saether] [Dagfinn_Saether]
+pwrsevent        2694/tcp # pwrsevent [Yoshinobu_Nakamura] [Yoshinobu_Nakamura]
+pwrsevent        2694/udp # pwrsevent [Yoshinobu_Nakamura] [Yoshinobu_Nakamura]
+vspread          2695/tcp # VSPREAD [Sumitake_kobayashi] [Sumitake_kobayashi]
+vspread          2695/udp # VSPREAD [Sumitake_kobayashi] [Sumitake_kobayashi]
+unifyadmin       2696/tcp # Unify Admin [Daegis_Inc] [Chris_Anderson] 2012-07-31
+unifyadmin       2696/udp # Unify Admin [Daegis_Inc] [Chris_Anderson] 2012-07-31
+oce-snmp-trap    2697/tcp # Oce SNMP Trap Port [Peter_Teeuwen] [Peter_Teeuwen]
+oce-snmp-trap    2697/udp # Oce SNMP Trap Port [Peter_Teeuwen] [Peter_Teeuwen]
+mck-ivpip        2698/tcp # MCK-IVPIP [Robert_Vincent] [Robert_Vincent]
+mck-ivpip        2698/udp # MCK-IVPIP [Robert_Vincent] [Robert_Vincent]
+csoft-plusclnt   2699/tcp # Csoft Plus Client [Nedelcho_Stanev] [Nedelcho_Stanev]
+csoft-plusclnt   2699/udp # Csoft Plus Client [Nedelcho_Stanev] [Nedelcho_Stanev]
+tqdata           2700/tcp # tqdata [Al_Guetzlaff] [Al_Guetzlaff]
+tqdata           2700/udp # tqdata [Al_Guetzlaff] [Al_Guetzlaff]
+sms-rcinfo       2701/tcp # SMS RCINFO
+sms-rcinfo       2701/udp # SMS RCINFO
+sms-xfer         2702/tcp # SMS XFER
+sms-xfer         2702/udp # SMS XFER
+sms-chat         2703/tcp # SMS CHAT
+sms-chat         2703/udp # SMS CHAT
+sms-remctrl      2704/tcp # SMS REMCTRL [Tom_Friend] [Tom_Friend]
+sms-remctrl      2704/udp # SMS REMCTRL [Tom_Friend] [Tom_Friend]
+sds-admin        2705/tcp # SDS Admin [Don_Traub] [Don_Traub]
+sds-admin        2705/udp # SDS Admin [Don_Traub] [Don_Traub]
+ncdmirroring     2706/tcp # NCD Mirroring [Tim_Stevenson] [Tim_Stevenson]
+ncdmirroring     2706/udp # NCD Mirroring [Tim_Stevenson] [Tim_Stevenson]
+emcsymapiport    2707/tcp # EMCSYMAPIPORT [Bruce_Ferjulian] [Bruce_Ferjulian]
+emcsymapiport    2707/udp # EMCSYMAPIPORT [Bruce_Ferjulian] [Bruce_Ferjulian]
+banyan-net       2708/tcp # Banyan-Net [R_Thirumurthy] [R_Thirumurthy]
+banyan-net       2708/udp # Banyan-Net [R_Thirumurthy] [R_Thirumurthy]
+supermon         2709/tcp # Supermon [Ron_Minnich] [Ron_Minnich]
+supermon         2709/udp # Supermon [Ron_Minnich] [Ron_Minnich]
+sso-service      2710/tcp # SSO Service
+sso-service      2710/udp # SSO Service
+sso-control      2711/tcp # SSO Control [Axel_Kern] [Axel_Kern]
+sso-control      2711/udp # SSO Control [Axel_Kern] [Axel_Kern]
+aocp             2712/tcp # Axapta Object Communication Protocol [Jakob_Steen_Hansen] [Jakob_Steen_Hansen]
+aocp             2712/udp # Axapta Object Communication Protocol [Jakob_Steen_Hansen] [Jakob_Steen_Hansen]
+raventbs         2713/tcp # Raven Trinity Broker Service
+raventbs         2713/udp # Raven Trinity Broker Service
+raventdm         2714/tcp # Raven Trinity Data Mover [Daniel_Sorlov] [Daniel_Sorlov]
+raventdm         2714/udp # Raven Trinity Data Mover [Daniel_Sorlov] [Daniel_Sorlov]
+hpstgmgr2        2715/tcp # HPSTGMGR2 [Kevin_Collins_2] [Kevin_Collins_2]
+hpstgmgr2        2715/udp # HPSTGMGR2 [Kevin_Collins_2] [Kevin_Collins_2]
+inova-ip-disco   2716/tcp # Inova IP Disco [Chris_Koeritz] [Chris_Koeritz]
+inova-ip-disco   2716/udp # Inova IP Disco [Chris_Koeritz] [Chris_Koeritz]
+pn-requester     2717/tcp # PN REQUESTER
+pn-requester     2717/udp # PN REQUESTER
+pn-requester2    2718/tcp # PN REQUESTER 2 [Portnoy_Boxman] [Portnoy_Boxman]
+pn-requester2    2718/udp # PN REQUESTER 2 [Portnoy_Boxman] [Portnoy_Boxman]
+scan-change      2719/tcp # Scan & Change [Alexander_Raji] [Alexander_Raji]
+scan-change      2719/udp # Scan & Change [Alexander_Raji] [Alexander_Raji]
+wkars            2720/tcp # wkars [Barry_Shelton] [Barry_Shelton]
+wkars            2720/udp # wkars [Barry_Shelton] [Barry_Shelton]
+smart-diagnose   2721/tcp # Smart Diagnose [Geoffry_Meek] [Geoffry_Meek]
+smart-diagnose   2721/udp # Smart Diagnose [Geoffry_Meek] [Geoffry_Meek]
+proactivesrvr    2722/tcp # Proactive Server [Dalit_Naor] [Dalit_Naor]
+proactivesrvr    2722/udp # Proactive Server [Dalit_Naor] [Dalit_Naor]
+watchdog-nt      2723/tcp # WatchDog NT Protocol [Glen_Sansoucie] [Glen_Sansoucie]
+watchdog-nt      2723/udp # WatchDog NT Protocol [Glen_Sansoucie] [Glen_Sansoucie]
+qotps            2724/tcp # qotps [Piotr_Parlewicz] [Piotr_Parlewicz]
+qotps            2724/udp # qotps [Piotr_Parlewicz] [Piotr_Parlewicz]
+msolap-ptp2      2725/tcp # MSOLAP PTP2 [Cristian_Petculescu] [Cristian_Petculescu]
+msolap-ptp2      2725/udp # MSOLAP PTP2 [Cristian_Petculescu] [Cristian_Petculescu]
+tams             2726/tcp # TAMS [David_Leinbach] [David_Leinbach]
+tams             2726/udp # TAMS [David_Leinbach] [David_Leinbach]
+mgcp-callagent   2727/tcp # Media Gateway Control Protocol Call Agent [Christian_Huitema] [Christian_Huitema]
+mgcp-callagent   2727/udp # Media Gateway Control Protocol Call Agent [Christian_Huitema] [Christian_Huitema]
+sqdr             2728/tcp # SQDR [Matthew_Orzen] [Matthew_Orzen]
+sqdr             2728/udp # SQDR [Matthew_Orzen] [Matthew_Orzen]
+tcim-control     2729/tcp # TCIM Control [Dean_Skelton] [Dean_Skelton]
+tcim-control     2729/udp # TCIM Control [Dean_Skelton] [Dean_Skelton]
+nec-raidplus     2730/tcp # NEC RaidPlus [Yusuke_Asai] [Yusuke_Asai]
+nec-raidplus     2730/udp # NEC RaidPlus [Yusuke_Asai] [Yusuke_Asai]
+fyre-messanger   2731/tcp # Fyre Messanger [Robert_Waters] [Robert_Waters]
+fyre-messanger   2731/udp # Fyre Messagner [Robert_Waters] [Robert_Waters]
+g5m              2732/tcp # G5M [Graham_Klyne] [Graham_Klyne]
+g5m              2732/udp # G5M [Graham_Klyne] [Graham_Klyne]
+signet-ctf       2733/tcp # Signet CTF [Greg_Broiles] [Greg_Broiles]
+signet-ctf       2733/udp # Signet CTF [Greg_Broiles] [Greg_Broiles]
+ccs-software     2734/tcp # CCS Software [Bertus_Jacobs] [Bertus_Jacobs]
+ccs-software     2734/udp # CCS Software [Bertus_Jacobs] [Bertus_Jacobs]
+netiq-mc         2735/tcp # NetIQ Monitor Console [Scott_Southard] [Scott_Southard] 2010-08-25
+netiq-mc         2735/udp # NetIQ Monitor Console [Scott_Southard] [Scott_Southard] 2010-08-25
+radwiz-nms-srv   2736/tcp # RADWIZ NMS SRV [Israel_Shainert] [Israel_Shainert]
+radwiz-nms-srv   2736/udp # RADWIZ NMS SRV [Israel_Shainert] [Israel_Shainert]
+srp-feedback     2737/tcp # SRP Feedback [Werner_Almesberger] [Werner_Almesberger]
+srp-feedback     2737/udp # SRP Feedback [Werner_Almesberger] [Werner_Almesberger]
+ndl-tcp-ois-gw   2738/tcp # NDL TCP-OSI Gateway [Martin_Norman] [Martin_Norman]
+ndl-tcp-ois-gw   2738/udp # NDL TCP-OSI Gateway [Martin_Norman] [Martin_Norman]
+tn-timing        2739/tcp # TN Timing [Paul_Roberts] [Paul_Roberts]
+tn-timing        2739/udp # TN Timing [Paul_Roberts] [Paul_Roberts]
+alarm            2740/tcp # Alarm [Uriy_Makasjuk] [Uriy_Makasjuk]
+alarm            2740/udp # Alarm [Uriy_Makasjuk] [Uriy_Makasjuk]
+tsb              2741/tcp # TSB
+tsb              2741/udp # TSB
+tsb2             2742/tcp # TSB2 [Ashish_Chatterjee] [Ashish_Chatterjee]
+tsb2             2742/udp # TSB2 [Ashish_Chatterjee] [Ashish_Chatterjee]
+murx             2743/tcp # murx [Thomas_Kuiper] [Thomas_Kuiper]
+murx             2743/udp # murx [Thomas_Kuiper] [Thomas_Kuiper]
+honyaku          2744/tcp # honyaku [Yasunari_Yamashita] [Yasunari_Yamashita]
+honyaku          2744/udp # honyaku [Yasunari_Yamashita] [Yasunari_Yamashita]
+urbisnet         2745/tcp # URBISNET [Urbis_Net_Ltd] [Urbis_Net_Ltd]
+urbisnet         2745/udp # URBISNET [Urbis_Net_Ltd] [Urbis_Net_Ltd]
+cpudpencap       2746/tcp # CPUDPENCAP [Tamir_Zegman] [Tamir_Zegman]
+cpudpencap       2746/udp # CPUDPENCAP [Tamir_Zegman] [Tamir_Zegman]
+fjippol-swrly    2747/tcp # 
+fjippol-swrly    2747/udp # 
+fjippol-polsvr   2748/tcp # 
+fjippol-polsvr   2748/udp # 
+fjippol-cnsl     2749/tcp # 
+fjippol-cnsl     2749/udp # 
+fjippol-port1    2750/tcp # 
+fjippol-port1    2750/udp # 
+fjippol-port2    2751/tcp # [Shoichi_Tachibana] [Shoichi_Tachibana]
+fjippol-port2    2751/udp # [Shoichi_Tachibana] [Shoichi_Tachibana]
+rsisysaccess     2752/tcp # RSISYS ACCESS [Christophe_Besant] [Christophe_Besant]
+rsisysaccess     2752/udp # RSISYS ACCESS [Christophe_Besant] [Christophe_Besant]
+de-spot          2753/tcp # de-spot [Sanjay_Parekh] [Sanjay_Parekh]
+de-spot          2753/udp # de-spot [Sanjay_Parekh] [Sanjay_Parekh]
+apollo-cc        2754/tcp # APOLLO CC [Brand_Communications] [Brand_Communications]
+apollo-cc        2754/udp # APOLLO CC [Brand_Communications] [Brand_Communications]
+expresspay       2755/tcp # Express Pay [Ben_Higgins] [Ben_Higgins]
+expresspay       2755/udp # Express Pay [Ben_Higgins] [Ben_Higgins]
+simplement-tie   2756/tcp # simplement-tie [Tzvika_Chumash] [Tzvika_Chumash]
+simplement-tie   2756/udp # simplement-tie [Tzvika_Chumash] [Tzvika_Chumash]
+cnrp             2757/tcp # CNRP [Jacob_Ulmert] [Jacob_Ulmert]
+cnrp             2757/udp # CNRP [Jacob_Ulmert] [Jacob_Ulmert]
+apollo-status    2758/tcp # APOLLO Status
+apollo-status    2758/udp # APOLLO Status
+apollo-gms       2759/tcp # APOLLO GMS [Simon_Hovell] [Simon_Hovell]
+apollo-gms       2759/udp # APOLLO GMS [Simon_Hovell] [Simon_Hovell]
+sabams           2760/tcp # Saba MS [Davoud_Maha] [Davoud_Maha]
+sabams           2760/udp # Saba MS [Davoud_Maha] [Davoud_Maha]
+dicom-iscl       2761/tcp # DICOM ISCL
+dicom-iscl       2761/udp # DICOM ISCL
+dicom-tls        2762/tcp # DICOM TLS [Lawrence_Tarbox] [Lawrence_Tarbox]
+dicom-tls        2762/udp # DICOM TLS [Lawrence_Tarbox] [Lawrence_Tarbox]
+desktop-dna      2763/tcp # Desktop DNA [Jon_Walker] [Jon_Walker]
+desktop-dna      2763/udp # Desktop DNA [Jon_Walker] [Jon_Walker]
+data-insurance   2764/tcp # Data Insurance [Brent_Irwin] [Brent_Irwin]
+data-insurance   2764/udp # Data Insurance [Brent_Irwin] [Brent_Irwin]
+qip-audup        2765/tcp # qip-audup [Mike_Morgan] [Mike_Morgan]
+qip-audup        2765/udp # qip-audup [Mike_Morgan] [Mike_Morgan]
+compaq-scp       2766/tcp # Compaq SCP [Ferruccio_Barletta] [Ferruccio_Barletta]
+compaq-scp       2766/udp # Compaq SCP [Ferruccio_Barletta] [Ferruccio_Barletta]
+uadtc            2767/tcp # UADTC
+uadtc            2767/udp # UADTC
+uacs             2768/tcp # UACS [Vishwas_Lele] [Vishwas_Lele]
+uacs             2768/udp # UACS [Vishwas_Lele] [Vishwas_Lele]
+exce             2769/tcp # eXcE [Norm_Freedman] [Norm_Freedman]
+exce             2769/udp # eXcE [Norm_Freedman] [Norm_Freedman]
+veronica         2770/tcp # Veronica [Jonas_Oberg] [Jonas_Oberg]
+veronica         2770/udp # Veronica [Jonas_Oberg] [Jonas_Oberg]
+vergencecm       2771/tcp # Vergence CM [Mark_Morwood] [Mark_Morwood]
+vergencecm       2771/udp # Vergence CM [Mark_Morwood] [Mark_Morwood]
+auris            2772/tcp # auris [Francisco_Saez_Aranc] [Francisco_Saez_Aranc]
+auris            2772/udp # auris [Francisco_Saez_Aranc] [Francisco_Saez_Aranc]
+rbakcup1         2773/tcp # RBackup Remote Backup
+rbakcup1         2773/udp # RBackup Remote Backup
+rbakcup2         2774/tcp # RBackup Remote Backup [Rob_Cosgrove] [Rob_Cosgrove]
+rbakcup2         2774/udp # RBackup Remote Backup [Rob_Cosgrove] [Rob_Cosgrove]
+smpp             2775/tcp # SMPP [Owen_Sullivan] [Owen_Sullivan]
+smpp             2775/udp # SMPP [Owen_Sullivan] [Owen_Sullivan]
+ridgeway1        2776/tcp # Ridgeway Systems & Software
+ridgeway1        2776/udp # Ridgeway Systems & Software
+ridgeway2        2777/tcp # Ridgeway Systems & Software [Steve_Read] [Steve_Read]
+ridgeway2        2777/udp # Ridgeway Systems & Software [Steve_Read] [Steve_Read]
+gwen-sonya       2778/tcp # Gwen-Sonya [Mark_Hurst] [Mark_Hurst]
+gwen-sonya       2778/udp # Gwen-Sonya [Mark_Hurst] [Mark_Hurst]
+lbc-sync         2779/tcp # LBC Sync
+lbc-sync         2779/udp # LBC Sync
+lbc-control      2780/tcp # LBC Control [Keiji_Michine] [Keiji_Michine]
+lbc-control      2780/udp # LBC Control [Keiji_Michine] [Keiji_Michine]
+whosells         2781/tcp # whosells [William_Randolph_Roy] [William_Randolph_Roy]
+whosells         2781/udp # whosells [William_Randolph_Roy] [William_Randolph_Roy]
+everydayrc       2782/tcp # everydayrc [Ahti_Heinla] [Ahti_Heinla]
+everydayrc       2782/udp # everydayrc [Ahti_Heinla] [Ahti_Heinla]
+aises            2783/tcp # AISES [Daniel_Grazioli] [Daniel_Grazioli]
+aises            2783/udp # AISES [Daniel_Grazioli] [Daniel_Grazioli]
+www-dev          2784/tcp # world wide web - development
+www-dev          2784/udp # world wide web - development
+aic-np           2785/tcp # aic-np [Brad_Parker] [Brad_Parker]
+aic-np           2785/udp # aic-np [Brad_Parker] [Brad_Parker]
+aic-oncrpc       2786/tcp # aic-oncrpc - Destiny MCD database [Brad_Parker] [Brad_Parker]
+aic-oncrpc       2786/udp # aic-oncrpc - Destiny MCD database [Brad_Parker] [Brad_Parker]
+piccolo          2787/tcp # piccolo - Cornerstone Software [Dave_Bellivea] [Dave_Bellivea]
+piccolo          2787/udp # piccolo - Cornerstone Software [Dave_Bellivea] [Dave_Bellivea]
+fryeserv         2788/tcp # NetWare Loadable Module - Seagate Software [Joseph_LoPilato] [Joseph_LoPilato]
+fryeserv         2788/udp # NetWare Loadable Module - Seagate Software [Joseph_LoPilato] [Joseph_LoPilato]
+media-agent      2789/tcp # Media Agent [Nitzan_Daube] [Nitzan_Daube]
+media-agent      2789/udp # Media Agent [Nitzan_Daube] [Nitzan_Daube]
+plgproxy         2790/tcp # PLG Proxy [Charlie_Hava] [Charlie_Hava]
+plgproxy         2790/udp # PLG Proxy [Charlie_Hava] [Charlie_Hava]
+mtport-regist    2791/tcp # MT Port Registrator [Maxim_Tseitlin] [Maxim_Tseitlin]
+mtport-regist    2791/udp # MT Port Registrator [Maxim_Tseitlin] [Maxim_Tseitlin]
+f5-globalsite    2792/tcp # f5-globalsite [Christian_Saether_2] [Christian_Saether_2]
+f5-globalsite    2792/udp # f5-globalsite [Christian_Saether_2] [Christian_Saether_2]
+initlsmsad       2793/tcp # initlsmsad [Kelly_Green] [Kelly_Green]
+initlsmsad       2793/udp # initlsmsad [Kelly_Green] [Kelly_Green]
+livestats        2795/tcp # LiveStats [Chris_Greene] [Chris_Greene]
+livestats        2795/udp # LiveStats [Chris_Greene] [Chris_Greene]
+ac-tech          2796/tcp # ac-tech [Chiming_Huang] [Chiming_Huang]
+ac-tech          2796/udp # ac-tech [Chiming_Huang] [Chiming_Huang]
+esp-encap        2797/tcp # esp-encap [Jorn_Sierwald] [Jorn_Sierwald]
+esp-encap        2797/udp # esp-encap [Jorn_Sierwald] [Jorn_Sierwald]
+tmesis-upshot    2798/tcp # TMESIS-UPShot [Brian_Schenkenberger] [Brian_Schenkenberger]
+tmesis-upshot    2798/udp # TMESIS-UPShot [Brian_Schenkenberger] [Brian_Schenkenberger]
+icon-discover    2799/tcp # ICON Discover [Alexander_Falk] [Alexander_Falk]
+icon-discover    2799/udp # ICON Discover [Alexander_Falk] [Alexander_Falk]
+acc-raid         2800/tcp # ACC RAID [Scott_St_Clair] [Scott_St_Clair]
+acc-raid         2800/udp # ACC RAID [Scott_St_Clair] [Scott_St_Clair]
+igcp             2801/tcp # IGCP [David_Hampson] [David_Hampson]
+igcp             2801/udp # IGCP [David_Hampson] [David_Hampson]
+veritas-tcp1     2802/tcp # Veritas TCP1
+veritas-udp1     2802/udp # Veritas UDP1 [Russ_Thrasher] [Russ_Thrasher]
+btprjctrl        2803/tcp # btprjctrl [Huw_Thomas] [Huw_Thomas]
+btprjctrl        2803/udp # btprjctrl [Huw_Thomas] [Huw_Thomas]
+dvr-esm          2804/tcp # March Networks Digital Video Recorders and Enterprise Service Manager products [Paul_Streatch] [Paul_Streatch] 2004-06
+dvr-esm          2804/udp # March Networks Digital Video Recorders and Enterprise Service Manager products [Paul_Streatch] [Paul_Streatch] 2004-06
+wta-wsp-s        2805/tcp # WTA WSP-S [Sebastien_Bury] [Sebastien_Bury]
+wta-wsp-s        2805/udp # WTA WSP-S [Sebastien_Bury] [Sebastien_Bury]
+cspuni           2806/tcp # cspuni
+cspuni           2806/udp # cspuni
+cspmulti         2807/tcp # cspmulti [Terumasa_Yoneda] [Terumasa_Yoneda]
+cspmulti         2807/udp # cspmulti [Terumasa_Yoneda] [Terumasa_Yoneda]
+j-lan-p          2808/tcp # J-LAN-P [Takeshi_Sahara] [Takeshi_Sahara]
+j-lan-p          2808/udp # J-LAN-P [Takeshi_Sahara] [Takeshi_Sahara]
+corbaloc         2809/tcp # CORBA LOC [Ted_McFadden] [Ted_McFadden]
+corbaloc         2809/udp # CORBA LOC [Ted_McFadden] [Ted_McFadden]
+netsteward       2810/tcp # Active Net Steward [Keith_Morley] [Keith_Morley]
+netsteward       2810/udp # Active Net Steward [Keith_Morley] [Keith_Morley]
+gsiftp           2811/tcp # GSI FTP [Von_Welch] [Von_Welch]
+gsiftp           2811/udp # GSI FTP [Von_Welch] [Von_Welch]
+atmtcp           2812/tcp # atmtcp [Werner_Almesberger] [Werner_Almesberger]
+atmtcp           2812/udp # atmtcp [Werner_Almesberger] [Werner_Almesberger]
+llm-pass         2813/tcp # llm-pass
+llm-pass         2813/udp # llm-pass
+llm-csv          2814/tcp # llm-csv [Glen_Sansoucie_2] [Glen_Sansoucie_2]
+llm-csv          2814/udp # llm-csv [Glen_Sansoucie_2] [Glen_Sansoucie_2]
+lbc-measure      2815/tcp # LBC Measurement
+lbc-measure      2815/udp # LBC Measurement
+lbc-watchdog     2816/tcp # LBC Watchdog [Akiyoshi_Ochi] [Akiyoshi_Ochi]
+lbc-watchdog     2816/udp # LBC Watchdog [Akiyoshi_Ochi] [Akiyoshi_Ochi]
+nmsigport        2817/tcp # NMSig Port [Peter_Egli_2] [Peter_Egli_2]
+nmsigport        2817/udp # NMSig Port [Peter_Egli_2] [Peter_Egli_2]
+rmlnk            2818/tcp # rmlnk
+rmlnk            2818/udp # rmlnk
+fc-faultnotify   2819/tcp # FC Fault Notification [Dave_Watkins] [Dave_Watkins]
+fc-faultnotify   2819/udp # FC Fault Notification [Dave_Watkins] [Dave_Watkins]
+univision        2820/tcp # UniVision [Keith_Ansell] [Keith_Ansell]
+univision        2820/udp # UniVision [Keith_Ansell] [Keith_Ansell]
+vrts-at-port     2821/tcp # VERITAS Authentication Service [Stefan_Winkel] [Stefan_Winkel]
+vrts-at-port     2821/udp # VERITAS Authentication Service [Stefan_Winkel] [Stefan_Winkel]
+ka0wuc           2822/tcp # ka0wuc [Kit_Haskins] [Kit_Haskins]
+ka0wuc           2822/udp # ka0wuc [Kit_Haskins] [Kit_Haskins]
+cqg-netlan       2823/tcp # CQG Net/LAN
+cqg-netlan       2823/udp # CQG Net/LAN
+cqg-netlan-1     2824/tcp # CQG Net/LAN 1 [Jeff_Wood] [Jeff_Wood]
+cqg-netlan-1     2824/udp # CQG Net/Lan 1 [Jeff_Wood] [Jeff_Wood]
+slc-systemlog    2826/tcp # slc systemlog
+slc-systemlog    2826/udp # slc systemlog
+slc-ctrlrloops   2827/tcp # slc ctrlrloops [Erwin_Hogeweg] [Erwin_Hogeweg]
+slc-ctrlrloops   2827/udp # slc ctrlrloops [Erwin_Hogeweg] [Erwin_Hogeweg]
+itm-lm           2828/tcp # ITM License Manager [Portnoy_Boxman] [Portnoy_Boxman]
+itm-lm           2828/udp # ITM License Manager [Portnoy_Boxman] [Portnoy_Boxman]
+silkp1           2829/tcp # silkp1
+silkp1           2829/udp # silkp1
+silkp2           2830/tcp # silkp2
+silkp2           2830/udp # silkp2
+silkp3           2831/tcp # silkp3
+silkp3           2831/udp # silkp3
+silkp4           2832/tcp # silkp4 [Erik_Skyten] [Erik_Skyten]
+silkp4           2832/udp # silkp4 [Erik_Skyten] [Erik_Skyten]
+glishd           2833/tcp # glishd [Darrell_Schiebel] [Darrell_Schiebel]
+glishd           2833/udp # glishd [Darrell_Schiebel] [Darrell_Schiebel]
+evtp             2834/tcp # EVTP
+evtp             2834/udp # EVTP
+evtp-data        2835/tcp # EVTP-DATA [Eric_Bruno] [Eric_Bruno]
+evtp-data        2835/udp # EVTP-DATA [Eric_Bruno] [Eric_Bruno]
+catalyst         2836/tcp # catalyst [Garret_Tollkuhn] [Garret_Tollkuhn]
+catalyst         2836/udp # catalyst [Garret_Tollkuhn] [Garret_Tollkuhn]
+repliweb         2837/tcp # Repliweb [William_Orme] [William_Orme]
+repliweb         2837/udp # Repliweb [William_Orme] [William_Orme]
+starbot          2838/tcp # Starbot [Markus_Sabadello_2] [Markus_Sabadello_2]
+starbot          2838/udp # Starbot [Markus_Sabadello_2] [Markus_Sabadello_2]
+nmsigport        2839/tcp # NMSigPort [Peter_Egli_2] [Peter_Egli_2]
+nmsigport        2839/udp # NMSigPort [Peter_Egli_2] [Peter_Egli_2]
+l3-exprt         2840/tcp # l3-exprt
+l3-exprt         2840/udp # l3-exprt
+l3-ranger        2841/tcp # l3-ranger
+l3-ranger        2841/udp # l3-ranger
+l3-hawk          2842/tcp # l3-hawk [Dolores_Scott_2] [Dolores_Scott_2]
+l3-hawk          2842/udp # l3-hawk [Dolores_Scott_2] [Dolores_Scott_2]
+pdnet            2843/tcp # PDnet [Torsten_Scheffler] [Torsten_Scheffler]
+pdnet            2843/udp # PDnet [Torsten_Scheffler] [Torsten_Scheffler]
+bpcp-poll        2844/tcp # BPCP POLL
+bpcp-poll        2844/udp # BPCP POLL
+bpcp-trap        2845/tcp # BPCP TRAP [Steve_Van_Duser] [Steve_Van_Duser]
+bpcp-trap        2845/udp # BPCP TRAP [Steve_Van_Duser] [Steve_Van_Duser]
+aimpp-hello      2846/tcp # AIMPP Hello
+aimpp-hello      2846/udp # AIMPP Hello
+aimpp-port-req   2847/tcp # AIMPP Port Req [Brian_Martinicky] [Brian_Martinicky]
+aimpp-port-req   2847/udp # AIMPP Port Req [Brian_Martinicky] [Brian_Martinicky]
+amt-blc-port     2848/tcp # AMT-BLC-PORT [Sandra_Frulloni] [Sandra_Frulloni]
+amt-blc-port     2848/udp # AMT-BLC-PORT [Sandra_Frulloni] [Sandra_Frulloni]
+fxp              2849/tcp # FXP [Martin_Lichtin] [Martin_Lichtin]
+fxp              2849/udp # FXP [Martin_Lichtin] [Martin_Lichtin]
+metaconsole      2850/tcp # MetaConsole [Rakesh_Mahajan] [Rakesh_Mahajan]
+metaconsole      2850/udp # MetaConsole [Rakesh_Mahajan] [Rakesh_Mahajan]
+webemshttp       2851/tcp # webemshttp [Stephen_Tsun] [Stephen_Tsun]
+webemshttp       2851/udp # webemshttp [Stephen_Tsun] [Stephen_Tsun]
+bears-01         2852/tcp # bears-01 [Bruce_McKinnon] [Bruce_McKinnon]
+bears-01         2852/udp # bears-01 [Bruce_McKinnon] [Bruce_McKinnon]
+ispipes          2853/tcp # ISPipes [Rajesh_Nandyalam] [Rajesh_Nandyalam]
+ispipes          2853/udp # ISPipes [Rajesh_Nandyalam] [Rajesh_Nandyalam]
+infomover        2854/tcp # InfoMover [Carla_Caputo] [Carla_Caputo]
+infomover        2854/udp # InfoMover [Carla_Caputo] [Carla_Caputo]
+msrp             2855/tcp # MSRP over TCP [RFC4975]
+msrp             2855/udp # MSRP [RFC4975]
+cesdinv          2856/tcp # cesdinv [Yoshiaki_Tokumoto] [Yoshiaki_Tokumoto]
+cesdinv          2856/udp # cesdinv [Yoshiaki_Tokumoto] [Yoshiaki_Tokumoto]
+simctlp          2857/tcp # SimCtIP [Christian_Zietz] [Christian_Zietz]
+simctlp          2857/udp # SimCtIP [Christian_Zietz] [Christian_Zietz]
+ecnp             2858/tcp # ECNP [Robert_Reimiller] [Robert_Reimiller]
+ecnp             2858/udp # ECNP [Robert_Reimiller] [Robert_Reimiller]
+activememory     2859/tcp # Active Memory [Joe_Graham] [Joe_Graham]
+activememory     2859/udp # Active Memory [Joe_Graham] [Joe_Graham]
+dialpad-voice1   2860/tcp # Dialpad Voice 1
+dialpad-voice1   2860/udp # Dialpad Voice 1
+dialpad-voice2   2861/tcp # Dialpad Voice 2 [Wongyu_Cho] [Wongyu_Cho]
+dialpad-voice2   2861/udp # Dialpad Voice 2 [Wongyu_Cho] [Wongyu_Cho]
+ttg-protocol     2862/tcp # TTG Protocol [Mark_Boler] [Mark_Boler]
+ttg-protocol     2862/udp # TTG Protocol [Mark_Boler] [Mark_Boler]
+sonardata        2863/tcp # Sonar Data [Ian_Higginbottom] [Ian_Higginbottom]
+sonardata        2863/udp # Sonar Data [Ian_Higginbottom] [Ian_Higginbottom]
+astromed-main    2864/tcp # main 5001 cmd [Chris_Tate] [Chris_Tate]
+astromed-main    2864/udp # main 5001 cmd [Chris_Tate] [Chris_Tate]
+pit-vpn          2865/tcp # pit-vpn [Norbert_Sendetzky] [Norbert_Sendetzky]
+pit-vpn          2865/udp # pit-vpn [Norbert_Sendetzky] [Norbert_Sendetzky]
+iwlistener       2866/tcp # iwlistener [Fred_Surr] [Fred_Surr]
+iwlistener       2866/udp # iwlistener [Fred_Surr] [Fred_Surr]
+esps-portal      2867/tcp # esps-portal [Nicholas_Stowfis] [Nicholas_Stowfis]
+esps-portal      2867/udp # esps-portal [Nicholas_Stowfis] [Nicholas_Stowfis]
+npep-messaging   2868/tcp # NPEP Messaging [Kristian_A_Bognaes] [Kristian_A_Bognaes]
+npep-messaging   2868/udp # NPEP Messaging [Kristian_A_Bognaes] [Kristian_A_Bognaes]
+icslap           2869/tcp # ICSLAP [Richard_Lamb] [Richard_Lamb]
+icslap           2869/udp # ICSLAP [Richard_Lamb] [Richard_Lamb]
+daishi           2870/tcp # daishi [Patrick_Chipman] [Patrick_Chipman]
+daishi           2870/udp # daishi [Patrick_Chipman] [Patrick_Chipman]
+msi-selectplay   2871/tcp # MSI Select Play [Paul_Fonte] [Paul_Fonte]
+msi-selectplay   2871/udp # MSI Select Play [Paul_Fonte] [Paul_Fonte]
+radix            2872/tcp # RADIX [Stein_Roger_Skaflott] [Stein_Roger_Skaflott] 2011-07-06
+radix            2872/udp # RADIX [Stein_Roger_Skaflott] [Stein_Roger_Skaflott] 2011-07-06
+dxmessagebase1   2874/tcp # DX Message Base Transport Protocol
+dxmessagebase1   2874/udp # DX Message Base Transport Protocol
+dxmessagebase2   2875/tcp # DX Message Base Transport Protocol [G_E_Ozz_Nixon_Jr] [G_E_Ozz_Nixon_Jr] 2009-01-13
+dxmessagebase2   2875/udp # DX Message Base Transport Protocol [G_E_Ozz_Nixon_Jr] [G_E_Ozz_Nixon_Jr] 2009-01-13
+sps-tunnel       2876/tcp # SPS Tunnel [Bill_McIntosh] [Bill_McIntosh]
+sps-tunnel       2876/udp # SPS Tunnel [Bill_McIntosh] [Bill_McIntosh]
+bluelance        2877/tcp # BLUELANCE [Michael_Padrezas] [Michael_Padrezas]
+bluelance        2877/udp # BLUELANCE [Michael_Padrezas] [Michael_Padrezas]
+aap              2878/tcp # AAP [Stephen_Hanna_2] [Stephen_Hanna_2]
+aap              2878/udp # AAP [Stephen_Hanna_2] [Stephen_Hanna_2]
+ucentric-ds      2879/tcp # ucentric-ds [Alex_Vasilevsky] [Alex_Vasilevsky]
+ucentric-ds      2879/udp # ucentric-ds [Alex_Vasilevsky] [Alex_Vasilevsky]
+synapse          2880/tcp # Synapse Transport [Ali_Fracyon] [Ali_Fracyon]
+synapse          2880/udp # Synapse Transport [Ali_Fracyon] [Ali_Fracyon]
+ndsp             2881/tcp # NDSP
+ndsp             2881/udp # NDSP
+ndtp             2882/tcp # NDTP
+ndtp             2882/udp # NDTP
+ndnp             2883/tcp # NDNP [Khelben_Blackstaff] [Khelben_Blackstaff]
+ndnp             2883/udp # NDNP [Khelben_Blackstaff] [Khelben_Blackstaff]
+flashmsg         2884/tcp # Flash Msg [Jeffrey_Zinkerman] [Jeffrey_Zinkerman]
+flashmsg         2884/udp # Flash Msg [Jeffrey_Zinkerman] [Jeffrey_Zinkerman]
+topflow          2885/tcp # TopFlow [Ted_Ross] [Ted_Ross]
+topflow          2885/udp # TopFlow [Ted_Ross] [Ted_Ross]
+responselogic    2886/tcp # RESPONSELOGIC [Bruce_Casey] [Bruce_Casey]
+responselogic    2886/udp # RESPONSELOGIC [Bruce_Casey] [Bruce_Casey]
+aironetddp       2887/tcp # aironet [Victor_Griswold] [Victor_Griswold]
+aironetddp       2887/udp # aironet [Victor_Griswold] [Victor_Griswold]
+spcsdlobby       2888/tcp # SPCSDLOBBY [Matthew_Williams] [Matthew_Williams]
+spcsdlobby       2888/udp # SPCSDLOBBY [Matthew_Williams] [Matthew_Williams]
+rsom             2889/tcp # RSOM [Justine_Higgins] [Justine_Higgins]
+rsom             2889/udp # RSOM [Justine_Higgins] [Justine_Higgins]
+cspclmulti       2890/tcp # CSPCLMULTI [Yoneda_Terumasa] [Yoneda_Terumasa]
+cspclmulti       2890/udp # CSPCLMULTI [Yoneda_Terumasa] [Yoneda_Terumasa]
+cinegrfx-elmd    2891/tcp # CINEGRFX-ELMD License Manager [Greg_Ercolano_2] [Greg_Ercolano_2]
+cinegrfx-elmd    2891/udp # CINEGRFX-ELMD License Manager [Greg_Ercolano_2] [Greg_Ercolano_2]
+snifferdata      2892/tcp # SNIFFERDATA [Jeff_Mangasarian] [Jeff_Mangasarian]
+snifferdata      2892/udp # SNIFFERDATA [Jeff_Mangasarian] [Jeff_Mangasarian]
+vseconnector     2893/tcp # VSECONNECTOR [Ingo_Franzki] [Ingo_Franzki]
+vseconnector     2893/udp # VSECONNECTOR [Ingo_Franzki] [Ingo_Franzki]
+abacus-remote    2894/tcp # ABACUS-REMOTE [Mike_Bello] [Mike_Bello]
+abacus-remote    2894/udp # ABACUS-REMOTE [Mike_Bello] [Mike_Bello]
+natuslink        2895/tcp # NATUS LINK [Jonathan_Mergy] [Jonathan_Mergy]
+natuslink        2895/udp # NATUS LINK [Jonathan_Mergy] [Jonathan_Mergy]
+ecovisiong6-1    2896/tcp # ECOVISIONG6-1 [Henrik_Holst] [Henrik_Holst]
+ecovisiong6-1    2896/udp # ECOVISIONG6-1 [Henrik_Holst] [Henrik_Holst]
+citrix-rtmp      2897/tcp # Citrix RTMP [Myk_Willis] [Myk_Willis]
+citrix-rtmp      2897/udp # Citrix RTMP [Myk_Willis] [Myk_Willis]
+appliance-cfg    2898/tcp # APPLIANCE-CFG [Gary_A_James] [Gary_A_James]
+appliance-cfg    2898/udp # APPLIANCE-CFG [Gary_A_James] [Gary_A_James]
+powergemplus     2899/tcp # POWERGEMPLUS [Koich_Nakamura] [Koich_Nakamura]
+powergemplus     2899/udp # POWERGEMPLUS [Koich_Nakamura] [Koich_Nakamura]
+quicksuite       2900/tcp # QUICKSUITE [William_Egge] [William_Egge]
+quicksuite       2900/udp # QUICKSUITE [William_Egge] [William_Egge]
+allstorcns       2901/tcp # ALLSTORCNS [Steve_Dobson] [Steve_Dobson]
+allstorcns       2901/udp # ALLSTORCNS [Steve_Dobson] [Steve_Dobson]
+netaspi          2902/tcp # NET ASPI [Johnson_Luo] [Johnson_Luo]
+netaspi          2902/udp # NET ASPI [Johnson_Luo] [Johnson_Luo]
+suitcase         2903/tcp # SUITCASE [Milton_E_Sagen] [Milton_E_Sagen]
+suitcase         2903/udp # SUITCASE [Milton_E_Sagen] [Milton_E_Sagen]
+m2ua             2904/tcp # M2UA [Lyndon_Ong] [Lyndon_Ong]
+m2ua             2904/udp # M2UA [Lyndon_Ong] [Lyndon_Ong]
+m2ua             2904/sctp # M2UA [Lyndon_Ong] [Lyndon_Ong]
+m3ua             2905/tcp # M3UA [Lyndon_Ong] [Lyndon_Ong] [RFC4666]
+m3ua             2905/sctp # M3UA [Lyndon_Ong] [Lyndon_Ong] [RFC4666]
+caller9          2906/tcp # CALLER9 [Shams_Naqi] [Shams_Naqi]
+caller9          2906/udp # CALLER9 [Shams_Naqi] [Shams_Naqi]
+webmethods-b2b   2907/tcp # WEBMETHODS B2B [Joseph_Hines] [Joseph_Hines]
+webmethods-b2b   2907/udp # WEBMETHODS B2B [Joseph_Hines] [Joseph_Hines]
+mao              2908/tcp # mao [Marc_Baudoin] [Marc_Baudoin]
+mao              2908/udp # mao [Marc_Baudoin] [Marc_Baudoin]
+funk-dialout     2909/tcp # Funk Dialout [Cimarron_Boozer] [Cimarron_Boozer]
+funk-dialout     2909/udp # Funk Dialout [Cimarron_Boozer] [Cimarron_Boozer]
+tdaccess         2910/tcp # TDAccess [Tom_Haapanen] [Tom_Haapanen]
+tdaccess         2910/udp # TDAccess [Tom_Haapanen] [Tom_Haapanen]
+blockade         2911/tcp # Blockade [Blockade] [Blockade]
+blockade         2911/udp # Blockade [Blockade] [Blockade]
+epicon           2912/tcp # Epicon [Michael_Khalandovsky] [Michael_Khalandovsky]
+epicon           2912/udp # Epicon [Michael_Khalandovsky] [Michael_Khalandovsky]
+boosterware      2913/tcp # Booster Ware [Ido_Ben_David] [Ido_Ben_David]
+boosterware      2913/udp # Booster Ware [Ido_Ben_David] [Ido_Ben_David]
+gamelobby        2914/tcp # Game Lobby [Paul_Ford_Hutchinson] [Paul_Ford_Hutchinson]
+gamelobby        2914/udp # Game Lobby [Paul_Ford_Hutchinson] [Paul_Ford_Hutchinson]
+tksocket         2915/tcp # TK Socket [Dino_Ciano] [Dino_Ciano] 2011-03-02
+tksocket         2915/udp # TK Socket [Dino_Ciano] [Dino_Ciano] 2011-03-02
+elvin-server     2916/tcp # Elvin ServerIANA assigned this well-formed service name as a replacement for "elvin_server".
+elvin_server     2916/tcp # Elvin Server This entry is an alias to "elvin-server".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+elvin-server     2916/udp # Elvin ServerIANA assigned this well-formed service name as a replacement for "elvin_server".
+elvin_server     2916/udp # Elvin Server This entry is an alias to "elvin-server".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+elvin-client     2917/tcp # Elvin ClientIANA assigned this well-formed service name as a replacement for "elvin_client". [David_Arnold] [David_Arnold]
+elvin_client     2917/tcp # Elvin Client [David_Arnold] [David_Arnold] This entry is an alias to "elvin-client".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+elvin-client     2917/udp # Elvin ClientIANA assigned this well-formed service name as a replacement for "elvin_client". [David_Arnold] [David_Arnold]
+elvin_client     2917/udp # Elvin Client [David_Arnold] [David_Arnold] This entry is an alias to "elvin-client".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+kastenchasepad   2918/tcp # Kasten Chase Pad [Marc_Gauthier] [Marc_Gauthier]
+kastenchasepad   2918/udp # Kasten Chase Pad [Marc_Gauthier] [Marc_Gauthier]
+roboer           2919/tcp # roboER [Paul_Snook] [Paul_Snook]
+roboer           2919/udp # roboER [Paul_Snook] [Paul_Snook]
+roboeda          2920/tcp # roboEDA [Paul_Snook] [Paul_Snook]
+roboeda          2920/udp # roboEDA [Paul_Snook] [Paul_Snook]
+cesdcdman        2921/tcp # CESD Contents Delivery Management [Shinya_Abe] [Shinya_Abe]
+cesdcdman        2921/udp # CESD Contents Delivery Management [Shinya_Abe] [Shinya_Abe]
+cesdcdtrn        2922/tcp # CESD Contents Delivery Data Transfer [Shinya_Abe] [Shinya_Abe]
+cesdcdtrn        2922/udp # CESD Contents Delivery Data Transfer [Shinya_Abe] [Shinya_Abe]
+wta-wsp-wtp-s    2923/tcp # WTA-WSP-WTP-S [Sebastien_Bury] [Sebastien_Bury]
+wta-wsp-wtp-s    2923/udp # WTA-WSP-WTP-S [Sebastien_Bury] [Sebastien_Bury]
+precise-vip      2924/tcp # PRECISE-VIP [Michael_Landwehr] [Michael_Landwehr]
+precise-vip      2924/udp # PRECISE-VIP [Michael_Landwehr] [Michael_Landwehr]
+mobile-file-dl   2926/tcp # MOBILE-FILE-DL [Mitsuji_Toda] [Mitsuji_Toda]
+mobile-file-dl   2926/udp # MOBILE-FILE-DL [Mitsuji_Toda] [Mitsuji_Toda]
+unimobilectrl    2927/tcp # UNIMOBILECTRL [Vikas] [Vikas]
+unimobilectrl    2927/udp # UNIMOBILECTRL [Vikas] [Vikas]
+redstone-cpss    2928/tcp # REDSTONE-CPSS [Jeff_Looman] [Jeff_Looman]
+redstone-cpss    2928/udp # REDSTONE-CPSS [Jeff_Looman] [Jeff_Looman]
+amx-webadmin     2929/tcp # AMX-WEBADMIN [Mike_Morris] [Mike_Morris]
+amx-webadmin     2929/udp # AMX-WEBADMIN [Mike_Morris] [Mike_Morris]
+amx-weblinx      2930/tcp # AMX-WEBLINX [Mike_Morris] [Mike_Morris]
+amx-weblinx      2930/udp # AMX-WEBLINX [Mike_Morris] [Mike_Morris]
+circle-x         2931/tcp # Circle-X [Norm_Freedman_2] [Norm_Freedman_2]
+circle-x         2931/udp # Circle-X [Norm_Freedman_2] [Norm_Freedman_2]
+incp             2932/tcp # INCP [Keith_Paulsen] [Keith_Paulsen]
+incp             2932/udp # INCP [Keith_Paulsen] [Keith_Paulsen]
+4-tieropmgw      2933/tcp # 4-TIER OPM GW [Francois_Peloffy] [Francois_Peloffy]
+4-tieropmgw      2933/udp # 4-TIER OPM GW [Francois_Peloffy] [Francois_Peloffy]
+4-tieropmcli     2934/tcp # 4-TIER OPM CLI [Francois_Peloffy] [Francois_Peloffy]
+4-tieropmcli     2934/udp # 4-TIER OPM CLI [Francois_Peloffy] [Francois_Peloffy]
+qtp              2935/tcp # QTP [Cameron_Young] [Cameron_Young]
+qtp              2935/udp # QTP [Cameron_Young] [Cameron_Young]
+otpatch          2936/tcp # OTPatch [Brett_Goldstein] [Brett_Goldstein]
+otpatch          2936/udp # OTPatch [Brett_Goldstein] [Brett_Goldstein]
+pnaconsult-lm    2937/tcp # PNACONSULT-LM [Theo_Nijssen] [Theo_Nijssen]
+pnaconsult-lm    2937/udp # PNACONSULT-LM [Theo_Nijssen] [Theo_Nijssen]
+sm-pas-1         2938/tcp # SM-PAS-1
+sm-pas-1         2938/udp # SM-PAS-1
+sm-pas-2         2939/tcp # SM-PAS-2
+sm-pas-2         2939/udp # SM-PAS-2
+sm-pas-3         2940/tcp # SM-PAS-3
+sm-pas-3         2940/udp # SM-PAS-3
+sm-pas-4         2941/tcp # SM-PAS-4
+sm-pas-4         2941/udp # SM-PAS-4
+sm-pas-5         2942/tcp # SM-PAS-5 [Tom_Haapanen] [Tom_Haapanen]
+sm-pas-5         2942/udp # SM-PAS-5 [Tom_Haapanen] [Tom_Haapanen]
+ttnrepository    2943/tcp # TTNRepository [Robert_Orr] [Robert_Orr]
+ttnrepository    2943/udp # TTNRepository [Robert_Orr] [Robert_Orr]
+megaco-h248      2944/tcp # Megaco H-248 [Tom_Taylor_2] [Tom_Taylor_2]
+megaco-h248      2944/udp # Megaco H-248 [Tom_Taylor_2] [Tom_Taylor_2]
+megaco-h248      2944/sctp # Megaco-H.248 text [Tom_Taylor_3] [Tom_Taylor_3] 2006-09
+h248-binary      2945/tcp # H248 Binary [Tom_Taylor_2] [Tom_Taylor_2]
+h248-binary      2945/udp # H248 Binary [Tom_Taylor_2] [Tom_Taylor_2]
+h248-binary      2945/sctp # Megaco/H.248 binary [Tom_Taylor_3] [Tom_Taylor_3] 2006-09
+fjsvmpor         2946/tcp # FJSVmpor [Naoki_Hayashi] [Naoki_Hayashi]
+fjsvmpor         2946/udp # FJSVmpor [Naoki_Hayashi] [Naoki_Hayashi]
+gpsd             2947/tcp # GPS Daemon request/response protocol [Eric_S_Raymond] [Eric_S_Raymond] 2010-04-19
+gpsd             2947/udp # GPS Daemon request/response protocol [Eric_S_Raymond] [Eric_S_Raymond] 2010-04-19
+wap-push         2948/tcp # WAP PUSH
+wap-push         2948/udp # WAP PUSH
+wap-pushsecure   2949/tcp # WAP PUSH SECURE [WAP_Forum] [WAP_Forum]
+wap-pushsecure   2949/udp # WAP PUSH SECURE [WAP_Forum] [WAP_Forum]
+esip             2950/tcp # ESIP [David_Stephenson] [David_Stephenson]
+esip             2950/udp # ESIP [David_Stephenson] [David_Stephenson]
+ottp             2951/tcp # OTTP [Brent_Foster] [Brent_Foster]
+ottp             2951/udp # OTTP [Brent_Foster] [Brent_Foster]
+mpfwsas          2952/tcp # MPFWSAS [Toru_Murai] [Toru_Murai]
+mpfwsas          2952/udp # MPFWSAS [Toru_Murai] [Toru_Murai]
+ovalarmsrv       2953/tcp # OVALARMSRV
+ovalarmsrv       2953/udp # OVALARMSRV
+ovalarmsrv-cmd   2954/tcp # OVALARMSRV-CMD [Eric_Pulsipher] [Eric_Pulsipher]
+ovalarmsrv-cmd   2954/udp # OVALARMSRV-CMD [Eric_Pulsipher] [Eric_Pulsipher]
+csnotify         2955/tcp # CSNOTIFY [Israel_Beniaminy] [Israel_Beniaminy]
+csnotify         2955/udp # CSNOTIFY [Israel_Beniaminy] [Israel_Beniaminy]
+ovrimosdbman     2956/tcp # OVRIMOSDBMAN [Dimitrios_Souflis] [Dimitrios_Souflis]
+ovrimosdbman     2956/udp # OVRIMOSDBMAN [Dimitrios_Souflis] [Dimitrios_Souflis]
+jmact5           2957/tcp # JAMCT5
+jmact5           2957/udp # JAMCT5
+jmact6           2958/tcp # JAMCT6
+jmact6           2958/udp # JAMCT6
+rmopagt          2959/tcp # RMOPAGT [Shuji_Okubo] [Shuji_Okubo]
+rmopagt          2959/udp # RMOPAGT [Shuji_Okubo] [Shuji_Okubo]
+dfoxserver       2960/tcp # DFOXSERVER [David_Holden] [David_Holden]
+dfoxserver       2960/udp # DFOXSERVER [David_Holden] [David_Holden]
+boldsoft-lm      2961/tcp # BOLDSOFT-LM [Fredrik_Haglund] [Fredrik_Haglund]
+boldsoft-lm      2961/udp # BOLDSOFT-LM [Fredrik_Haglund] [Fredrik_Haglund]
+iph-policy-cli   2962/tcp # IPH-POLICY-CLI
+iph-policy-cli   2962/udp # IPH-POLICY-CLI
+iph-policy-adm   2963/tcp # IPH-POLICY-ADM [Shai_Herzog] [Shai_Herzog]
+iph-policy-adm   2963/udp # IPH-POLICY-ADM [Shai_Herzog] [Shai_Herzog]
+bullant-srap     2964/tcp # BULLANT SRAP
+bullant-srap     2964/udp # BULLANT SRAP
+bullant-rap      2965/tcp # BULLANT RAP [Michael_Cahill] [Michael_Cahill]
+bullant-rap      2965/udp # BULLANT RAP [Michael_Cahill] [Michael_Cahill]
+idp-infotrieve   2966/tcp # IDP-INFOTRIEVE [Kevin_Bruckert] [Kevin_Bruckert]
+idp-infotrieve   2966/udp # IDP-INFOTRIEVE [Kevin_Bruckert] [Kevin_Bruckert]
+ssc-agent        2967/tcp # SSC-AGENT [George_Dzieciol] [George_Dzieciol]
+ssc-agent        2967/udp # SSC-AGENT [George_Dzieciol] [George_Dzieciol]
+enpp             2968/tcp # ENPP [Kazuhito_Gassho] [Kazuhito_Gassho]
+enpp             2968/udp # ENPP [Kazuhito_Gassho] [Kazuhito_Gassho]
+essp             2969/tcp # ESSP [Hitoshi_Ishida] [Hitoshi_Ishida]
+essp             2969/udp # ESSP [Hitoshi_Ishida] [Hitoshi_Ishida]
+index-net        2970/tcp # INDEX-NET [Chris_J_Wren] [Chris_J_Wren]
+index-net        2970/udp # INDEX-NET [Chris_J_Wren] [Chris_J_Wren]
+netclip          2971/tcp # NetClip clipboard daemon [Rudi_Chiarito] [Rudi_Chiarito]
+netclip          2971/udp # NetClip clipboard daemon [Rudi_Chiarito] [Rudi_Chiarito]
+pmsm-webrctl     2972/tcp # PMSM Webrctl [Markus_Michels] [Markus_Michels]
+pmsm-webrctl     2972/udp # PMSM Webrctl [Markus_Michels] [Markus_Michels]
+svnetworks       2973/tcp # SV Networks [Sylvia_Siu_2] [Sylvia_Siu_2]
+svnetworks       2973/udp # SV Networks [Sylvia_Siu_2] [Sylvia_Siu_2]
+signal           2974/tcp # Signal [Wyatt_Williams] [Wyatt_Williams]
+signal           2974/udp # Signal [Wyatt_Williams] [Wyatt_Williams]
+fjmpcm           2975/tcp # Fujitsu Configuration Management Service [Hiroki_Kawano] [Hiroki_Kawano]
+fjmpcm           2975/udp # Fujitsu Configuration Management Service [Hiroki_Kawano] [Hiroki_Kawano]
+cns-srv-port     2976/tcp # CNS Server Port [Ram_Golla] [Ram_Golla]
+cns-srv-port     2976/udp # CNS Server Port [Ram_Golla] [Ram_Golla]
+ttc-etap-ns      2977/tcp # TTCs Enterprise Test Access Protocol - NS
+ttc-etap-ns      2977/udp # TTCs Enterprise Test Access Protocol - NS
+ttc-etap-ds      2978/tcp # TTCs Enterprise Test Access Protocol - DS [Daniel_Becker_2] [Daniel_Becker_2]
+ttc-etap-ds      2978/udp # TTCs Enterprise Test Access Protocol - DS [Daniel_Becker_2] [Daniel_Becker_2]
+h263-video       2979/tcp # H.263 Video Streaming [Jauvane_C_de_Olivei] [Jauvane_C_de_Olivei]
+h263-video       2979/udp # H.263 Video Streaming [Jauvane_C_de_Olivei] [Jauvane_C_de_Olivei]
+wimd             2980/tcp # Instant Messaging Service [Kevin_Birch] [Kevin_Birch]
+wimd             2980/udp # Instant Messaging Service [Kevin_Birch] [Kevin_Birch]
+mylxamport       2981/tcp # MYLXAMPORT [Wei_Gao] [Wei_Gao]
+mylxamport       2981/udp # MYLXAMPORT [Wei_Gao] [Wei_Gao]
+iwb-whiteboard   2982/tcp # IWB-WHITEBOARD [David_W_Radcliffe] [David_W_Radcliffe]
+iwb-whiteboard   2982/udp # IWB-WHITEBOARD [David_W_Radcliffe] [David_W_Radcliffe]
+netplan          2983/tcp # NETPLAN [Thomas_Driemeyer] [Thomas_Driemeyer]
+netplan          2983/udp # NETPLAN [Thomas_Driemeyer] [Thomas_Driemeyer]
+hpidsadmin       2984/tcp # HPIDSADMIN
+hpidsadmin       2984/udp # HPIDSADMIN
+hpidsagent       2985/tcp # HPIDSAGENT [John_Trudeau] [John_Trudeau]
+hpidsagent       2985/udp # HPIDSAGENT [John_Trudeau] [John_Trudeau]
+stonefalls       2986/tcp # STONEFALLS [Scott_Grau] [Scott_Grau]
+stonefalls       2986/udp # STONEFALLS [Scott_Grau] [Scott_Grau]
+identify         2987/tcp # identify
+identify         2987/udp # identify
+hippad           2988/tcp # HIPPA Reporting Protocol [William_Randolph_Roy] [William_Randolph_Roy]
+hippad           2988/udp # HIPPA Reporting Protocol [William_Randolph_Roy] [William_Randolph_Roy]
+zarkov           2989/tcp # ZARKOV Intelligent Agent Communication [Robin_Felix] [Robin_Felix]
+zarkov           2989/udp # ZARKOV Intelligent Agent Communication [Robin_Felix] [Robin_Felix]
+boscap           2990/tcp # BOSCAP [Dirk_Hillbrecht] [Dirk_Hillbrecht]
+boscap           2990/udp # BOSCAP [Dirk_Hillbrecht] [Dirk_Hillbrecht]
+wkstn-mon        2991/tcp # WKSTN-MON [William_David] [William_David]
+wkstn-mon        2991/udp # WKSTN-MON [William_David] [William_David]
+avenyo           2992/tcp # Avenyo Server [Bodo_Rueskamp] [Bodo_Rueskamp]
+avenyo           2992/udp # Avenyo Server [Bodo_Rueskamp] [Bodo_Rueskamp]
+veritas-vis1     2993/tcp # VERITAS VIS1
+veritas-vis1     2993/udp # VERITAS VIS1
+veritas-vis2     2994/tcp # VERITAS VIS2 [Dinkar_Chivaluri] [Dinkar_Chivaluri]
+veritas-vis2     2994/udp # VERITAS VIS2 [Dinkar_Chivaluri] [Dinkar_Chivaluri]
+idrs             2995/tcp # IDRS [Jeff_Eaton] [Jeff_Eaton]
+idrs             2995/udp # IDRS [Jeff_Eaton] [Jeff_Eaton]
+vsixml           2996/tcp # vsixml [Rob_Juergens] [Rob_Juergens]
+vsixml           2996/udp # vsixml [Rob_Juergens] [Rob_Juergens]
+rebol            2997/tcp # REBOL [Holger_Kruse] [Holger_Kruse]
+rebol            2997/udp # REBOL [Holger_Kruse] [Holger_Kruse]
+realsecure       2998/tcp # Real Secure [Wes_Wilson] [Wes_Wilson]
+realsecure       2998/udp # Real Secure [Wes_Wilson] [Wes_Wilson]
+remoteware-un    2999/tcp # RemoteWare Unassigned [Tim_Farley] [Tim_Farley]
+remoteware-un    2999/udp # RemoteWare Unassigned [Tim_Farley] [Tim_Farley]
+hbci             3000/tcp # HBCI [Kurt_Haubner] [Kurt_Haubner]
+hbci             3000/udp # HBCI [Kurt_Haubner] [Kurt_Haubner]
+remoteware-cl    3000/tcp # RemoteWare Client [Tim_Farley] [Tim_Farley] This entry records an unassigned but widespread use
+remoteware-cl    3000/udp # RemoteWare Client [Tim_Farley] [Tim_Farley] This entry records an unassigned but widespread use
+origo-native     3001/tcp # OrigoDB Server Native Interface [Devrex_Labs] [Robert_Friberg] 2013-03-29 port 3001 previously "Removed on 2006-05-25"
+exlm-agent       3002/tcp # EXLM Agent [Randy_Martin] [Randy_Martin]
+exlm-agent       3002/udp # EXLM Agent [Randy_Martin] [Randy_Martin]
+remoteware-srv   3002/tcp # RemoteWare Server [Tim_Farley] [Tim_Farley] This entry records an unassigned but widespread use
+remoteware-srv   3002/udp # RemoteWare Server [Tim_Farley] [Tim_Farley] This entry records an unassigned but widespread use
+cgms             3003/tcp # CGMS [Corey_Clinton] [Corey_Clinton] 2011-02-02
+cgms             3003/udp # CGMS [Corey_Clinton] [Corey_Clinton] 2011-02-02
+csoftragent      3004/tcp # Csoft Agent [Nedelcho_Stanev_2] [Nedelcho_Stanev_2]
+csoftragent      3004/udp # Csoft Agent [Nedelcho_Stanev_2] [Nedelcho_Stanev_2]
+geniuslm         3005/tcp # Genius License Manager [Jakob_Spies] [Jakob_Spies]
+geniuslm         3005/udp # Genius License Manager [Jakob_Spies] [Jakob_Spies]
+ii-admin         3006/tcp # Instant Internet Admin [Lewis_Donzis] [Lewis_Donzis]
+ii-admin         3006/udp # Instant Internet Admin [Lewis_Donzis] [Lewis_Donzis]
+lotusmtap        3007/tcp # Lotus Mail Tracking Agent Protocol [Ken_Lin] [Ken_Lin]
+lotusmtap        3007/udp # Lotus Mail Tracking Agent Protocol [Ken_Lin] [Ken_Lin]
+midnight-tech    3008/tcp # Midnight Technologies [Kyle_Unice] [Kyle_Unice]
+midnight-tech    3008/udp # Midnight Technologies [Kyle_Unice] [Kyle_Unice]
+pxc-ntfy         3009/tcp # PXC-NTFY [Takeshi_Nishizawa] [Takeshi_Nishizawa]
+pxc-ntfy         3009/udp # PXC-NTFY [Takeshi_Nishizawa] [Takeshi_Nishizawa]
+gw               3010/tcp # Telerate Workstation
+ping-pong        3010/udp # Telerate Workstation [Timo_Sivonen] [Timo_Sivonen]
+trusted-web      3011/tcp # Trusted Web
+trusted-web      3011/udp # Trusted Web
+twsdss           3012/tcp # Trusted Web Client [Alex_Duncan] [Alex_Duncan]
+twsdss           3012/udp # Trusted Web Client [Alex_Duncan] [Alex_Duncan]
+gilatskysurfer   3013/tcp # Gilat Sky Surfer [Yossi_Gal] [Yossi_Gal]
+gilatskysurfer   3013/udp # Gilat Sky Surfer [Yossi_Gal] [Yossi_Gal]
+broker-service   3014/tcp # Broker ServiceIANA assigned this well-formed service name as a replacement for "broker_service". [Dale_Bethers] [Dale_Bethers]
+broker_service   3014/tcp # Broker Service [Dale_Bethers] [Dale_Bethers] This entry is an alias to "broker-service".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+broker-service   3014/udp # Broker ServiceIANA assigned this well-formed service name as a replacement for "broker_service". [Dale_Bethers] [Dale_Bethers]
+broker_service   3014/udp # Broker Service [Dale_Bethers] [Dale_Bethers] This entry is an alias to "broker-service".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+nati-dstp        3015/tcp # NATI DSTP [Paul_Austin] [Paul_Austin]
+nati-dstp        3015/udp # NATI DSTP [Paul_Austin] [Paul_Austin]
+notify-srvr      3016/tcp # Notify ServerIANA assigned this well-formed service name as a replacement for "notify_srvr". [Hugo_Parra] [Hugo_Parra]
+notify_srvr      3016/tcp # Notify Server [Hugo_Parra] [Hugo_Parra] This entry is an alias to "notify-srvr".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+notify-srvr      3016/udp # Notify ServerIANA assigned this well-formed service name as a replacement for "notify_srvr". [Hugo_Parra] [Hugo_Parra]
+notify_srvr      3016/udp # Notify Server [Hugo_Parra] [Hugo_Parra] This entry is an alias to "notify-srvr".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+event-listener   3017/tcp # Event ListenerIANA assigned this well-formed service name as a replacement for "event_listener". [Ted_Tronson] [Ted_Tronson]
+event_listener   3017/tcp # Event Listener [Ted_Tronson] [Ted_Tronson] This entry is an alias to "event-listener".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+event-listener   3017/udp # Event ListenerIANA assigned this well-formed service name as a replacement for "event_listener". [Ted_Tronson] [Ted_Tronson]
+event_listener   3017/udp # Event Listener [Ted_Tronson] [Ted_Tronson] This entry is an alias to "event-listener".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+srvc-registry    3018/tcp # Service RegistryIANA assigned this well-formed service name as a replacement for "srvc_registry". [Mark_Killgore] [Mark_Killgore]
+srvc_registry    3018/tcp # Service Registry [Mark_Killgore] [Mark_Killgore] This entry is an alias to "srvc-registry".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+srvc-registry    3018/udp # Service RegistryIANA assigned this well-formed service name as a replacement for "srvc_registry". [Mark_Killgore] [Mark_Killgore]
+srvc_registry    3018/udp # Service Registry [Mark_Killgore] [Mark_Killgore] This entry is an alias to "srvc-registry".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+resource-mgr     3019/tcp # Resource ManagerIANA assigned this well-formed service name as a replacement for "resource_mgr". [Gary_Glover] [Gary_Glover]
+resource_mgr     3019/tcp # Resource Manager [Gary_Glover] [Gary_Glover] This entry is an alias to "resource-mgr".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+resource-mgr     3019/udp # Resource ManagerIANA assigned this well-formed service name as a replacement for "resource_mgr". [Gary_Glover] [Gary_Glover]
+resource_mgr     3019/udp # Resource Manager [Gary_Glover] [Gary_Glover] This entry is an alias to "resource-mgr".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+cifs             3020/tcp # CIFS [Paul_Leach] [Paul_Leach]
+cifs             3020/udp # CIFS [Paul_Leach] [Paul_Leach]
+agriserver       3021/tcp # AGRI Server [Frank_Neulichedl] [Frank_Neulichedl]
+agriserver       3021/udp # AGRI Server [Frank_Neulichedl] [Frank_Neulichedl]
+csregagent       3022/tcp # CSREGAGENT [Nedelcho_Stanev] [Nedelcho_Stanev]
+csregagent       3022/udp # CSREGAGENT [Nedelcho_Stanev] [Nedelcho_Stanev]
+magicnotes       3023/tcp # magicnotes [Karl_Edwall] [Karl_Edwall]
+magicnotes       3023/udp # magicnotes [Karl_Edwall] [Karl_Edwall]
+nds-sso          3024/tcp # NDS_SSOIANA assigned this well-formed service name as a replacement for "nds_sso". [Mel_Oyler] [Mel_Oyler]
+nds_sso          3024/tcp # NDS_SSO [Mel_Oyler] [Mel_Oyler] This entry is an alias to "nds-sso".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+nds-sso          3024/udp # NDS_SSOIANA assigned this well-formed service name as a replacement for "nds_sso". [Mel_Oyler] [Mel_Oyler]
+nds_sso          3024/udp # NDS_SSO [Mel_Oyler] [Mel_Oyler] This entry is an alias to "nds-sso".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+arepa-raft       3025/tcp # Arepa Raft [Stuart_Schaefer] [Stuart_Schaefer]
+arepa-raft       3025/udp # Arepa Raft [Stuart_Schaefer] [Stuart_Schaefer]
+agri-gateway     3026/tcp # AGRI Gateway [Agri_Datalog] [Agri_Datalog]
+agri-gateway     3026/udp # AGRI Gateway [Agri_Datalog] [Agri_Datalog]
+LiebDevMgmt-C    3027/tcp # LiebDevMgmt_CIANA assigned this well-formed service name as a replacement for "LiebDevMgmt_C".
+LiebDevMgmt_C    3027/tcp # LiebDevMgmt_C This entry is an alias to "LiebDevMgmt-C".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+LiebDevMgmt-C    3027/udp # LiebDevMgmt_CIANA assigned this well-formed service name as a replacement for "LiebDevMgmt_C".
+LiebDevMgmt_C    3027/udp # LiebDevMgmt_C This entry is an alias to "LiebDevMgmt-C".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+LiebDevMgmt-DM   3028/tcp # LiebDevMgmt_DMIANA assigned this well-formed service name as a replacement for "LiebDevMgmt_DM".
+LiebDevMgmt_DM   3028/tcp # LiebDevMgmt_DM This entry is an alias to "LiebDevMgmt-DM".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+LiebDevMgmt-DM   3028/udp # LiebDevMgmt_DMIANA assigned this well-formed service name as a replacement for "LiebDevMgmt_DM".
+LiebDevMgmt_DM   3028/udp # LiebDevMgmt_DM This entry is an alias to "LiebDevMgmt-DM".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+LiebDevMgmt-A    3029/tcp # LiebDevMgmt_AIANA assigned this well-formed service name as a replacement for "LiebDevMgmt_A". [Mike_Velten] [Mike_Velten]
+LiebDevMgmt_A    3029/tcp # LiebDevMgmt_A [Mike_Velten] [Mike_Velten] This entry is an alias to "LiebDevMgmt-A".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+LiebDevMgmt-A    3029/udp # LiebDevMgmt_AIANA assigned this well-formed service name as a replacement for "LiebDevMgmt_A". [Mike_Velten] [Mike_Velten]
+LiebDevMgmt_A    3029/udp # LiebDevMgmt_A [Mike_Velten] [Mike_Velten] This entry is an alias to "LiebDevMgmt-A".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+arepa-cas        3030/tcp # Arepa Cas [Stuart_Schaefer] [Stuart_Schaefer]
+arepa-cas        3030/udp # Arepa Cas [Stuart_Schaefer] [Stuart_Schaefer]
+eppc             3031/tcp # Remote AppleEvents/PPC Toolbox [Steve_Zellers] [Steve_Zellers]
+eppc             3031/udp # Remote AppleEvents/PPC Toolbox [Steve_Zellers] [Steve_Zellers]
+redwood-chat     3032/tcp # Redwood Chat [Songwon_Chi] [Songwon_Chi]
+redwood-chat     3032/udp # Redwood Chat [Songwon_Chi] [Songwon_Chi]
+pdb              3033/tcp # PDB [Don_Bowman] [Don_Bowman]
+pdb              3033/udp # PDB [Don_Bowman] [Don_Bowman]
+osmosis-aeea     3034/tcp # Osmosis / Helix (R) AEEA Port [Larry_Atkin] [Larry_Atkin]
+osmosis-aeea     3034/udp # Osmosis / Helix (R) AEEA Port [Larry_Atkin] [Larry_Atkin]
+fjsv-gssagt      3035/tcp # FJSV gssagt [Tomoji_Koike] [Tomoji_Koike]
+fjsv-gssagt      3035/udp # FJSV gssagt [Tomoji_Koike] [Tomoji_Koike]
+hagel-dump       3036/tcp # Hagel DUMP [Haim_Gelfenbeyn] [Haim_Gelfenbeyn]
+hagel-dump       3036/udp # Hagel DUMP [Haim_Gelfenbeyn] [Haim_Gelfenbeyn]
+hp-san-mgmt      3037/tcp # HP SAN Mgmt [Steve_Britt] [Steve_Britt]
+hp-san-mgmt      3037/udp # HP SAN Mgmt [Steve_Britt] [Steve_Britt]
+santak-ups       3038/tcp # Santak UPS [Tom_Liu] [Tom_Liu]
+santak-ups       3038/udp # Santak UPS [Tom_Liu] [Tom_Liu]
+cogitate         3039/tcp # Cogitate, Inc. [Jim_Harlan] [Jim_Harlan]
+cogitate         3039/udp # Cogitate, Inc. [Jim_Harlan] [Jim_Harlan]
+tomato-springs   3040/tcp # Tomato Springs [Jack_Waller_III] [Jack_Waller_III]
+tomato-springs   3040/udp # Tomato Springs [Jack_Waller_III] [Jack_Waller_III]
+di-traceware     3041/tcp # di-traceware [Carlos_Hung] [Carlos_Hung]
+di-traceware     3041/udp # di-traceware [Carlos_Hung] [Carlos_Hung]
+journee          3042/tcp # journee [Kevin_Calman] [Kevin_Calman]
+journee          3042/udp # journee [Kevin_Calman] [Kevin_Calman]
+brp              3043/tcp # Broadcast Routing Protocol [John_Border] [John_Border]
+brp              3043/udp # Broadcast Routing Protocol [John_Border] [John_Border]
+epp              3044/tcp # EndPoint Protocol [Stephen_Cipolli] [Stephen_Cipolli]
+epp              3044/udp # EndPoint Protocol [Stephen_Cipolli] [Stephen_Cipolli]
+responsenet      3045/tcp # ResponseNet [Chul_Yoon] [Chul_Yoon]
+responsenet      3045/udp # ResponseNet [Chul_Yoon] [Chul_Yoon]
+di-ase           3046/tcp # di-ase [Carlos_Hung] [Carlos_Hung]
+di-ase           3046/udp # di-ase [Carlos_Hung] [Carlos_Hung]
+hlserver         3047/tcp # Fast Security HL Server [Michael_Zunke] [Michael_Zunke] 2010-07-23
+hlserver         3047/udp # Fast Security HL Server [Michael_Zunke] [Michael_Zunke] 2010-07-23
+pctrader         3048/tcp # Sierra Net PC Trader [Chris_Hahn] [Chris_Hahn]
+pctrader         3048/udp # Sierra Net PC Trader [Chris_Hahn] [Chris_Hahn]
+nsws             3049/tcp # NSWS [Ray_Gwinn] [Ray_Gwinn]
+nsws             3049/udp # NSWS [Ray_Gwinn] [Ray_Gwinn]
+gds-db           3050/tcp # gds_dbIANA assigned this well-formed service name as a replacement for "gds_db". [Madhukar_N_Thakur] [Madhukar_N_Thakur]
+gds_db           3050/tcp # gds_db [Madhukar_N_Thakur] [Madhukar_N_Thakur] This entry is an alias to "gds-db".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+gds-db           3050/udp # gds_dbIANA assigned this well-formed service name as a replacement for "gds_db". [Madhukar_N_Thakur] [Madhukar_N_Thakur]
+gds_db           3050/udp # gds_db [Madhukar_N_Thakur] [Madhukar_N_Thakur] This entry is an alias to "gds-db".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+galaxy-server    3051/tcp # Galaxy Server [Michael_Andre] [Michael_Andre]
+galaxy-server    3051/udp # Galaxy Server [Michael_Andre] [Michael_Andre]
+apc-3052         3052/tcp # APC 3052 [American_Power_Conve] [American_Power_Conve]
+apc-3052         3052/udp # APC 3052 [American_Power_Conve] [American_Power_Conve]
+dsom-server      3053/tcp # dsom-server [Daniel_Sisk] [Daniel_Sisk]
+dsom-server      3053/udp # dsom-server [Daniel_Sisk] [Daniel_Sisk]
+amt-cnf-prot     3054/tcp # AMT CNF PROT [Marco_Marcucci] [Marco_Marcucci]
+amt-cnf-prot     3054/udp # AMT CNF PROT [Marco_Marcucci] [Marco_Marcucci]
+policyserver     3055/tcp # Policy Server [Mark_Garti] [Mark_Garti]
+policyserver     3055/udp # Policy Server [Mark_Garti] [Mark_Garti]
+cdl-server       3056/tcp # CDL Server [Paul_Roberts] [Paul_Roberts]
+cdl-server       3056/udp # CDL Server [Paul_Roberts] [Paul_Roberts]
+goahead-fldup    3057/tcp # GoAhead FldUp [Alan_Pickrell] [Alan_Pickrell]
+goahead-fldup    3057/udp # GoAhead FldUp [Alan_Pickrell] [Alan_Pickrell]
+videobeans       3058/tcp # videobeans [Hiroyuki_Takahashi] [Hiroyuki_Takahashi]
+videobeans       3058/udp # videobeans [Hiroyuki_Takahashi] [Hiroyuki_Takahashi]
+qsoft            3059/tcp # qsoft [James_Kunz] [James_Kunz]
+qsoft            3059/udp # qsoft [James_Kunz] [James_Kunz]
+interserver      3060/tcp # interserver [Madhukar_N_Thakur] [Madhukar_N_Thakur]
+interserver      3060/udp # interserver [Madhukar_N_Thakur] [Madhukar_N_Thakur]
+cautcpd          3061/tcp # cautcpd
+cautcpd          3061/udp # cautcpd
+ncacn-ip-tcp     3062/tcp # ncacn-ip-tcp
+ncacn-ip-tcp     3062/udp # ncacn-ip-tcp
+ncadg-ip-udp     3063/tcp # ncadg-ip-udp [Gabi_Kalmar] [Gabi_Kalmar]
+ncadg-ip-udp     3063/udp # ncadg-ip-udp [Gabi_Kalmar] [Gabi_Kalmar]
+rprt             3064/tcp # Remote Port Redirector [Robin_Johnston] [Robin_Johnston]
+rprt             3064/udp # Remote Port Redirector [Robin_Johnston] [Robin_Johnston]
+slinterbase      3065/tcp # slinterbase [Bie_Tie] [Bie_Tie]
+slinterbase      3065/udp # slinterbase [Bie_Tie] [Bie_Tie]
+netattachsdmp    3066/tcp # NETATTACHSDMP [Mike_Young] [Mike_Young]
+netattachsdmp    3066/udp # NETATTACHSDMP [Mike_Young] [Mike_Young]
+fjhpjp           3067/tcp # FJHPJP [Ryozo_Furutani] [Ryozo_Furutani]
+fjhpjp           3067/udp # FJHPJP [Ryozo_Furutani] [Ryozo_Furutani]
+ls3bcast         3068/tcp # ls3 Broadcast
+ls3bcast         3068/udp # ls3 Broadcast
+ls3              3069/tcp # ls3 [Jim_Thompson] [Jim_Thompson]
+ls3              3069/udp # ls3 [Jim_Thompson] [Jim_Thompson]
+mgxswitch        3070/tcp # MGXSWITCH [George_Walter] [George_Walter]
+mgxswitch        3070/udp # MGXSWITCH [George_Walter] [George_Walter]
+csd-mgmt-port    3071/tcp # ContinuStor Manager Port
+csd-mgmt-port    3071/udp # ContinuStor Manager Port
+csd-monitor      3072/tcp # ContinuStor Monitor Port [Ray_Jantz] [Ray_Jantz]
+csd-monitor      3072/udp # ContinuStor Monitor Port [Ray_Jantz] [Ray_Jantz]
+vcrp             3073/tcp # Very simple chatroom prot [Andreas_Wurf] [Andreas_Wurf]
+vcrp             3073/udp # Very simple chatroom prot [Andreas_Wurf] [Andreas_Wurf]
+xbox             3074/tcp # Xbox game port [Damon_Danieli] [Damon_Danieli]
+xbox             3074/udp # Xbox game port [Damon_Danieli] [Damon_Danieli]
+orbix-locator    3075/tcp # Orbix 2000 Locator
+orbix-locator    3075/udp # Orbix 2000 Locator
+orbix-config     3076/tcp # Orbix 2000 Config
+orbix-config     3076/udp # Orbix 2000 Config
+orbix-loc-ssl    3077/tcp # Orbix 2000 Locator SSL
+orbix-loc-ssl    3077/udp # Orbix 2000 Locator SSL
+orbix-cfg-ssl    3078/tcp # Orbix 2000 Locator SSL [Eric_Newcomer] [Eric_Newcomer]
+orbix-cfg-ssl    3078/udp # Orbix 2000 Locator SSL [Eric_Newcomer] [Eric_Newcomer]
+lv-frontpanel    3079/tcp # LV Front Panel [Darshan_Shah] [Darshan_Shah]
+lv-frontpanel    3079/udp # LV Front Panel [Darshan_Shah] [Darshan_Shah]
+stm-pproc        3080/tcp # stm_pprocIANA assigned this well-formed service name as a replacement for "stm_pproc". [Paul_McGinnis] [Paul_McGinnis]
+stm_pproc        3080/tcp # stm_pproc [Paul_McGinnis] [Paul_McGinnis] This entry is an alias to "stm-pproc".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+stm-pproc        3080/udp # stm_pprocIANA assigned this well-formed service name as a replacement for "stm_pproc". [Paul_McGinnis] [Paul_McGinnis]
+stm_pproc        3080/udp # stm_pproc [Paul_McGinnis] [Paul_McGinnis] This entry is an alias to "stm-pproc".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+tl1-lv           3081/tcp # TL1-LV
+tl1-lv           3081/udp # TL1-LV
+tl1-raw          3082/tcp # TL1-RAW
+tl1-raw          3082/udp # TL1-RAW
+tl1-telnet       3083/tcp # TL1-TELNET [SONET_Internetworkin] [SONET_Internetworkin]
+tl1-telnet       3083/udp # TL1-TELNET [SONET_Internetworkin] [SONET_Internetworkin]
+itm-mccs         3084/tcp # ITM-MCCS [Portnoy_Boxman] [Portnoy_Boxman]
+itm-mccs         3084/udp # ITM-MCCS [Portnoy_Boxman] [Portnoy_Boxman]
+pcihreq          3085/tcp # PCIHReq [Paul_Sanders] [Paul_Sanders]
+pcihreq          3085/udp # PCIHReq [Paul_Sanders] [Paul_Sanders]
+jdl-dbkitchen    3086/tcp # JDL-DBKitchen [Hideo_Wakabayashi] [Hideo_Wakabayashi]
+jdl-dbkitchen    3086/udp # JDL-DBKitchen [Hideo_Wakabayashi] [Hideo_Wakabayashi]
+asoki-sma        3087/tcp # Asoki SMA [Andrew_Mossberg] [Andrew_Mossberg]
+asoki-sma        3087/udp # Asoki SMA [Andrew_Mossberg] [Andrew_Mossberg]
+xdtp             3088/tcp # eXtensible Data Transfer Protocol [Michael_Shearson] [Michael_Shearson]
+xdtp             3088/udp # eXtensible Data Transfer Protocol [Michael_Shearson] [Michael_Shearson]
+ptk-alink        3089/tcp # ParaTek Agent Linking [Robert_Hodgson_2] [Robert_Hodgson_2]
+ptk-alink        3089/udp # ParaTek Agent Linking [Robert_Hodgson_2] [Robert_Hodgson_2]
+stss             3090/tcp # Senforce Session Services [Peter_Boucher] [Peter_Boucher]
+stss             3090/udp # Senforce Session Services [Peter_Boucher] [Peter_Boucher]
+1ci-smcs         3091/tcp # 1Ci Server Management [Ralf_Bensmann] [Ralf_Bensmann]
+1ci-smcs         3091/udp # 1Ci Server Management [Ralf_Bensmann] [Ralf_Bensmann]
+rapidmq-center   3093/tcp # Jiiva RapidMQ Center
+rapidmq-center   3093/udp # Jiiva RapidMQ Center
+rapidmq-reg      3094/tcp # Jiiva RapidMQ Registry [Mark_Ericksen] [Mark_Ericksen]
+rapidmq-reg      3094/udp # Jiiva RapidMQ Registry [Mark_Ericksen] [Mark_Ericksen]
+panasas          3095/tcp # Panasas rendevous port [Peter_Berger] [Peter_Berger]
+panasas          3095/udp # Panasas rendevous port [Peter_Berger] [Peter_Berger]
+ndl-aps          3096/tcp # Active Print Server Port [Martin_Norman] [Martin_Norman]
+ndl-aps          3096/udp # Active Print Server Port [Martin_Norman] [Martin_Norman]
+itu-bicc-stc     3097/sctp # ITU-T Q.1902.1/Q.2150.3 [Greg_Sidebottom] [Greg_Sidebottom]
+umm-port         3098/tcp # Universal Message Manager [Phil_Braham] [Phil_Braham]
+umm-port         3098/udp # Universal Message Manager [Phil_Braham] [Phil_Braham]
+chmd             3099/tcp # CHIPSY Machine Daemon [Trond_Borsting] [Trond_Borsting]
+chmd             3099/udp # CHIPSY Machine Daemon [Trond_Borsting] [Trond_Borsting]
+opcon-xps        3100/tcp # OpCon/xps [David_Bourland] [David_Bourland]
+opcon-xps        3100/udp # OpCon/xps [David_Bourland] [David_Bourland]
+hp-pxpib         3101/tcp # HP PolicyXpert PIB Server [Brian_O_Keefe] [Brian_O_Keefe]
+hp-pxpib         3101/udp # HP PolicyXpert PIB Server [Brian_O_Keefe] [Brian_O_Keefe]
+slslavemon       3102/tcp # SoftlinK Slave Mon Port [Moshe_Livne] [Moshe_Livne]
+slslavemon       3102/udp # SoftlinK Slave Mon Port [Moshe_Livne] [Moshe_Livne]
+autocuesmi       3103/tcp # Autocue SMI Protocol
+autocuesmi       3103/udp # Autocue SMI Protocol
+autocuelog       3104/tcp # Autocue Logger Protocol
+autocuetime      3104/udp # Autocue Time Service [Geoff_Back] [Geoff_Back]
+cardbox          3105/tcp # Cardbox
+cardbox          3105/udp # Cardbox
+cardbox-http     3106/tcp # Cardbox HTTP [Martin_Kochanski] [Martin_Kochanski]
+cardbox-http     3106/udp # Cardbox HTTP [Martin_Kochanski] [Martin_Kochanski]
+business         3107/tcp # Business protocol
+business         3107/udp # Business protocol
+geolocate        3108/tcp # Geolocate protocol
+geolocate        3108/udp # Geolocate protocol
+personnel        3109/tcp # Personnel protocol [William_Randolph_Roy] [William_Randolph_Roy]
+personnel        3109/udp # Personnel protocol [William_Randolph_Roy] [William_Randolph_Roy]
+sim-control      3110/tcp # simulator control port [Ian_Bell] [Ian_Bell]
+sim-control      3110/udp # simulator control port [Ian_Bell] [Ian_Bell]
+wsynch           3111/tcp # Web Synchronous Services [Valery_Fremaux] [Valery_Fremaux]
+wsynch           3111/udp # Web Synchronous Services [Valery_Fremaux] [Valery_Fremaux]
+ksysguard        3112/tcp # KDE System Guard [Chris_Schlaeger] [Chris_Schlaeger]
+ksysguard        3112/udp # KDE System Guard [Chris_Schlaeger] [Chris_Schlaeger]
+cs-auth-svr      3113/tcp # CS-Authenticate Svr Port [Cliff_Diamond][Andy_Georgiou] [Cliff_Diamond][Andy_Georgiou]
+cs-auth-svr      3113/udp # CS-Authenticate Svr Port [Cliff_Diamond][Andy_Georgiou] [Cliff_Diamond][Andy_Georgiou]
+ccmad            3114/tcp # CCM AutoDiscover [Ram_Sudama] [Ram_Sudama]
+ccmad            3114/udp # CCM AutoDiscover [Ram_Sudama] [Ram_Sudama]
+mctet-master     3115/tcp # MCTET Master
+mctet-master     3115/udp # MCTET Master
+mctet-gateway    3116/tcp # MCTET Gateway
+mctet-gateway    3116/udp # MCTET Gateway
+mctet-jserv      3117/tcp # MCTET Jserv [Portnoy_Boxman] [Portnoy_Boxman]
+mctet-jserv      3117/udp # MCTET Jserv [Portnoy_Boxman] [Portnoy_Boxman]
+pkagent          3118/tcp # PKAgent [Michael_Douglass] [Michael_Douglass]
+pkagent          3118/udp # PKAgent [Michael_Douglass] [Michael_Douglass]
+d2000kernel      3119/tcp # D2000 Kernel Port
+d2000kernel      3119/udp # D2000 Kernel Port
+d2000webserver   3120/tcp # D2000 Webserver Port [Tomas_Rajcan] [Tomas_Rajcan]
+d2000webserver   3120/udp # D2000 Webserver Port [Tomas_Rajcan] [Tomas_Rajcan]
+pcmk-remote      3121/tcp # The pacemaker remote (pcmk-remote) service extends high availability functionality outside of the Linux cluster into remote nodes. [David_Vossel] [Andrew_Beekhof] 2013-03-15 port 3121 previously noted "Removed on 2003-09-17"
+vtr-emulator     3122/tcp # MTI VTR Emulator port [John_Mertus] [John_Mertus]
+vtr-emulator     3122/udp # MTI VTR Emulator port [John_Mertus] [John_Mertus]
+edix             3123/tcp # EDI Translation Protocol [William_Randolph_Roy] [William_Randolph_Roy]
+edix             3123/udp # EDI Translation Protocol [William_Randolph_Roy] [William_Randolph_Roy]
+beacon-port      3124/tcp # Beacon Port [James_Paul_Duncan] [James_Paul_Duncan]
+beacon-port      3124/udp # Beacon Port [James_Paul_Duncan] [James_Paul_Duncan]
+a13-an           3125/tcp # A13-AN Interface [Douglas_Knisely] [Douglas_Knisely]
+a13-an           3125/udp # A13-AN Interface [Douglas_Knisely] [Douglas_Knisely]
+ctx-bridge       3127/tcp # CTX Bridge Port [Alexander_Dubrovsky] [Alexander_Dubrovsky]
+ctx-bridge       3127/udp # CTX Bridge Port [Alexander_Dubrovsky] [Alexander_Dubrovsky]
+ndl-aas          3128/tcp # Active API Server Port [Martin_Norman] [Martin_Norman]
+ndl-aas          3128/udp # Active API Server Port [Martin_Norman] [Martin_Norman]
+netport-id       3129/tcp # NetPort Discovery Port [P_T_K_Farrar] [P_T_K_Farrar]
+netport-id       3129/udp # NetPort Discovery Port [P_T_K_Farrar] [P_T_K_Farrar]
+icpv2            3130/tcp # ICPv2 [Duane_Wessels] [Duane_Wessels]
+icpv2            3130/udp # ICPv2 [Duane_Wessels] [Duane_Wessels]
+netbookmark      3131/tcp # Net Book Mark [Yiftach_Ravid] [Yiftach_Ravid]
+netbookmark      3131/udp # Net Book Mark [Yiftach_Ravid] [Yiftach_Ravid]
+ms-rule-engine   3132/tcp # Microsoft Business Rule Engine Update Service [Anush_Kumar] [Anush_Kumar]
+ms-rule-engine   3132/udp # Microsoft Business Rule Engine Update Service [Anush_Kumar] [Anush_Kumar]
+prism-deploy     3133/tcp # Prism Deploy User Port [Joan_Linck] [Joan_Linck]
+prism-deploy     3133/udp # Prism Deploy User Port [Joan_Linck] [Joan_Linck]
+ecp              3134/tcp # Extensible Code Protocol [Jim_Trek][Mark_Bocko] [Jim_Trek][Mark_Bocko]
+ecp              3134/udp # Extensible Code Protocol [Jim_Trek][Mark_Bocko] [Jim_Trek][Mark_Bocko]
+peerbook-port    3135/tcp # PeerBook Port [John_Flowers] [John_Flowers]
+peerbook-port    3135/udp # PeerBook Port [John_Flowers] [John_Flowers]
+grubd            3136/tcp # Grub Server Port [Kord_Campbell] [Kord_Campbell]
+grubd            3136/udp # Grub Server Port [Kord_Campbell] [Kord_Campbell]
+rtnt-1           3137/tcp # rtnt-1 data packets
+rtnt-1           3137/udp # rtnt-1 data packets
+rtnt-2           3138/tcp # rtnt-2 data packets [Ron_Muellerschoen] [Ron_Muellerschoen]
+rtnt-2           3138/udp # rtnt-2 data packets [Ron_Muellerschoen] [Ron_Muellerschoen]
+incognitorv      3139/tcp # Incognito Rendez-Vous [Stephane_Bourque] [Stephane_Bourque]
+incognitorv      3139/udp # Incognito Rendez-Vous [Stephane_Bourque] [Stephane_Bourque]
+ariliamulti      3140/tcp # Arilia Multiplexor [Stephane_Bourque_2] [Stephane_Bourque_2]
+ariliamulti      3140/udp # Arilia Multiplexor [Stephane_Bourque_2] [Stephane_Bourque_2]
+vmodem           3141/tcp # VMODEM [Ray_Gwinn] [Ray_Gwinn]
+vmodem           3141/udp # VMODEM [Ray_Gwinn] [Ray_Gwinn]
+rdc-wh-eos       3142/tcp # RDC WH EOS [Udi_Nir] [Udi_Nir]
+rdc-wh-eos       3142/udp # RDC WH EOS [Udi_Nir] [Udi_Nir]
+seaview          3143/tcp # Sea View [Jim_Flaherty_2] [Jim_Flaherty_2]
+seaview          3143/udp # Sea View [Jim_Flaherty_2] [Jim_Flaherty_2]
+tarantella       3144/tcp # Tarantella [Roger_Binns] [Roger_Binns]
+tarantella       3144/udp # Tarantella [Roger_Binns] [Roger_Binns]
+csi-lfap         3145/tcp # CSI-LFAP [Paul_Amsden] [Paul_Amsden] Known UNAUTHORIZED USE: port 3145
+csi-lfap         3145/udp # CSI-LFAP [Paul_Amsden] [Paul_Amsden] Known UNAUTHORIZED USE: port 3145
+bears-02         3146/tcp # bears-02 [Bruce_McKinnon_2] [Bruce_McKinnon_2]
+bears-02         3146/udp # bears-02 [Bruce_McKinnon_2] [Bruce_McKinnon_2]
+rfio             3147/tcp # RFIO [Frederic_Hemmer] [Frederic_Hemmer]
+rfio             3147/udp # RFIO [Frederic_Hemmer] [Frederic_Hemmer]
+nm-game-admin    3148/tcp # NetMike Game Administrator
+nm-game-admin    3148/udp # NetMike Game Administrator
+nm-game-server   3149/tcp # NetMike Game Server
+nm-game-server   3149/udp # NetMike Game Server
+nm-asses-admin   3150/tcp # NetMike Assessor Administrator
+nm-asses-admin   3150/udp # NetMike Assessor Administrator
+nm-assessor      3151/tcp # NetMike Assessor [Andrew_Sharpe] [Andrew_Sharpe]
+nm-assessor      3151/udp # NetMike Assessor [Andrew_Sharpe] [Andrew_Sharpe]
+feitianrockey    3152/tcp # FeiTian Port [Huang_Yu] [Huang_Yu]
+feitianrockey    3152/udp # FeiTian Port [Huang_Yu] [Huang_Yu]
+s8-client-port   3153/tcp # S8Cargo Client Port [Jon_S_Kyle] [Jon_S_Kyle]
+s8-client-port   3153/udp # S8Cargo Client Port [Jon_S_Kyle] [Jon_S_Kyle]
+ccmrmi           3154/tcp # ON RMI Registry [Ram_Sudama] [Ram_Sudama]
+ccmrmi           3154/udp # ON RMI Registry [Ram_Sudama] [Ram_Sudama]
+jpegmpeg         3155/tcp # JpegMpeg Port [Richard_Bassous] [Richard_Bassous]
+jpegmpeg         3155/udp # JpegMpeg Port [Richard_Bassous] [Richard_Bassous]
+indura           3156/tcp # Indura Collector [Bruce_Kosbab] [Bruce_Kosbab]
+indura           3156/udp # Indura Collector [Bruce_Kosbab] [Bruce_Kosbab]
+e3consultants    3157/tcp # CCC Listener Port [Brian_Carnell] [Brian_Carnell]
+e3consultants    3157/udp # CCC Listener Port [Brian_Carnell] [Brian_Carnell]
+stvp             3158/tcp # SmashTV Protocol [Christian_Wolff] [Christian_Wolff]
+stvp             3158/udp # SmashTV Protocol [Christian_Wolff] [Christian_Wolff]
+navegaweb-port   3159/tcp # NavegaWeb Tarification [Miguel_Angel_Fernand] [Miguel_Angel_Fernand]
+navegaweb-port   3159/udp # NavegaWeb Tarification [Miguel_Angel_Fernand] [Miguel_Angel_Fernand]
+tip-app-server   3160/tcp # TIP Application Server [Olivier_Mascia] [Olivier_Mascia]
+tip-app-server   3160/udp # TIP Application Server [Olivier_Mascia] [Olivier_Mascia]
+doc1lm           3161/tcp # DOC1 License Manager [Greg_Goodson] [Greg_Goodson]
+doc1lm           3161/udp # DOC1 License Manager [Greg_Goodson] [Greg_Goodson]
+sflm             3162/tcp # SFLM [System_Administrator] [System_Administrator]
+sflm             3162/udp # SFLM [System_Administrator] [System_Administrator]
+res-sap          3163/tcp # RES-SAP [Bob_Janssen] [Bob_Janssen]
+res-sap          3163/udp # RES-SAP [Bob_Janssen] [Bob_Janssen]
+imprs            3164/tcp # IMPRS [Lars_Bohn] [Lars_Bohn]
+imprs            3164/udp # IMPRS [Lars_Bohn] [Lars_Bohn]
+newgenpay        3165/tcp # Newgenpay Engine Service [Ilan_Zisser] [Ilan_Zisser]
+newgenpay        3165/udp # Newgenpay Engine Service [Ilan_Zisser] [Ilan_Zisser]
+sossecollector   3166/tcp # Quest Spotlight Out-Of-Process Collector [Greg_Cottman] [Greg_Cottman] 2008-10-23
+sossecollector   3166/udp # Quest Spotlight Out-Of-Process Collector [Greg_Cottman] [Greg_Cottman] 2008-10-23
+nowcontact       3167/tcp # Now Contact Public Server
+nowcontact       3167/udp # Now Contact Public Server
+poweronnud       3168/tcp # Now Up-to-Date Public Server [John_Wallace] [John_Wallace]
+poweronnud       3168/udp # Now Up-to-Date Public Server [John_Wallace] [John_Wallace]
+serverview-as    3169/tcp # SERVERVIEW-AS
+serverview-as    3169/udp # SERVERVIEW-AS
+serverview-asn   3170/tcp # SERVERVIEW-ASN
+serverview-asn   3170/udp # SERVERVIEW-ASN
+serverview-gf    3171/tcp # SERVERVIEW-GF
+serverview-gf    3171/udp # SERVERVIEW-GF
+serverview-rm    3172/tcp # SERVERVIEW-RM
+serverview-rm    3172/udp # SERVERVIEW-RM
+serverview-icc   3173/tcp # SERVERVIEW-ICC [Detlef_Rothe] [Detlef_Rothe] 2009-05-15
+serverview-icc   3173/udp # SERVERVIEW-ICC [Detlef_Rothe] [Detlef_Rothe] 2009-05-15
+armi-server      3174/tcp # ARMI Server [Bobby_Martin] [Bobby_Martin]
+armi-server      3174/udp # ARMI Server [Bobby_Martin] [Bobby_Martin]
+t1-e1-over-ip    3175/tcp # T1_E1_Over_IP [Mark_Doyle] [Mark_Doyle]
+t1-e1-over-ip    3175/udp # T1_E1_Over_IP [Mark_Doyle] [Mark_Doyle]
+ars-master       3176/tcp # ARS Master [Portnoy_Boxman] [Portnoy_Boxman]
+ars-master       3176/udp # ARS Master [Portnoy_Boxman] [Portnoy_Boxman]
+phonex-port      3177/tcp # Phonex Protocol [Doug_Grover] [Doug_Grover]
+phonex-port      3177/udp # Phonex Protocol [Doug_Grover] [Doug_Grover]
+radclientport    3178/tcp # Radiance UltraEdge Port [Sri_Subramaniam] [Sri_Subramaniam]
+radclientport    3178/udp # Radiance UltraEdge Port [Sri_Subramaniam] [Sri_Subramaniam]
+h2gf-w-2m        3179/tcp # H2GF W.2m Handover prot. [Arne_Norefors] [Arne_Norefors]
+h2gf-w-2m        3179/udp # H2GF W.2m Handover prot. [Arne_Norefors] [Arne_Norefors]
+mc-brk-srv       3180/tcp # Millicent Broker Server [Steve_Glassman] [Steve_Glassman]
+mc-brk-srv       3180/udp # Millicent Broker Server [Steve_Glassman] [Steve_Glassman]
+bmcpatrolagent   3181/tcp # BMC Patrol Agent
+bmcpatrolagent   3181/udp # BMC Patrol Agent
+bmcpatrolrnvu    3182/tcp # BMC Patrol Rendezvous [Portnoy_Boxman] [Portnoy_Boxman]
+bmcpatrolrnvu    3182/udp # BMC Patrol Rendezvous [Portnoy_Boxman] [Portnoy_Boxman]
+cops-tls         3183/tcp # COPS/TLS [Mark_Stevens] [Mark_Stevens]
+cops-tls         3183/udp # COPS/TLS [Mark_Stevens] [Mark_Stevens]
+apogeex-port     3184/tcp # ApogeeX Port [Tom_Nys] [Tom_Nys]
+apogeex-port     3184/udp # ApogeeX Port [Tom_Nys] [Tom_Nys]
+smpppd           3185/tcp # SuSE Meta PPPD [Arvin_Schnell] [Arvin_Schnell]
+smpppd           3185/udp # SuSE Meta PPPD [Arvin_Schnell] [Arvin_Schnell]
+iiw-port         3186/tcp # IIW Monitor User Port [Corey_Burnett] [Corey_Burnett]
+iiw-port         3186/udp # IIW Monitor User Port [Corey_Burnett] [Corey_Burnett]
+odi-port         3187/tcp # Open Design Listen Port [Phivos_Aristides] [Phivos_Aristides]
+odi-port         3187/udp # Open Design Listen Port [Phivos_Aristides] [Phivos_Aristides]
+brcm-comm-port   3188/tcp # Broadcom Port [Thomas_L_Johnson] [Thomas_L_Johnson]
+brcm-comm-port   3188/udp # Broadcom Port [Thomas_L_Johnson] [Thomas_L_Johnson]
+pcle-infex       3189/tcp # Pinnacle Sys InfEx Port [Anthon_van_der_Neut] [Anthon_van_der_Neut]
+pcle-infex       3189/udp # Pinnacle Sys InfEx Port [Anthon_van_der_Neut] [Anthon_van_der_Neut]
+csvr-proxy       3190/tcp # ConServR Proxy
+csvr-proxy       3190/udp # ConServR Proxy
+csvr-sslproxy    3191/tcp # ConServR SSL Proxy [Mikhail_Kruk] [Mikhail_Kruk]
+csvr-sslproxy    3191/udp # ConServR SSL Proxy [Mikhail_Kruk] [Mikhail_Kruk]
+firemonrcc       3192/tcp # FireMon Revision Control [Michael_Bishop] [Michael_Bishop]
+firemonrcc       3192/udp # FireMon Revision Control [Michael_Bishop] [Michael_Bishop]
+spandataport     3193/tcp # SpanDataPort [Jesse_McKay] [Jesse_McKay]
+spandataport     3193/udp # SpanDataPort [Jesse_McKay] [Jesse_McKay]
+magbind          3194/tcp # Rockstorm MAG protocol [Jens_Nilsson] [Jens_Nilsson]
+magbind          3194/udp # Rockstorm MAG protocol [Jens_Nilsson] [Jens_Nilsson]
+ncu-1            3195/tcp # Network Control Unit
+ncu-1            3195/udp # Network Control Unit
+ncu-2            3196/tcp # Network Control Unit [Charlie_Hundre] [Charlie_Hundre]
+ncu-2            3196/udp # Network Control Unit [Charlie_Hundre] [Charlie_Hundre]
+embrace-dp-s     3197/tcp # Embrace Device Protocol Server
+embrace-dp-s     3197/udp # Embrace Device Protocol Server
+embrace-dp-c     3198/tcp # Embrace Device Protocol Client [Elliot_Schwartz] [Elliot_Schwartz]
+embrace-dp-c     3198/udp # Embrace Device Protocol Client [Elliot_Schwartz] [Elliot_Schwartz]
+dmod-workspace   3199/tcp # DMOD WorkSpace [Nick_Plante] [Nick_Plante]
+dmod-workspace   3199/udp # DMOD WorkSpace [Nick_Plante] [Nick_Plante]
+tick-port        3200/tcp # Press-sense Tick Port [Boris_Svetlitsky] [Boris_Svetlitsky]
+tick-port        3200/udp # Press-sense Tick Port [Boris_Svetlitsky] [Boris_Svetlitsky]
+cpq-tasksmart    3201/tcp # CPQ-TaskSmart [Jackie_Lau] [Jackie_Lau]
+cpq-tasksmart    3201/udp # CPQ-TaskSmart [Jackie_Lau] [Jackie_Lau]
+intraintra       3202/tcp # IntraIntra [Matthew_Asham] [Matthew_Asham]
+intraintra       3202/udp # IntraIntra [Matthew_Asham] [Matthew_Asham]
+netwatcher-mon   3203/tcp # Network Watcher Monitor
+netwatcher-mon   3203/udp # Network Watcher Monitor
+netwatcher-db    3204/tcp # Network Watcher DB Access [Hirokazu_Fujisawa] [Hirokazu_Fujisawa]
+netwatcher-db    3204/udp # Network Watcher DB Access [Hirokazu_Fujisawa] [Hirokazu_Fujisawa]
+isns             3205/tcp # iSNS Server Port [RFC4171]
+isns             3205/udp # iSNS Server Port [RFC4171]
+ironmail         3206/tcp # IronMail POP Proxy [Mike_Hudack] [Mike_Hudack]
+ironmail         3206/udp # IronMail POP Proxy [Mike_Hudack] [Mike_Hudack]
+vx-auth-port     3207/tcp # Veritas Authentication Port [Senthil_Ponnuswamy] [Senthil_Ponnuswamy]
+vx-auth-port     3207/udp # Veritas Authentication Port [Senthil_Ponnuswamy] [Senthil_Ponnuswamy]
+pfu-prcallback   3208/tcp # PFU PR Callback [Tetsuharu_Hanada] [Tetsuharu_Hanada]
+pfu-prcallback   3208/udp # PFU PR Callback [Tetsuharu_Hanada] [Tetsuharu_Hanada]
+netwkpathengine  3209/tcp # HP OpenView Network Path Engine Server [Anthony_Walker] [Anthony_Walker]
+netwkpathengine  3209/udp # HP OpenView Network Path Engine Server [Anthony_Walker] [Anthony_Walker]
+flamenco-proxy   3210/tcp # Flamenco Networks Proxy [Corey_Corrick] [Corey_Corrick]
+flamenco-proxy   3210/udp # Flamenco Networks Proxy [Corey_Corrick] [Corey_Corrick]
+avsecuremgmt     3211/tcp # Avocent Secure Management [Brian_S_Stewart] [Brian_S_Stewart]
+avsecuremgmt     3211/udp # Avocent Secure Management [Brian_S_Stewart] [Brian_S_Stewart]
+surveyinst       3212/tcp # Survey Instrument [Al_Amet] [Al_Amet]
+surveyinst       3212/udp # Survey Instrument [Al_Amet] [Al_Amet]
+neon24x7         3213/tcp # NEON 24X7 Mission Control [Tony_Lubrano] [Tony_Lubrano]
+neon24x7         3213/udp # NEON 24X7 Mission Control [Tony_Lubrano] [Tony_Lubrano]
+jmq-daemon-1     3214/tcp # JMQ Daemon Port 1
+jmq-daemon-1     3214/udp # JMQ Daemon Port 1
+jmq-daemon-2     3215/tcp # JMQ Daemon Port 2 [Martin_West] [Martin_West]
+jmq-daemon-2     3215/udp # JMQ Daemon Port 2 [Martin_West] [Martin_West]
+ferrari-foam     3216/tcp # Ferrari electronic FOAM [Johann_Deutinger] [Johann_Deutinger]
+ferrari-foam     3216/udp # Ferrari electronic FOAM [Johann_Deutinger] [Johann_Deutinger]
+unite            3217/tcp # Unified IP & Telecom Environment [Christer_Gunnarsson] [Christer_Gunnarsson] 2009-03-26
+unite            3217/udp # Unified IP & Telecom Environment [Christer_Gunnarsson] [Christer_Gunnarsson] 2009-03-26
+smartpackets     3218/tcp # EMC SmartPackets [Steve_Spataro] [Steve_Spataro]
+smartpackets     3218/udp # EMC SmartPackets [Steve_Spataro] [Steve_Spataro]
+wms-messenger    3219/tcp # WMS Messenger [Michael_Monasterio] [Michael_Monasterio]
+wms-messenger    3219/udp # WMS Messenger [Michael_Monasterio] [Michael_Monasterio]
+xnm-ssl          3220/tcp # XML NM over SSL
+xnm-ssl          3220/udp # XML NM over SSL
+xnm-clear-text   3221/tcp # XML NM over TCP [Mark_Trostler] [Mark_Trostler]
+xnm-clear-text   3221/udp # XML NM over TCP [Mark_Trostler] [Mark_Trostler]
+glbp             3222/tcp # Gateway Load Balancing Pr [Douglas_McLaggan] [Douglas_McLaggan]
+glbp             3222/udp # Gateway Load Balancing Pr [Douglas_McLaggan] [Douglas_McLaggan]
+digivote         3223/tcp # DIGIVOTE (R) Vote-Server [Christian_Treczoks] [Christian_Treczoks]
+digivote         3223/udp # DIGIVOTE (R) Vote-Server [Christian_Treczoks] [Christian_Treczoks]
+aes-discovery    3224/tcp # AES Discovery Port [Ken_Richard] [Ken_Richard]
+aes-discovery    3224/udp # AES Discovery Port [Ken_Richard] [Ken_Richard]
+fcip-port        3225/tcp # FCIP [RFC3821]
+fcip-port        3225/udp # FCIP [RFC3821]
+isi-irp          3226/tcp # ISI Industry Software IRP [Peter_Sandstrom] [Peter_Sandstrom]
+isi-irp          3226/udp # ISI Industry Software IRP [Peter_Sandstrom] [Peter_Sandstrom]
+dwnmshttp        3227/tcp # DiamondWave NMS Server
+dwnmshttp        3227/udp # DiamondWave NMS Server
+dwmsgserver      3228/tcp # DiamondWave MSG Server [Varma_Bhupatiraju] [Varma_Bhupatiraju]
+dwmsgserver      3228/udp # DiamondWave MSG Server [Varma_Bhupatiraju] [Varma_Bhupatiraju]
+global-cd-port   3229/tcp # Global CD Port [Vitaly_Revsin_2] [Vitaly_Revsin_2]
+global-cd-port   3229/udp # Global CD Port [Vitaly_Revsin_2] [Vitaly_Revsin_2]
+sftdst-port      3230/tcp # Software Distributor Port [Andrea_Lanza] [Andrea_Lanza]
+sftdst-port      3230/udp # Software Distributor Port [Andrea_Lanza] [Andrea_Lanza]
+vidigo           3231/tcp # VidiGo communication (previous was: Delta Solutions Direct) [Peter_Ijkhout] [Peter_Ijkhout]
+vidigo           3231/udp # VidiGo communication (previous was: Delta Solutions Direct) [Peter_Ijkhout] [Peter_Ijkhout]
+mdtp             3232/tcp # MDT port 2012-02-21 [RFC6513]
+mdtp             3232/udp # MDT port 2012-02-21 [RFC6513]
+whisker          3233/tcp # WhiskerControl main port [Rudolf_Cardinal] [Rudolf_Cardinal] 2002-02
+whisker          3233/udp # WhiskerControl main port [Rudolf_Cardinal] [Rudolf_Cardinal] 2002-02
+alchemy          3234/tcp # Alchemy Server [Mikhail_Belov] [Mikhail_Belov] 2002-02
+alchemy          3234/udp # Alchemy Server [Mikhail_Belov] [Mikhail_Belov] 2002-02
+mdap-port        3235/tcp # MDAP port [Johan_Deleu] [Johan_Deleu] 2002-02
+mdap-port        3235/udp # MDAP Port [Johan_Deleu] [Johan_Deleu] 2002-02
+apparenet-ts     3236/tcp # appareNet Test Server
+apparenet-ts     3236/udp # appareNet Test Server
+apparenet-tps    3237/tcp # appareNet Test Packet Sequencer
+apparenet-tps    3237/udp # appareNet Test Packet Sequencer
+apparenet-as     3238/tcp # appareNet Analysis Server
+apparenet-as     3238/udp # appareNet Analysis Server
+apparenet-ui     3239/tcp # appareNet User Interface [Fred_Klassen] [Fred_Klassen] 2002-02
+apparenet-ui     3239/udp # appareNet User Interface [Fred_Klassen] [Fred_Klassen] 2002-02
+triomotion       3240/tcp # Trio Motion Control Port [Tony_Matthews] [Tony_Matthews] 2002-02
+triomotion       3240/udp # Trio Motion Control Port [Tony_Matthews] [Tony_Matthews] 2002-02
+sysorb           3241/tcp # SysOrb Monitoring Server [Jakob_Oestergaard] [Jakob_Oestergaard] 2002-02
+sysorb           3241/udp # SysOrb Monitoring Server [Jakob_Oestergaard] [Jakob_Oestergaard] 2002-02
+sdp-id-port      3242/tcp # Session Description ID [Greg_Rose_2] [Greg_Rose_2] 2002-02
+sdp-id-port      3242/udp # Session Description ID [Greg_Rose_2] [Greg_Rose_2] 2002-02
+timelot          3243/tcp # Timelot Port [David_Ferguson] [David_Ferguson] 2002-02
+timelot          3243/udp # Timelot Port [David_Ferguson] [David_Ferguson] 2002-02
+onesaf           3244/tcp # OneSAF [Gene_McCulley] [Gene_McCulley] 2002-02
+onesaf           3244/udp # OneSAF [Gene_McCulley] [Gene_McCulley] 2002-02
+vieo-fe          3245/tcp # VIEO Fabric Executive [James_Cox] [James_Cox] 2002-02
+vieo-fe          3245/udp # VIEO Fabric Executive [James_Cox] [James_Cox] 2002-02
+dvt-system       3246/tcp # DVT SYSTEM PORT
+dvt-system       3246/udp # DVT SYSTEM PORT
+dvt-data         3247/tcp # DVT DATA LINK [Phillip_Heil] [Phillip_Heil] 2002-02
+dvt-data         3247/udp # DVT DATA LINK [Phillip_Heil] [Phillip_Heil] 2002-02
+procos-lm        3248/tcp # PROCOS LM [Torsten_Rendelmann] [Torsten_Rendelmann]
+procos-lm        3248/udp # PROCOS LM [Torsten_Rendelmann] [Torsten_Rendelmann]
+ssp              3249/tcp # State Sync Protocol [Stephane_Beaulieu] [Stephane_Beaulieu] 2002-02
+ssp              3249/udp # State Sync Protocol [Stephane_Beaulieu] [Stephane_Beaulieu] 2002-02
+hicp             3250/tcp # HMS hicp port [Joel_Palsson] [Joel_Palsson] 2002-02
+hicp             3250/udp # HMS hicp port [Joel_Palsson] [Joel_Palsson] 2002-02
+sysscanner       3251/tcp # Sys Scanner [Dick_Georges] [Dick_Georges] 2002-02
+sysscanner       3251/udp # Sys Scanner [Dick_Georges] [Dick_Georges] 2002-02
+dhe              3252/tcp # DHE port [Fabrizio_Massimo_Fer] [Fabrizio_Massimo_Fer] 2002-02
+dhe              3252/udp # DHE port [Fabrizio_Massimo_Fer] [Fabrizio_Massimo_Fer] 2002-02
+pda-data         3253/tcp # PDA Data
+pda-data         3253/udp # PDA Data
+pda-sys          3254/tcp # PDA System [Jian_Fan] [Jian_Fan] 2002-02
+pda-sys          3254/udp # PDA System [Jian_Fan] [Jian_Fan] 2002-02
+semaphore        3255/tcp # Semaphore Connection Port [Jay_Eckles] [Jay_Eckles] 2002-02
+semaphore        3255/udp # Semaphore Connection Port [Jay_Eckles] [Jay_Eckles] 2002-02
+cpqrpm-agent     3256/tcp # Compaq RPM Agent Port
+cpqrpm-agent     3256/udp # Compaq RPM Agent Port
+cpqrpm-server    3257/tcp # Compaq RPM Server Port [Royal_King] [Royal_King] 2002-02
+cpqrpm-server    3257/udp # Compaq RPM Server Port [Royal_King] [Royal_King] 2002-02
+ivecon-port      3258/tcp # Ivecon Server Port [Serguei_Tevs] [Serguei_Tevs] 2002-02
+ivecon-port      3258/udp # Ivecon Server Port [Serguei_Tevs] [Serguei_Tevs] 2002-02
+epncdp2          3259/tcp # Epson Network Common Devi [Oishi_Toshiaki] [Oishi_Toshiaki] 2002-02
+epncdp2          3259/udp # Epson Network Common Devi [Oishi_Toshiaki] [Oishi_Toshiaki] 2002-02
+iscsi-target     3260/tcp # iSCSI port [IESG] [IETF_Chair] 2013-08-27 [RFC-ietf-storm-iscsi-cons-10]
+iscsi-target     3260/udp # iSCSI port [IESG] [IETF_Chair] 2013-08-27 [RFC-ietf-storm-iscsi-cons-10]
+winshadow        3261/tcp # winShadow [Colin_Barry] [Colin_Barry]
+winshadow        3261/udp # winShadow [Colin_Barry] [Colin_Barry]
+necp             3262/tcp # NECP [Alberto_Cerpa] [Alberto_Cerpa]
+necp             3262/udp # NECP [Alberto_Cerpa] [Alberto_Cerpa]
+ecolor-imager    3263/tcp # E-Color Enterprise Imager [Tamara_Baker] [Tamara_Baker]
+ecolor-imager    3263/udp # E-Color Enterprise Imager [Tamara_Baker] [Tamara_Baker]
+ccmail           3264/tcp # cc:mail/lotus [brockman] [brockman]
+ccmail           3264/udp # cc:mail/lotus [brockman] [brockman]
+altav-tunnel     3265/tcp # Altav Tunnel [Gary_M_Allen] [Gary_M_Allen]
+altav-tunnel     3265/udp # Altav Tunnel [Gary_M_Allen] [Gary_M_Allen]
+ns-cfg-server    3266/tcp # NS CFG Server [Aivi_Lie] [Aivi_Lie]
+ns-cfg-server    3266/udp # NS CFG Server [Aivi_Lie] [Aivi_Lie]
+ibm-dial-out     3267/tcp # IBM Dial Out [Skip_Booth] [Skip_Booth]
+ibm-dial-out     3267/udp # IBM Dial Out [Skip_Booth] [Skip_Booth]
+msft-gc          3268/tcp # Microsoft Global Catalog
+msft-gc          3268/udp # Microsoft Global Catalog
+msft-gc-ssl      3269/tcp # Microsoft Global Catalog with LDAP/SSL [Asaf_Kashi] [Asaf_Kashi]
+msft-gc-ssl      3269/udp # Microsoft Global Catalog with LDAP/SSL [Asaf_Kashi] [Asaf_Kashi]
+verismart        3270/tcp # Verismart [Jay_Weber] [Jay_Weber]
+verismart        3270/udp # Verismart [Jay_Weber] [Jay_Weber]
+csoft-prev       3271/tcp # CSoft Prev Port [Nedelcho_Stanev_3] [Nedelcho_Stanev_3]
+csoft-prev       3271/udp # CSoft Prev Port [Nedelcho_Stanev_3] [Nedelcho_Stanev_3]
+user-manager     3272/tcp # Fujitsu User Manager [Yukihiko_Sakurai] [Yukihiko_Sakurai]
+user-manager     3272/udp # Fujitsu User Manager [Yukihiko_Sakurai] [Yukihiko_Sakurai]
+sxmp             3273/tcp # Simple Extensible Multiplexed Protocol [admin] [admin]
+sxmp             3273/udp # Simple Extensible Multiplexed Protocol [admin] [admin]
+ordinox-server   3274/tcp # Ordinox Server [Denis_Ducharme] [Denis_Ducharme]
+ordinox-server   3274/udp # Ordinox Server [Denis_Ducharme] [Denis_Ducharme]
+samd             3275/tcp # SAMD [Edgar_Circenis] [Edgar_Circenis]
+samd             3275/udp # SAMD [Edgar_Circenis] [Edgar_Circenis]
+maxim-asics      3276/tcp # Maxim ASICs [Dave_Inman] [Dave_Inman]
+maxim-asics      3276/udp # Maxim ASICs [Dave_Inman] [Dave_Inman]
+awg-proxy        3277/tcp # AWG Proxy [Alex_McDonald] [Alex_McDonald]
+awg-proxy        3277/udp # AWG Proxy [Alex_McDonald] [Alex_McDonald]
+lkcmserver       3278/tcp # LKCM Server [Javier_Jimenez] [Javier_Jimenez]
+lkcmserver       3278/udp # LKCM Server [Javier_Jimenez] [Javier_Jimenez]
+admind           3279/tcp # admind [Jeff_Haynes] [Jeff_Haynes]
+admind           3279/udp # admind [Jeff_Haynes] [Jeff_Haynes]
+vs-server        3280/tcp # VS Server [Scott_Godlew] [Scott_Godlew]
+vs-server        3280/udp # VS Server [Scott_Godlew] [Scott_Godlew]
+sysopt           3281/tcp # SYSOPT [Tony_Hoffman] [Tony_Hoffman]
+sysopt           3281/udp # SYSOPT [Tony_Hoffman] [Tony_Hoffman]
+datusorb         3282/tcp # Datusorb [Thomas_Martin] [Thomas_Martin]
+datusorb         3282/udp # Datusorb [Thomas_Martin] [Thomas_Martin]
+Apple Remote Desktop (Net Assistant)  3283/tcp # Net Assistant [Michael_Stein] [Michael_Stein] 2011-11-09
+Apple Remote Desktop (Net Assistant)  3283/udp # Net Assistant [Michael_Stein] [Michael_Stein] 2011-11-09
+4talk            3284/tcp # 4Talk [Tony_Bushnell] [Tony_Bushnell]
+4talk            3284/udp # 4Talk [Tony_Bushnell] [Tony_Bushnell]
+plato            3285/tcp # Plato [Jim_Battin] [Jim_Battin]
+plato            3285/udp # Plato [Jim_Battin] [Jim_Battin]
+e-net            3286/tcp # E-Net [Steven_Grigsby] [Steven_Grigsby]
+e-net            3286/udp # E-Net [Steven_Grigsby] [Steven_Grigsby]
+directvdata      3287/tcp # DIRECTVDATA [Michael_Friedman] [Michael_Friedman]
+directvdata      3287/udp # DIRECTVDATA [Michael_Friedman] [Michael_Friedman]
+cops             3288/tcp # COPS [Shai_Herzog] [Shai_Herzog]
+cops             3288/udp # COPS [Shai_Herzog] [Shai_Herzog]
+enpc             3289/tcp # ENPC [SEIKO_EPSON_2] [SEIKO_EPSON_2]
+enpc             3289/udp # ENPC [SEIKO_EPSON_2] [SEIKO_EPSON_2]
+caps-lm          3290/tcp # CAPS LOGISTICS TOOLKIT - LM [Joseph_Krebs] [Joseph_Krebs]
+caps-lm          3290/udp # CAPS LOGISTICS TOOLKIT - LM [Joseph_Krebs] [Joseph_Krebs]
+sah-lm           3291/tcp # S A Holditch & Associates - LM [Randy_Hudgens] [Randy_Hudgens]
+sah-lm           3291/udp # S A Holditch & Associates - LM [Randy_Hudgens] [Randy_Hudgens]
+cart-o-rama      3292/tcp # Cart O Rama [Phillip_Dillinger] [Phillip_Dillinger]
+cart-o-rama      3292/udp # Cart O Rama [Phillip_Dillinger] [Phillip_Dillinger]
+fg-fps           3293/tcp # fg-fps
+fg-fps           3293/udp # fg-fps
+fg-gip           3294/tcp # fg-gip [Jean_Marc_Frailong] [Jean_Marc_Frailong]
+fg-gip           3294/udp # fg-gip [Jean_Marc_Frailong] [Jean_Marc_Frailong]
+dyniplookup      3295/tcp # Dynamic IP Lookup [Eugene_Osovetsky] [Eugene_Osovetsky]
+dyniplookup      3295/udp # Dynamic IP Lookup [Eugene_Osovetsky] [Eugene_Osovetsky]
+rib-slm          3296/tcp # Rib License Manager [Kristean_Heisler] [Kristean_Heisler]
+rib-slm          3296/udp # Rib License Manager [Kristean_Heisler] [Kristean_Heisler]
+cytel-lm         3297/tcp # Cytel License Manager [Yogesh_P_Gajjar] [Yogesh_P_Gajjar]
+cytel-lm         3297/udp # Cytel License Manager [Yogesh_P_Gajjar] [Yogesh_P_Gajjar]
+deskview         3298/tcp # DeskView [Manfred_Randelzofer] [Manfred_Randelzofer]
+deskview         3298/udp # DeskView [Manfred_Randelzofer] [Manfred_Randelzofer]
+pdrncs           3299/tcp # pdrncs [Paul_Wissenbach] [Paul_Wissenbach]
+pdrncs           3299/udp # pdrncs [Paul_Wissenbach] [Paul_Wissenbach]
+mcs-fastmail     3302/tcp # MCS Fastmail [Patti_Jo_Newsom] [Patti_Jo_Newsom]
+mcs-fastmail     3302/udp # MCS Fastmail [Patti_Jo_Newsom] [Patti_Jo_Newsom]
+opsession-clnt   3303/tcp # OP Session Client
+opsession-clnt   3303/udp # OP Session Client
+opsession-srvr   3304/tcp # OP Session Server [Amir_Blich] [Amir_Blich]
+opsession-srvr   3304/udp # OP Session Server [Amir_Blich] [Amir_Blich]
+odette-ftp       3305/tcp # ODETTE-FTP [David_Nash] [David_Nash] [RFC5024]
+odette-ftp       3305/udp # ODETTE-FTP [David_Nash] [David_Nash] [RFC5024]
+mysql            3306/tcp # MySQL [Monty] [Monty]
+mysql            3306/udp # MySQL [Monty] [Monty]
+opsession-prxy   3307/tcp # OP Session Proxy [Amir_Blich] [Amir_Blich]
+opsession-prxy   3307/udp # OP Session Proxy [Amir_Blich] [Amir_Blich]
+tns-server       3308/tcp # TNS Server
+tns-server       3308/udp # TNS Server
+tns-adv          3309/tcp # TNS ADV [Jerome_Albin] [Jerome_Albin]
+tns-adv          3309/udp # TNS ADV [Jerome_Albin] [Jerome_Albin]
+dyna-access      3310/tcp # Dyna Access [Dave_Belliveau] [Dave_Belliveau]
+dyna-access      3310/udp # Dyna Access [Dave_Belliveau] [Dave_Belliveau]
+mcns-tel-ret     3311/tcp # MCNS Tel Ret [Randall_Atkinson] [Randall_Atkinson]
+mcns-tel-ret     3311/udp # MCNS Tel Ret [Randall_Atkinson] [Randall_Atkinson]
+appman-server    3312/tcp # Application Management Server
+appman-server    3312/udp # Application Management Server
+uorb             3313/tcp # Unify Object Broker [Daegis_Inc] [Chris_Anderson] 2012-07-31
+uorb             3313/udp # Unify Object Broker [Daegis_Inc] [Chris_Anderson] 2012-07-31
+uohost           3314/tcp # Unify Object Host [Daegis_Inc] [Chris_Anderson] 2012-07-31
+uohost           3314/udp # Unify Object Host [Daegis_Inc] [Chris_Anderson] 2012-07-31
+cdid             3315/tcp # CDID [Andrew_Borisov] [Andrew_Borisov]
+cdid             3315/udp # CDID [Andrew_Borisov] [Andrew_Borisov]
+aicc-cmi         3316/tcp # AICC/CMI [William_McDonald] [William_McDonald]
+aicc-cmi         3316/udp # AICC/CMI [William_McDonald] [William_McDonald]
+vsaiport         3317/tcp # VSAI PORT [Rieko_Asai] [Rieko_Asai]
+vsaiport         3317/udp # VSAI PORT [Rieko_Asai] [Rieko_Asai]
+ssrip            3318/tcp # Swith to Swith Routing Information Protocol [Baba_Hidekazu] [Baba_Hidekazu]
+ssrip            3318/udp # Swith to Swith Routing Information Protocol [Baba_Hidekazu] [Baba_Hidekazu]
+sdt-lmd          3319/tcp # SDT License Manager [Salvo_Nassisi] [Salvo_Nassisi]
+sdt-lmd          3319/udp # SDT License Manager [Salvo_Nassisi] [Salvo_Nassisi]
+officelink2000   3320/tcp # Office Link 2000 [Mike_Balch] [Mike_Balch]
+officelink2000   3320/udp # Office Link 2000 [Mike_Balch] [Mike_Balch]
+vnsstr           3321/tcp # VNSSTR [Takeshi_Ohmura] [Takeshi_Ohmura]
+vnsstr           3321/udp # VNSSTR [Takeshi_Ohmura] [Takeshi_Ohmura]
+sftu             3326/tcp # SFTU [Eduardo_Rosenberg_de] [Eduardo_Rosenberg_de]
+sftu             3326/udp # SFTU [Eduardo_Rosenberg_de] [Eduardo_Rosenberg_de]
+bbars            3327/tcp # BBARS [Lou_Harris] [Lou_Harris]
+bbars            3327/udp # BBARS [Lou_Harris] [Lou_Harris]
+egptlm           3328/tcp # Eaglepoint License Manager [Dave_Benton] [Dave_Benton]
+egptlm           3328/udp # Eaglepoint License Manager [Dave_Benton] [Dave_Benton]
+hp-device-disc   3329/tcp # HP Device Disc [Shivaun_Albright] [Shivaun_Albright]
+hp-device-disc   3329/udp # HP Device Disc [Shivaun_Albright] [Shivaun_Albright]
+mcs-calypsoicf   3330/tcp # MCS Calypso ICF
+mcs-calypsoicf   3330/udp # MCS Calypso ICF
+mcs-messaging    3331/tcp # MCS Messaging
+mcs-messaging    3331/udp # MCS Messaging
+mcs-mailsvr      3332/tcp # MCS Mail Server [Patti_Jo_Newsom] [Patti_Jo_Newsom]
+mcs-mailsvr      3332/udp # MCS Mail Server [Patti_Jo_Newsom] [Patti_Jo_Newsom]
+dec-notes        3333/tcp # DEC Notes [Kim_Moraros] [Kim_Moraros]
+dec-notes        3333/udp # DEC Notes [Kim_Moraros] [Kim_Moraros]
+directv-web      3334/tcp # Direct TV Webcasting
+directv-web      3334/udp # Direct TV Webcasting
+directv-soft     3335/tcp # Direct TV Software Updates
+directv-soft     3335/udp # Direct TV Software Updates
+directv-tick     3336/tcp # Direct TV Tickers
+directv-tick     3336/udp # Direct TV Tickers
+directv-catlg    3337/tcp # Direct TV Data Catalog [Michael_Friedman] [Michael_Friedman]
+directv-catlg    3337/udp # Direct TV Data Catalog [Michael_Friedman] [Michael_Friedman]
+anet-b           3338/tcp # OMF data b
+anet-b           3338/udp # OMF data b
+anet-l           3339/tcp # OMF data l
+anet-l           3339/udp # OMF data l
+anet-m           3340/tcp # OMF data m
+anet-m           3340/udp # OMF data m
+anet-h           3341/tcp # OMF data h [Per_Sahlqvist] [Per_Sahlqvist]
+anet-h           3341/udp # OMF data h [Per_Sahlqvist] [Per_Sahlqvist]
+webtie           3342/tcp # WebTIE [Kevin_Frender] [Kevin_Frender]
+webtie           3342/udp # WebTIE [Kevin_Frender] [Kevin_Frender]
+ms-cluster-net   3343/tcp # MS Cluster Net [David_Dion] [David_Dion] 2009-02-12
+ms-cluster-net   3343/udp # MS Cluster Net [David_Dion] [David_Dion] 2009-02-12
+bnt-manager      3344/tcp # BNT Manager [Engineering_Dept] [Engineering_Dept]
+bnt-manager      3344/udp # BNT Manager [Engineering_Dept] [Engineering_Dept]
+influence        3345/tcp # Influence [Russ_Ferriday] [Russ_Ferriday]
+influence        3345/udp # Influence [Russ_Ferriday] [Russ_Ferriday]
+trnsprntproxy    3346/tcp # Trnsprnt Proxy [Grant_Kirby] [Grant_Kirby]
+trnsprntproxy    3346/udp # Trnsprnt Proxy [Grant_Kirby] [Grant_Kirby]
+phoenix-rpc      3347/tcp # Phoenix RPC [Ian_Anderson] [Ian_Anderson]
+phoenix-rpc      3347/udp # Phoenix RPC [Ian_Anderson] [Ian_Anderson]
+pangolin-laser   3348/tcp # Pangolin Laser [William_Benner] [William_Benner]
+pangolin-laser   3348/udp # Pangolin Laser [William_Benner] [William_Benner]
+chevinservices   3349/tcp # Chevin Services [Gus_McNaughton] [Gus_McNaughton]
+chevinservices   3349/udp # Chevin Services [Gus_McNaughton] [Gus_McNaughton]
+findviatv        3350/tcp # FINDVIATV [Oran_Davis] [Oran_Davis]
+findviatv        3350/udp # FINDVIATV [Oran_Davis] [Oran_Davis]
+btrieve          3351/tcp # Btrieve port
+btrieve          3351/udp # Btrieve port
+ssql             3352/tcp # Scalable SQL [Chuck_Talk] [Chuck_Talk]
+ssql             3352/udp # Scalable SQL [Chuck_Talk] [Chuck_Talk]
+fatpipe          3353/tcp # FATPIPE [Sanchaita_Datta] [Sanchaita_Datta]
+fatpipe          3353/udp # FATPIPE [Sanchaita_Datta] [Sanchaita_Datta]
+suitjd           3354/tcp # SUITJD [Todd_Moyer] [Todd_Moyer]
+suitjd           3354/udp # SUITJD [Todd_Moyer] [Todd_Moyer]
+ordinox-dbase    3355/tcp # Ordinox Dbase [Denis_Ducharme] [Denis_Ducharme]
+ordinox-dbase    3355/udp # Ordinox Dbase [Denis_Ducharme] [Denis_Ducharme]
+upnotifyps       3356/tcp # UPNOTIFYPS [Mark_Fox] [Mark_Fox]
+upnotifyps       3356/udp # UPNOTIFYPS [Mark_Fox] [Mark_Fox]
+adtech-test      3357/tcp # Adtech Test IP [Robin_Uyeshiro] [Robin_Uyeshiro]
+adtech-test      3357/udp # Adtech Test IP [Robin_Uyeshiro] [Robin_Uyeshiro]
+mpsysrmsvr       3358/tcp # Mp Sys Rmsvr [Hiroyuki_Kawabuchi] [Hiroyuki_Kawabuchi]
+mpsysrmsvr       3358/udp # Mp Sys Rmsvr [Hiroyuki_Kawabuchi] [Hiroyuki_Kawabuchi]
+wg-netforce      3359/tcp # WG NetForce [Lee_Wheat] [Lee_Wheat]
+wg-netforce      3359/udp # WG NetForce [Lee_Wheat] [Lee_Wheat]
+kv-server        3360/tcp # KV Server
+kv-server        3360/udp # KV Server
+kv-agent         3361/tcp # KV Agent [Thomas_Soranno] [Thomas_Soranno]
+kv-agent         3361/udp # KV Agent [Thomas_Soranno] [Thomas_Soranno]
+dj-ilm           3362/tcp # DJ ILM [Don_Tyson] [Don_Tyson]
+dj-ilm           3362/udp # DJ ILM [Don_Tyson] [Don_Tyson]
+nati-vi-server   3363/tcp # NATI Vi Server [Robert_Dye] [Robert_Dye]
+nati-vi-server   3363/udp # NATI Vi Server [Robert_Dye] [Robert_Dye]
+creativeserver   3364/tcp # Creative Server
+creativeserver   3364/udp # Creative Server
+contentserver    3365/tcp # Content Server
+contentserver    3365/udp # Content Server
+creativepartnr   3366/tcp # Creative Partner [Jesus_Ortiz_2] [Jesus_Ortiz_2]
+creativepartnr   3366/udp # Creative Partner [Jesus_Ortiz_2] [Jesus_Ortiz_2]
+tip2             3372/tcp # TIP 2 [Keith_Evans] [Keith_Evans]
+tip2             3372/udp # TIP 2 [Keith_Evans] [Keith_Evans]
+lavenir-lm       3373/tcp # Lavenir License Manager [Marius_Matioc] [Marius_Matioc]
+lavenir-lm       3373/udp # Lavenir License Manager [Marius_Matioc] [Marius_Matioc]
+cluster-disc     3374/tcp # Cluster Disc [Jeff_Hughes] [Jeff_Hughes]
+cluster-disc     3374/udp # Cluster Disc [Jeff_Hughes] [Jeff_Hughes]
+vsnm-agent       3375/tcp # VSNM Agent [Venkat_Rangan] [Venkat_Rangan]
+vsnm-agent       3375/udp # VSNM Agent [Venkat_Rangan] [Venkat_Rangan]
+cdbroker         3376/tcp # CD Broker [Moon_Ho_Chung] [Moon_Ho_Chung]
+cdbroker         3376/udp # CD Broker [Moon_Ho_Chung] [Moon_Ho_Chung]
+cogsys-lm        3377/tcp # Cogsys Network License Manager [Simon_Chinnick] [Simon_Chinnick]
+cogsys-lm        3377/udp # Cogsys Network License Manager [Simon_Chinnick] [Simon_Chinnick]
+wsicopy          3378/tcp # WSICOPY [James_Overby] [James_Overby]
+wsicopy          3378/udp # WSICOPY [James_Overby] [James_Overby]
+socorfs          3379/tcp # SOCORFS [Hugo_Charbonneau] [Hugo_Charbonneau]
+socorfs          3379/udp # SOCORFS [Hugo_Charbonneau] [Hugo_Charbonneau]
+sns-channels     3380/tcp # SNS Channels [Shekar_Pasumarthi] [Shekar_Pasumarthi]
+sns-channels     3380/udp # SNS Channels [Shekar_Pasumarthi] [Shekar_Pasumarthi]
+geneous          3381/tcp # Geneous [Nick_de_Smith] [Nick_de_Smith]
+geneous          3381/udp # Geneous [Nick_de_Smith] [Nick_de_Smith]
+fujitsu-neat     3382/tcp # Fujitsu Network Enhanced Antitheft function [Markku_Viima] [Markku_Viima]
+fujitsu-neat     3382/udp # Fujitsu Network Enhanced Antitheft function [Markku_Viima] [Markku_Viima]
+esp-lm           3383/tcp # Enterprise Software Products License Manager [George_Rudy] [George_Rudy]
+esp-lm           3383/udp # Enterprise Software Products License Manager [George_Rudy] [George_Rudy]
+hp-clic          3384/tcp # Cluster Management Services [Rajesh_Srinivasaragh] [Rajesh_Srinivasaragh]
+hp-clic          3384/udp # Hardware Management [Rajesh_Srinivasaragh] [Rajesh_Srinivasaragh]
+qnxnetman        3385/tcp # qnxnetman [Michael_Hunter] [Michael_Hunter]
+qnxnetman        3385/udp # qnxnetman [Michael_Hunter] [Michael_Hunter]
+gprs-data        3386/tcp # GPRS Data
+gprs-sig         3386/udp # GPRS SIG [Ansgar_Bergmann] [Ansgar_Bergmann]
+backroomnet      3387/tcp # Back Room Net [Clayton_Wilkinson] [Clayton_Wilkinson]
+backroomnet      3387/udp # Back Room Net [Clayton_Wilkinson] [Clayton_Wilkinson]
+cbserver         3388/tcp # CB Server [Allen_Wei] [Allen_Wei]
+cbserver         3388/udp # CB Server [Allen_Wei] [Allen_Wei]
+ms-wbt-server    3389/tcp # MS WBT Server [Ritu_Bahl] [Ritu_Bahl]
+ms-wbt-server    3389/udp # MS WBT Server [Ritu_Bahl] [Ritu_Bahl]
+dsc              3390/tcp # Distributed Service Coordinator [Charles_Honton] [Charles_Honton]
+dsc              3390/udp # Distributed Service Coordinator [Charles_Honton] [Charles_Honton]
+savant           3391/tcp # SAVANT [Andy_Bruce] [Andy_Bruce]
+savant           3391/udp # SAVANT [Andy_Bruce] [Andy_Bruce]
+efi-lm           3392/tcp # EFI License Management [Ross_E_Greinke] [Ross_E_Greinke]
+efi-lm           3392/udp # EFI License Management [Ross_E_Greinke] [Ross_E_Greinke]
+d2k-tapestry1    3393/tcp # D2K Tapestry Client to Server
+d2k-tapestry1    3393/udp # D2K Tapestry Client to Server
+d2k-tapestry2    3394/tcp # D2K Tapestry Server to Server [Eric_Lan] [Eric_Lan]
+d2k-tapestry2    3394/udp # D2K Tapestry Server to Server [Eric_Lan] [Eric_Lan]
+dyna-lm          3395/tcp # Dyna License Manager (Elam) [Anjana_Iyer] [Anjana_Iyer]
+dyna-lm          3395/udp # Dyna License Manager (Elam) [Anjana_Iyer] [Anjana_Iyer]
+printer-agent    3396/tcp # Printer AgentIANA assigned this well-formed service name as a replacement for "printer_agent". [Devon_Taylor] [Devon_Taylor]
+printer_agent    3396/tcp # Printer Agent [Devon_Taylor] [Devon_Taylor] This entry is an alias to "printer-agent".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+printer-agent    3396/udp # Printer AgentIANA assigned this well-formed service name as a replacement for "printer_agent". [Devon_Taylor] [Devon_Taylor]
+printer_agent    3396/udp # Printer Agent [Devon_Taylor] [Devon_Taylor] This entry is an alias to "printer-agent".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+cloanto-lm       3397/tcp # Cloanto License Manager [Takeo_Sato] [Takeo_Sato] 2010-04-30
+cloanto-lm       3397/udp # Cloanto License Manager [Takeo_Sato] [Takeo_Sato] 2010-04-30
+mercantile       3398/tcp # Mercantile [Erik_Kragh_Jensen] [Erik_Kragh_Jensen]
+mercantile       3398/udp # Mercantile [Erik_Kragh_Jensen] [Erik_Kragh_Jensen]
+csms             3399/tcp # CSMS
+csms             3399/udp # CSMS
+csms2            3400/tcp # CSMS2 [Markus_Michels_2] [Markus_Michels_2]
+csms2            3400/udp # CSMS2 [Markus_Michels_2] [Markus_Michels_2]
+filecast         3401/tcp # filecast [Eden_Sherry] [Eden_Sherry]
+filecast         3401/udp # filecast [Eden_Sherry] [Eden_Sherry]
+fxaengine-net    3402/tcp # FXa Engine Network Port [Lucas_Alonso] [Lucas_Alonso] 2002-02
+fxaengine-net    3402/udp # FXa Engine Network Port [Lucas_Alonso] [Lucas_Alonso] 2002-02
+nokia-ann-ch1    3405/tcp # Nokia Announcement ch 1
+nokia-ann-ch1    3405/udp # Nokia Announcement ch 1
+nokia-ann-ch2    3406/tcp # Nokia Announcement ch 2 [Morteza_Kalhour] [Morteza_Kalhour] 2002-02
+nokia-ann-ch2    3406/udp # Nokia Announcement ch 2 [Morteza_Kalhour] [Morteza_Kalhour] 2002-02
+ldap-admin       3407/tcp # LDAP admin server port [Stephen_Tsun_2] [Stephen_Tsun_2] 2002-02
+ldap-admin       3407/udp # LDAP admin server port [Stephen_Tsun_2] [Stephen_Tsun_2] 2002-02
+BESApi           3408/tcp # BES Api Port [Colin_Griffiths] [Colin_Griffiths] 2002-02
+BESApi           3408/udp # BES Api Port [Colin_Griffiths] [Colin_Griffiths] 2002-02
+networklens      3409/tcp # NetworkLens Event Port
+networklens      3409/udp # NetworkLens Event Port
+networklenss     3410/tcp # NetworkLens SSL Event [Greg_Bailey] [Greg_Bailey] 2002-02
+networklenss     3410/udp # NetworkLens SSL Event [Greg_Bailey] [Greg_Bailey] 2002-02
+biolink-auth     3411/tcp # BioLink Authenteon server [BioLink_Support] [BioLink_Support] 2002-02
+biolink-auth     3411/udp # BioLink Authenteon server [BioLink_Support] [BioLink_Support] 2002-02
+xmlblaster       3412/tcp # xmlBlaster [Marcel_Ruff] [Marcel_Ruff] 2002-02
+xmlblaster       3412/udp # xmlBlaster [Marcel_Ruff] [Marcel_Ruff] 2002-02
+svnet            3413/tcp # SpecView Networking [Richard_Dickins] [Richard_Dickins] 2002-02
+svnet            3413/udp # SpecView Networking [Richard_Dickins] [Richard_Dickins] 2002-02
+wip-port         3414/tcp # BroadCloud WIP Port
+wip-port         3414/udp # BroadCloud WIP Port
+bcinameservice   3415/tcp # BCI Name Service [Dennis_Parker] [Dennis_Parker] 2002-02
+bcinameservice   3415/udp # BCI Name Service [Dennis_Parker] [Dennis_Parker] 2002-02
+commandport      3416/tcp # AirMobile IS Command Port [Mike_Klein] [Mike_Klein] 2002-02
+commandport      3416/udp # AirMobile IS Command Port [Mike_Klein] [Mike_Klein] 2002-02
+csvr             3417/tcp # ConServR file translation [Albert_Leung] [Albert_Leung] 2002-02
+csvr             3417/udp # ConServR file translation [Albert_Leung] [Albert_Leung] 2002-02
+rnmap            3418/tcp # Remote nmap [Tuomo_Makinen] [Tuomo_Makinen] 2002-02
+rnmap            3418/udp # Remote nmap [Tuomo_Makinen] [Tuomo_Makinen] 2002-02
+softaudit        3419/tcp # Isogon SoftAudit [Per_Hellberg] [Per_Hellberg] 2002-02
+softaudit        3419/udp # ISogon SoftAudit [Per_Hellberg] [Per_Hellberg] 2002-02
+ifcp-port        3420/tcp # iFCP User Port [RFC4172]
+ifcp-port        3420/udp # iFCP User Port [RFC4172]
+bmap             3421/tcp # Bull Apprise portmapper [Jeremy_Gilbert] [Jeremy_Gilbert]
+bmap             3421/udp # Bull Apprise portmapper [Jeremy_Gilbert] [Jeremy_Gilbert]
+rusb-sys-port    3422/tcp # Remote USB System Port [Steven_Klein] [Steven_Klein] 2002-02
+rusb-sys-port    3422/udp # Remote USB System Port [Steven_Klein] [Steven_Klein] 2002-02
+xtrm             3423/tcp # xTrade Reliable Messaging
+xtrm             3423/udp # xTrade Reliable Messaging
+xtrms            3424/tcp # xTrade over TLS/SSL [Mats_Nilsson] [Mats_Nilsson] 2002-02
+xtrms            3424/udp # xTrade over TLS/SSL [Mats_Nilsson] [Mats_Nilsson] 2002-02
+agps-port        3425/tcp # AGPS Access Port [Kristoffer_Nilsson] [Kristoffer_Nilsson] 2002-02
+agps-port        3425/udp # AGPS Access Port [Kristoffer_Nilsson] [Kristoffer_Nilsson] 2002-02
+arkivio          3426/tcp # Arkivio Storage Protocol [Bruce_Greenblatt] [Bruce_Greenblatt] 2002-02
+arkivio          3426/udp # Arkivio Storage Protocol [Bruce_Greenblatt] [Bruce_Greenblatt] 2002-02
+websphere-snmp   3427/tcp # WebSphere SNMP [Richard_Mills] [Richard_Mills] 2002-02
+websphere-snmp   3427/udp # WebSphere SNMP [Richard_Mills] [Richard_Mills] 2002-02
+twcss            3428/tcp # 2Wire CSS [Wire_IANA_Contact] [Wire_IANA_Contact] 2002-02
+twcss            3428/udp # 2Wire CSS [Wire_IANA_Contact] [Wire_IANA_Contact] 2002-02
+gcsp             3429/tcp # GCSP user port [Anirban_Majumder] [Anirban_Majumder] 2002-03
+gcsp             3429/udp # GCSP user port [Anirban_Majumder] [Anirban_Majumder] 2002-03
+ssdispatch       3430/tcp # Scott Studios Dispatch [Michael_Settles] [Michael_Settles] 2002-03
+ssdispatch       3430/udp # Scott Studios Dispatch [Michael_Settles] [Michael_Settles] 2002-03
+ndl-als          3431/tcp # Active License Server Port [Quentin_Brown] [Quentin_Brown] 2002-03
+ndl-als          3431/udp # Active License Server Port [Quentin_Brown] [Quentin_Brown] 2002-03
+osdcp            3432/tcp # Secure Device Protocol [Peter_Fernandez] [Peter_Fernandez] 2002-03
+osdcp            3432/udp # Secure Device Protocol [Peter_Fernandez] [Peter_Fernandez] 2002-03
+opnet-smp        3433/tcp # OPNET Service Management Platform [OPNET_Technologies_Inc] [Edward_Macomber] 2002-03 2011-09-21
+opnet-smp        3433/udp # OPNET Service Management Platform [OPNET_Technologies_Inc] [Edward_Macomber] 2002-03 2011-09-21
+opencm           3434/tcp # OpenCM Server [Jonathan_S_Shapiro] [Jonathan_S_Shapiro] 2002-03
+opencm           3434/udp # OpenCM Server [Jonathan_S_Shapiro] [Jonathan_S_Shapiro] 2002-03
+pacom            3435/tcp # Pacom Security User Port [Steve_Barton] [Steve_Barton] 2002-03
+pacom            3435/udp # Pacom Security User Port [Steve_Barton] [Steve_Barton] 2002-03
+gc-config        3436/tcp # GuardControl Exchange Protocol [Andreas_Schwarz] [Andreas_Schwarz] 2002-03
+gc-config        3436/udp # GuardControl Exchange Protocol [Andreas_Schwarz] [Andreas_Schwarz] 2002-03
+autocueds        3437/tcp # Autocue Directory Service [Geoff_Back] [Geoff_Back] 2002-03
+autocueds        3437/udp # Autocue Directory Service [Geoff_Back] [Geoff_Back] 2002-03
+spiral-admin     3438/tcp # Spiralcraft Admin [Michael_Toth] [Michael_Toth] 2002-03
+spiral-admin     3438/udp # Spiralcraft Admin [Michael_Toth] [Michael_Toth] 2002-03
+hri-port         3439/tcp # HRI Interface Port [John_Fayos] [John_Fayos] 2002-03
+hri-port         3439/udp # HRI Interface Port [John_Fayos] [John_Fayos] 2002-03
+ans-console      3440/tcp # Net Steward Mgmt Console [John_Richmond] [John_Richmond] 2002-03
+ans-console      3440/udp # Net Steward Mgmt Console [John_Richmond] [John_Richmond] 2002-03
+connect-client   3441/tcp # OC Connect Client
+connect-client   3441/udp # OC Connect Client
+connect-server   3442/tcp # OC Connect Server [Mike_Velten_2] [Mike_Velten_2] 2002-03
+connect-server   3442/udp # OC Connect Server [Mike_Velten_2] [Mike_Velten_2] 2002-03
+ov-nnm-websrv    3443/tcp # OpenView Network Node Manager WEB Server [Anthony_Walker] [Anthony_Walker] 2002-03
+ov-nnm-websrv    3443/udp # OpenView Network Node Manager WEB Server [Anthony_Walker] [Anthony_Walker] 2002-03
+denali-server    3444/tcp # Denali Server [Joe_Devlin] [Joe_Devlin] 2002-03
+denali-server    3444/udp # Denali Server [Joe_Devlin] [Joe_Devlin] 2002-03
+monp             3445/tcp # Media Object Network [Ron_Herardian] [Ron_Herardian] 2002-03
+monp             3445/udp # Media Object Network [Ron_Herardian] [Ron_Herardian] 2002-03
+3comfaxrpc       3446/tcp # 3Com FAX RPC port [Christopher_Wells_2] [Christopher_Wells_2] 2002-04
+3comfaxrpc       3446/udp # 3Com FAX RPC port [Christopher_Wells_2] [Christopher_Wells_2] 2002-04
+directnet        3447/tcp # DirectNet IM System [Gregory_Richards] [Gregory_Richards] 2002-04
+directnet        3447/udp # DirectNet IM System [Gregory_Richards] [Gregory_Richards] 2002-04
+dnc-port         3448/tcp # Discovery and Net Config [Chi_Chen] [Chi_Chen] 2002-04
+dnc-port         3448/udp # Discovery and Net Config [Chi_Chen] [Chi_Chen] 2002-04
+hotu-chat        3449/tcp # HotU Chat [Tim_Burgess] [Tim_Burgess] 2002-04
+hotu-chat        3449/udp # HotU Chat [Tim_Burgess] [Tim_Burgess] 2002-04
+castorproxy      3450/tcp # CAStorProxy [Raymond_J_Young] [Raymond_J_Young] 2002-04
+castorproxy      3450/udp # CAStorProxy [Raymond_J_Young] [Raymond_J_Young] 2002-04
+asam             3451/tcp # ASAM Services [Mike_Gossett] [Mike_Gossett] 2002-04
+asam             3451/udp # ASAM Services [Mike_Gossett] [Mike_Gossett] 2002-04
+sabp-signal      3452/tcp # SABP-Signalling Protocol [Brendan_McWilliams] [Brendan_McWilliams] 2002-04
+sabp-signal      3452/udp # SABP-Signalling Protocol [Brendan_McWilliams] [Brendan_McWilliams] 2002-04
+pscupd           3453/tcp # PSC Update Port [Reid_B_Ligon] [Reid_B_Ligon]
+pscupd           3453/udp # PSC Update Port [Reid_B_Ligon] [Reid_B_Ligon]
+mira             3454/tcp # Apple Remote Access Protocol [Mike_Alexander] [Mike_Alexander]
+mira             3454/udp # Apple Remote Access Protocol [Mike_Alexander] [Mike_Alexander]
+prsvp            3455/tcp # RSVP Port [Bob_Braden] [Bob_Braden]
+prsvp            3455/udp # RSVP Port [Bob_Braden] [Bob_Braden]
+vat              3456/tcp # VAT default data [Van_Jacobson] [Van_Jacobson]
+vat              3456/udp # VAT default data [Van_Jacobson] [Van_Jacobson]
+vat-control      3457/tcp # VAT default control [Van_Jacobson] [Van_Jacobson]
+vat-control      3457/udp # VAT default control [Van_Jacobson] [Van_Jacobson]
+d3winosfi        3458/tcp # D3WinOSFI [Brad_Hamilton] [Brad_Hamilton]
+d3winosfi        3458/udp # D3WinOSFI [Brad_Hamilton] [Brad_Hamilton]
+integral         3459/tcp # TIP Integral [Olivier_Mascia] [Olivier_Mascia]
+integral         3459/udp # TIP Integral [Olivier_Mascia] [Olivier_Mascia]
+edm-manager      3460/tcp # EDM Manger
+edm-manager      3460/udp # EDM Manger
+edm-stager       3461/tcp # EDM Stager
+edm-stager       3461/udp # EDM Stager
+edm-std-notify   3462/tcp # EDM STD Notify
+edm-std-notify   3462/udp # EDM STD Notify
+edm-adm-notify   3463/tcp # EDM ADM Notify
+edm-adm-notify   3463/udp # EDM ADM Notify
+edm-mgr-sync     3464/tcp # EDM MGR Sync
+edm-mgr-sync     3464/udp # EDM MGR Sync
+edm-mgr-cntrl    3465/tcp # EDM MGR Cntrl [Tom_Hennessy] [Tom_Hennessy]
+edm-mgr-cntrl    3465/udp # EDM MGR Cntrl [Tom_Hennessy] [Tom_Hennessy]
+workflow         3466/tcp # WORKFLOW [Robert_Hufsky] [Robert_Hufsky]
+workflow         3466/udp # WORKFLOW [Robert_Hufsky] [Robert_Hufsky]
+rcst             3467/tcp # RCST [Kit_Sturgeon] [Kit_Sturgeon]
+rcst             3467/udp # RCST [Kit_Sturgeon] [Kit_Sturgeon]
+ttcmremotectrl   3468/tcp # TTCM Remote Controll [Yossi_Cohen_Shahar] [Yossi_Cohen_Shahar]
+ttcmremotectrl   3468/udp # TTCM Remote Controll [Yossi_Cohen_Shahar] [Yossi_Cohen_Shahar]
+pluribus         3469/tcp # Pluribus [Mark_Miller] [Mark_Miller]
+pluribus         3469/udp # Pluribus [Mark_Miller] [Mark_Miller]
+jt400            3470/tcp # jt400
+jt400            3470/udp # jt400
+jt400-ssl        3471/tcp # jt400-ssl [Clifton_Nock] [Clifton_Nock]
+jt400-ssl        3471/udp # jt400-ssl [Clifton_Nock] [Clifton_Nock]
+jaugsremotec-1   3472/tcp # JAUGS N-G Remotec 1
+jaugsremotec-1   3472/udp # JAUGS N-G Remotec 1
+jaugsremotec-2   3473/tcp # JAUGS N-G Remotec 2 [Steven_B_Cliff] [Steven_B_Cliff] 2002-04
+jaugsremotec-2   3473/udp # JAUGS N-G Remotec 2 [Steven_B_Cliff] [Steven_B_Cliff] 2002-04
+ttntspauto       3474/tcp # TSP Automation [Arnie_Koster] [Arnie_Koster] 2002-04
+ttntspauto       3474/udp # TSP Automation [Arnie_Koster] [Arnie_Koster] 2002-04
+genisar-port     3475/tcp # Genisar Comm Port [Candace_Niccolson] [Candace_Niccolson] 2002-04
+genisar-port     3475/udp # Genisar Comm Port [Candace_Niccolson] [Candace_Niccolson] 2002-04
+nppmp            3476/tcp # NVIDIA Mgmt Protocol [Gilbert_Yeung] [Gilbert_Yeung] 2002-04
+nppmp            3476/udp # NVIDIA Mgmt Protocol [Gilbert_Yeung] [Gilbert_Yeung] 2002-04
+ecomm            3477/tcp # eComm link port [Thomas_Soerensen] [Thomas_Soerensen] 2002-04
+ecomm            3477/udp # eComm link port [Thomas_Soerensen] [Thomas_Soerensen] 2002-04
+stun             3478/tcp # Session Traversal Utilities for NAT (STUN) port [RFC5389]
+stun             3478/udp # Session Traversal Utilities for NAT (STUN) port [RFC5389]
+turn             3478/tcp # TURN over TCP [RFC5766]
+turn             3478/udp # TURN over UDP [RFC5766]
+stun-behavior    3478/tcp # STUN Behavior Discovery over TCP [RFC5780]
+stun-behavior    3478/udp # STUN Behavior Discovery over UDP [RFC5780]
+twrpc            3479/tcp # 2Wire RPC [Wire_IANA_Contact] [Wire_IANA_Contact] 2002-04
+twrpc            3479/udp # 2Wire RPC [Wire_IANA_Contact] [Wire_IANA_Contact] 2002-04
+plethora         3480/tcp # Secure Virtual Workspace [Tim_Simms] [Tim_Simms] 2002-04
+plethora         3480/udp # Secure Virtual Workspace [Tim_Simms] [Tim_Simms] 2002-04
+cleanerliverc    3481/tcp # CleanerLive remote ctrl [David_Mojdehi] [David_Mojdehi] 2002-04
+cleanerliverc    3481/udp # CleanerLive remote ctrl [David_Mojdehi] [David_Mojdehi] 2002-04
+vulture          3482/tcp # Vulture Monitoring System [Jason_Santos] [Jason_Santos] 2002-04
+vulture          3482/udp # Vulture Monitoring System [Jason_Santos] [Jason_Santos] 2002-04
+slim-devices     3483/tcp # Slim Devices Protocol [Sean_Adams] [Sean_Adams] 2002-05
+slim-devices     3483/udp # Slim Devices Protocol [Sean_Adams] [Sean_Adams] 2002-05
+gbs-stp          3484/tcp # GBS SnapTalk Protocol [Eric_Harris_Braun] [Eric_Harris_Braun] 2002-05
+gbs-stp          3484/udp # GBS SnapTalk Protocol [Eric_Harris_Braun] [Eric_Harris_Braun] 2002-05
+celatalk         3485/tcp # CelaTalk [Carl_Blundell] [Carl_Blundell] 2002-05
+celatalk         3485/udp # CelaTalk [Carl_Blundell] [Carl_Blundell] 2002-05
+ifsf-hb-port     3486/tcp # IFSF Heartbeat Port [IFSF_Secretary] [IFSF_Secretary] 2002-05
+ifsf-hb-port     3486/udp # IFSF Heartbeat Port [IFSF_Secretary] [IFSF_Secretary] 2002-05
+ltctcp           3487/tcp # LISA TCP Transfer Channel
+ltcudp           3487/udp # LISA UDP Transfer Channel [Pit_Vetterick] [Pit_Vetterick] 2002-05
+fs-rh-srv        3488/tcp # FS Remote Host Server [Brian_Nickles] [Brian_Nickles] 2002-05
+fs-rh-srv        3488/udp # FS Remote Host Server [Brian_Nickles] [Brian_Nickles] 2002-05
+dtp-dia          3489/tcp # DTP/DIA [Alexei_V_Soloviev] [Alexei_V_Soloviev] 2002-05
+dtp-dia          3489/udp # DTP/DIA [Alexei_V_Soloviev] [Alexei_V_Soloviev] 2002-05
+colubris         3490/tcp # Colubris Management Port [Gilbert_Moineau] [Gilbert_Moineau] 2002-05
+colubris         3490/udp # Colubris Management Port [Gilbert_Moineau] [Gilbert_Moineau] 2002-05
+swr-port         3491/tcp # SWR Port [Ian_Manning] [Ian_Manning] 2002-05
+swr-port         3491/udp # SWR Port [Ian_Manning] [Ian_Manning] 2002-05
+tvdumtray-port   3492/tcp # TVDUM Tray Port [Peter_Boers] [Peter_Boers] 2002-05
+tvdumtray-port   3492/udp # TVDUM Tray Port [Peter_Boers] [Peter_Boers] 2002-05
+nut              3493/tcp # Network UPS Tools [Russell_Kroll] [Russell_Kroll] 2002-05
+nut              3493/udp # Network UPS Tools [Russell_Kroll] [Russell_Kroll] 2002-05
+ibm3494          3494/tcp # IBM 3494 [Jeffrey_Pilch] [Jeffrey_Pilch]
+ibm3494          3494/udp # IBM 3494 [Jeffrey_Pilch] [Jeffrey_Pilch]
+seclayer-tcp     3495/tcp # securitylayer over tcp
+seclayer-tcp     3495/udp # securitylayer over tcp
+seclayer-tls     3496/tcp # securitylayer over tls [Arno_Hollosi] [Arno_Hollosi] 2002-03
+seclayer-tls     3496/udp # securitylayer over tls [Arno_Hollosi] [Arno_Hollosi] 2002-03
+ipether232port   3497/tcp # ipEther232Port [Marcus_Leufgen] [Marcus_Leufgen] 2002-05
+ipether232port   3497/udp # ipEther232Port [Marcus_Leufgen] [Marcus_Leufgen] 2002-05
+dashpas-port     3498/tcp # DASHPAS user port [Albrecht_Mayer] [Albrecht_Mayer] 2002-05
+dashpas-port     3498/udp # DASHPAS user port [Albrecht_Mayer] [Albrecht_Mayer] 2002-05
+sccip-media      3499/tcp # SccIP Media [David_Yon_2] [David_Yon_2] 2002-05
+sccip-media      3499/udp # SccIP Media [David_Yon_2] [David_Yon_2] 2002-05
+rtmp-port        3500/tcp # RTMP Port [Miriam_Wohlgelernter] [Miriam_Wohlgelernter]
+rtmp-port        3500/udp # RTMP Port [Miriam_Wohlgelernter] [Miriam_Wohlgelernter]
+isoft-p2p        3501/tcp # iSoft-P2P [David_Walling_2] [David_Walling_2]
+isoft-p2p        3501/udp # iSoft-P2P [David_Walling_2] [David_Walling_2]
+avinstalldisc    3502/tcp # Avocent Install Discovery [Brian_S_Stewart_2] [Brian_S_Stewart_2]
+avinstalldisc    3502/udp # Avocent Install Discovery [Brian_S_Stewart_2] [Brian_S_Stewart_2]
+lsp-ping         3503/tcp # MPLS LSP-echo Port [RFC4379]
+lsp-ping         3503/udp # MPLS LSP-echo Port [RFC4379]
+ironstorm        3504/tcp # IronStorm game server [Arnaud_Clermonte] [Arnaud_Clermonte]
+ironstorm        3504/udp # IronStorm game server [Arnaud_Clermonte] [Arnaud_Clermonte]
+ccmcomm          3505/tcp # CCM communications port [Tom_Bougan] [Tom_Bougan]
+ccmcomm          3505/udp # CCM communications port [Tom_Bougan] [Tom_Bougan]
+apc-3506         3506/tcp # APC 3506 [American_Power_Conve] [American_Power_Conve]
+apc-3506         3506/udp # APC 3506 [American_Power_Conve] [American_Power_Conve]
+nesh-broker      3507/tcp # Nesh Broker Port [Jeremy_Maiden] [Jeremy_Maiden]
+nesh-broker      3507/udp # Nesh Broker Port [Jeremy_Maiden] [Jeremy_Maiden]
+interactionweb   3508/tcp # Interaction Web [Mike_Gagle_2] [Mike_Gagle_2]
+interactionweb   3508/udp # Interaction Web [Mike_Gagle_2] [Mike_Gagle_2]
+vt-ssl           3509/tcp # Virtual Token SSL Port [Libor_Sykora] [Libor_Sykora] 2002-05
+vt-ssl           3509/udp # Virtual Token SSL Port [Libor_Sykora] [Libor_Sykora] 2002-05
+xss-port         3510/tcp # XSS Port [Joe_Purcell] [Joe_Purcell] 2002-05
+xss-port         3510/udp # XSS Port [Joe_Purcell] [Joe_Purcell] 2002-05
+webmail-2        3511/tcp # WebMail/2 [Dimitris_Michelinaki] [Dimitris_Michelinaki] 2002-05
+webmail-2        3511/udp # WebMail/2 [Dimitris_Michelinaki] [Dimitris_Michelinaki] 2002-05
+aztec            3512/tcp # Aztec Distribution Port [Alan_Francis] [Alan_Francis] 2002-05
+aztec            3512/udp # Aztec Distribution Port [Alan_Francis] [Alan_Francis] 2002-05
+arcpd            3513/tcp # Adaptec Remote Protocol [Hardy_Doelfel] [Hardy_Doelfel] 2002-05
+arcpd            3513/udp # Adaptec Remote Protocol [Hardy_Doelfel] [Hardy_Doelfel] 2002-05
+must-p2p         3514/tcp # MUST Peer to Peer
+must-p2p         3514/udp # MUST Peer to Peer
+must-backplane   3515/tcp # MUST Backplane [Rick_Stefanik] [Rick_Stefanik] 2002-05
+must-backplane   3515/udp # MUST Backplane [Rick_Stefanik] [Rick_Stefanik] 2002-05
+smartcard-port   3516/tcp # Smartcard Port [Scott_Guthery] [Scott_Guthery] 2002-05
+smartcard-port   3516/udp # Smartcard Port [Scott_Guthery] [Scott_Guthery] 2002-05
+802-11-iapp      3517/tcp # IEEE 802.11 WLANs WG IAPP [Stuart_J_Kerry] [Stuart_J_Kerry] 2002-05
+802-11-iapp      3517/udp # IEEE 802.11 WLANs WG IAPP [Stuart_J_Kerry] [Stuart_J_Kerry] 2002-05
+artifact-msg     3518/tcp # Artifact Message Server [Ron_Capwell] [Ron_Capwell] 2002-06
+artifact-msg     3518/udp # Artifact Message Server [Ron_Capwell] [Ron_Capwell] 2002-06
+nvmsgd           3519/tcp # Netvion Messenger Port
+galileo          3519/udp # Netvion Galileo Port
+galileolog       3520/tcp # Netvion Galileo Log Port [Ray_Caruso] [Ray_Caruso] 2002-06
+galileolog       3520/udp # Netvion Galileo Log Port [Ray_Caruso] [Ray_Caruso] 2002-06
+mc3ss            3521/tcp # Telequip Labs MC3SS [Michael_Sparks] [Michael_Sparks] 2002-06
+mc3ss            3521/udp # Telequip Labs MC3SS [Michael_Sparks] [Michael_Sparks] 2002-06
+nssocketport     3522/tcp # DO over NSSocketPort [Douglas_Davidson] [Douglas_Davidson] 2002-06
+nssocketport     3522/udp # DO over NSSocketPort [Douglas_Davidson] [Douglas_Davidson] 2002-06
+odeumservlink    3523/tcp # Odeum Serverlink [Mads_Peter_Back] [Mads_Peter_Back] 2002-06
+odeumservlink    3523/udp # Odeum Serverlink [Mads_Peter_Back] [Mads_Peter_Back] 2002-06
+ecmport          3524/tcp # ECM Server port
+ecmport          3524/udp # ECM Server port
+eisport          3525/tcp # EIS Server port [Paul_Kraus] [Paul_Kraus] 2002-06
+eisport          3525/udp # EIS Server port [Paul_Kraus] [Paul_Kraus] 2002-06
+starquiz-port    3526/tcp # starQuiz Port [Adam_Ernst_2] [Adam_Ernst_2] 2002-06
+starquiz-port    3526/udp # starQuiz Port [Adam_Ernst_2] [Adam_Ernst_2] 2002-06
+beserver-msg-q   3527/tcp # VERITAS Backup Exec Server [Katherine_Wattwood] [Katherine_Wattwood] 2002-06
+beserver-msg-q   3527/udp # VERITAS Backup Exec Server [Katherine_Wattwood] [Katherine_Wattwood] 2002-06
+jboss-iiop       3528/tcp # JBoss IIOP
+jboss-iiop       3528/udp # JBoss IIOP
+jboss-iiop-ssl   3529/tcp # JBoss IIOP/SSL [Francisco_Reverbel] [Francisco_Reverbel] 2002-06
+jboss-iiop-ssl   3529/udp # JBoss IIOP/SSL [Francisco_Reverbel] [Francisco_Reverbel] 2002-06
+gf               3530/tcp # Grid Friendly [Daivd_P_Chassin] [Daivd_P_Chassin] 2002-06
+gf               3530/udp # Grid Friendly [Daivd_P_Chassin] [Daivd_P_Chassin] 2002-06
+joltid           3531/tcp # Joltid [Ahti_Heinla] [Ahti_Heinla] 2002-06
+joltid           3531/udp # Joltid [Ahti_Heinla] [Ahti_Heinla] 2002-06
+raven-rmp        3532/tcp # Raven Remote Management Control
+raven-rmp        3532/udp # Raven Remote Management Control
+raven-rdp        3533/tcp # Raven Remote Management Data [Daniel_Sorlov_2] [Daniel_Sorlov_2] 2002-06
+raven-rdp        3533/udp # Raven Remote Management Data [Daniel_Sorlov_2] [Daniel_Sorlov_2] 2002-06
+urld-port        3534/tcp # URL Daemon Port [Jim_Binkley] [Jim_Binkley] 2002-06
+urld-port        3534/udp # URL Daemon Port [Jim_Binkley] [Jim_Binkley] 2002-06
+ms-la            3535/tcp # MS-LA [Eric_Ledoux] [Eric_Ledoux]
+ms-la            3535/udp # MS-LA [Eric_Ledoux] [Eric_Ledoux]
+snac             3536/tcp # SNAC [Tatsuya_Igarashi] [Tatsuya_Igarashi] 2002-07
+snac             3536/udp # SNAC [Tatsuya_Igarashi] [Tatsuya_Igarashi] 2002-07
+ni-visa-remote   3537/tcp # Remote NI-VISA port [Sinnadurai_Dharshan] [Sinnadurai_Dharshan] 2002-07
+ni-visa-remote   3537/udp # Remote NI-VISA port [Sinnadurai_Dharshan] [Sinnadurai_Dharshan] 2002-07
+ibm-diradm       3538/tcp # IBM Directory Server
+ibm-diradm       3538/udp # IBM Directory Server
+ibm-diradm-ssl   3539/tcp # IBM Directory Server SSL [Mark_Cavage] [Mark_Cavage] 2002-07
+ibm-diradm-ssl   3539/udp # IBM Directory Server SSL [Mark_Cavage] [Mark_Cavage] 2002-07
+pnrp-port        3540/tcp # PNRP User Port [Igor_Kostic] [Igor_Kostic] 2002-07
+pnrp-port        3540/udp # PNRP User Port [Igor_Kostic] [Igor_Kostic] 2002-07
+voispeed-port    3541/tcp # VoiSpeed Port [Virgilio_Lattanzi] [Virgilio_Lattanzi] 2002-07
+voispeed-port    3541/udp # VoiSpeed Port [Virgilio_Lattanzi] [Virgilio_Lattanzi] 2002-07
+hacl-monitor     3542/tcp # HA cluster monitor [Jason_Ko] [Jason_Ko] 2002-07
+hacl-monitor     3542/udp # HA cluster monitor [Jason_Ko] [Jason_Ko] 2002-07
+qftest-lookup    3543/tcp # qftest Lookup Port [Gregor_Schmid] [Gregor_Schmid] 2002-07
+qftest-lookup    3543/udp # qftest Lookup Port [Gregor_Schmid] [Gregor_Schmid] 2002-07
+teredo           3544/tcp # Teredo Port [RFC4380]
+teredo           3544/udp # Teredo Port [RFC4380]
+camac            3545/tcp # CAMAC equipment [Eugene_Zhiganov] [Eugene_Zhiganov] 2002-07
+camac            3545/udp # CAMAC equipment [Eugene_Zhiganov] [Eugene_Zhiganov] 2002-07
+symantec-sim     3547/tcp # Symantec SIM [George_Dzieciol] [George_Dzieciol] 2002-07
+symantec-sim     3547/udp # Symantec SIM [George_Dzieciol] [George_Dzieciol] 2002-07
+interworld       3548/tcp # Interworld [John_Stephen] [John_Stephen] 2002-07
+interworld       3548/udp # Interworld [John_Stephen] [John_Stephen] 2002-07
+tellumat-nms     3549/tcp # Tellumat MDR NMS [Hennie_van_der_Merwe] [Hennie_van_der_Merwe] 2002-07
+tellumat-nms     3549/udp # Tellumat MDR NMS [Hennie_van_der_Merwe] [Hennie_van_der_Merwe] 2002-07
+ssmpp            3550/tcp # Secure SMPP [Cormac_Long] [Cormac_Long] 2002-07
+ssmpp            3550/udp # Secure SMPP [Cormac_Long] [Cormac_Long] 2002-07
+apcupsd          3551/tcp # Apcupsd Information Port [Riccardo_Facchetti] [Riccardo_Facchetti] 2002-07
+apcupsd          3551/udp # Apcupsd Information Port [Riccardo_Facchetti] [Riccardo_Facchetti] 2002-07
+taserver         3552/tcp # TeamAgenda Server Port [Dany_Ayotte] [Dany_Ayotte] 2002-07
+taserver         3552/udp # TeamAgenda Server Port [Dany_Ayotte] [Dany_Ayotte] 2002-07
+rbr-discovery    3553/tcp # Red Box Recorder ADP [Simon_Jolly] [Simon_Jolly] 2002-07
+rbr-discovery    3553/udp # Red Box Recorder ADP [Simon_Jolly] [Simon_Jolly] 2002-07
+questnotify      3554/tcp # Quest Notification Server [Rob_Griffin] [Rob_Griffin] 2002-07
+questnotify      3554/udp # Quest Notification Server [Rob_Griffin] [Rob_Griffin] 2002-07
+razor            3555/tcp # Vipul's Razor [Vipul_Ved_Prakash] [Vipul_Ved_Prakash] 2002-07
+razor            3555/udp # Vipul's Razor [Vipul_Ved_Prakash] [Vipul_Ved_Prakash] 2002-07
+sky-transport    3556/tcp # Sky Transport Protocol [Michael_Paddon] [Michael_Paddon] 2002-07
+sky-transport    3556/udp # Sky Transport Protocol [Michael_Paddon] [Michael_Paddon] 2002-07
+personalos-001   3557/tcp # PersonalOS Comm Port [Shane_Roberts] [Shane_Roberts] 2002-07
+personalos-001   3557/udp # PersonalOS Comm Port [Shane_Roberts] [Shane_Roberts] 2002-07
+mcp-port         3558/tcp # MCP user port [Professor_Paul_S_Wa] [Professor_Paul_S_Wa] 2002-07
+mcp-port         3558/udp # MCP user port [Professor_Paul_S_Wa] [Professor_Paul_S_Wa] 2002-07
+cctv-port        3559/tcp # CCTV control port [John_Skidmore] [John_Skidmore] 2002-07
+cctv-port        3559/udp # CCTV control port [John_Skidmore] [John_Skidmore] 2002-07
+iniserve-port    3560/tcp # INIServe port [Peter_Moylan] [Peter_Moylan] 2002-08
+iniserve-port    3560/udp # INIServe port [Peter_Moylan] [Peter_Moylan] 2002-08
+bmc-onekey       3561/tcp # BMC-OneKey [Portnoy_Boxman] [Portnoy_Boxman] 2002-08
+bmc-onekey       3561/udp # BMC-OneKey [Portnoy_Boxman] [Portnoy_Boxman] 2002-08
+sdbproxy         3562/tcp # SDBProxy [Eric_Grange] [Eric_Grange] 2002-08
+sdbproxy         3562/udp # SDBProxy [Eric_Grange] [Eric_Grange] 2002-08
+watcomdebug      3563/tcp # Watcom Debug [Dave_Neudoerffer] [Dave_Neudoerffer]
+watcomdebug      3563/udp # Watcom Debug [Dave_Neudoerffer] [Dave_Neudoerffer]
+esimport         3564/tcp # Electromed SIM port [Francois_Marchand] [Francois_Marchand] 2002-08
+esimport         3564/udp # Electromed SIM port [Francois_Marchand] [Francois_Marchand] 2002-08
+m2pa             3565/tcp # M2PA [RFC4165]
+m2pa             3565/sctp # M2PA [RFC4165]
+quest-data-hub   3566/tcp # Quest Data Hub [Greg_Cottman_2] [Greg_Cottman_2] 2010-10-18
+enc-eps          3567/tcp # EMIT protocol stack [Panasonic_Intranet_Panasonic_North_America_PEWLA] [Bryant_Eastham] 2002-08 2012-11-12
+enc-eps          3567/udp # EMIT protocol stack [Panasonic_Intranet_Panasonic_North_America_PEWLA] [Bryant_Eastham] 2002-08 2012-11-12
+enc-tunnel-sec   3568/tcp # EMIT secure tunnel [Panasonic_Intranet_Panasonic_North_America_PEWLA] [Bryant_Eastham] 2003-01 2012-11-12
+enc-tunnel-sec   3568/udp # EMIT secure tunnel [Panasonic_Intranet_Panasonic_North_America_PEWLA] [Bryant_Eastham] 2003-01 2012-11-12
+mbg-ctrl         3569/tcp # Meinberg Control Service [Martin_Burnicki] [Martin_Burnicki] 2002-08
+mbg-ctrl         3569/udp # Meinberg Control Service [Martin_Burnicki] [Martin_Burnicki] 2002-08
+mccwebsvr-port   3570/tcp # MCC Web Server Port
+mccwebsvr-port   3570/udp # MCC Web Server Port
+megardsvr-port   3571/tcp # MegaRAID Server Port
+megardsvr-port   3571/udp # MegaRAID Server Port
+megaregsvrport   3572/tcp # Registration Server Port [Sreenivas_Bagalkote] [Sreenivas_Bagalkote] 2002-08
+megaregsvrport   3572/udp # Registration Server Port [Sreenivas_Bagalkote] [Sreenivas_Bagalkote] 2002-08
+tag-ups-1        3573/tcp # Advantage Group UPS Suite [James_Goddard] [James_Goddard] 2002-08
+tag-ups-1        3573/udp # Advantage Group UPS Suite [James_Goddard] [James_Goddard] 2002-08
+dmaf-server      3574/tcp # DMAF Server
+dmaf-caster      3574/udp # DMAF Caster [Ramakrishna_Nadendla] [Ramakrishna_Nadendla] 2002-08
+ccm-port         3575/tcp # Coalsere CCM Port
+ccm-port         3575/udp # Coalsere CCM Port
+cmc-port         3576/tcp # Coalsere CMC Port [Chris_Hawkinson] [Chris_Hawkinson] 2002-08
+cmc-port         3576/udp # Coalsere CMC Port [Chris_Hawkinson] [Chris_Hawkinson] 2002-08
+config-port      3577/tcp # Configuration Port
+config-port      3577/udp # Configuration Port
+data-port        3578/tcp # Data Port [Anupam_Bharali] [Anupam_Bharali] 2002-08
+data-port        3578/udp # Data Port [Anupam_Bharali] [Anupam_Bharali] 2002-08
+ttat3lb          3579/tcp # Tarantella Load Balancing [Jim_Musgrave] [Jim_Musgrave] 2002-08
+ttat3lb          3579/udp # Tarantella Load Balancing [Jim_Musgrave] [Jim_Musgrave] 2002-08
+nati-svrloc      3580/tcp # NATI-ServiceLocator [Jason_Case] [Jason_Case] 2002-08
+nati-svrloc      3580/udp # NATI-ServiceLocator [Jason_Case] [Jason_Case] 2002-08
+kfxaclicensing   3581/tcp # Ascent Capture Licensing [Brad_Hamilton_2] [Brad_Hamilton_2] 2002-08
+kfxaclicensing   3581/udp # Ascent Capture Licensing [Brad_Hamilton_2] [Brad_Hamilton_2] 2002-08
+press            3582/tcp # PEG PRESS Server [Jim_DeLisle] [Jim_DeLisle] 2002-08
+press            3582/udp # PEG PRESS Server [Jim_DeLisle] [Jim_DeLisle] 2002-08
+canex-watch      3583/tcp # CANEX Watch System [Peter_Kollath] [Peter_Kollath] 2002-08
+canex-watch      3583/udp # CANEX Watch System [Peter_Kollath] [Peter_Kollath] 2002-08
+u-dbap           3584/tcp # U-DBase Access Protocol [Bodo_Rueskamp] [Bodo_Rueskamp] 2002-08
+u-dbap           3584/udp # U-DBase Access Protocol [Bodo_Rueskamp] [Bodo_Rueskamp] 2002-08
+emprise-lls      3585/tcp # Emprise License Server
+emprise-lls      3585/udp # Emprise License Server
+emprise-lsc      3586/tcp # License Server Console [James_J_Diaz] [James_J_Diaz] 2002-08
+emprise-lsc      3586/udp # License Server Console [James_J_Diaz] [James_J_Diaz] 2002-08
+p2pgroup         3587/tcp # Peer to Peer Grouping [Igor_Kostic] [Igor_Kostic] 2002-08
+p2pgroup         3587/udp # Peer to Peer Grouping [Igor_Kostic] [Igor_Kostic] 2002-08
+sentinel         3588/tcp # Sentinel Server [Ian_Gordon] [Ian_Gordon] 2002-08
+sentinel         3588/udp # Sentinel Server [Ian_Gordon] [Ian_Gordon] 2002-08
+isomair          3589/tcp # isomair [Richard_Fleming] [Richard_Fleming] 2002-08
+isomair          3589/udp # isomair [Richard_Fleming] [Richard_Fleming] 2002-08
+wv-csp-sms       3590/tcp # WV CSP SMS Binding [Matti_Salmi] [Matti_Salmi] 2002-08
+wv-csp-sms       3590/udp # WV CSP SMS Binding [Matti_Salmi] [Matti_Salmi] 2002-08
+gtrack-server    3591/tcp # LOCANIS G-TRACK Server
+gtrack-server    3591/udp # LOCANIS G-TRACK Server
+gtrack-ne        3592/tcp # LOCANIS G-TRACK NE Port [Juergen_Edelhaeuser] [Juergen_Edelhaeuser] 2002-08
+gtrack-ne        3592/udp # LOCANIS G-TRACK NE Port [Juergen_Edelhaeuser] [Juergen_Edelhaeuser] 2002-08
+bpmd             3593/tcp # BP Model Debugger [Keith_Fligg] [Keith_Fligg] 2002-09
+bpmd             3593/udp # BP Model Debugger [Keith_Fligg] [Keith_Fligg] 2002-09
+mediaspace       3594/tcp # MediaSpace
+mediaspace       3594/udp # MediaSpace
+shareapp         3595/tcp # ShareApp [Jeff_King] [Jeff_King] 2002-09
+shareapp         3595/udp # ShareApp [Jeff_King] [Jeff_King] 2002-09
+iw-mmogame       3596/tcp # Illusion Wireless MMOG [Jan_Vrsinsky] [Jan_Vrsinsky] 2002-09
+iw-mmogame       3596/udp # Illusion Wireless MMOG [Jan_Vrsinsky] [Jan_Vrsinsky] 2002-09
+a14              3597/tcp # A14 (AN-to-SC/MM)
+a14              3597/udp # A14 (AN-to-SC/MM)
+a15              3598/tcp # A15 (AN-to-AN) [David_Ott] [David_Ott] 2002-09
+a15              3598/udp # A15 (AN-to-AN) [David_Ott] [David_Ott] 2002-09
+quasar-server    3599/tcp # Quasar Accounting Server [Brad_Pepers] [Brad_Pepers] 2002-09
+quasar-server    3599/udp # Quasar Accounting Server [Brad_Pepers] [Brad_Pepers] 2002-09
+trap-daemon      3600/tcp # text relay-answer [John_Willis] [John_Willis] 2002-09
+trap-daemon      3600/udp # text relay-answer [John_Willis] [John_Willis] 2002-09
+visinet-gui      3601/tcp # Visinet Gui [Jeff_Douglass] [Jeff_Douglass] 2002-09
+visinet-gui      3601/udp # Visinet Gui [Jeff_Douglass] [Jeff_Douglass] 2002-09
+infiniswitchcl   3602/tcp # InfiniSwitch Mgr Client [Lee_VanTine] [Lee_VanTine] 2002-09
+infiniswitchcl   3602/udp # InfiniSwitch Mgr Client [Lee_VanTine] [Lee_VanTine] 2002-09
+int-rcv-cntrl    3603/tcp # Integrated Rcvr Control [Dave_Stone] [Dave_Stone] 2002-09
+int-rcv-cntrl    3603/udp # Integrated Rcvr Control [Dave_Stone] [Dave_Stone] 2002-09
+bmc-jmx-port     3604/tcp # BMC JMX Port [Portnoy_Boxman] [Portnoy_Boxman] 2002-09
+bmc-jmx-port     3604/udp # BMC JMX Port [Portnoy_Boxman] [Portnoy_Boxman] 2002-09
+comcam-io        3605/tcp # ComCam IO Port [Don_Gilbreath] [Don_Gilbreath] 2002-09
+comcam-io        3605/udp # ComCam IO Port [Don_Gilbreath] [Don_Gilbreath] 2002-09
+splitlock        3606/tcp # Splitlock Server [Andrew_Tune] [Andrew_Tune] 2002-09
+splitlock        3606/udp # Splitlock Server [Andrew_Tune] [Andrew_Tune] 2002-09
+precise-i3       3607/tcp # Precise I3 [Tomer_Shain] [Tomer_Shain] 2002-09
+precise-i3       3607/udp # Precise I3 [Tomer_Shain] [Tomer_Shain] 2002-09
+trendchip-dcp    3608/tcp # Trendchip control protocol [Ming_Jen_Chen] [Ming_Jen_Chen] 2002-09
+trendchip-dcp    3608/udp # Trendchip control protocol [Ming_Jen_Chen] [Ming_Jen_Chen] 2002-09
+cpdi-pidas-cm    3609/tcp # CPDI PIDAS Connection Mon [Tony_Splaver] [Tony_Splaver] 2002-09
+cpdi-pidas-cm    3609/udp # CPDI PIDAS Connection Mon [Tony_Splaver] [Tony_Splaver] 2002-09
+echonet          3610/tcp # ECHONET [Takeshi_Saito] [Takeshi_Saito] 2002-09
+echonet          3610/udp # ECHONET [Takeshi_Saito] [Takeshi_Saito] 2002-09
+six-degrees      3611/tcp # Six Degrees Port [Zach_Nies] [Zach_Nies] 2002-09
+six-degrees      3611/udp # Six Degrees Port [Zach_Nies] [Zach_Nies] 2002-09
+hp-dataprotect   3612/tcp # HP Data Protector [Hewlett_Packard_2] [Oliver_Breyel] 2002-09 2013-02-07
+hp-dataprotect   3612/udp # HP Data Protector [Hewlett_Packard_2] [Oliver_Breyel] 2002-09 2013-02-07
+alaris-disc      3613/tcp # Alaris Device Discovery [Chris_Dern] [Chris_Dern] 2004-06
+alaris-disc      3613/udp # Alaris Device Discovery [Chris_Dern] [Chris_Dern] 2004-06
+sigma-port       3614/tcp # Satchwell Sigma [Dave_Chapman] [Dave_Chapman] 2011-06-06
+sigma-port       3614/udp # Satchwell Sigma [Dave_Chapman] [Dave_Chapman] 2011-06-06
+start-network    3615/tcp # Start Messaging Network [Peter_Rocca] [Peter_Rocca] 2002-10
+start-network    3615/udp # Start Messaging Network [Peter_Rocca] [Peter_Rocca] 2002-10
+cd3o-protocol    3616/tcp # cd3o Control Protocol [Chris_Wilcox] [Chris_Wilcox] 2002-10
+cd3o-protocol    3616/udp # cd3o Control Protocol [Chris_Wilcox] [Chris_Wilcox] 2002-10
+sharp-server     3617/tcp # ATI SHARP Logic Engine [Bill_Reveile] [Bill_Reveile]
+sharp-server     3617/udp # ATI SHARP Logic Engine [Bill_Reveile] [Bill_Reveile]
+aairnet-1        3618/tcp # AAIR-Network 1
+aairnet-1        3618/udp # AAIR-Network 1
+aairnet-2        3619/tcp # AAIR-Network 2 [James_Mealey] [James_Mealey] 2002-10
+aairnet-2        3619/udp # AAIR-Network 2 [James_Mealey] [James_Mealey] 2002-10
+ep-pcp           3620/tcp # EPSON Projector Control Port
+ep-pcp           3620/udp # EPSON Projector Control Port
+ep-nsp           3621/tcp # EPSON Network Screen Port [SEIKO_EPSON_3] [SEIKO_EPSON_3] 2002-10
+ep-nsp           3621/udp # EPSON Network Screen Port [SEIKO_EPSON_3] [SEIKO_EPSON_3] 2002-10
+ff-lr-port       3622/tcp # FF LAN Redundancy Port [Fieldbus_Foundation] [Fieldbus_Foundation] 2002-10
+ff-lr-port       3622/udp # FF LAN Redundancy Port [Fieldbus_Foundation] [Fieldbus_Foundation] 2002-10
+haipe-discover   3623/tcp # HAIPIS Dynamic Discovery [Mike_Irani] [Mike_Irani] 2002-10
+haipe-discover   3623/udp # HAIPIS Dynamic Discovery [Mike_Irani] [Mike_Irani] 2002-10
+dist-upgrade     3624/tcp # Distributed Upgrade Port [Jason_Schoon] [Jason_Schoon] 2002-10
+dist-upgrade     3624/udp # Distributed Upgrade Port [Jason_Schoon] [Jason_Schoon] 2002-10
+volley           3625/tcp # Volley [David_Catmull] [David_Catmull] 2002-10
+volley           3625/udp # Volley [David_Catmull] [David_Catmull] 2002-10
+bvcdaemon-port   3626/tcp # bvControl Daemon [Ravi_Gokhale] [Ravi_Gokhale] 2002-10
+bvcdaemon-port   3626/udp # bvControl Daemon [Ravi_Gokhale] [Ravi_Gokhale] 2002-10
+jamserverport    3627/tcp # Jam Server Port [Art_Pope] [Art_Pope] 2002-10
+jamserverport    3627/udp # Jam Server Port [Art_Pope] [Art_Pope] 2002-10
+ept-machine      3628/tcp # EPT Machine Interface [Victor_H_Farrace] [Victor_H_Farrace] 2002-10
+ept-machine      3628/udp # EPT Machine Interface [Victor_H_Farrace] [Victor_H_Farrace] 2002-10
+escvpnet         3629/tcp # ESC/VP.net [Hiroyuki_Hashimoto] [Hiroyuki_Hashimoto] 2002-10
+escvpnet         3629/udp # ESC/VP.net [Hiroyuki_Hashimoto] [Hiroyuki_Hashimoto] 2002-10
+cs-remote-db     3630/tcp # C&S Remote Database Port
+cs-remote-db     3630/udp # C&S Remote Database Port
+cs-services      3631/tcp # C&S Web Services Port [Computer_Software_Gm] [Computer_Software_Gm] 2002-10
+cs-services      3631/udp # C&S Web Services Port [Computer_Software_Gm] [Computer_Software_Gm] 2002-10
+distcc           3632/tcp # distributed compiler [Martin_Pool] [Martin_Pool] 2002-11 Defined TXT keys: None
+distcc           3632/udp # distributed compiler [Martin_Pool] [Martin_Pool] 2002-11 Defined TXT keys: None
+wacp             3633/tcp # Wyrnix AIS port [Harry_T_Vennik] [Harry_T_Vennik] 2002-11
+wacp             3633/udp # Wyrnix AIS port [Harry_T_Vennik] [Harry_T_Vennik] 2002-11
+hlibmgr          3634/tcp # hNTSP Library Manager [Kenji_Tetsuyama] [Kenji_Tetsuyama] 2002-11
+hlibmgr          3634/udp # hNTSP Library Manager [Kenji_Tetsuyama] [Kenji_Tetsuyama] 2002-11
+sdo              3635/tcp # Simple Distributed Objects [Alexander_Philippou] [Alexander_Philippou] 2002-11
+sdo              3635/udp # Simple Distributed Objects [Alexander_Philippou] [Alexander_Philippou] 2002-11
+servistaitsm     3636/tcp # SerVistaITSM [Ralph_Campbell] [Ralph_Campbell] 2002-11
+servistaitsm     3636/udp # SerVistaITSM [Ralph_Campbell] [Ralph_Campbell] 2002-11
+scservp          3637/tcp # Customer Service Port [Jonathan_A_Zdziarsk] [Jonathan_A_Zdziarsk] 2002-11
+scservp          3637/udp # Customer Service Port [Jonathan_A_Zdziarsk] [Jonathan_A_Zdziarsk] 2002-11
+ehp-backup       3638/tcp # EHP Backup Protocol [Ed_Fair] [Ed_Fair] 2002-11
+ehp-backup       3638/udp # EHP Backup Protocol [Ed_Fair] [Ed_Fair] 2002-11
+xap-ha           3639/tcp # Extensible Automation [Mark_Harrison] [Mark_Harrison] 2002-11
+xap-ha           3639/udp # Extensible Automation [Mark_Harrison] [Mark_Harrison] 2002-11
+netplay-port1    3640/tcp # Netplay Port 1
+netplay-port1    3640/udp # Netplay Port 1
+netplay-port2    3641/tcp # Netplay Port 2 [Predrag_Filipovic] [Predrag_Filipovic] 2002-11
+netplay-port2    3641/udp # Netplay Port 2 [Predrag_Filipovic] [Predrag_Filipovic] 2002-11
+juxml-port       3642/tcp # Juxml Replication port [Colin_Reid] [Colin_Reid] 2002-11
+juxml-port       3642/udp # Juxml Replication port [Colin_Reid] [Colin_Reid] 2002-11
+audiojuggler     3643/tcp # AudioJuggler [Morten_Mertner] [Morten_Mertner] 2002-11
+audiojuggler     3643/udp # AudioJuggler [Morten_Mertner] [Morten_Mertner] 2002-11
+ssowatch         3644/tcp # ssowatch [Marie_France_Dubreui] [Marie_France_Dubreui] 2002-11
+ssowatch         3644/udp # ssowatch [Marie_France_Dubreui] [Marie_France_Dubreui] 2002-11
+cyc              3645/tcp # Cyc [Stephen_Reed] [Stephen_Reed] 2003-01
+cyc              3645/udp # Cyc [Stephen_Reed] [Stephen_Reed] 2003-01
+xss-srv-port     3646/tcp # XSS Server Port [Joe_Purcell] [Joe_Purcell] 2003-01
+xss-srv-port     3646/udp # XSS Server Port [Joe_Purcell] [Joe_Purcell] 2003-01
+splitlock-gw     3647/tcp # Splitlock Gateway [Andrew_Tune] [Andrew_Tune] 2003-01
+splitlock-gw     3647/udp # Splitlock Gateway [Andrew_Tune] [Andrew_Tune] 2003-01
+fjcp             3648/tcp # Fujitsu Cooperation Port [Kouji_Sugisawa] [Kouji_Sugisawa] 2003-01
+fjcp             3648/udp # Fujitsu Cooperation Port [Kouji_Sugisawa] [Kouji_Sugisawa] 2003-01
+nmmp             3649/tcp # Nishioka Miyuki Msg Protocol [TAKEDA_Hiroyuki] [TAKEDA_Hiroyuki] 2003-01
+nmmp             3649/udp # Nishioka Miyuki Msg Protocol [TAKEDA_Hiroyuki] [TAKEDA_Hiroyuki] 2003-01
+prismiq-plugin   3650/tcp # PRISMIQ VOD plug-in [Richard_Hodges_3] [Richard_Hodges_3] 2003-01
+prismiq-plugin   3650/udp # PRISMIQ VOD plug-in [Richard_Hodges_3] [Richard_Hodges_3] 2003-01
+xrpc-registry    3651/tcp # XRPC Registry [Slava_Monich] [Slava_Monich] 2003-01
+xrpc-registry    3651/udp # XRPC Registry [Slava_Monich] [Slava_Monich] 2003-01
+vxcrnbuport      3652/tcp # VxCR NBU Default Port [Boris_Star] [Boris_Star] 2003-01
+vxcrnbuport      3652/udp # VxCR NBU Default Port [Boris_Star] [Boris_Star] 2003-01
+tsp              3653/tcp # Tunnel Setup Protocol [Marc_Blanchet] [Marc_Blanchet] 2003-01 [RFC5572]
+tsp              3653/udp # Tunnel Setup Protocol [Marc_Blanchet] [Marc_Blanchet] 2003-01 [RFC5572]
+vaprtm           3654/tcp # VAP RealTime Messenger [Boris_Polevoy] [Boris_Polevoy] 2003-01
+vaprtm           3654/udp # VAP RealTime Messenger [Boris_Polevoy] [Boris_Polevoy] 2003-01
+abatemgr         3655/tcp # ActiveBatch Exec Agent
+abatemgr         3655/udp # ActiveBatch Exec Agent
+abatjss          3656/tcp # ActiveBatch Job Scheduler [Ben_Rosenberg] [Ben_Rosenberg] 2003-01
+abatjss          3656/udp # ActiveBatch Job Scheduler [Ben_Rosenberg] [Ben_Rosenberg] 2003-01
+immedianet-bcn   3657/tcp # ImmediaNet Beacon [Bill_Homan] [Bill_Homan] 2003-01
+immedianet-bcn   3657/udp # ImmediaNet Beacon [Bill_Homan] [Bill_Homan] 2003-01
+ps-ams           3658/tcp # PlayStation AMS (Secure) [Edgar_Alan_Tu] [Edgar_Alan_Tu] 2003-01
+ps-ams           3658/udp # PlayStation AMS (Secure) [Edgar_Alan_Tu] [Edgar_Alan_Tu] 2003-01
+apple-sasl       3659/tcp # Apple SASL [David_M_O_Rourke] [David_M_O_Rourke] 2003-01
+apple-sasl       3659/udp # Apple SASL [David_M_O_Rourke] [David_M_O_Rourke] 2003-01
+can-nds-ssl      3660/tcp # IBM Tivoli Directory Service using SSL
+can-nds-ssl      3660/udp # IBM Tivoli Directory Service using SSL
+can-ferret-ssl   3661/tcp # IBM Tivoli Directory Service using SSL [Nic_Catrambone] [Nic_Catrambone] 2003-01
+can-ferret-ssl   3661/udp # IBM Tivoli Directory Service using SSL [Nic_Catrambone] [Nic_Catrambone] 2003-01
+pserver          3662/tcp # pserver [Patrick_Furlong] [Patrick_Furlong] 2003-01
+pserver          3662/udp # pserver [Patrick_Furlong] [Patrick_Furlong] 2003-01
+dtp              3663/tcp # DIRECWAY Tunnel Protocol [John_Border] [John_Border] 2003-01
+dtp              3663/udp # DIRECWAY Tunnel Protocol [John_Border] [John_Border] 2003-01
+ups-engine       3664/tcp # UPS Engine Port
+ups-engine       3664/udp # UPS Engine Port
+ent-engine       3665/tcp # Enterprise Engine Port [Mike_Delgrosso] [Mike_Delgrosso] 2003-01
+ent-engine       3665/udp # Enterprise Engine Port [Mike_Delgrosso] [Mike_Delgrosso] 2003-01
+eserver-pap      3666/tcp # IBM eServer PAP [Dave_Gimpl] [Dave_Gimpl] 2003-01
+eserver-pap      3666/udp # IBM EServer PAP [Dave_Gimpl] [Dave_Gimpl] 2003-01
+infoexch         3667/tcp # IBM Information Exchange [Paul_Ford_Hutchinson] [Paul_Ford_Hutchinson] 2003-01
+infoexch         3667/udp # IBM Information Exchange [Paul_Ford_Hutchinson] [Paul_Ford_Hutchinson] 2003-01
+dell-rm-port     3668/tcp # Dell Remote Management [Bradley_Bransom] [Bradley_Bransom] 2003-01
+dell-rm-port     3668/udp # Dell Remote Management [Bradley_Bransom] [Bradley_Bransom] 2003-01
+casanswmgmt      3669/tcp # CA SAN Switch Management [Emre_Tunar] [Emre_Tunar] 2003-01
+casanswmgmt      3669/udp # CA SAN Switch Management [Emre_Tunar] [Emre_Tunar] 2003-01
+smile            3670/tcp # SMILE TCP/UDP Interface [Andre_Petras] [Andre_Petras] 2003-01
+smile            3670/udp # SMILE TCP/UDP Interface [Andre_Petras] [Andre_Petras] 2003-01
+efcp             3671/tcp # e Field Control (EIBnet) [Marc_Goossens] [Marc_Goossens] 2003-01
+efcp             3671/udp # e Field Control (EIBnet) [Marc_Goossens] [Marc_Goossens] 2003-01
+lispworks-orb    3672/tcp # LispWorks ORB [Lisp_Support] [Lisp_Support]
+lispworks-orb    3672/udp # LispWorks ORB [Lisp_Support] [Lisp_Support]
+mediavault-gui   3673/tcp # Openview Media Vault GUI [Stephen_Gold] [Stephen_Gold] 2003-01
+mediavault-gui   3673/udp # Openview Media Vault GUI [Stephen_Gold] [Stephen_Gold] 2003-01
+wininstall-ipc   3674/tcp # WinINSTALL IPC Port [Bill_Somerville] [Bill_Somerville] 2008-08-13
+wininstall-ipc   3674/udp # WinINSTALL IPC Port [Bill_Somerville] [Bill_Somerville] 2008-08-13
+calltrax         3675/tcp # CallTrax Data Port [Oliver_Bailey] [Oliver_Bailey] 2003-01
+calltrax         3675/udp # CallTrax Data Port [Oliver_Bailey] [Oliver_Bailey] 2003-01
+va-pacbase       3676/tcp # VisualAge Pacbase server [Dominique_Lelievre] [Dominique_Lelievre] 2003-01
+va-pacbase       3676/udp # VisualAge Pacbase server [Dominique_Lelievre] [Dominique_Lelievre] 2003-01
+roverlog         3677/tcp # RoverLog IPC [Tom_Mayo] [Tom_Mayo] 2003-01
+roverlog         3677/udp # RoverLog IPC [Tom_Mayo] [Tom_Mayo] 2003-01
+ipr-dglt         3678/tcp # DataGuardianLT [Bruce_Carlson] [Bruce_Carlson] 2003-01
+ipr-dglt         3678/udp # DataGuardianLT [Bruce_Carlson] [Bruce_Carlson] 2003-01
+Escale (Newton Dock)  3679/tcp # Newton Dock [Paul_Guyot] [Paul_Guyot] 2011-11-09
+Escale (Newton Dock)  3679/udp # Newton Dock [Paul_Guyot] [Paul_Guyot] 2011-11-09
+npds-tracker     3680/tcp # NPDS Tracker [Paul_Guyot] [Paul_Guyot] 2003-01
+npds-tracker     3680/udp # NPDS Tracker [Paul_Guyot] [Paul_Guyot] 2003-01
+bts-x73          3681/tcp # BTS X73 Port [Todd_Cooper] [Todd_Cooper] 2003-01
+bts-x73          3681/udp # BTS X73 Port [Todd_Cooper] [Todd_Cooper] 2003-01
+cas-mapi         3682/tcp # EMC SmartPackets-MAPI [Koen_Schoofs] [Koen_Schoofs] 2003-01
+cas-mapi         3682/udp # EMC SmartPackets-MAPI [Koen_Schoofs] [Koen_Schoofs] 2003-01
+bmc-ea           3683/tcp # BMC EDV/EA [Portnoy_Boxman] [Portnoy_Boxman] 2003-01
+bmc-ea           3683/udp # BMC EDV/EA [Portnoy_Boxman] [Portnoy_Boxman] 2003-01
+faxstfx-port     3684/tcp # FAXstfX [Alec_Carlson] [Alec_Carlson] 2003-01
+faxstfx-port     3684/udp # FAXstfX [Alec_Carlson] [Alec_Carlson] 2003-01
+dsx-agent        3685/tcp # DS Expert Agent [Jason_Lockett][Melanie_Kacerek] [Jason_Lockett][Melanie_Kacerek] 2008-12-16
+dsx-agent        3685/udp # DS Expert Agent [Jason_Lockett][Melanie_Kacerek] [Jason_Lockett][Melanie_Kacerek] 2008-12-16
+tnmpv2           3686/tcp # Trivial Network Management [Andrea_Premoli] [Andrea_Premoli] 2003-01
+tnmpv2           3686/udp # Trivial Network Management [Andrea_Premoli] [Andrea_Premoli] 2003-01
+simple-push      3687/tcp # simple-push
+simple-push      3687/udp # simple-push
+simple-push-s    3688/tcp # simple-push Secure [C_Enrique_Ortiz] [C_Enrique_Ortiz] 2003-01
+simple-push-s    3688/udp # simple-push Secure [C_Enrique_Ortiz] [C_Enrique_Ortiz] 2003-01
+daap             3689/tcp # Digital Audio Access Protocol (iTunes) [Amandeep_Jawa] [Amandeep_Jawa] 2003-01 Defined TXT keys: txtvers, Version, iTSh Version, Machine ID, Database ID, Machine Name, Password
+daap             3689/udp # Digital Audio Access Protocol (iTunes) [Amandeep_Jawa] [Amandeep_Jawa] 2003-01 Defined TXT keys: txtvers, Version, iTSh Version, Machine ID, Database ID, Machine Name, Password
+svn              3690/tcp # Subversion [Greg_Hudson_2] [Greg_Hudson_2] 2003-01
+svn              3690/udp # Subversion [Greg_Hudson_2] [Greg_Hudson_2] 2003-01
+magaya-network   3691/tcp # Magaya Network Port [Jesus_David_Rodrigue] [Jesus_David_Rodrigue] 2003-02
+magaya-network   3691/udp # Magaya Network Port [Jesus_David_Rodrigue] [Jesus_David_Rodrigue] 2003-02
+intelsync        3692/tcp # Brimstone IntelSync [Davey_Taylor] [Davey_Taylor] 2003-02
+intelsync        3692/udp # Brimstone IntelSync [Davey_Taylor] [Davey_Taylor] 2003-02
+bmc-data-coll    3695/tcp # BMC Data Collection [Portnoy_Boxman] [Portnoy_Boxman] 2003-02
+bmc-data-coll    3695/udp # BMC Data Collection [Portnoy_Boxman] [Portnoy_Boxman] 2003-02
+telnetcpcd       3696/tcp # Telnet Com Port Control [Thomas_J_Pinkl] [Thomas_J_Pinkl] 2003-02
+telnetcpcd       3696/udp # Telnet Com Port Control [Thomas_J_Pinkl] [Thomas_J_Pinkl] 2003-02
+nw-license       3697/tcp # NavisWorks License System [Tim_Wiegand] [Tim_Wiegand] 2003-02
+nw-license       3697/udp # NavisWorks Licnese System [Tim_Wiegand] [Tim_Wiegand] 2003-02
+sagectlpanel     3698/tcp # SAGECTLPANEL [Mark_Gamble] [Mark_Gamble] 2003-02
+sagectlpanel     3698/udp # SAGECTLPANEL [Mark_Gamble] [Mark_Gamble] 2003-02
+kpn-icw          3699/tcp # Internet Call Waiting [B_J_Kortekaas] [B_J_Kortekaas] 2003-02
+kpn-icw          3699/udp # Internet Call Waiting [B_J_Kortekaas] [B_J_Kortekaas] 2003-02
+lrs-paging       3700/tcp # LRS NetPage [Geoffrey_Wossum] [Geoffrey_Wossum] 2003-02
+lrs-paging       3700/udp # LRS NetPage [Geoffrey_Wossum] [Geoffrey_Wossum] 2003-02
+netcelera        3701/tcp # NetCelera [Tarek_Nabhan] [Tarek_Nabhan] 2003-02
+netcelera        3701/udp # NetCelera [Tarek_Nabhan] [Tarek_Nabhan] 2003-02
+ws-discovery     3702/tcp # Web Service Discovery [Christian_Huitema_2] [Christian_Huitema_2] 2003-02
+ws-discovery     3702/udp # Web Service Discovery [Christian_Huitema_2] [Christian_Huitema_2] 2003-02
+adobeserver-3    3703/tcp # Adobe Server 3
+adobeserver-3    3703/udp # Adobe Server 3
+adobeserver-4    3704/tcp # Adobe Server 4 [Frank_Soetebeer] [Frank_Soetebeer] 2003-01
+adobeserver-4    3704/udp # Adobe Server 4 [Frank_Soetebeer] [Frank_Soetebeer] 2003-01
+adobeserver-5    3705/tcp # Adobe Server 5 [Bernd_Paradies] [Bernd_Paradies] 2008-01-14
+adobeserver-5    3705/udp # Adobe Server 5 [Bernd_Paradies] [Bernd_Paradies] 2008-01-14
+rt-event         3706/tcp # Real-Time Event Port
+rt-event         3706/udp # Real-Time Event Port
+rt-event-s       3707/tcp # Real-Time Event Secure Port [Terry_Gin] [Terry_Gin] 2003-02
+rt-event-s       3707/udp # Real-Time Event Secure Port [Terry_Gin] [Terry_Gin] 2003-02
+sun-as-iiops     3708/tcp # Sun App Svr - Naming [Abhijit_Kumar] [Abhijit_Kumar] 2005-11
+sun-as-iiops     3708/udp # Sun App Svr - Naming [Abhijit_Kumar] [Abhijit_Kumar] 2005-11
+ca-idms          3709/tcp # CA-IDMS Server [Dave_Ross] [Dave_Ross]
+ca-idms          3709/udp # CA-IDMS Server [Dave_Ross] [Dave_Ross]
+portgate-auth    3710/tcp # PortGate Authentication [Scott_Harris] [Scott_Harris] 2003-02
+portgate-auth    3710/udp # PortGate Authentication [Scott_Harris] [Scott_Harris] 2003-02
+edb-server2      3711/tcp # EBD Server 2 [Carlos_Portela] [Carlos_Portela] 2003-02
+edb-server2      3711/udp # EBD Server 2 [Carlos_Portela] [Carlos_Portela] 2003-02
+sentinel-ent     3712/tcp # Sentinel Enterprise [Ian_Gordon_2] [Ian_Gordon_2] 2003-03
+sentinel-ent     3712/udp # Sentinel Enterprise [Ian_Gordon_2] [Ian_Gordon_2] 2003-03
+tftps            3713/tcp # TFTP over TLS [Mark_mayernick] [Mark_mayernick] 2003-03
+tftps            3713/udp # TFTP over TLS [Mark_mayernick] [Mark_mayernick] 2003-03
+delos-dms        3714/tcp # DELOS Direct Messaging [Ekkehard_Morgenstern] [Ekkehard_Morgenstern] 2003-03
+delos-dms        3714/udp # DELOS Direct Messaging [Ekkehard_Morgenstern] [Ekkehard_Morgenstern] 2003-03
+anoto-rendezv    3715/tcp # Anoto Rendezvous Port [Ola_Sandstrom] [Ola_Sandstrom] 2003-03
+anoto-rendezv    3715/udp # Anoto Rendezvous Port [Ola_Sandstrom] [Ola_Sandstrom] 2003-03
+wv-csp-sms-cir   3716/tcp # WV CSP SMS CIR Channel
+wv-csp-sms-cir   3716/udp # WV CSP SMS CIR Channel
+wv-csp-udp-cir   3717/tcp # WV CSP UDP/IP CIR Channel [Jon_Ingi_Ingimundars] [Jon_Ingi_Ingimundars] 2003-03
+wv-csp-udp-cir   3717/udp # WV CSP UDP/IP CIR Channel [Jon_Ingi_Ingimundars] [Jon_Ingi_Ingimundars] 2003-03
+opus-services    3718/tcp # OPUS Server Port [Detlef_Stoever] [Detlef_Stoever] 2003-03
+opus-services    3718/udp # OPUS Server Port [Detlef_Stoever] [Detlef_Stoever] 2003-03
+itelserverport   3719/tcp # iTel Server Port [Mark_Hendricks] [Mark_Hendricks] 2003-03
+itelserverport   3719/udp # iTel Server Port [Mark_Hendricks] [Mark_Hendricks] 2003-03
+ufastro-instr    3720/tcp # UF Astro. Instr. Services [David_B_Hon] [David_B_Hon] 2003-03
+ufastro-instr    3720/udp # UF Astro. Instr. Services [David_B_Hon] [David_B_Hon] 2003-03
+xsync            3721/tcp # Xsync
+xsync            3721/udp # Xsync
+xserveraid       3722/tcp # Xserve RAID [Bob_Bradley] [Bob_Bradley] 2003-03
+xserveraid       3722/udp # Xserve RAID [Bob_Bradley] [Bob_Bradley] 2003-03
+sychrond         3723/tcp # Sychron Service Daemon [Robert_Marinelli] [Robert_Marinelli] 2003-03
+sychrond         3723/udp # Sychron Service Daemon [Robert_Marinelli] [Robert_Marinelli] 2003-03
+blizwow          3724/tcp # World of Warcraft [Domain_Tech] [Domain_Tech] 2005-04
+blizwow          3724/udp # World of Warcraft [Domain_Tech] [Domain_Tech] 2005-04
+na-er-tip        3725/tcp # Netia NA-ER Port [Jean_Pierre_Garcia] [Jean_Pierre_Garcia] 2003-04
+na-er-tip        3725/udp # Netia NA-ER Port [Jean_Pierre_Garcia] [Jean_Pierre_Garcia] 2003-04
+array-manager    3726/tcp # Xyratex Array Manager [David_A_Lethe] [David_A_Lethe] 2003-04
+array-manager    3726/udp # Xyartex Array Manager [David_A_Lethe] [David_A_Lethe] 2003-04
+e-mdu            3727/tcp # Ericsson Mobile Data Unit
+e-mdu            3727/udp # Ericsson Mobile Data Unit
+e-woa            3728/tcp # Ericsson Web on Air [Marco_Casole] [Marco_Casole] 2003-04
+e-woa            3728/udp # Ericsson Web on Air [Marco_Casole] [Marco_Casole] 2003-04
+fksp-audit       3729/tcp # Fireking Audit Port [Richard_Thurman] [Richard_Thurman] 2003-04
+fksp-audit       3729/udp # Fireking Audit Port [Richard_Thurman] [Richard_Thurman] 2003-04
+client-ctrl      3730/tcp # Client Control [Lawrence_W_Dunn] [Lawrence_W_Dunn] 2003-04
+client-ctrl      3730/udp # Client Control [Lawrence_W_Dunn] [Lawrence_W_Dunn] 2003-04
+smap             3731/tcp # Service Manager
+smap             3731/udp # Service Manager
+m-wnn            3732/tcp # Mobile Wnn [Yasunari_Yamashita] [Yasunari_Yamashita] 2003-04
+m-wnn            3732/udp # Mobile Wnn [Yasunari_Yamashita] [Yasunari_Yamashita] 2003-04
+multip-msg       3733/tcp # Multipuesto Msg Port [Felisa_Ares] [Felisa_Ares] 2003-04
+multip-msg       3733/udp # Multipuesto Msg Port [Felisa_Ares] [Felisa_Ares] 2003-04
+synel-data       3734/tcp # Synel Data Collection Port [David_Ashkenazi] [David_Ashkenazi] 2003-04
+synel-data       3734/udp # Synel Data Collection Port [David_Ashkenazi] [David_Ashkenazi] 2003-04
+pwdis            3735/tcp # Password Distribution [Robert_Erl] [Robert_Erl] 2003-04
+pwdis            3735/udp # Password Distribution [Robert_Erl] [Robert_Erl] 2003-04
+rs-rmi           3736/tcp # RealSpace RMI [Barry_McDarby] [Barry_McDarby] 2003-04
+rs-rmi           3736/udp # RealSpace RMI [Barry_McDarby] [Barry_McDarby] 2003-04
+xpanel           3737/tcp # XPanel Daemon [Lilian_Rudenco] [Lilian_Rudenco] 2009-03-04
+versatalk        3738/tcp # versaTalk Server Port [Dr_Kingsley_C_Nwos] [Dr_Kingsley_C_Nwos] 2003-04
+versatalk        3738/udp # versaTalk Server Port [Dr_Kingsley_C_Nwos] [Dr_Kingsley_C_Nwos] 2003-04
+launchbird-lm    3739/tcp # Launchbird LicenseManager [Tom_Hawkins] [Tom_Hawkins] 2003-04
+launchbird-lm    3739/udp # Launchbird LicenseManager [Tom_Hawkins] [Tom_Hawkins] 2003-04
+heartbeat        3740/tcp # Heartbeat Protocol [Jeroen_Massar] [Jeroen_Massar] 2003-04
+heartbeat        3740/udp # Heartbeat Protocol [Jeroen_Massar] [Jeroen_Massar] 2003-04
+wysdma           3741/tcp # WysDM Agent [Jim_McDonald] [Jim_McDonald] 2003-04
+wysdma           3741/udp # WysDM Agent [Jim_McDonald] [Jim_McDonald] 2003-04
+cst-port         3742/tcp # CST - Configuration & Service Tracker [Hai_Ou_Yang] [Hai_Ou_Yang] 2003-04
+cst-port         3742/udp # CST - Configuration & Service Tracker [Hai_Ou_Yang] [Hai_Ou_Yang] 2003-04
+ipcs-command     3743/tcp # IP Control Systems Ltd. [Paul_Anderson] [Paul_Anderson] 2003-04
+ipcs-command     3743/udp # IP Control Systems Ltd. [Paul_Anderson] [Paul_Anderson] 2003-04
+sasg             3744/tcp # SASG [Cristian_Petculescu_2] [Cristian_Petculescu_2] 2003-04
+sasg             3744/udp # SASG [Cristian_Petculescu_2] [Cristian_Petculescu_2] 2003-04
+gw-call-port     3745/tcp # GWRTC Call Port [Felisa_Ares] [Felisa_Ares] 2003-04
+gw-call-port     3745/udp # GWRTC Call Port [Felisa_Ares] [Felisa_Ares] 2003-04
+linktest         3746/tcp # LXPRO.COM LinkTest
+linktest         3746/udp # LXPRO.COM LinkTest
+linktest-s       3747/tcp # LXPRO.COM LinkTest SSL [Greg_Bailey] [Greg_Bailey] 2003-04
+linktest-s       3747/udp # LXPRO.COM LinkTest SSL [Greg_Bailey] [Greg_Bailey] 2003-04
+webdata          3748/tcp # webData [Michael_Whiteley] [Michael_Whiteley] 2003-04
+webdata          3748/udp # webData [Michael_Whiteley] [Michael_Whiteley] 2003-04
+cimtrak          3749/tcp # CimTrak [Robert_E_Johnson_II] [Robert_E_Johnson_II] 2003-04
+cimtrak          3749/udp # CimTrak [Robert_E_Johnson_II] [Robert_E_Johnson_II] 2003-04
+cbos-ip-port     3750/tcp # CBOS/IP ncapsalation port [Thomas_Dannemiller] [Thomas_Dannemiller] 2003-04
+cbos-ip-port     3750/udp # CBOS/IP ncapsalatoin port [Thomas_Dannemiller] [Thomas_Dannemiller] 2003-04
+gprs-cube        3751/tcp # CommLinx GPRS Cube [Peter_Johnson] [Peter_Johnson] 2003-04
+gprs-cube        3751/udp # CommLinx GPRS Cube [Peter_Johnson] [Peter_Johnson] 2003-04
+vipremoteagent   3752/tcp # Vigil-IP RemoteAgent [Bryan_Alvord] [Bryan_Alvord] 2003-04
+vipremoteagent   3752/udp # Vigil-IP RemoteAgent [Bryan_Alvord] [Bryan_Alvord] 2003-04
+nattyserver      3753/tcp # NattyServer Port [Akira_Saito] [Akira_Saito] 2003-04
+nattyserver      3753/udp # NattyServer Port [Akira_Saito] [Akira_Saito] 2003-04
+timestenbroker   3754/tcp # TimesTen Broker Port [David_Aspinwall] [David_Aspinwall] 2003-04
+timestenbroker   3754/udp # TimesTen Broker Port [David_Aspinwall] [David_Aspinwall] 2003-04
+sas-remote-hlp   3755/tcp # SAS Remote Help Server [Gary_T_Ciampa] [Gary_T_Ciampa] 2003-04
+sas-remote-hlp   3755/udp # SAS Remote Help Server [Gary_T_Ciampa] [Gary_T_Ciampa] 2003-04
+canon-capt       3756/tcp # Canon CAPT Port [Takashi_Okazawa] [Takashi_Okazawa] 2003-04
+canon-capt       3756/udp # Canon CAPT Port [Takashi_Okazawa] [Takashi_Okazawa] 2003-04
+grf-port         3757/tcp # GRF Server Port [Robert_Banfill] [Robert_Banfill] 2003-04
+grf-port         3757/udp # GRF Server Port [Robert_Banfill] [Robert_Banfill] 2003-04
+apw-registry     3758/tcp # apw RMI registry [Dan_Davis] [Dan_Davis] 2003-04
+apw-registry     3758/udp # apw RMI registry [Dan_Davis] [Dan_Davis] 2003-04
+exapt-lmgr       3759/tcp # Exapt License Manager [Christoph_Kukulies] [Christoph_Kukulies] 2003-04
+exapt-lmgr       3759/udp # Exapt License Manager [Christoph_Kukulies] [Christoph_Kukulies] 2003-04
+adtempusclient   3760/tcp # adTempus Client [Bill_Wingate] [Bill_Wingate] 2003-05
+adtempusclient   3760/udp # adTEmpus Client [Bill_Wingate] [Bill_Wingate] 2003-05
+gsakmp           3761/tcp # gsakmp port [RFC4535]
+gsakmp           3761/udp # gsakmp port [RFC4535]
+gbs-smp          3762/tcp # GBS SnapMail Protocol [Eric_Harris_Braun] [Eric_Harris_Braun] 2003-06
+gbs-smp          3762/udp # GBS SnapMail Protocol [Eric_Harris_Braun] [Eric_Harris_Braun] 2003-06
+xo-wave          3763/tcp # XO Wave Control Port [Bjorn_Dittmer_Roche] [Bjorn_Dittmer_Roche] 2003-06
+xo-wave          3763/udp # XO Wave Control Port [Bjorn_Dittmer_Roche] [Bjorn_Dittmer_Roche] 2003-06
+mni-prot-rout    3764/tcp # MNI Protected Routing [Tim_Behne] [Tim_Behne] 2003-06
+mni-prot-rout    3764/udp # MNI Protected Routing [Tim_Behne] [Tim_Behne] 2003-06
+rtraceroute      3765/tcp # Remote Traceroute [A_Blake_Cooper] [A_Blake_Cooper] 2003-06
+rtraceroute      3765/udp # Remote Traceroute [A_Blake_Cooper] [A_Blake_Cooper] 2003-06
+listmgr-port     3767/tcp # ListMGR Port [Takashi_Kubota] [Takashi_Kubota] 2003-06
+listmgr-port     3767/udp # ListMGR Port [Takashi_Kubota] [Takashi_Kubota] 2003-06
+rblcheckd        3768/tcp # rblcheckd server daemon [Sabri_Berisha] [Sabri_Berisha] 2003-06
+rblcheckd        3768/udp # rblcheckd server daemon [Sabri_Berisha] [Sabri_Berisha] 2003-06
+haipe-otnk       3769/tcp # HAIPE Network Keying [Mike_Irani_2] [Mike_Irani_2] 2003-06
+haipe-otnk       3769/udp # HAIPE Network Keying [Mike_Irani_2] [Mike_Irani_2] 2003-06
+cindycollab      3770/tcp # Cinderella Collaboration [Ulrich_Kortenkamp] [Ulrich_Kortenkamp] 2003-06
+cindycollab      3770/udp # Cinderella Collaboration [Ulrich_Kortenkamp] [Ulrich_Kortenkamp] 2003-06
+paging-port      3771/tcp # RTP Paging Port [Patrick_Ferriter] [Patrick_Ferriter] 2003-06
+paging-port      3771/udp # RTP Paging Port [Patrick_Ferriter] [Patrick_Ferriter] 2003-06
+ctp              3772/tcp # Chantry Tunnel Protocol [Inderpreet_Singh] [Inderpreet_Singh] 2003-06
+ctp              3772/udp # Chantry Tunnel Protocol [Inderpreet_Singh] [Inderpreet_Singh] 2003-06
+ctdhercules      3773/tcp # ctdhercules [Carl_Banzhof] [Carl_Banzhof] 2003-06
+ctdhercules      3773/udp # ctdhercules [Carl_Banzhof] [Carl_Banzhof] 2003-06
+zicom            3774/tcp # ZICOM [Sabu_Das] [Sabu_Das] 2003-06
+zicom            3774/udp # ZICOM [Sabu_Das] [Sabu_Das] 2003-06
+ispmmgr          3775/tcp # ISPM Manager Port [Eric_Anderson] [Eric_Anderson] 2003-06
+ispmmgr          3775/udp # ISPM Manager Port [Eric_Anderson] [Eric_Anderson] 2003-06
+dvcprov-port     3776/tcp # Device Provisioning Port [Rob_Lehew] [Rob_Lehew] 2003-06
+dvcprov-port     3776/udp # Device Provisioning Port [Rob_Lehew] [Rob_Lehew] 2003-06
+jibe-eb          3777/tcp # Jibe EdgeBurst [Chap_Tippin] [Chap_Tippin] 2003-06
+jibe-eb          3777/udp # Jibe EdgeBurst [Chap_Tippin] [Chap_Tippin] 2003-06
+c-h-it-port      3778/tcp # Cutler-Hammer IT Port [Thomas_Ruchti] [Thomas_Ruchti] 2003-06
+c-h-it-port      3778/udp # Cutler-Hammer IT Port [Thomas_Ruchti] [Thomas_Ruchti] 2003-06
+cognima          3779/tcp # Cognima Replication [Ralph_Greenwell] [Ralph_Greenwell] 2003-06
+cognima          3779/udp # Cognima Replication [Ralph_Greenwell] [Ralph_Greenwell] 2003-06
+nnp              3780/tcp # Nuzzler Network Protocol [Andreas_Schwarz_2] [Andreas_Schwarz_2] 2003-06
+nnp              3780/udp # Nuzzler Network Protocol [Andreas_Schwarz_2] [Andreas_Schwarz_2] 2003-06
+abcvoice-port    3781/tcp # ABCvoice server port [Carlos_Gonzalez_Roma] [Carlos_Gonzalez_Roma] 2003-06
+abcvoice-port    3781/udp # ABCvoice server port [Carlos_Gonzalez_Roma] [Carlos_Gonzalez_Roma] 2003-06
+iso-tp0s         3782/tcp # Secure ISO TP0 port [Herbert_Falk] [Herbert_Falk] 2003-06
+iso-tp0s         3782/udp # Secure ISO TP0 port [Herbert_Falk] [Herbert_Falk] 2003-06
+bim-pem          3783/tcp # Impact Mgr./PEM Gateway [Walter_G_Giroir] [Walter_G_Giroir] 2003-07
+bim-pem          3783/udp # Impact Mgr./PEM Gateway [Walter_G_Giroir] [Walter_G_Giroir] 2003-07
+bfd-control      3784/tcp # BFD Control Protocol [RFC5881]
+bfd-control      3784/udp # BFD Control Protocol [RFC5881]
+bfd-echo         3785/tcp # BFD Echo Protocol [RFC5881]
+bfd-echo         3785/udp # BFD Echo Protocol [RFC5881]
+upstriggervsw    3786/tcp # VSW Upstrigger port [Mark_Tim_Junghanns] [Mark_Tim_Junghanns] 2003-07
+upstriggervsw    3786/udp # VSW Upstrigger port [Mark_Tim_Junghanns] [Mark_Tim_Junghanns] 2003-07
+fintrx           3787/tcp # Fintrx [Peter_G_L_Potgiese] [Peter_G_L_Potgiese] 2003-07
+fintrx           3787/udp # Fintrx [Peter_G_L_Potgiese] [Peter_G_L_Potgiese] 2003-07
+isrp-port        3788/tcp # SPACEWAY Routing port [Vaibhav_Kumar] [Vaibhav_Kumar] 2003-07
+isrp-port        3788/udp # SPACEWAY Routing port [Vaibhav_Kumar] [Vaibhav_Kumar] 2003-07
+remotedeploy     3789/tcp # RemoteDeploy Administration Port [July 2003] [Detlef_Rothe] [Detlef_Rothe] 2009-05-15
+remotedeploy     3789/udp # RemoteDeploy Administration Port [July 2003] [Detlef_Rothe] [Detlef_Rothe] 2009-05-15
+quickbooksrds    3790/tcp # QuickBooks RDS [Almira] [Almira] 2003-07
+quickbooksrds    3790/udp # QuickBooks RDS [Almira] [Almira] 2003-07
+tvnetworkvideo   3791/tcp # TV NetworkVideo Data port [Kevin_Brunner] [Kevin_Brunner] 2003-07
+tvnetworkvideo   3791/udp # TV NetworkVideo Data port [Kevin_Brunner] [Kevin_Brunner] 2003-07
+sitewatch        3792/tcp # e-Watch Corporation SiteWatch [John_M_Baird] [John_M_Baird] 2003-07
+sitewatch        3792/udp # e-Watch Corporation SiteWatch [John_M_Baird] [John_M_Baird] 2003-07
+dcsoftware       3793/tcp # DataCore Software [Andre_Cato] [Andre_Cato] 2003-07
+dcsoftware       3793/udp # DataCore Software [Andre_Cato] [Andre_Cato] 2003-07
+jaus             3794/tcp # JAUS Robots [Steven_B_Cliff] [Steven_B_Cliff] 2003-07
+jaus             3794/udp # JAUS Robots [Steven_B_Cliff] [Steven_B_Cliff] 2003-07
+myblast          3795/tcp # myBLAST Mekentosj port [Alexander_Griekspoor] [Alexander_Griekspoor] 2003-07
+myblast          3795/udp # myBLAST Mekentosj port [Alexander_Griekspoor] [Alexander_Griekspoor] 2003-07
+spw-dialer       3796/tcp # Spaceway Dialer [Patrick_Fisher] [Patrick_Fisher] 2003-07
+spw-dialer       3796/udp # Spaceway Dialer [Patrick_Fisher] [Patrick_Fisher] 2003-07
+idps             3797/tcp # idps [Jean_Francois_Rabass] [Jean_Francois_Rabass] 2003-07
+idps             3797/udp # idps [Jean_Francois_Rabass] [Jean_Francois_Rabass] 2003-07
+minilock         3798/tcp # Minilock [Daniel_Julio_Reyes] [Daniel_Julio_Reyes] 2003-08
+minilock         3798/udp # Minilock [Daniel_Julio_Reyes] [Daniel_Julio_Reyes] 2003-08
+radius-dynauth   3799/tcp # RADIUS Dynamic Authorization [RFC3576]
+radius-dynauth   3799/udp # RADIUS Dynamic Authorization [RFC3576]
+pwgpsi           3800/tcp # Print Services Interface [Harry_Lewis] [Harry_Lewis] 2003-05
+pwgpsi           3800/udp # Print Services Interface [Harry_Lewis] [Harry_Lewis] 2003-05
+ibm-mgr          3801/tcp # ibm manager service [Tim_Hahn] [Tim_Hahn] 2006-03
+ibm-mgr          3801/udp # ibm manager service [Tim_Hahn] [Tim_Hahn] 2006-03
+vhd              3802/tcp # VHD [Chris_Duncombe] [Chris_Duncombe]
+vhd              3802/udp # VHD [Chris_Duncombe] [Chris_Duncombe]
+soniqsync        3803/tcp # SoniqSync [Ryan_Melville] [Ryan_Melville] 2004-01
+soniqsync        3803/udp # SoniqSync [Ryan_Melville] [Ryan_Melville] 2004-01
+iqnet-port       3804/tcp # Harman IQNet Port [Bruce_Vander_Werf] [Bruce_Vander_Werf] 2004-02
+iqnet-port       3804/udp # Harman IQNet Port [Bruce_Vander_Werf] [Bruce_Vander_Werf] 2004-02
+tcpdataserver    3805/tcp # ThorGuard Server Port [Joel_E_Steiger] [Joel_E_Steiger] 2004-02
+tcpdataserver    3805/udp # ThorGuard Server Port [Joel_E_Steiger] [Joel_E_Steiger] 2004-02
+wsmlb            3806/tcp # Remote System Manager [Thomas_Fiege] [Thomas_Fiege] 2004-02
+wsmlb            3806/udp # Remote System Manager [Thomas_Fiege] [Thomas_Fiege] 2004-02
+spugna           3807/tcp # SpuGNA Communication Port [Samuele_Sequi] [Samuele_Sequi] 2004-02
+spugna           3807/udp # SpuGNA Communication Port [Samuele_Sequi] [Samuele_Sequi] 2004-02
+sun-as-iiops-ca  3808/tcp # Sun App Svr-IIOPClntAuth [Abhijit_Kumar] [Abhijit_Kumar] 2005-11
+sun-as-iiops-ca  3808/udp # Sun App Svr-IIOPClntAuth [Abhijit_Kumar] [Abhijit_Kumar] 2005-11
+apocd            3809/tcp # Java Desktop System Configuration Agent [Geoff_Higgins] [Geoff_Higgins] 2006-03
+apocd            3809/udp # Java Desktop System Configuration Agent [Geoff_Higgins] [Geoff_Higgins] 2006-03
+wlanauth         3810/tcp # WLAN AS server [Bianling_Zhang] [Bianling_Zhang] 2004-02
+wlanauth         3810/udp # WLAN AS server [Bianling_Zhang] [Bianling_Zhang] 2004-02
+amp              3811/tcp # AMP [Northon_Rodrigues] [Northon_Rodrigues] 2004-02
+amp              3811/udp # AMP [Northon_Rodrigues] [Northon_Rodrigues] 2004-02
+neto-wol-server  3812/tcp # netO WOL Server [Martin_Bestmann_2] [Martin_Bestmann_2] 2004-03
+neto-wol-server  3812/udp # netO WOL Server [Martin_Bestmann_2] [Martin_Bestmann_2] 2004-03
+rap-ip           3813/tcp # Rhapsody Interface Protocol [Paul_Zander] [Paul_Zander] 2004-03
+rap-ip           3813/udp # Rhapsody Interface Protocol [Paul_Zander] [Paul_Zander] 2004-03
+neto-dcs         3814/tcp # netO DCS [Martin_Bestmann_2] [Martin_Bestmann_2] 2004-03
+neto-dcs         3814/udp # netO DCS [Martin_Bestmann_2] [Martin_Bestmann_2] 2004-03
+lansurveyorxml   3815/tcp # LANsurveyor XML [Michael_Swan] [Michael_Swan] 2004-04
+lansurveyorxml   3815/udp # LANsurveyor XML [Michael_Swan] [Michael_Swan] 2004-04
+sunlps-http      3816/tcp # Sun Local Patch Server [Barry_Greenberg] [Barry_Greenberg] 2004-04
+sunlps-http      3816/udp # Sun Local Patch Server [Barry_Greenberg] [Barry_Greenberg] 2004-04
+tapeware         3817/tcp # Yosemite Tech Tapeware [Luke_Dion] [Luke_Dion] 2004-04
+tapeware         3817/udp # Yosemite Tech Tapeware [Luke_Dion] [Luke_Dion] 2004-04
+crinis-hb        3818/tcp # Crinis Heartbeat [Eric_McMurry] [Eric_McMurry] 2004-04
+crinis-hb        3818/udp # Crinis Heartbeat [Eric_McMurry] [Eric_McMurry] 2004-04
+epl-slp          3819/tcp # EPL Sequ Layer Protocol [Hans_Weibel] [Hans_Weibel] 2004-10
+epl-slp          3819/udp # EPL Sequ Layer Protocol [Hans_Weibel] [Hans_Weibel] 2004-10
+scp              3820/tcp # Siemens AuD SCP [Johann_Arnold] [Johann_Arnold] 2004-10
+scp              3820/udp # Siemens AuD SCP [Johann_Arnold] [Johann_Arnold] 2004-10
+pmcp             3821/tcp # ATSC PMCP Standard [Graham_Jones] [Graham_Jones] 2004-11
+pmcp             3821/udp # ATSC PMCP Standard [Graham_Jones] [Graham_Jones] 2004-11
+acp-discovery    3822/tcp # Compute Pool Discovery
+acp-discovery    3822/udp # Compute Pool Discovery
+acp-conduit      3823/tcp # Compute Pool Conduit
+acp-conduit      3823/udp # Compute Pool Conduit
+acp-policy       3824/tcp # Compute Pool Policy [Andy_Belk_2] [Andy_Belk_2] 2005-02
+acp-policy       3824/udp # Compute Pool Policy [Andy_Belk_2] [Andy_Belk_2] 2005-02
+ffserver         3825/tcp # Antera FlowFusion Process Simulation [Armin_Liebchen] [Armin_Liebchen] 2007-06
+ffserver         3825/udp # Antera FlowFusion Process Simulation [Armin_Liebchen] [Armin_Liebchen] 2007-06
+warmux           3826/tcp # WarMUX game server [Christophe_Gisquet] [Christophe_Gisquet] 2011-05-26
+warmux           3826/udp # WarMUX game server [Christophe_Gisquet] [Christophe_Gisquet] 2011-05-26
+netmpi           3827/tcp # Netadmin Systems MPI service [G_Runfeldt] [G_Runfeldt] 2007-07-10
+netmpi           3827/udp # Netadmin Systems MPI service [G_Runfeldt] [G_Runfeldt] 2007-07-10
+neteh            3828/tcp # Netadmin Systems Event Handler
+neteh            3828/udp # Netadmin Systems Event Handler
+neteh-ext        3829/tcp # Netadmin Systems Event Handler External [Jonas_Krogell] [Jonas_Krogell] 2007-07-10
+neteh-ext        3829/udp # Netadmin Systems Event Handler External [Jonas_Krogell] [Jonas_Krogell] 2007-07-10
+cernsysmgmtagt   3830/tcp # Cerner System Management Agent [Mike_Craft] [Mike_Craft] 2008-01-29
+cernsysmgmtagt   3830/udp # Cerner System Management Agent [Mike_Craft] [Mike_Craft] 2008-01-29
+dvapps           3831/tcp # Docsvault Application Service [Ketul_Patel] [Ketul_Patel] 2006-10
+dvapps           3831/udp # Docsvault Application Service [Ketul_Patel] [Ketul_Patel] 2006-10
+xxnetserver      3832/tcp # xxNETserver [XXT_LLC] [Matt_Ferrari] 2006-10 2012-07-12
+xxnetserver      3832/udp # xxNETserver [XXT_LLC] [Matt_Ferrari] 2006-10 2012-07-12
+aipn-auth        3833/tcp # AIPN LS Authentication [Qiang_Zhang] [Qiang_Zhang] 2006-10
+aipn-auth        3833/udp # AIPN LS Authentication [Qiang_Zhang] [Qiang_Zhang] 2006-10
+spectardata      3834/tcp # Spectar Data Stream Service
+spectardata      3834/udp # Spectar Data Stream Service
+spectardb        3835/tcp # Spectar Database Rights Service [Jan_Rutger_Voorhorst] [Jan_Rutger_Voorhorst] 2006-10
+spectardb        3835/udp # Spectar Database Rights Service [Jan_Rutger_Voorhorst] [Jan_Rutger_Voorhorst] 2006-10
+markem-dcp       3836/tcp # MARKEM NEXTGEN DCP
+markem-dcp       3836/udp # MARKEM NEXTGEN DCP
+mkm-discovery    3837/tcp # MARKEM Auto-Discovery [Vadym_Kargin] [Vadym_Kargin] 2005-08
+mkm-discovery    3837/udp # MARKEM Auto-Discovery [Vadym_Kargin] [Vadym_Kargin] 2005-08
+sos              3838/tcp # Scito Object Server [Arno_Klaassen] [Arno_Klaassen] 2003-11
+sos              3838/udp # Scito Object Server [Arno_Klaassen] [Arno_Klaassen] 2003-11
+amx-rms          3839/tcp # AMX Resource Management Suite [Ron_Barber] [Ron_Barber] 2003-11
+amx-rms          3839/udp # AMX Resource Management Suite [Ron_Barber] [Ron_Barber] 2003-11
+flirtmitmir      3840/tcp # www.FlirtMitMir.de [Carsten_Falticska] [Carsten_Falticska] 2003-11
+flirtmitmir      3840/udp # www.FlirtMitMir.de [Carsten_Falticska] [Carsten_Falticska] 2003-11
+zfirm-shiprush3  3841/tcp # Z-Firm ShipRush v3 [Rafael_Zimberoff] [Rafael_Zimberoff] 2003-11
+zfirm-shiprush3  3841/udp # Z-Firm ShipRush v3 [Rafael_Zimberoff] [Rafael_Zimberoff] 2003-11
+nhci             3842/tcp # NHCI status port [Eric_Welch_2] [Eric_Welch_2] 2003-11
+nhci             3842/udp # NHCI status port [Eric_Welch_2] [Eric_Welch_2] 2003-11
+quest-agent      3843/tcp # Quest Common Agent [Peter_Maher] [Peter_Maher] 2003-11
+quest-agent      3843/udp # Quest Common Agent [Peter_Maher] [Peter_Maher] 2003-11
+rnm              3844/tcp # RNM [sn_w_of_renegade_lab] [sn_w_of_renegade_lab] 2003-11
+rnm              3844/udp # RNM [sn_w_of_renegade_lab] [sn_w_of_renegade_lab] 2003-11
+v-one-spp        3845/tcp # V-ONE Single Port Proxy [Daniel_Becker_3] [Daniel_Becker_3]
+v-one-spp        3845/udp # V-ONE Single Port Proxy [Daniel_Becker_3] [Daniel_Becker_3]
+an-pcp           3846/tcp # Astare Network PCP [Tony_Gulino] [Tony_Gulino] 2003-08
+an-pcp           3846/udp # Astare Network PCP [Tony_Gulino] [Tony_Gulino] 2003-08
+msfw-control     3847/tcp # MS Firewall Control [Oren_Trutner] [Oren_Trutner] 2003-08
+msfw-control     3847/udp # MS Firewall Control [Oren_Trutner] [Oren_Trutner] 2003-08
+item             3848/tcp # IT Environmental Monitor [Keith_Wright] [Keith_Wright] 2003-08
+item             3848/udp # IT Environmental Monitor [Keith_Wright] [Keith_Wright] 2003-08
+spw-dnspreload   3849/tcp # SPACEWAY DNS Preload [Daniel_Friedman] [Daniel_Friedman] 2003-08
+spw-dnspreload   3849/udp # SPACEWAY DNS Prelaod [Daniel_Friedman] [Daniel_Friedman] 2003-08
+qtms-bootstrap   3850/tcp # QTMS Bootstrap Protocol [Phil_Willis] [Phil_Willis] 2003-08
+qtms-bootstrap   3850/udp # QTMS Bootstrap Protocol [Phil_Willis] [Phil_Willis] 2003-08
+spectraport      3851/tcp # SpectraTalk Port [Madhav_Karhade] [Madhav_Karhade] 2003-08
+spectraport      3851/udp # SpectraTalk Port [Madhav_Karhade] [Madhav_Karhade] 2003-08
+sse-app-config   3852/tcp # SSE App Configuration [Tim_Wilson] [Tim_Wilson] 2003-08
+sse-app-config   3852/udp # SSE App Configuration [Tim_Wilson] [Tim_Wilson] 2003-08
+sscan            3853/tcp # SONY scanning protocol [Takashi_Aihara] [Takashi_Aihara] 2003-08
+sscan            3853/udp # SONY scanning protocol [Takashi_Aihara] [Takashi_Aihara] 2003-08
+stryker-com      3854/tcp # Stryker Comm Port [Andrew_Schultz] [Andrew_Schultz] 2003-08
+stryker-com      3854/udp # Stryker Comm Port [Andrew_Schultz] [Andrew_Schultz] 2003-08
+opentrac         3855/tcp # OpenTRAC [Scott_Miller] [Scott_Miller] 2003-08
+opentrac         3855/udp # OpenTRAC [Scott_Miller] [Scott_Miller] 2003-08
+informer         3856/tcp # INFORMER [Filippo_Fadda] [Filippo_Fadda] 2003-08
+informer         3856/udp # INFORMER [Filippo_Fadda] [Filippo_Fadda] 2003-08
+trap-port        3857/tcp # Trap Port [Norm_Freedman] [Norm_Freedman] 2003-08
+trap-port        3857/udp # Trap Port [Norm_Freedman] [Norm_Freedman] 2003-08
+trap-port-mom    3858/tcp # Trap Port MOM [Norm_Freedman] [Norm_Freedman] 2003-08
+trap-port-mom    3858/udp # Trap Port MOM [Norm_Freedman] [Norm_Freedman] 2003-08
+nav-port         3859/tcp # Navini Port [Chris_Sanders] [Chris_Sanders] 2003-08
+nav-port         3859/udp # Navini Port [Chris_Sanders] [Chris_Sanders] 2003-08
+sasp             3860/tcp # Server/Application State Protocol (SASP) [Alan_Bivens] [Alan_Bivens] 2003-08
+sasp             3860/udp # Server/Application State Protocol (SASP) [Alan_Bivens] [Alan_Bivens] 2003-08
+winshadow-hd     3861/tcp # winShadow Host Discovery [Shu_Wei_Tan] [Shu_Wei_Tan] 2003-03
+winshadow-hd     3861/udp # winShadow Host Discovery [Shu_Wei_Tan] [Shu_Wei_Tan] 2003-03
+giga-pocket      3862/tcp # GIGA-POCKET [Yoshikazu_Watanabe] [Yoshikazu_Watanabe]
+giga-pocket      3862/udp # GIGA-POCKET [Yoshikazu_Watanabe] [Yoshikazu_Watanabe]
+asap-tcp         3863/tcp # asap tcp port
+asap-udp         3863/udp # asap udp port [RFC5352]
+asap-sctp        3863/sctp # asap sctp [RFC5352]
+asap-tcp-tls     3864/tcp # asap/tls tcp port [RFC5352]
+asap-sctp-tls    3864/sctp # asap-sctp/tls [RFC5352]
+xpl              3865/tcp # xpl automation protocol [Ian_Lowe] [Ian_Lowe] 2003-08
+xpl              3865/udp # xpl automation protocol [Ian_Lowe] [Ian_Lowe] 2003-08
+dzdaemon         3866/tcp # Sun SDViz DZDAEMON Port [Kevin_Rushforth] [Kevin_Rushforth] 2003-08
+dzdaemon         3866/udp # Sun SDViz DZDAEMON Port [Kevin_Rushforth] [Kevin_Rushforth] 2003-08
+dzoglserver      3867/tcp # Sun SDViz DZOGLSERVER Port [Kevin_Rushforth] [Kevin_Rushforth] 2003-08
+dzoglserver      3867/udp # Sun SDViz DZOGLSERVER Port [Kevin_Rushforth] [Kevin_Rushforth] 2003-08
+diameter         3868/tcp # DIAMETER
+diameter         3868/sctp # DIAMETER [RFC3588]
+ovsam-mgmt       3869/tcp # hp OVSAM MgmtServer Disco [Mike_Pontillo] [Mike_Pontillo] 2003-08
+ovsam-mgmt       3869/udp # hp OVSAM MgmtServer Disco [Mike_Pontillo] [Mike_Pontillo] 2003-08
+ovsam-d-agent    3870/tcp # hp OVSAM HostAgent Disco [Mike_Pontillo] [Mike_Pontillo] 2003-08
+ovsam-d-agent    3870/udp # hp OVSAM HostAgent Disco [Mike_Pontillo] [Mike_Pontillo] 2003-08
+avocent-adsap    3871/tcp # Avocent DS Authorization [Eduardo_Fernandez] [Eduardo_Fernandez] 2003-08
+avocent-adsap    3871/udp # Avocent DS Authorization [Eduardo_Fernandez] [Eduardo_Fernandez] 2003-08
+oem-agent        3872/tcp # OEM Agent [Narain_Jagathesan] [Narain_Jagathesan] 2003-11
+oem-agent        3872/udp # OEM Agent [Narain_Jagathesan] [Narain_Jagathesan] 2003-11
+fagordnc         3873/tcp # fagordnc [Luis_Zugasti] [Luis_Zugasti] 2003-11
+fagordnc         3873/udp # fagordnc [Luis_Zugasti] [Luis_Zugasti] 2003-11
+sixxsconfig      3874/tcp # SixXS Configuration [Jeroen_Massar] [Jeroen_Massar] 2003-11
+sixxsconfig      3874/udp # SixXS Configuration [Jeroen_Massar] [Jeroen_Massar] 2003-11
+pnbscada         3875/tcp # PNBSCADA [Philip_N_Bergstress] [Philip_N_Bergstress]
+pnbscada         3875/udp # PNBSCADA [Philip_N_Bergstress] [Philip_N_Bergstress]
+dl-agent         3876/tcp # DirectoryLockdown AgentIANA assigned this well-formed service name as a replacement for "dl_agent". [Jason_Lockett][Melanie_Kacerek] [Jason_Lockett][Melanie_Kacerek] 2008-12-16
+dl_agent         3876/tcp # DirectoryLockdown Agent [Jason_Lockett][Melanie_Kacerek] [Jason_Lockett][Melanie_Kacerek] 2008-12-16 This entry is an alias to "dl-agent".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+dl-agent         3876/udp # DirectoryLockdown AgentIANA assigned this well-formed service name as a replacement for "dl_agent". [Jason_Lockett][Melanie_Kacerek] [Jason_Lockett][Melanie_Kacerek] 2008-12-16
+dl_agent         3876/udp # DirectoryLockdown Agent [Jason_Lockett][Melanie_Kacerek] [Jason_Lockett][Melanie_Kacerek] 2008-12-16 This entry is an alias to "dl-agent".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+xmpcr-interface  3877/tcp # XMPCR Interface Port [Christopher_Carlson] [Christopher_Carlson] 2003-10
+xmpcr-interface  3877/udp # XMPCR Interface Port [Christopher_Carlson] [Christopher_Carlson] 2003-10
+fotogcad         3878/tcp # FotoG CAD interface [Jason_Szabo] [Jason_Szabo] 2003-10
+fotogcad         3878/udp # FotoG CAD interface [Jason_Szabo] [Jason_Szabo] 2003-10
+appss-lm         3879/tcp # appss license manager [Peter_Krueger] [Peter_Krueger] 2003-10
+appss-lm         3879/udp # appss license manager [Peter_Krueger] [Peter_Krueger] 2003-10
+igrs             3880/tcp # IGRS [Huang_Jingnan] [Huang_Jingnan] 2003-10
+igrs             3880/udp # IGRS [Huang_Jingnan] [Huang_Jingnan] 2003-10
+idac             3881/tcp # Data Acquisition and Control [Chatziandreoglou_Chr] [Chatziandreoglou_Chr] 2003-10
+idac             3881/udp # Data Acquisition and Control [Chatziandreoglou_Chr] [Chatziandreoglou_Chr] 2003-10
+msdts1           3882/tcp # DTS Service Port [Sergei_Ivanov] [Sergei_Ivanov] 2003-10
+msdts1           3882/udp # DTS Service Port [Sergei_Ivanov] [Sergei_Ivanov] 2003-10
+vrpn             3883/tcp # VR Peripheral Network [Russell_M_Taylor_II] [Russell_M_Taylor_II] 2003-10
+vrpn             3883/udp # VR Peripheral Network [Russell_M_Taylor_II] [Russell_M_Taylor_II] 2003-10
+softrack-meter   3884/tcp # SofTrack Metering [John_T_McCann] [John_T_McCann] 2003-10
+softrack-meter   3884/udp # SofTrack Metering [John_T_McCann] [John_T_McCann] 2003-10
+topflow-ssl      3885/tcp # TopFlow SSL [Ken_Nelson] [Ken_Nelson]
+topflow-ssl      3885/udp # TopFlow SSL [Ken_Nelson] [Ken_Nelson]
+nei-management   3886/tcp # NEI management port [Kevin_Murphy_2] [Kevin_Murphy_2] 2003-10
+nei-management   3886/udp # NEI management port [Kevin_Murphy_2] [Kevin_Murphy_2] 2003-10
+ciphire-data     3887/tcp # Ciphire Data Transport [Lars_Eilebrecht] [Lars_Eilebrecht] 2003-10
+ciphire-data     3887/udp # Ciphire Data Transport [Lars_Eilebrecht] [Lars_Eilebrecht] 2003-10
+ciphire-serv     3888/tcp # Ciphire Services [Lars_Eilebrecht] [Lars_Eilebrecht] 2003-10
+ciphire-serv     3888/udp # Ciphire Services [Lars_Eilebrecht] [Lars_Eilebrecht] 2003-10
+dandv-tester     3889/tcp # D and V Tester Control Port [Voiko_Loukanov] [Voiko_Loukanov] 2003-10
+dandv-tester     3889/udp # D and V Tester Control Port [Voiko_Loukanov] [Voiko_Loukanov] 2003-10
+ndsconnect       3890/tcp # Niche Data Server Connect [Roland_Schneider] [Roland_Schneider] 2003-10
+ndsconnect       3890/udp # Niche Data Server Connect [Roland_Schneider] [Roland_Schneider] 2003-10
+rtc-pm-port      3891/tcp # Oracle RTC-PM port [PV_Shivkumar] [PV_Shivkumar] 2003-10
+rtc-pm-port      3891/udp # Oracle RTC-PM port [PV_Shivkumar] [PV_Shivkumar] 2003-10
+pcc-image-port   3892/tcp # PCC-image-port [Shiro_Tamoto] [Shiro_Tamoto] 2003-10
+pcc-image-port   3892/udp # PCC-image-port [Shiro_Tamoto] [Shiro_Tamoto] 2003-10
+cgi-starapi      3893/tcp # CGI StarAPI Server [Garry_Moore] [Garry_Moore] 2003-10
+cgi-starapi      3893/udp # CGI StarAPI Server [Garry_Moore] [Garry_Moore] 2003-10
+syam-agent       3894/tcp # SyAM Agent Port [Michael_Daniele] [Michael_Daniele] 2003-10
+syam-agent       3894/udp # SyAM Agent Port [Michael_Daniele] [Michael_Daniele] 2003-10
+syam-smc         3895/tcp # SyAm SMC Service Port [Michael_Daniele] [Michael_Daniele] 2003-10
+syam-smc         3895/udp # SyAm SMC Service Port [Michael_Daniele] [Michael_Daniele] 2003-10
+sdo-tls          3896/tcp # Simple Distributed Objects over TLS [Alexander_Philippou] [Alexander_Philippou] 2003-10
+sdo-tls          3896/udp # Simple Distributed Objects over TLS [Alexander_Philippou] [Alexander_Philippou] 2003-10
+sdo-ssh          3897/tcp # Simple Distributed Objects over SSH [Alexander_Philippou] [Alexander_Philippou] 2003-10
+sdo-ssh          3897/udp # Simple Distributed Objects over SSH [Alexander_Philippou] [Alexander_Philippou] 2003-10
+senip            3898/tcp # IAS, Inc. SmartEye NET Internet Protocol [Matt_Nowicki] [Matt_Nowicki] 2003-10
+senip            3898/udp # IAS, Inc. SmartEye NET Internet Protocol [Matt_Nowicki] [Matt_Nowicki] 2003-10
+itv-control      3899/tcp # ITV Port [Alex_Nicu] [Alex_Nicu] 2003-10
+itv-control      3899/udp # ITV Port [Alex_Nicu] [Alex_Nicu] 2003-10
+udt-os           3900/tcp # Unidata UDT OSIANA assigned this well-formed service name as a replacement for "udt_os". [James_Powell] [James_Powell]
+udt_os           3900/tcp # Unidata UDT OS [James_Powell] [James_Powell] This entry is an alias to "udt-os".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+udt-os           3900/udp # Unidata UDT OSIANA assigned this well-formed service name as a replacement for "udt_os". [James_Powell] [James_Powell]
+udt_os           3900/udp # Unidata UDT OS [James_Powell] [James_Powell] This entry is an alias to "udt-os".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+nimsh            3901/tcp # NIM Service Handler [Paul_B_Finley] [Paul_B_Finley] 2003-10
+nimsh            3901/udp # NIM Service Handler [Paul_B_Finley] [Paul_B_Finley] 2003-10
+nimaux           3902/tcp # NIMsh Auxiliary Port [Paul_B_Finley] [Paul_B_Finley] 2003-10
+nimaux           3902/udp # NIMsh Auxiliary Port [Paul_B_Finley] [Paul_B_Finley] 2003-10
+charsetmgr       3903/tcp # CharsetMGR [Tatsuya_Ueda] [Tatsuya_Ueda] 2003-10
+charsetmgr       3903/udp # CharsetMGR [Tatsuya_Ueda] [Tatsuya_Ueda] 2003-10
+omnilink-port    3904/tcp # Arnet Omnilink Port [Ronen_Shaul] [Ronen_Shaul] 2003-10
+omnilink-port    3904/udp # Arnet Omnilink Port [Ronen_Shaul] [Ronen_Shaul] 2003-10
+mupdate          3905/tcp # Mailbox Update (MUPDATE) protocol [RFC3656]
+mupdate          3905/udp # Mailbox Update (MUPDATE) protocol [RFC3656]
+topovista-data   3906/tcp # TopoVista elevation data [Gregg_Townsend] [Gregg_Townsend] 2003-11
+topovista-data   3906/udp # TopoVista elevation data [Gregg_Townsend] [Gregg_Townsend] 2003-11
+imoguia-port     3907/tcp # Imoguia Port [Emidio_Cunha] [Emidio_Cunha] 2003-11
+imoguia-port     3907/udp # Imoguia Port [Emidio_Cunha] [Emidio_Cunha] 2003-11
+hppronetman      3908/tcp # HP Procurve NetManagement [Devon_Dawson] [Devon_Dawson] 2003-11
+hppronetman      3908/udp # HP Procurve NetManagement [Devon_Dawson] [Devon_Dawson] 2003-11
+surfcontrolcpa   3909/tcp # SurfControl CPA [Hywel_Morgan] [Hywel_Morgan] 2003-11
+surfcontrolcpa   3909/udp # SurfControl CPA [Hywel_Morgan] [Hywel_Morgan] 2003-11
+prnrequest       3910/tcp # Printer Request Port [Brett_Green] [Brett_Green] 2003-11
+prnrequest       3910/udp # Printer Request Port [Brett_Green] [Brett_Green] 2003-11
+prnstatus        3911/tcp # Printer Status Port [Brett_Green] [Brett_Green] 2003-11
+prnstatus        3911/udp # Printer Status Port [Brett_Green] [Brett_Green] 2003-11
+gbmt-stars       3912/tcp # Global Maintech Stars [Harry_Goldschmitt] [Harry_Goldschmitt] 2003-11
+gbmt-stars       3912/udp # Global Maintech Stars [Harry_Goldschmitt] [Harry_Goldschmitt] 2003-11
+listcrt-port     3913/tcp # ListCREATOR Port [Tomokazu_Asai] [Tomokazu_Asai] 2003-11
+listcrt-port     3913/udp # ListCREATOR Port [Tomokazu_Asai] [Tomokazu_Asai] 2003-11
+listcrt-port-2   3914/tcp # ListCREATOR Port 2 [Tomokazu_Asai] [Tomokazu_Asai] 2003-11
+listcrt-port-2   3914/udp # ListCREATOR Port 2 [Tomokazu_Asai] [Tomokazu_Asai] 2003-11
+agcat            3915/tcp # Auto-Graphics Cataloging [Paul_Cope] [Paul_Cope] 2003-11
+agcat            3915/udp # Auto-Graphics Cataloging [Paul_Cope] [Paul_Cope] 2003-11
+wysdmc           3916/tcp # WysDM Controller [Jim_McDonald_2] [Jim_McDonald_2] 2003-11
+wysdmc           3916/udp # WysDM Controller [Jim_McDonald_2] [Jim_McDonald_2] 2003-11
+aftmux           3917/tcp # AFT multiplex port [Alfred_Schmidt] [Alfred_Schmidt] 2003-11
+aftmux           3917/udp # AFT multiples port [Alfred_Schmidt] [Alfred_Schmidt] 2003-11
+pktcablemmcops   3918/tcp # PacketCableMultimediaCOPS [Eric_Rosenfeld] [Eric_Rosenfeld] 2003-11
+pktcablemmcops   3918/udp # PacketCableMultimediaCOPS [Eric_Rosenfeld] [Eric_Rosenfeld] 2003-11
+hyperip          3919/tcp # HyperIP [Dave_Reiland] [Dave_Reiland] 2003-11
+hyperip          3919/udp # HyperIP [Dave_Reiland] [Dave_Reiland] 2003-11
+exasoftport1     3920/tcp # Exasoft IP Port [Alan_Malik] [Alan_Malik] 2003-11
+exasoftport1     3920/udp # Exasoft IP Port [Alan_Malik] [Alan_Malik] 2003-11
+herodotus-net    3921/tcp # Herodotus Net [Adam_Gawne_Cain] [Adam_Gawne_Cain] 2003-11
+herodotus-net    3921/udp # Herodotus Net [Adam_Gawne_Cain] [Adam_Gawne_Cain] 2003-11
+sor-update       3922/tcp # Soronti Update Port [Carleton_Watkins] [Carleton_Watkins] 2003-11
+sor-update       3922/udp # Soronti Update Port [Carleton_Watkins] [Carleton_Watkins] 2003-11
+symb-sb-port     3923/tcp # Symbian Service Broker [Ian_McDowall] [Ian_McDowall] 2003-11
+symb-sb-port     3923/udp # Symbian Service Broker [Ian_McDowall] [Ian_McDowall] 2003-11
+mpl-gprs-port    3924/tcp # MPL_GPRS_PORT [David_Barrass_2] [David_Barrass_2] 2003-11
+mpl-gprs-port    3924/udp # MPL_GPRS_Port [David_Barrass_2] [David_Barrass_2] 2003-11
+zmp              3925/tcp # Zoran Media Port [Gerard_Cerchio] [Gerard_Cerchio] 2003-11
+zmp              3925/udp # Zoran Media Port [Gerard_Cerchio] [Gerard_Cerchio] 2003-11
+winport          3926/tcp # WINPort [Alwin_Egger] [Alwin_Egger] 2003-11
+winport          3926/udp # WINPort [Alwin_Egger] [Alwin_Egger] 2003-11
+natdataservice   3927/tcp # ScsTsr [Ghanshyam_Patel] [Ghanshyam_Patel] 2003-11
+natdataservice   3927/udp # ScsTsr [Ghanshyam_Patel] [Ghanshyam_Patel] 2003-11
+netboot-pxe      3928/tcp # PXE NetBoot Manager [Markus_Treinen] [Markus_Treinen] 2003-11
+netboot-pxe      3928/udp # PXE NetBoot Manager [Markus_Treinen] [Markus_Treinen] 2003-11
+smauth-port      3929/tcp # AMS Port [Angelique_Dokos] [Angelique_Dokos] 2003-11
+smauth-port      3929/udp # AMS Port [Angelique_Dokos] [Angelique_Dokos] 2003-11
+syam-webserver   3930/tcp # Syam Web Server Port [Michael_Daniele] [Michael_Daniele] 2003-11
+syam-webserver   3930/udp # Syam Web Server Port [Michael_Daniele] [Michael_Daniele] 2003-11
+msr-plugin-port  3931/tcp # MSR Plugin Port [Ron_Steed] [Ron_Steed] 2003-11
+msr-plugin-port  3931/udp # MSR Plugin Port [Ron_Steed] [Ron_Steed] 2003-11
+dyn-site         3932/tcp # Dynamic Site System [Steve_Qi] [Steve_Qi] 2003-11
+dyn-site         3932/udp # Dynamic Site System [Steve_Qi] [Steve_Qi] 2003-11
+plbserve-port    3933/tcp # PL/B App Server User Port [Edward_R_Boedecker] [Edward_R_Boedecker] 2003-11
+plbserve-port    3933/udp # PL/B App Server User Port [Edward_R_Boedecker] [Edward_R_Boedecker] 2003-11
+sunfm-port       3934/tcp # PL/B File Manager Port [Edward_R_Boedecker] [Edward_R_Boedecker] 2003-11
+sunfm-port       3934/udp # PL/B File Manager Port [Edward_R_Boedecker] [Edward_R_Boedecker] 2003-11
+sdp-portmapper   3935/tcp # SDP Port Mapper Protocol [James_Pinkerton] [James_Pinkerton] 2003-11
+sdp-portmapper   3935/udp # SDP Port Mapper Protocol [James_Pinkerton] [James_Pinkerton] 2003-11
+mailprox         3936/tcp # Mailprox [Christof_Drescher] [Christof_Drescher] 2003-11
+mailprox         3936/udp # Mailprox [Christof_Drescher] [Christof_Drescher] 2003-11
+dvbservdsc       3937/tcp # DVB Service Discovery [Bert_van_Willigen][Peter_MacAvock] [Bert_van_Willigen][Peter_MacAvock] 2003-11
+dvbservdsc       3937/udp # DVB Service Discovery [Bert_van_Willigen][Peter_MacAvock] [Bert_van_Willigen][Peter_MacAvock] 2003-11
+dbcontrol-agent  3938/tcp # Oracle dbControl Agent poIANA assigned this well-formed service name as a replacement for "dbcontrol_agent". [Todd_Guay] [Todd_Guay] 2003-11
+dbcontrol_agent  3938/tcp # Oracle dbControl Agent po [Todd_Guay] [Todd_Guay] 2003-11 This entry is an alias to "dbcontrol-agent".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+dbcontrol-agent  3938/udp # Oracel dbControl Agent poIANA assigned this well-formed service name as a replacement for "dbcontrol_agent". [Todd_Guay] [Todd_Guay] 2003-11
+dbcontrol_agent  3938/udp # Oracel dbControl Agent po [Todd_Guay] [Todd_Guay] 2003-11 This entry is an alias to "dbcontrol-agent".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+aamp             3939/tcp # Anti-virus Application Management Port [In_sik_Choi] [In_sik_Choi] 2002-02
+aamp             3939/udp # Anti-virus Application Management Port [In_sik_Choi] [In_sik_Choi] 2002-02
+xecp-node        3940/tcp # XeCP Node Service [Brent_McCullough] [Brent_McCullough] 2003-11
+xecp-node        3940/udp # XeCP Node Service [Brent_McCullough] [Brent_McCullough] 2003-11
+homeportal-web   3941/tcp # Home Portal Web Server [Christian_Beaumont] [Christian_Beaumont] 2003-11
+homeportal-web   3941/udp # Home Portal Web Server [Christian_Beaumont] [Christian_Beaumont] 2003-11
+srdp             3942/tcp # satellite distribution [Simone_Molendini] [Simone_Molendini] 2003-11
+srdp             3942/udp # satellite distribution [Simone_Molendini] [Simone_Molendini] 2003-11
+tig              3943/tcp # TetraNode Ip Gateway [B_van_Klinken] [B_van_Klinken] 2003-12
+tig              3943/udp # TetraNode Ip Gateway [B_van_Klinken] [B_van_Klinken] 2003-12
+sops             3944/tcp # S-Ops Management [Stefan_Hochuli] [Stefan_Hochuli] 2003-12
+sops             3944/udp # S-Ops Management [Stefan_Hochuli] [Stefan_Hochuli] 2003-12
+emcads           3945/tcp # EMCADS Server Port [Lars_Struwe_Christen] [Lars_Struwe_Christen] 2004-01
+emcads           3945/udp # EMCADS Server Port [Lars_Struwe_Christen] [Lars_Struwe_Christen] 2004-01
+backupedge       3946/tcp # BackupEDGE Server [Frank_Liberato] [Frank_Liberato] 2004-06
+backupedge       3946/udp # BackupEDGE Server [Frank_Liberato] [Frank_Liberato] 2004-06
+ccp              3947/tcp # Connect and Control Protocol for Consumer, Commercial, and Industrial Electronic Devices [Aaron_Myer] [Aaron_Myer] 2004-06
+ccp              3947/udp # Connect and Control Protocol for Consumer, Commercial, and Industrial Electronic Devices [Aaron_Myer] [Aaron_Myer] 2004-06
+apdap            3948/tcp # Anton Paar Device Administration Protocol [Martin_Leitner] [Martin_Leitner] 2004-06
+apdap            3948/udp # Anton Paar Device Administration Protocol [Martin_Leitner] [Martin_Leitner] 2004-06
+drip             3949/tcp # Dynamic Routing Information Protocol [Dana_Blair] [Dana_Blair] 2004-06
+drip             3949/udp # Dynamic Routing Information Protocol [Dana_Blair] [Dana_Blair] 2004-06
+namemunge        3950/tcp # Name Munging [John_C_Klensin] [John_C_Klensin] 2004-07
+namemunge        3950/udp # Name Munging [John_C_Klensin] [John_C_Klensin] 2004-07
+pwgippfax        3951/tcp # PWG IPP Facsimile [Ira_McDonald] [Ira_McDonald] 2004-08
+pwgippfax        3951/udp # PWG IPP Facsimile [Ira_McDonald] [Ira_McDonald] 2004-08
+i3-sessionmgr    3952/tcp # I3 Session Manager [Mike_Gagle_2] [Mike_Gagle_2] 2004-08
+i3-sessionmgr    3952/udp # I3 Session Manager [Mike_Gagle_2] [Mike_Gagle_2] 2004-08
+xmlink-connect   3953/tcp # Eydeas XMLink Connect [David_Crewson] [David_Crewson] 2004-09
+xmlink-connect   3953/udp # Eydeas XMLink Connect [David_Crewson] [David_Crewson] 2004-09
+adrep            3954/tcp # AD Replication RPC [Robert_Ball] [Robert_Ball] 2008-03-26
+adrep            3954/udp # AD Replication RPC [Robert_Ball] [Robert_Ball] 2008-03-26
+p2pcommunity     3955/tcp # p2pCommunity [Tiago_Bittencourt_Si] [Tiago_Bittencourt_Si] 2005-08
+p2pcommunity     3955/udp # p2pCommunity [Tiago_Bittencourt_Si] [Tiago_Bittencourt_Si] 2005-08
+gvcp             3956/tcp # GigE Vision Control [Eric_Carey] [Eric_Carey] 2005-08
+gvcp             3956/udp # GigE Vision Control [Eric_Carey] [Eric_Carey] 2005-08
+mqe-broker       3957/tcp # MQEnterprise Broker
+mqe-broker       3957/udp # MQEnterprise Broker
+mqe-agent        3958/tcp # MQEnterprise Agent [Bob_Lauria] [Bob_Lauria] 2005-08
+mqe-agent        3958/udp # MQEnterprise Agent [Bob_Lauria] [Bob_Lauria] 2005-08
+treehopper       3959/tcp # Tree Hopper Networking [Gary_Whelan] [Gary_Whelan] 2005-08
+treehopper       3959/udp # Tree Hopper Networking [Gary_Whelan] [Gary_Whelan] 2005-08
+bess             3960/tcp # Bess Peer Assessment [Peter_Verdon] [Peter_Verdon] 2005-08
+bess             3960/udp # Bess Peer Assessment [Peter_Verdon] [Peter_Verdon] 2005-08
+proaxess         3961/tcp # ProAxess Server [Jonas_Ahlqvist] [Jonas_Ahlqvist] 2005-08
+proaxess         3961/udp # ProAxess Server [Jonas_Ahlqvist] [Jonas_Ahlqvist] 2005-08
+sbi-agent        3962/tcp # SBI Agent Protocol [Yossi_Appleboum_2] [Yossi_Appleboum_2] 2005-08
+sbi-agent        3962/udp # SBI Agent Protocol [Yossi_Appleboum_2] [Yossi_Appleboum_2] 2005-08
+thrp             3963/tcp # Teran Hybrid Routing Protocol [Spencer_Teran] [Spencer_Teran] 2005-08
+thrp             3963/udp # Teran Hybrid Routing Protocol [Spencer_Teran] [Spencer_Teran] 2005-08
+sasggprs         3964/tcp # SASG GPRS [Cristian_Petculescu_3] [Cristian_Petculescu_3] 2005-08
+sasggprs         3964/udp # SASG GPRS [Cristian_Petculescu_3] [Cristian_Petculescu_3] 2005-08
+ati-ip-to-ncpe   3965/tcp # Avanti IP to NCPE API [Steve_Meyer_Sr] [Steve_Meyer_Sr] 2005-08
+ati-ip-to-ncpe   3965/udp # Avanti IP to NCPE API [Steve_Meyer_Sr] [Steve_Meyer_Sr] 2005-08
+bflckmgr         3966/tcp # BuildForge Lock Manager [Joe_Senner] [Joe_Senner] 2005-08
+bflckmgr         3966/udp # BuildForge Lock Manager [Joe_Senner] [Joe_Senner] 2005-08
+ppsms            3967/tcp # PPS Message Service [Bart_Schaefer] [Bart_Schaefer] 2005-08
+ppsms            3967/udp # PPS Message Service [Bart_Schaefer] [Bart_Schaefer] 2005-08
+ianywhere-dbns   3968/tcp # iAnywhere DBNS [Graeme_Perrow] [Graeme_Perrow] 2005-08
+ianywhere-dbns   3968/udp # iAnywhere DBNS [Graeme_Perrow] [Graeme_Perrow] 2005-08
+landmarks        3969/tcp # Landmark Messages [Petri_Rauhala] [Petri_Rauhala] 2005-08
+landmarks        3969/udp # Landmark Messages [Petri_Rauhala] [Petri_Rauhala] 2005-08
+lanrevagent      3970/tcp # LANrev Agent [Martin_Bestmann_3] [Martin_Bestmann_3] Defined TXT keys:  txtvers  server=<main LANrev server for agent>  vers=<version of LANrev Agent>  build=<build number of LANrev Agent>  id=<agent identifier>
+lanrevagent      3970/udp # LANrev Agent [Martin_Bestmann_3] [Martin_Bestmann_3] Defined TXT keys:  txtvers  server=<main LANrev server for agent>  vers=<version of LANrev Agent>  build=<build number of LANrev Agent>  id=<agent identifier>
+lanrevserver     3971/tcp # LANrev Server [Martin_Bestmann_3] [Martin_Bestmann_3] 2005-08
+lanrevserver     3971/udp # LANrev Server [Martin_Bestmann_3] [Martin_Bestmann_3] 2005-08
+iconp            3972/tcp # ict-control Protocol [Roel_Harbers] [Roel_Harbers] 2005-08
+iconp            3972/udp # ict-control Protocol [Roel_Harbers] [Roel_Harbers] 2005-08
+progistics       3973/tcp # ConnectShip Progistics [Jeff_Skaistis] [Jeff_Skaistis] 2005-08
+progistics       3973/udp # ConnectShip Progistics [Jeff_Skaistis] [Jeff_Skaistis] 2005-08
+citysearch       3974/tcp # Remote Applicant Tracking Service [Marc_Castelluccio] [Marc_Castelluccio] 2005-08
+citysearch       3974/udp # Remote Applicant Tracking Service [Marc_Castelluccio] [Marc_Castelluccio] 2005-08
+airshot          3975/tcp # Air Shot [Shingo_Kimura] [Shingo_Kimura] 2005-08
+airshot          3975/udp # Air Shot [Shingo_Kimura] [Shingo_Kimura] 2005-08
+opswagent        3976/tcp # Opsware Agent
+opswagent        3976/udp # Opsware Agent
+opswmanager      3977/tcp # Opsware Manager [Dave_Jagoda] [Dave_Jagoda] 2006-06
+opswmanager      3977/udp # Opsware Manager [Dave_Jagoda] [Dave_Jagoda] 2006-06
+secure-cfg-svr   3978/tcp # Secured Configuration Server [Dr_Anupam_Bharali] [Dr_Anupam_Bharali] 2006-06
+secure-cfg-svr   3978/udp # Secured Configuration Server [Dr_Anupam_Bharali] [Dr_Anupam_Bharali] 2006-06
+smwan            3979/tcp # Smith Micro Wide Area Network Service [David_Sperling] [David_Sperling] 2006-06
+smwan            3979/udp # Smith Micro Wide Area Network Service [David_Sperling] [David_Sperling] 2006-06
+acms             3980/tcp # Aircraft Cabin Management System [Dustin_Zack] [Dustin_Zack] 2006-06
+acms             3980/udp # Aircraft Cabin Management System [Dustin_Zack] [Dustin_Zack] 2006-06
+starfish         3981/tcp # Starfish System Admin [Dan_Razzell] [Dan_Razzell] 2006-06
+starfish         3981/udp # Starfish System Admin [Dan_Razzell] [Dan_Razzell] 2006-06
+eis              3982/tcp # ESRI Image Server
+eis              3982/udp # ESRI Image Server
+eisp             3983/tcp # ESRI Image Service [Keith_Ryden] [Keith_Ryden] 2006-07
+eisp             3983/udp # ESRI Image Service [Keith_Ryden] [Keith_Ryden] 2006-07
+mapper-nodemgr   3984/tcp # MAPPER network node manager
+mapper-nodemgr   3984/udp # MAPPER network node manager
+mapper-mapethd   3985/tcp # MAPPER TCP/IP server
+mapper-mapethd   3985/udp # MAPPER TCP/IP server
+mapper-ws-ethd   3986/tcp # MAPPER workstation serverIANA assigned this well-formed service name as a replacement for "mapper-ws_ethd". [John_C_Horton] [John_C_Horton]
+mapper-ws_ethd   3986/tcp # MAPPER workstation server [John_C_Horton] [John_C_Horton] This entry is an alias to "mapper-ws-ethd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+mapper-ws-ethd   3986/udp # MAPPER workstation serverIANA assigned this well-formed service name as a replacement for "mapper-ws_ethd". [John_C_Horton] [John_C_Horton]
+mapper-ws_ethd   3986/udp # MAPPER workstation server [John_C_Horton] [John_C_Horton] This entry is an alias to "mapper-ws-ethd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+centerline       3987/tcp # Centerline [Mark_Simpson] [Mark_Simpson]
+centerline       3987/udp # Centerline [Mark_Simpson] [Mark_Simpson]
+dcs-config       3988/tcp # DCS Configuration Port [Ian_Cargill] [Ian_Cargill] 2005-08
+dcs-config       3988/udp # DCS Configuration Port [Ian_Cargill] [Ian_Cargill] 2005-08
+bv-queryengine   3989/tcp # BindView-Query Engine
+bv-queryengine   3989/udp # BindView-Query Engine
+bv-is            3990/tcp # BindView-IS
+bv-is            3990/udp # BindView-IS
+bv-smcsrv        3991/tcp # BindView-SMCServer
+bv-smcsrv        3991/udp # BindView-SMCServer
+bv-ds            3992/tcp # BindView-DirectoryServer
+bv-ds            3992/udp # BindView-DirectoryServer
+bv-agent         3993/tcp # BindView-Agent [David_A_Gayler] [David_A_Gayler] 2005-08
+bv-agent         3993/udp # BindView-Agent [David_A_Gayler] [David_A_Gayler] 2005-08
+iss-mgmt-ssl     3995/tcp # ISS Management Svcs SSL [Wes_Wilson] [Wes_Wilson] 2003-10
+iss-mgmt-ssl     3995/udp # ISS Management Svcs SSL [Wes_Wilson] [Wes_Wilson] 2003-10
+abcsoftware      3996/tcp # abcsoftware-01 [Andrew_Zimmerman] [Andrew_Zimmerman] 2004-06
+abcsoftware      3996/udp # abcsoftware-01 [Andrew_Zimmerman] [Andrew_Zimmerman] 2004-06
+agentsease-db    3997/tcp # aes_db [Colin_Hughes] [Colin_Hughes] 2006-02
+agentsease-db    3997/udp # aes_db [Colin_Hughes] [Colin_Hughes] 2006-02
+dnx              3998/tcp # Distributed Nagios Executor Service [John_Calcote] [John_Calcote] 2007-11-06
+dnx              3998/udp # Distributed Nagios Executor Service [John_Calcote] [John_Calcote] 2007-11-06
+nvcnet           3999/tcp # Norman distributes scanning service [Kristian_A_Bognaes] [Kristian_A_Bognaes] 2007-11-06
+nvcnet           3999/udp # Norman distributes scanning service [Kristian_A_Bognaes] [Kristian_A_Bognaes] 2007-11-06
+terabase         4000/tcp # Terabase [Thor_Olson] [Thor_Olson] Potential Conflict of portsPORT 4000 also used by ICQ <www.icq.com>
+terabase         4000/udp # Terabase [Thor_Olson] [Thor_Olson] Potential Conflict of portsPORT 4000 also used by ICQ <www.icq.com>
+newoak           4001/tcp # NewOak [Jim_Philippou] [Jim_Philippou]
+newoak           4001/udp # NewOak [Jim_Philippou] [Jim_Philippou]
+pxc-spvr-ft      4002/tcp # pxc-spvr-ft
+pxc-spvr-ft      4002/udp # pxc-spvr-ft
+pxc-splr-ft      4003/tcp # pxc-splr-ft
+pxc-splr-ft      4003/udp # pxc-splr-ft
+pxc-roid         4004/tcp # pxc-roid
+pxc-roid         4004/udp # pxc-roid
+pxc-pin          4005/tcp # pxc-pin
+pxc-pin          4005/udp # pxc-pin
+pxc-spvr         4006/tcp # pxc-spvr
+pxc-spvr         4006/udp # pxc-spvr
+pxc-splr         4007/tcp # pxc-splr [Dave_Nesbitt] [Dave_Nesbitt]
+pxc-splr         4007/udp # pxc-splr [Dave_Nesbitt] [Dave_Nesbitt]
+netcheque        4008/tcp # NetCheque accounting [B_Clifford_Neuman] [B_Clifford_Neuman]
+netcheque        4008/udp # NetCheque accounting [B_Clifford_Neuman] [B_Clifford_Neuman]
+chimera-hwm      4009/tcp # Chimera HWM [Ken_Anderson] [Ken_Anderson]
+chimera-hwm      4009/udp # Chimera HWM [Ken_Anderson] [Ken_Anderson]
+samsung-unidex   4010/tcp # Samsung Unidex [Konstantin_V_Vyazni] [Konstantin_V_Vyazni]
+samsung-unidex   4010/udp # Samsung Unidex [Konstantin_V_Vyazni] [Konstantin_V_Vyazni]
+altserviceboot   4011/tcp # Alternate Service Boot [Eric_Dittert] [Eric_Dittert]
+altserviceboot   4011/udp # Alternate Service Boot [Eric_Dittert] [Eric_Dittert]
+pda-gate         4012/tcp # PDA Gate [Masakuni_Okada] [Masakuni_Okada]
+pda-gate         4012/udp # PDA Gate [Masakuni_Okada] [Masakuni_Okada]
+acl-manager      4013/tcp # ACL Manager [Toru_Murai] [Toru_Murai]
+acl-manager      4013/udp # ACL Manager [Toru_Murai] [Toru_Murai]
+taiclock         4014/tcp # TAICLOCK [Dan_Bernstein_3] [Dan_Bernstein_3]
+taiclock         4014/udp # TAICLOCK [Dan_Bernstein_3] [Dan_Bernstein_3]
+talarian-mcast1  4015/tcp # Talarian Mcast
+talarian-mcast1  4015/udp # Talarian Mcast
+talarian-mcast2  4016/tcp # Talarian Mcast
+talarian-mcast2  4016/udp # Talarian Mcast
+talarian-mcast3  4017/tcp # Talarian Mcast
+talarian-mcast3  4017/udp # Talarian Mcast
+talarian-mcast4  4018/tcp # Talarian Mcast
+talarian-mcast4  4018/udp # Talarian Mcast
+talarian-mcast5  4019/tcp # Talarian Mcast [Geoff_Mendal] [Geoff_Mendal]
+talarian-mcast5  4019/udp # Talarian Mcast [Geoff_Mendal] [Geoff_Mendal]
+trap             4020/tcp # TRAP Port [Jeffrey_C_Byrd] [Jeffrey_C_Byrd]
+trap             4020/udp # TRAP Port [Jeffrey_C_Byrd] [Jeffrey_C_Byrd]
+nexus-portal     4021/tcp # Nexus Portal [Damian_Tarnawsky] [Damian_Tarnawsky]
+nexus-portal     4021/udp # Nexus Portal [Damian_Tarnawsky] [Damian_Tarnawsky]
+dnox             4022/tcp # DNOX [Leo_Rathnayake] [Leo_Rathnayake]
+dnox             4022/udp # DNOX [Leo_Rathnayake] [Leo_Rathnayake]
+esnm-zoning      4023/tcp # ESNM Zoning Port [Yong_Cai] [Yong_Cai]
+esnm-zoning      4023/udp # ESNM Zoning Port [Yong_Cai] [Yong_Cai]
+tnp1-port        4024/tcp # TNP1 User Port [Tony_Gibbs] [Tony_Gibbs]
+tnp1-port        4024/udp # TNP1 User Port [Tony_Gibbs] [Tony_Gibbs]
+partimage        4025/tcp # Partition Image Port [Franck_Ladurelle] [Franck_Ladurelle]
+partimage        4025/udp # Partition Image Port [Franck_Ladurelle] [Franck_Ladurelle]
+as-debug         4026/tcp # Graphical Debug Server [Steve_Halverson] [Steve_Halverson]
+as-debug         4026/udp # Graphical Debug Server [Steve_Halverson] [Steve_Halverson]
+bxp              4027/tcp # bitxpress [Morgan_Doyle] [Morgan_Doyle]
+bxp              4027/udp # bitxpress [Morgan_Doyle] [Morgan_Doyle]
+dtserver-port    4028/tcp # DTServer Port [Stephen_Aikins] [Stephen_Aikins]
+dtserver-port    4028/udp # DTServer Port [Stephen_Aikins] [Stephen_Aikins]
+ip-qsig          4029/tcp # IP Q signaling protocol [Toru_Tachibana] [Toru_Tachibana]
+ip-qsig          4029/udp # IP Q signaling protocol [Toru_Tachibana] [Toru_Tachibana]
+jdmn-port        4030/tcp # Accell/JSP Daemon Port [Daegis_Inc] [Chris_Anderson] 2012-07-12
+jdmn-port        4030/udp # Accell/JSP Daemon Port [Daegis_Inc] [Chris_Anderson] 2012-07-12
+suucp            4031/tcp # UUCP over SSL [Harald_Welte] [Harald_Welte]
+suucp            4031/udp # UUCP over SSL [Harald_Welte] [Harald_Welte]
+vrts-auth-port   4032/tcp # VERITAS Authorization Service [Stefan_Winkel] [Stefan_Winkel]
+vrts-auth-port   4032/udp # VERITAS Authorization Service [Stefan_Winkel] [Stefan_Winkel]
+sanavigator      4033/tcp # SANavigator Peer Port [Robert_J_Chansler] [Robert_J_Chansler]
+sanavigator      4033/udp # SANavigator Peer Port [Robert_J_Chansler] [Robert_J_Chansler]
+ubxd             4034/tcp # Ubiquinox Daemon [Kit_Smithers] [Kit_Smithers]
+ubxd             4034/udp # Ubiquinox Daemon [Kit_Smithers] [Kit_Smithers]
+wap-push-http    4035/tcp # WAP Push OTA-HTTP port
+wap-push-http    4035/udp # WAP Push OTA-HTTP port
+wap-push-https   4036/tcp # WAP Push OTA-HTTP secure [Matthieu_Lachance] [Matthieu_Lachance]
+wap-push-https   4036/udp # WAP Push OTA-HTTP secure [Matthieu_Lachance] [Matthieu_Lachance]
+ravehd           4037/tcp # RaveHD network control [Jason_Howard] [Jason_Howard] 2006-01
+ravehd           4037/udp # RaveHD network control [Jason_Howard] [Jason_Howard] 2006-01
+fazzt-ptp        4038/tcp # Fazzt Point-To-Point
+fazzt-ptp        4038/udp # Fazzt Point-To-Point
+fazzt-admin      4039/tcp # Fazzt Administration [Lewis_Wolfgang] [Lewis_Wolfgang] 2006-05
+fazzt-admin      4039/udp # Fazzt Administration [Lewis_Wolfgang] [Lewis_Wolfgang] 2006-05
+yo-main          4040/tcp # Yo.net main service [John_Tintor] [John_Tintor]
+yo-main          4040/udp # Yo.net main service [John_Tintor] [John_Tintor]
+houston          4041/tcp # Rocketeer-Houston [Johnny_C_Norris_II] [Johnny_C_Norris_II]
+houston          4041/udp # Rocketeer-Houston [Johnny_C_Norris_II] [Johnny_C_Norris_II]
+ldxp             4042/tcp # LDXP [Craig_Calef] [Craig_Calef]
+ldxp             4042/udp # LDXP [Craig_Calef] [Craig_Calef]
+nirp             4043/tcp # Neighbour Identity Resolution
+nirp             4043/udp # Neighbour Identity Resolution
+ltp              4044/tcp # Location Tracking Protocol
+ltp              4044/udp # Location Tracking Protocol
+npp              4045/tcp # Network Paging Protocol Known UNAUTHORIZED USE: Port 4045
+npp              4045/udp # Network Paging Protocol Known UNAUTHORIZED USE: Port 4045
+acp-proto        4046/tcp # Accounting Protocol
+acp-proto        4046/udp # Accounting Protocol
+ctp-state        4047/tcp # Context Transfer Protocol [Hesham_Soliman] [Hesham_Soliman] 2005-11
+ctp-state        4047/udp # Context Transfer Protocol [Hesham_Soliman] [Hesham_Soliman] 2005-11
+wafs             4049/tcp # Wide Area File Services [Yuval_Hager] [Yuval_Hager] 2006-01
+wafs             4049/udp # Wide Area File Services [Yuval_Hager] [Yuval_Hager] 2006-01
+cisco-wafs       4050/tcp # Wide Area File Services [Etai_Lev_Ran] [Etai_Lev_Ran] 2005-02
+cisco-wafs       4050/udp # Wide Area File Services [Etai_Lev_Ran] [Etai_Lev_Ran] 2005-02
+cppdp            4051/tcp # Cisco Peer to Peer Distribution Protocol [Susan_Sauter] [Susan_Sauter] 2006-07
+cppdp            4051/udp # Cisco Peer to Peer Distribution Protocol [Susan_Sauter] [Susan_Sauter] 2006-07
+interact         4052/tcp # VoiceConnect Interact [Jonathan_Custance] [Jonathan_Custance] 2006-07
+interact         4052/udp # VoiceConnect Interact [Jonathan_Custance] [Jonathan_Custance] 2006-07
+ccu-comm-1       4053/tcp # CosmoCall Universe Communications Port 1
+ccu-comm-1       4053/udp # CosmoCall Universe Communications Port 1
+ccu-comm-2       4054/tcp # CosmoCall Universe Communications Port 2
+ccu-comm-2       4054/udp # CosmoCall Universe Communications Port 2
+ccu-comm-3       4055/tcp # CosmoCall Universe Communications Port 3 [Steve_Dellutri_2] [Steve_Dellutri_2] 2006-07
+ccu-comm-3       4055/udp # CosmoCall Universe Communications Port 3 [Steve_Dellutri_2] [Steve_Dellutri_2] 2006-07
+lms              4056/tcp # Location Message Service [Sergey_Burnevsky] [Sergey_Burnevsky] 2006-08
+lms              4056/udp # Location Message Service [Sergey_Burnevsky] [Sergey_Burnevsky] 2006-08
+wfm              4057/tcp # Servigistics WFM server [Yuri_Machkasov_2] [Yuri_Machkasov_2] 2006-08
+wfm              4057/udp # Servigistics WFM server [Yuri_Machkasov_2] [Yuri_Machkasov_2] 2006-08
+kingfisher       4058/tcp # Kingfisher protocol [Vaughan_Wesson] [Vaughan_Wesson] 2006-10
+kingfisher       4058/udp # Kingfisher protocol [Vaughan_Wesson] [Vaughan_Wesson] 2006-10
+dlms-cosem       4059/tcp # DLMS/COSEM [Gyozo_Kmethy] [Gyozo_Kmethy] 2006-11
+dlms-cosem       4059/udp # DLMS/COSEM [Gyozo_Kmethy] [Gyozo_Kmethy] 2006-11
+dsmeter-iatc     4060/tcp # DSMETER Inter-Agent Transfer ChannelIANA assigned this well-formed service name as a replacement for "dsmeter_iatc". [John_McCann] [John_McCann] 2006-12
+dsmeter_iatc     4060/tcp # DSMETER Inter-Agent Transfer Channel [John_McCann] [John_McCann] 2006-12 This entry is an alias to "dsmeter-iatc".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+dsmeter-iatc     4060/udp # DSMETER Inter-Agent Transfer ChannelIANA assigned this well-formed service name as a replacement for "dsmeter_iatc". [John_McCann] [John_McCann] 2006-12
+dsmeter_iatc     4060/udp # DSMETER Inter-Agent Transfer Channel [John_McCann] [John_McCann] 2006-12 This entry is an alias to "dsmeter-iatc".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+ice-location     4061/tcp # Ice Location Service (TCP)
+ice-location     4061/udp # Ice Location Service (TCP)
+ice-slocation    4062/tcp # Ice Location Service (SSL)
+ice-slocation    4062/udp # Ice Location Service (SSL)
+ice-router       4063/tcp # Ice Firewall Traversal Service (TCP)
+ice-router       4063/udp # Ice Firewall Traversal Service (TCP)
+ice-srouter      4064/tcp # Ice Firewall Traversal Service (SSL) [Bernard_Normier] [Bernard_Normier] 2006-12
+ice-srouter      4064/udp # Ice Firewall Traversal Service (SSL) [Bernard_Normier] [Bernard_Normier] 2006-12
+avanti-cdp       4065/tcp # Avanti Common DataIANA assigned this well-formed service name as a replacement for "avanti_cdp". [Steve_Meyer_Sr] [Steve_Meyer_Sr] 2007-02
+avanti_cdp       4065/tcp # Avanti Common Data [Steve_Meyer_Sr] [Steve_Meyer_Sr] 2007-02 This entry is an alias to "avanti-cdp".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+avanti-cdp       4065/udp # Avanti Common DataIANA assigned this well-formed service name as a replacement for "avanti_cdp". [Steve_Meyer_Sr] [Steve_Meyer_Sr] 2007-02
+avanti_cdp       4065/udp # Avanti Common Data [Steve_Meyer_Sr] [Steve_Meyer_Sr] 2007-02 This entry is an alias to "avanti-cdp".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+pmas             4066/tcp # Performance Measurement and Analysis [Zenon_Fortuna] [Zenon_Fortuna] 2007-02
+pmas             4066/udp # Performance Measurement and Analysis [Zenon_Fortuna] [Zenon_Fortuna] 2007-02
+idp              4067/tcp # Information Distribution Protocol [Michaela_Vanderveen] [Michaela_Vanderveen] 2007-02
+idp              4067/udp # Information Distribution Protocol [Michaela_Vanderveen] [Michaela_Vanderveen] 2007-02
+ipfltbcst        4068/tcp # IP Fleet Broadcast [Trung_Huu_Tran] [Trung_Huu_Tran] 2007-03
+ipfltbcst        4068/udp # IP Fleet Broadcast [Trung_Huu_Tran] [Trung_Huu_Tran] 2007-03
+minger           4069/tcp # Minger Email Address Validation Service [Arvel_Hathcock] [Arvel_Hathcock] 2007-03
+minger           4069/udp # Minger Email Address Validation Service [Arvel_Hathcock] [Arvel_Hathcock] 2007-03
+tripe            4070/tcp # Trivial IP Encryption (TrIPE) [Mark_Wooding] [Mark_Wooding] 2007-07-10
+tripe            4070/udp # Trivial IP Encryption (TrIPE) [Mark_Wooding] [Mark_Wooding] 2007-07-10
+aibkup           4071/tcp # Automatically Incremental Backup [Volker_Wiegand] [Volker_Wiegand] 2007-07-10
+aibkup           4071/udp # Automatically Incremental Backup [Volker_Wiegand] [Volker_Wiegand] 2007-07-10
+zieto-sock       4072/tcp # Zieto Socket Communications [Malcolm_McLean] [Malcolm_McLean] 2007-07-19
+zieto-sock       4072/udp # Zieto Socket Communications [Malcolm_McLean] [Malcolm_McLean] 2007-07-19
+iRAPP            4073/tcp # iRAPP Server Protocol [Vladimir_Bickov] [Vladimir_Bickov] 2007-08-20
+iRAPP            4073/udp # iRAPP Server Protocol [Vladimir_Bickov] [Vladimir_Bickov] 2007-08-20
+cequint-cityid   4074/tcp # Cequint City ID UI trigger [Phill_Goeckler] [Phill_Goeckler] 2007-08-20
+cequint-cityid   4074/udp # Cequint City ID UI trigger [Phill_Goeckler] [Phill_Goeckler] 2007-08-20
+perimlan         4075/tcp # ISC Alarm Message Service [Bernie_Malkowski] [Bernie_Malkowski] 2007-08-20
+perimlan         4075/udp # ISC Alarm Message Service [Bernie_Malkowski] [Bernie_Malkowski] 2007-08-20
+seraph           4076/tcp # Seraph DCS [Jason_Spence] [Jason_Spence] 2008-01-22
+seraph           4076/udp # Seraph DCS [Jason_Spence] [Jason_Spence] 2008-01-22
+ascomalarm       4077/udp # Ascom IP Alarming [Ascom_Austria_GmbH] [Ascom_Austria_GmbH] 2008-05-01
+cssp             4078/tcp # Coordinated Security Service Protocol [Michael_McDaniels] [Michael_McDaniels] 2008-05-01
+santools         4079/tcp # SANtools Diagnostic Server [David_A_Lethe_2] [David_A_Lethe_2] 2008-05-01
+santools         4079/udp # SANtools Diagnostic Server [David_A_Lethe_2] [David_A_Lethe_2] 2008-05-01
+lorica-in        4080/tcp # Lorica inside facing
+lorica-in        4080/udp # Lorica inside facing
+lorica-in-sec    4081/tcp # Lorica inside facing (SSL)
+lorica-in-sec    4081/udp # Lorica inside facing (SSL)
+lorica-out       4082/tcp # Lorica outside facing
+lorica-out       4082/udp # Lorica outside facing
+lorica-out-sec   4083/tcp # Lorica outside facing (SSL) [Johannes_Skov_Frands] [Johannes_Skov_Frands] 2008-02-28
+lorica-out-sec   4083/udp # Lorica outside facing (SSL) [Johannes_Skov_Frands] [Johannes_Skov_Frands] 2008-02-28
+fortisphere-vm   4084/udp # Fortisphere VM Service [Daniel_Becker_4] [Daniel_Becker_4] 2008-06-03
+ezmessagesrv     4085/tcp # EZNews Newsroom Message Service [Gerald_R_Jensen] [Gerald_R_Jensen] 2008-06-05
+ftsync           4086/udp # Firewall/NAT state table synchronization [Heiner_Erne] [Heiner_Erne] 2008-06-06
+applusservice    4087/tcp # APplus Service [Thomas_Boerkel] [Thomas_Boerkel] 2008-06-05
+npsp             4088/tcp # Noah Printing Service Protocol [Hiromi_Ohara] [Hiromi_Ohara] 2008-06-18
+opencore         4089/tcp # OpenCORE Remote Control Service [Pim_van_Riezen] [Pim_van_Riezen] 2006-07
+opencore         4089/udp # OpenCORE Remote Control Service [Pim_van_Riezen] [Pim_van_Riezen] 2006-07
+omasgport        4090/tcp # OMA BCAST Service Guide [Mark_Lipford] [Mark_Lipford] 2006-07
+omasgport        4090/udp # OMA BCAST Service Guide [Mark_Lipford] [Mark_Lipford] 2006-07
+ewinstaller      4091/tcp # EminentWare Installer
+ewinstaller      4091/udp # EminentWare Installer
+ewdgs            4092/tcp # EminentWare DGS [David_A_Gayler_2] [David_A_Gayler_2] 2006-07
+ewdgs            4092/udp # EminentWare DGS [David_A_Gayler_2] [David_A_Gayler_2] 2006-07
+pvxpluscs        4093/tcp # Pvx Plus CS Host [Michael_King] [Michael_King] 2006-07
+pvxpluscs        4093/udp # Pvx Plus CS Host [Michael_King] [Michael_King] 2006-07
+sysrqd           4094/tcp # sysrq daemon [Julien_Danjou] [Julien_Danjou] 2006-07
+sysrqd           4094/udp # sysrq daemon [Julien_Danjou] [Julien_Danjou] 2006-07
+xtgui            4095/tcp # xtgui information service [Jim_Robanske] [Jim_Robanske] 2006-05
+xtgui            4095/udp # xtgui information service [Jim_Robanske] [Jim_Robanske] 2006-05
+bre              4096/tcp # BRE (Bridge Relay Element) [Stephen_Egbert] [Stephen_Egbert]
+bre              4096/udp # BRE (Bridge Relay Element) [Stephen_Egbert] [Stephen_Egbert]
+patrolview       4097/tcp # Patrol View [Portnoy_Boxman] [Portnoy_Boxman]
+patrolview       4097/udp # Patrol View [Portnoy_Boxman] [Portnoy_Boxman]
+drmsfsd          4098/tcp # drmsfsd [Masao_Iwai] [Masao_Iwai]
+drmsfsd          4098/udp # drmsfsd [Masao_Iwai] [Masao_Iwai]
+dpcp             4099/tcp # DPCP [John_Croft] [John_Croft]
+dpcp             4099/udp # DPCP [John_Croft] [John_Croft]
+igo-incognito    4100/tcp # IGo Incognito Data Port [Paul_Reddy_2] [Paul_Reddy_2] 2002-02
+igo-incognito    4100/udp # IGo Incognito Data Port [Paul_Reddy_2] [Paul_Reddy_2] 2002-02
+brlp-0           4101/tcp # Braille protocol
+brlp-0           4101/udp # Braille protocol
+brlp-1           4102/tcp # Braille protocol
+brlp-1           4102/udp # Braille protocol
+brlp-2           4103/tcp # Braille protocol
+brlp-2           4103/udp # Braille protocol
+brlp-3           4104/tcp # Braille protocol [Sebastien_Hinderer] [Sebastien_Hinderer] 2006-03
+brlp-3           4104/udp # Braille protocol [Sebastien_Hinderer] [Sebastien_Hinderer] 2006-03
+shofar           4105/tcp # Shofar [ShofarNexus] [John_Kozlowski] 2006-07 2012-02-20
+shofar           4105/udp # Shofar [ShofarNexus] [John_Kozlowski] 2006-07 2012-02-20
+synchronite      4106/tcp # Synchronite [James_Figgins] [James_Figgins] 2006-07
+synchronite      4106/udp # Synchronite [James_Figgins] [James_Figgins] 2006-07
+j-ac             4107/tcp # JDL Accounting LAN Service [Takashi_Sahara] [Takashi_Sahara] 2006-09
+j-ac             4107/udp # JDL Accounting LAN Service [Takashi_Sahara] [Takashi_Sahara] 2006-09
+accel            4108/tcp # ACCEL [Masahiro_Koiwai] [Masahiro_Koiwai] 2006-10
+accel            4108/udp # ACCEL [Masahiro_Koiwai] [Masahiro_Koiwai] 2006-10
+izm              4109/tcp # Instantiated Zero-control Messaging [David_Miller] [David_Miller] 2007-02
+izm              4109/udp # Instantiated Zero-control Messaging [David_Miller] [David_Miller] 2007-02
+g2tag            4110/tcp # G2 RFID Tag Telemetry Data [David_Goodall] [David_Goodall] 2007-02
+g2tag            4110/udp # G2 RFID Tag Telemetry Data [David_Goodall] [David_Goodall] 2007-02
+xgrid            4111/tcp # Xgrid [David_Kramer] [David_Kramer] 2004-11
+xgrid            4111/udp # Xgrid [David_Kramer] [David_Kramer] 2004-11
+apple-vpns-rp    4112/tcp # Apple VPN Server Reporting Protocol [Christophe_Allie] [Christophe_Allie] 2006-08
+apple-vpns-rp    4112/udp # Apple VPN Server Reporting Protocol [Christophe_Allie] [Christophe_Allie] 2006-08
+aipn-reg         4113/tcp # AIPN LS Registration [Qiang_Zhang_2] [Qiang_Zhang_2] 2006-10
+aipn-reg         4113/udp # AIPN LS Registration [Qiang_Zhang_2] [Qiang_Zhang_2] 2006-10
+jomamqmonitor    4114/tcp # JomaMQMonitor [Marcel_Hofstetter] [Marcel_Hofstetter] 2003-01
+jomamqmonitor    4114/udp # JomaMQMonitor [Marcel_Hofstetter] [Marcel_Hofstetter] 2003-01
+cds              4115/tcp # CDS Transfer Agent [Neil_Coggins] [Neil_Coggins] 2006-07
+cds              4115/udp # CDS Transfer Agent [Neil_Coggins] [Neil_Coggins] 2006-07
+smartcard-tls    4116/tcp # smartcard-TLS [Ilan_Mahalal] [Ilan_Mahalal] 2006-04
+smartcard-tls    4116/udp # smartcard-TLS [Ilan_Mahalal] [Ilan_Mahalal] 2006-04
+hillrserv        4117/tcp # Hillr Connection Manager [Freddy_A_Ayuso_Hens] [Freddy_A_Ayuso_Hens] 2008-05-22
+hillrserv        4117/udp # Hillr Connection Manager [Freddy_A_Ayuso_Hens] [Freddy_A_Ayuso_Hens] 2008-05-22
+netscript        4118/tcp # Netadmin Systems NETscript service [Goran_Runfeldt] [Goran_Runfeldt] 2006-12
+netscript        4118/udp # Netadmin Systems NETscript service [Goran_Runfeldt] [Goran_Runfeldt] 2006-12
+assuria-slm      4119/tcp # Assuria Log Manager [Nick_Connor] [Nick_Connor] 2006-12
+assuria-slm      4119/udp # Assuria Log Manager [Nick_Connor] [Nick_Connor] 2006-12
+e-builder        4121/tcp # e-Builder Application Communication [James_Caza] [James_Caza] 2006-12
+e-builder        4121/udp # e-Builder Application Communication [James_Caza] [James_Caza] 2006-12
+fprams           4122/tcp # Fiber Patrol Alarm Service [Zhizhong_Zhuang] [Zhizhong_Zhuang] 2006-12
+fprams           4122/udp # Fiber Patrol Alarm Service [Zhizhong_Zhuang] [Zhizhong_Zhuang] 2006-12
+z-wave           4123/tcp # Z-Wave Protocol [Sigma_Designs_Inc_2] [Anders_Brandt][Mary_Miller] 2007-02 2012-11-08
+z-wave           4123/udp # Z-Wave Protocol [Sigma_Designs_Inc_2] [Anders_Brandt][Mary_Miller] 2007-02 2012-11-08
+tigv2            4124/tcp # Rohill TetraNode Ip Gateway v2 [Bert_Bouwers] [Bert_Bouwers] 2007-05
+tigv2            4124/udp # Rohill TetraNode Ip Gateway v2 [Bert_Bouwers] [Bert_Bouwers] 2007-05
+opsview-envoy    4125/tcp # Opsview Envoy [Ton_Voon] [Ton_Voon] 2008-09-26
+opsview-envoy    4125/udp # Opsview Envoy [Ton_Voon] [Ton_Voon] 2008-09-26
+ddrepl           4126/tcp # Data Domain Replication Service [Pratik_Wadher] [Pratik_Wadher] 2007-05
+ddrepl           4126/udp # Data Domain Replication Service [Pratik_Wadher] [Pratik_Wadher] 2007-05
+unikeypro        4127/tcp # NetUniKeyServer [Raymond_Chaw] [Raymond_Chaw] 2007-05
+unikeypro        4127/udp # NetUniKeyServer [Raymond_Chaw] [Raymond_Chaw] 2007-05
+nufw             4128/tcp # NuFW decision delegation protocol
+nufw             4128/udp # NuFW decision delegation protocol
+nuauth           4129/tcp # NuFW authentication protocol [Eric_Leblond] [Eric_Leblond] 2007-06
+nuauth           4129/udp # NuFW authentication protocol [Eric_Leblond] [Eric_Leblond] 2007-06
+fronet           4130/tcp # FRONET message protocol [Christer_Nygren] [Christer_Nygren] 2007-08-07
+fronet           4130/udp # FRONET message protocol [Christer_Nygren] [Christer_Nygren] 2007-08-07
+stars            4131/tcp # Global Maintech Stars [Harry_Goldschmitt_2] [Harry_Goldschmitt_2] 2007-06
+stars            4131/udp # Global Maintech Stars [Harry_Goldschmitt_2] [Harry_Goldschmitt_2] 2007-06
+nuts-dem         4132/tcp # NUTS DaemonIANA assigned this well-formed service name as a replacement for "nuts_dem".
+nuts_dem         4132/tcp # NUTS Daemon This entry is an alias to "nuts-dem".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+nuts-dem         4132/udp # NUTS DaemonIANA assigned this well-formed service name as a replacement for "nuts_dem".
+nuts_dem         4132/udp # NUTS Daemon This entry is an alias to "nuts-dem".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+nuts-bootp       4133/tcp # NUTS Bootp ServerIANA assigned this well-formed service name as a replacement for "nuts_bootp". [Martin_Freiss_2] [Martin_Freiss_2]
+nuts_bootp       4133/tcp # NUTS Bootp Server [Martin_Freiss_2] [Martin_Freiss_2] This entry is an alias to "nuts-bootp".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+nuts-bootp       4133/udp # NUTS Bootp ServerIANA assigned this well-formed service name as a replacement for "nuts_bootp". [Martin_Freiss_2] [Martin_Freiss_2]
+nuts_bootp       4133/udp # NUTS Bootp Server [Martin_Freiss_2] [Martin_Freiss_2] This entry is an alias to "nuts-bootp".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+nifty-hmi        4134/tcp # NIFTY-Serve HMI protocol [Ryuichi_Suzuki] [Ryuichi_Suzuki]
+nifty-hmi        4134/udp # NIFTY-Serve HMI protocol [Ryuichi_Suzuki] [Ryuichi_Suzuki]
+cl-db-attach     4135/tcp # Classic Line Database Server Attach
+cl-db-attach     4135/udp # Classic Line Database Server Attach
+cl-db-request    4136/tcp # Classic Line Database Server Request
+cl-db-request    4136/udp # Classic Line Database Server Request
+cl-db-remote     4137/tcp # Classic Line Database Server Remote [Arno_Kirmeir] [Arno_Kirmeir] 2007-01
+cl-db-remote     4137/udp # Classic Line Database Server Remote [Arno_Kirmeir] [Arno_Kirmeir] 2007-01
+nettest          4138/tcp # nettest [David_Borman] [David_Borman] 2003-03
+nettest          4138/udp # nettest [David_Borman] [David_Borman] 2003-03
+thrtx            4139/tcp # Imperfect Networks Server [Dinkar_Chivaluri_2] [Dinkar_Chivaluri_2] 2006-02
+thrtx            4139/udp # Imperfect Networks Server [Dinkar_Chivaluri_2] [Dinkar_Chivaluri_2] 2006-02
+cedros-fds       4140/tcp # Cedros Fraud Detection SystemIANA assigned this well-formed service name as a replacement for "cedros_fds". [Markus_Michels_3] [Markus_Michels_3] 2006-10
+cedros_fds       4140/tcp # Cedros Fraud Detection System [Markus_Michels_3] [Markus_Michels_3] 2006-10 This entry is an alias to "cedros-fds".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+cedros-fds       4140/udp # Cedros Fraud Detection SystemIANA assigned this well-formed service name as a replacement for "cedros_fds". [Markus_Michels_3] [Markus_Michels_3] 2006-10
+cedros_fds       4140/udp # Cedros Fraud Detection System [Markus_Michels_3] [Markus_Michels_3] 2006-10 This entry is an alias to "cedros-fds".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+oirtgsvc         4141/tcp # Workflow Server
+oirtgsvc         4141/udp # Workflow Server
+oidocsvc         4142/tcp # Document Server
+oidocsvc         4142/udp # Document Server
+oidsr            4143/tcp # Document Replication [Norman_Brie] [Norman_Brie]
+oidsr            4143/udp # Document Replication [Norman_Brie] [Norman_Brie]
+vvr-control      4145/tcp # VVR Control [Ming_Xu] [Ming_Xu]
+vvr-control      4145/udp # VVR Control [Ming_Xu] [Ming_Xu]
+tgcconnect       4146/tcp # TGCConnect Beacon [Brian_Becker] [Brian_Becker] 2006-10
+tgcconnect       4146/udp # TGCConnect Beacon [Brian_Becker] [Brian_Becker] 2006-10
+vrxpservman      4147/tcp # Multum Service Manager [Scott_Mager] [Scott_Mager] 2006-10
+vrxpservman      4147/udp # Multum Service Manager [Scott_Mager] [Scott_Mager] 2006-10
+hhb-handheld     4148/tcp # HHB Handheld Client [Steven_G_Loughner] [Steven_G_Loughner] 2007-03
+hhb-handheld     4148/udp # HHB Handheld Client [Steven_G_Loughner] [Steven_G_Loughner] 2007-03
+agslb            4149/tcp # A10 GSLB Service [John_Chiong] [John_Chiong] 2007-07-02
+agslb            4149/udp # A10 GSLB Service [John_Chiong] [John_Chiong] 2007-07-02
+PowerAlert-nsa   4150/tcp # PowerAlert Network Shutdown Agent [Mike_Delgrosso_2] [Mike_Delgrosso_2] 2007-07-02
+PowerAlert-nsa   4150/udp # PowerAlert Network Shutdown Agent [Mike_Delgrosso_2] [Mike_Delgrosso_2] 2007-07-02
+menandmice-noh   4151/tcp # Men & Mice Remote ControlIANA assigned this well-formed service name as a replacement for "menandmice_noh". [Eggert_Thorlacius] [Eggert_Thorlacius] 2007-08-30
+menandmice_noh   4151/tcp # Men & Mice Remote Control [Eggert_Thorlacius] [Eggert_Thorlacius] 2007-08-30 This entry is an alias to "menandmice-noh".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+menandmice-noh   4151/udp # Men & Mice Remote ControlIANA assigned this well-formed service name as a replacement for "menandmice_noh". [Eggert_Thorlacius] [Eggert_Thorlacius] 2007-08-30
+menandmice_noh   4151/udp # Men & Mice Remote Control [Eggert_Thorlacius] [Eggert_Thorlacius] 2007-08-30 This entry is an alias to "menandmice-noh".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+idig-mux         4152/tcp # iDigTech MultiplexIANA assigned this well-formed service name as a replacement for "idig_mux". [Robin_Findley] [Robin_Findley] 2007-05
+idig_mux         4152/tcp # iDigTech Multiplex [Robin_Findley] [Robin_Findley] 2007-05 This entry is an alias to "idig-mux".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+idig-mux         4152/udp # iDigTech MultiplexIANA assigned this well-formed service name as a replacement for "idig_mux". [Robin_Findley] [Robin_Findley] 2007-05
+idig_mux         4152/udp # iDigTech Multiplex [Robin_Findley] [Robin_Findley] 2007-05 This entry is an alias to "idig-mux".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+mbl-battd        4153/tcp # MBL Remote Battery Monitoring [Claudio_Procida] [Claudio_Procida] 2007-05
+mbl-battd        4153/udp # MBL Remote Battery Monitoring [Claudio_Procida] [Claudio_Procida] 2007-05
+atlinks          4154/tcp # atlinks device discovery [Scott_Griepentrog] [Scott_Griepentrog] 2002-10
+atlinks          4154/udp # atlinks device discovery [Scott_Griepentrog] [Scott_Griepentrog] 2002-10
+bzr              4155/tcp # Bazaar version control system [Martin_Pool_2] [Martin_Pool_2] 2007-02
+bzr              4155/udp # Bazaar version control system [Martin_Pool_2] [Martin_Pool_2] 2007-02
+stat-results     4156/tcp # STAT Results
+stat-results     4156/udp # STAT Results
+stat-scanner     4157/tcp # STAT Scanner Control
+stat-scanner     4157/udp # STAT Scanner Control
+stat-cc          4158/tcp # STAT Command Center [Darwin_Ammala] [Darwin_Ammala] 2007-03
+stat-cc          4158/udp # STAT Command Center [Darwin_Ammala] [Darwin_Ammala] 2007-03
+nss              4159/tcp # Network Security Service [Dave_Wierbowski] [Dave_Wierbowski] 2006-08
+nss              4159/udp # Network Security Service [Dave_Wierbowski] [Dave_Wierbowski] 2006-08
+jini-discovery   4160/tcp # Jini Discovery [Mark_Hodapp] [Mark_Hodapp]
+jini-discovery   4160/udp # Jini Discovery [Mark_Hodapp] [Mark_Hodapp]
+omscontact       4161/tcp # OMS Contact
+omscontact       4161/udp # OMS Contact
+omstopology      4162/tcp # OMS Topology [David_Page] [David_Page] 2005-08
+omstopology      4162/udp # OMS Topology [David_Page] [David_Page] 2005-08
+silverpeakpeer   4163/tcp # Silver Peak Peer Protocol [Damon_Ennis] [Damon_Ennis] 2007-03
+silverpeakpeer   4163/udp # Silver Peak Peer Protocol [Damon_Ennis] [Damon_Ennis] 2007-03
+silverpeakcomm   4164/tcp # Silver Peak Communication Protocol [Damon_Ennis] [Damon_Ennis] 2007-03
+silverpeakcomm   4164/udp # Silver Peak Communication Protocol [Damon_Ennis] [Damon_Ennis] 2007-03
+altcp            4165/tcp # ArcLink over Ethernet [Dmitry_Brant] [Dmitry_Brant] 2007-03
+altcp            4165/udp # ArcLink over Ethernet [Dmitry_Brant] [Dmitry_Brant] 2007-03
+joost            4166/tcp # Joost Peer to Peer Protocol [Colm_MacCarthaigh] [Colm_MacCarthaigh] 2007-04
+joost            4166/udp # Joost Peer to Peer Protocol [Colm_MacCarthaigh] [Colm_MacCarthaigh] 2007-04
+ddgn             4167/tcp # DeskDirect Global Network [Laurie_Charlwood] [Laurie_Charlwood] 2007-08-22
+ddgn             4167/udp # DeskDirect Global Network [Laurie_Charlwood] [Laurie_Charlwood] 2007-08-22
+pslicser         4168/tcp # PrintSoft License Server [David_Weisgerber] [David_Weisgerber] 2007-09-27
+pslicser         4168/udp # PrintSoft License Server [David_Weisgerber] [David_Weisgerber] 2007-09-27
+iadt             4169/tcp # Automation Drive Interface Transport [Paul_Suhler] [Paul_Suhler] 2008-02-15
+iadt-disc        4169/udp # Internet ADT Discovery Protocol [Paul_A_Suhler] [Paul_A_Suhler] 2009-02-06
+d-cinema-csp     4170/tcp # SMPTE Content Synchonization Protocol [Michael_Karagosian] [Michael_Karagosian] 2008-09-04
+ml-svnet         4171/tcp # Maxlogic Supervisor Communication [Taha_Paksu] [Taha_Paksu] 2009-12-21
+pcoip            4172/tcp # PC over IP [Teradici] [Jeff_Dillabough] 2009-12-23 2012-03-06
+pcoip            4172/udp # PC over IP [Teradici] [Jeff_Dillabough] 2009-12-23 2012-03-06
+mma-discovery    4173/udp # MMA Device Discovery [MIDI_Manufacturers_Assoc_Inc] [Tom_White] 2011-11-14
+smcluster        4174/tcp # StorMagic Cluster Services [Chris_Farey] [Chris_Farey] 2011-03-09
+sm-disc          4174/udp # StorMagic Discovery [StorMagic_Ltd] [Chris_Farey] 2011-12-16
+bccp             4175/tcp # Brocade Cluster Communication Protocol [Norival_Figueira] [Norival_Figueira] 2010-04-07
+tl-ipcproxy      4176/tcp # Translattice Cluster IPC Proxy [Michael_Lyle] [Michael_Lyle] 2009-11-03
+wello            4177/tcp # Wello P2P pubsub service [Christian_Westbrook] [Christian_Westbrook] 2007-11-15
+wello            4177/udp # Wello P2P pubsub service [Christian_Westbrook] [Christian_Westbrook] 2007-11-15
+storman          4178/tcp # StorMan [Werner_Guertler] [Werner_Guertler] 2009-05-11
+storman          4178/udp # StorMan [Werner_Guertler] [Werner_Guertler] 2009-05-11
+MaxumSP          4179/tcp # Maxum Services [Greg_Stine] [Greg_Stine] 2007-07-05
+MaxumSP          4179/udp # Maxum Services [Greg_Stine] [Greg_Stine] 2007-07-05
+httpx            4180/tcp # HTTPX [Paul_McGough] [Paul_McGough] 2007-02
+httpx            4180/udp # HTTPX [Paul_McGough] [Paul_McGough] 2007-02
+macbak           4181/tcp # MacBak [Wes_Peters] [Wes_Peters] 2007-04
+macbak           4181/udp # MacBak [Wes_Peters] [Wes_Peters] 2007-04
+pcptcpservice    4182/tcp # Production Company Pro TCP Service [Ben_McNeill] [Ben_McNeill] 2007-05
+pcptcpservice    4182/udp # Production Company Pro TCP Service [Ben_McNeill] [Ben_McNeill] 2007-05
+gmmp             4183/tcp # General Metaverse Messaging Protocol [Gareth_Nelson] [Gareth_Nelson] 2007-06
+gmmp             4183/udp # General Metaverse Messaging Protocol [Gareth_Nelson] [Gareth_Nelson] 2007-06
+universe-suite   4184/tcp # UNIVERSE SUITE MESSAGE SERVICEIANA assigned this well-formed service name as a replacement for "universe_suite". [Gary_ANDREWS] [Gary_ANDREWS] 2008-01-07
+universe_suite   4184/tcp # UNIVERSE SUITE MESSAGE SERVICE [Gary_ANDREWS] [Gary_ANDREWS] 2008-01-07 This entry is an alias to "universe-suite".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+universe-suite   4184/udp # UNIVERSE SUITE MESSAGE SERVICEIANA assigned this well-formed service name as a replacement for "universe_suite". [Gary_ANDREWS] [Gary_ANDREWS] 2008-01-07
+universe_suite   4184/udp # UNIVERSE SUITE MESSAGE SERVICE [Gary_ANDREWS] [Gary_ANDREWS] 2008-01-07 This entry is an alias to "universe-suite".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+wcpp             4185/tcp # Woven Control Plane Protocol [Christopher_LILJENST] [Christopher_LILJENST] 2008-04-14
+wcpp             4185/udp # Woven Control Plane Protocol [Christopher_LILJENST] [Christopher_LILJENST] 2008-04-14
+boxbackupstore   4186/tcp # Box Backup Store Service [Chris_Wilson] [Chris_Wilson] 2008-09-11
+csc-proxy        4187/tcp # Cascade ProxyIANA assigned this well-formed service name as a replacement for "csc_proxy". [Matt_Craighead] [Matt_Craighead] 2008-09-11
+csc_proxy        4187/tcp # Cascade Proxy [Matt_Craighead] [Matt_Craighead] 2008-09-11 This entry is an alias to "csc-proxy".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+vatata           4188/tcp # Vatata Peer to Peer Protocol [Song_Jian] [Song_Jian] 2008-09-15
+vatata           4188/udp # Vatata Peer to Peer Protocol [Song_Jian] [Song_Jian] 2008-09-15
+pcep             4189/tcp # Path Computation Element Communication Protocol
+sieve            4190/tcp # ManageSieve Protocol
+dsmipv6          4191/udp # Dual Stack MIPv6 NAT Traversal [RFC5555]
+azeti            4192/tcp # Azeti Agent Service [Uwe_Holz] [Uwe_Holz] 2009-11-09
+azeti-bd         4192/udp # azeti blinddate [Michael_Werski] [Michael_Werski] 2010-02-18
+pvxplusio        4193/tcp # PxPlus remote file srvr [Mike_King] [Mike_King] 2009-11-09
+eims-admin       4199/tcp # EIMS ADMIN [Glenn_Anderson] [Glenn_Anderson]
+eims-admin       4199/udp # EIMS ADMIN [Glenn_Anderson] [Glenn_Anderson]
+corelccam        4300/tcp # Corel CCam [Jason_Aiken] [Jason_Aiken]
+corelccam        4300/udp # Corel CCam [Jason_Aiken] [Jason_Aiken]
+d-data           4301/tcp # Diagnostic Data
+d-data           4301/udp # Diagnostic Data
+d-data-control   4302/tcp # Diagnostic Data Control [Jon_March] [Jon_March] 2006-09
+d-data-control   4302/udp # Diagnostic Data Control [Jon_March] [Jon_March] 2006-09
+srcp             4303/tcp # Simple Railroad Command Protocol [Matthias_Trute] [Matthias_Trute] 2007-01
+srcp             4303/udp # Simple Railroad Command Protocol [Matthias_Trute] [Matthias_Trute] 2007-01
+owserver         4304/tcp # One-Wire Filesystem Server [Paul_Alfille] [Paul_Alfille] 2007-01 Defined TXT keys: txtvers
+owserver         4304/udp # One-Wire Filesystem Server [Paul_Alfille] [Paul_Alfille] 2007-01 Defined TXT keys: txtvers
+batman           4305/tcp # better approach to mobile ad-hoc networking [Simon_Wunderlich] [Simon_Wunderlich] 2007-08-30
+batman           4305/udp # better approach to mobile ad-hoc networking [Simon_Wunderlich] [Simon_Wunderlich] 2007-08-30
+pinghgl          4306/tcp # Hellgate London [David_Berk] [David_Berk] 2007-08-30
+pinghgl          4306/udp # Hellgate London [David_Berk] [David_Berk] 2007-08-30
+visicron-vs      4307/tcp # Visicron Videoconference Service [Alexey_Vlaskin] [Alexey_Vlaskin] 2007-10-22
+visicron-vs      4307/udp # Visicron Videoconference Service [Alexey_Vlaskin] [Alexey_Vlaskin] 2007-10-22
+compx-lockview   4308/tcp # CompX-LockView [John_Payson] [John_Payson] 2007-10-22
+compx-lockview   4308/udp # CompX-LockView [John_Payson] [John_Payson] 2007-10-22
+dserver          4309/tcp # Exsequi Appliance Discovery [Angelo_Masci] [Angelo_Masci] 2007-01
+dserver          4309/udp # Exsequi Appliance Discovery [Angelo_Masci] [Angelo_Masci] 2007-01
+mirrtex          4310/tcp # Mir-RT exchange service [Sylvain_Robert] [Sylvain_Robert] 2008-02-14
+mirrtex          4310/udp # Mir-RT exchange service [Sylvain_Robert] [Sylvain_Robert] 2008-02-14
+p6ssmc           4311/tcp # P6R Secure Server Management Console [Jim_Susoy] [Jim_Susoy] 2010-01-21
+pscl-mgt         4312/tcp # Parascale Membership Manager [John_Muth] [John_Muth] 2010-01-21
+perrla           4313/tcp # PERRLA User Services [Cliff_Batson] [Cliff_Batson] 2010-01-21
+choiceview-agt   4314/tcp # ChoiceView Agent [Radish_Systems] [Richard_A_Davis] 2013-03-28
+choiceview-clt   4316/tcp # ChoiceView Client [Radish_Systems] [Richard_A_Davis] 2013-03-28
+fdt-rcatp        4320/tcp # FDT Remote Categorization Protocol [Russell_P_Holsclaw] [Russell_P_Holsclaw] 2006-03
+fdt-rcatp        4320/udp # FDT Remote Categorization Protocol [Russell_P_Holsclaw] [Russell_P_Holsclaw] 2006-03
+rwhois           4321/tcp # Remote Who Is [Mark_Kosters] [Mark_Kosters] [RFC2167]
+rwhois           4321/udp # Remote Who Is [Mark_Kosters] [Mark_Kosters] [RFC2167]
+trim-event       4322/tcp # TRIM Event Service
+trim-event       4322/udp # TRIM Event Service
+trim-ice         4323/tcp # TRIM ICE Service [Siva_Poobalasingam_2] [Siva_Poobalasingam_2] 2007-02
+trim-ice         4323/udp # TRIM ICE Service [Siva_Poobalasingam_2] [Siva_Poobalasingam_2] 2007-02
+balour           4324/tcp # Balour Game Server [Konstantin_Schauweck] [Konstantin_Schauweck] 2007-02
+balour           4324/udp # Balour Game Server [Konstantin_Schauweck] [Konstantin_Schauweck] 2007-02
+geognosisman     4325/tcp # Cadcorp GeognoSIS Manager Service
+geognosisman     4325/udp # Cadcorp GeognoSIS Manager Service
+geognosis        4326/tcp # Cadcorp GeognoSIS Service [Martin_Daly] [Martin_Daly] 2006-11
+geognosis        4326/udp # Cadcorp GeognoSIS Service [Martin_Daly] [Martin_Daly] 2006-11
+jaxer-web        4327/tcp # Jaxer Web Protocol [Uri_Sarid] [Uri_Sarid] 2008-01-07
+jaxer-web        4327/udp # Jaxer Web Protocol [Uri_Sarid] [Uri_Sarid] 2008-01-07
+jaxer-manager    4328/tcp # Jaxer Manager Command Protocol [Uri_Sarid] [Uri_Sarid] 2008-01-22
+jaxer-manager    4328/udp # Jaxer Manager Command Protocol [Uri_Sarid] [Uri_Sarid] 2008-01-22
+publiqare-sync   4329/tcp # PubliQare Distributed Environment Synchronisation Engine [Tom_Maaswinkel] [Tom_Maaswinkel] 2011-02-07
+dey-sapi         4330/tcp # DEY Storage Administration REST API [DEY_Storage_Systems_Inc] [Garrett_D_Amore] 2013-03-01
+gaia             4340/tcp # Gaia Connector Protocol [Philippe_Detournay] [Philippe_Detournay] 2007-11-12
+gaia             4340/udp # Gaia Connector Protocol [Philippe_Detournay] [Philippe_Detournay] 2007-11-12
+lisp-data        4341/tcp # LISP Data Packets [Dino_Farinacci] [Dino_Farinacci] 2007-11-12
+lisp-data        4341/udp # LISP Data Packets [IESG] [IETF_Chair] 2007-11-12 2012-04-26 [RFC6830]
+lisp-cons        4342/tcp # LISP-CONS Control
+lisp-control     4342/udp # LISP Control Packets [IESG] [IETF_Chair] 2007-05 2012-04-26 [RFC6830]
+unicall          4343/tcp # UNICALL [James_Powell_2] [James_Powell_2]
+unicall          4343/udp # UNICALL [James_Powell_2] [James_Powell_2]
+vinainstall      4344/tcp # VinaInstall [Jay_Slupesky] [Jay_Slupesky]
+vinainstall      4344/udp # VinaInstall [Jay_Slupesky] [Jay_Slupesky]
+m4-network-as    4345/tcp # Macro 4 Network AS [Paul_Wren] [Paul_Wren]
+m4-network-as    4345/udp # Macro 4 Network AS [Paul_Wren] [Paul_Wren]
+elanlm           4346/tcp # ELAN LM [Paul_Ballew] [Paul_Ballew]
+elanlm           4346/udp # ELAN LM [Paul_Ballew] [Paul_Ballew]
+lansurveyor      4347/tcp # LAN Surveyor [Michael_Swan] [Michael_Swan]
+lansurveyor      4347/udp # LAN Surveyor [Michael_Swan] [Michael_Swan]
+itose            4348/tcp # ITOSE [Michael_Haeuptle] [Michael_Haeuptle]
+itose            4348/udp # ITOSE [Michael_Haeuptle] [Michael_Haeuptle]
+fsportmap        4349/tcp # File System Port Map [Ron_Minnich_2] [Ron_Minnich_2]
+fsportmap        4349/udp # File System Port Map [Ron_Minnich_2] [Ron_Minnich_2]
+net-device       4350/tcp # Net Device [Glenn_Peterson] [Glenn_Peterson]
+net-device       4350/udp # Net Device [Glenn_Peterson] [Glenn_Peterson]
+plcy-net-svcs    4351/tcp # PLCY Net Services [J_J_Ekstrom] [J_J_Ekstrom]
+plcy-net-svcs    4351/udp # PLCY Net Services [J_J_Ekstrom] [J_J_Ekstrom]
+pjlink           4352/tcp # Projector Link [Mitsuo_Kodama] [Mitsuo_Kodama] 2005-06
+pjlink           4352/udp # Projector Link [Mitsuo_Kodama] [Mitsuo_Kodama] 2005-06
+f5-iquery        4353/tcp # F5 iQuery [Tom_Kee] [Tom_Kee]
+f5-iquery        4353/udp # F5 iQuery [Tom_Kee] [Tom_Kee]
+qsnet-trans      4354/tcp # QSNet Transmitter
+qsnet-trans      4354/udp # QSNet Transmitter
+qsnet-workst     4355/tcp # QSNet Workstation
+qsnet-workst     4355/udp # QSNet Workstation
+qsnet-assist     4356/tcp # QSNet Assistant
+qsnet-assist     4356/udp # QSNet Assistant
+qsnet-cond       4357/tcp # QSNet Conductor
+qsnet-cond       4357/udp # QSNet Conductor
+qsnet-nucl       4358/tcp # QSNet Nucleus [Neer_Kleinman] [Neer_Kleinman]
+qsnet-nucl       4358/udp # QSNet Nucleus [Neer_Kleinman] [Neer_Kleinman]
+omabcastltkm     4359/tcp # OMA BCAST Long-Term Key Messages [Frank_Hartung] [Frank_Hartung] 2007-09-07
+omabcastltkm     4359/udp # OMA BCAST Long-Term Key Messages [Frank_Hartung] [Frank_Hartung] 2007-09-07
+matrix-vnet      4360/tcp # Matrix VNet Communication ProtocolIANA assigned this well-formed service name as a replacement for "matrix_vnet". [Rehan_Mahmood] [Rehan_Mahmood] 2009-03-18
+matrix_vnet      4360/tcp # Matrix VNet Communication Protocol [Rehan_Mahmood] [Rehan_Mahmood] 2009-03-18 This entry is an alias to "matrix-vnet".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+nacnl            4361/udp # NavCom Discovery and Control Port [Yilei_Jia] [Yilei_Jia] 2009-03-18
+afore-vdp-disc   4362/udp # AFORE vNode Discovery protocol [Michael_Richardson] [Michael_Richardson] 2011-02-08
+wxbrief          4368/tcp # WeatherBrief Direct [Kim_Alan_Waggoner] [Kim_Alan_Waggoner] 2006-11
+wxbrief          4368/udp # WeatherBrief Direct [Kim_Alan_Waggoner] [Kim_Alan_Waggoner] 2006-11
+epmd             4369/tcp # Erlang Port Mapper Daemon [Erlang] [Erlang]
+epmd             4369/udp # Erlang Port Mapper Daemon [Erlang] [Erlang]
+elpro-tunnel     4370/tcp # ELPRO V2 Protocol TunnelIANA assigned this well-formed service name as a replacement for "elpro_tunnel". [Harry_Courtice] [Harry_Courtice] 2008-04-14
+elpro_tunnel     4370/tcp # ELPRO V2 Protocol Tunnel [Harry_Courtice] [Harry_Courtice] 2008-04-14 This entry is an alias to "elpro-tunnel".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+elpro-tunnel     4370/udp # ELPRO V2 Protocol TunnelIANA assigned this well-formed service name as a replacement for "elpro_tunnel". [Harry_Courtice] [Harry_Courtice] 2008-04-14
+elpro_tunnel     4370/udp # ELPRO V2 Protocol Tunnel [Harry_Courtice] [Harry_Courtice] 2008-04-14 This entry is an alias to "elpro-tunnel".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+l2c-control      4371/tcp # LAN2CAN Control [Phil_Tolson] [Phil_Tolson] 2008-07-07 Modified: 21 January 2010
+l2c-disc         4371/udp # LAN2CAN Discovery [Phil_Tolson] [Phil_Tolson] 2010-01-21
+l2c-data         4372/tcp # LAN2CAN Data [Phil_Tolson] [Phil_Tolson] 2008-07-07 Modified: 21 January 2010
+l2c-data         4372/udp # LAN2CAN Data [Phil_Tolson] [Phil_Tolson] 2010-01-21
+remctl           4373/tcp # Remote Authenticated Command Service [Russ_Allbery] [Russ_Allbery] 2007-08-30
+remctl           4373/udp # Remote Authenticated Command Service [Russ_Allbery] [Russ_Allbery] 2007-08-30
+psi-ptt          4374/tcp # PSI Push-to-Talk Protocol [Frank_B] [Frank_B] 2008-07-17
+tolteces         4375/tcp # Toltec EasyShare [Joon_Radley_2] [Joon_Radley_2] 2008-10-21
+tolteces         4375/udp # Toltec EasyShare [Joon_Radley_2] [Joon_Radley_2] 2008-10-21
+bip              4376/tcp # BioAPI Interworking [Jean_Paul_Lemaire] [Jean_Paul_Lemaire] 2007-07-05
+bip              4376/udp # BioAPI Interworking [Jean_Paul_Lemaire] [Jean_Paul_Lemaire] 2007-07-05
+cp-spxsvr        4377/tcp # Cambridge Pixel SPx Server
+cp-spxsvr        4377/udp # Cambridge Pixel SPx Server
+cp-spxdpy        4378/tcp # Cambridge Pixel SPx Display [Richard_Warren] [Richard_Warren] 2007-07-05
+cp-spxdpy        4378/udp # Cambridge Pixel SPx Display [Richard_Warren] [Richard_Warren] 2007-07-05
+ctdb             4379/tcp # CTDB [Ronnie_Sahlberg] [Ronnie_Sahlberg] 2007-07-05
+ctdb             4379/udp # CTDB [Ronnie_Sahlberg] [Ronnie_Sahlberg] 2007-07-05
+xandros-cms      4389/tcp # Xandros Community Management Service [Stephen_M_Webb] [Stephen_M_Webb] 2007-05
+xandros-cms      4389/udp # Xandros Community Management Service [Stephen_M_Webb] [Stephen_M_Webb] 2007-05
+wiegand          4390/tcp # Physical Access Control [Scott_Guthery_2] [Scott_Guthery_2] 2008-08-25
+wiegand          4390/udp # Physical Access Control [Scott_Guthery_2] [Scott_Guthery_2] 2008-08-25
+apwi-imserver    4391/tcp # American Printware IMServer Protocol [Lech_Lakomy] [Lech_Lakomy] 2009-02-12
+apwi-rxserver    4392/tcp # American Printware RXServer Protocol [Lech_Lakomy] [Lech_Lakomy] 2009-02-12
+apwi-rxspooler   4393/tcp # American Printware RXSpooler Protocol [Lech_Lakomy] [Lech_Lakomy] 2009-02-12
+apwi-disc        4394/udp # American Printware Discovery [Lech_Lakomy] [Lech_Lakomy] 2009-02-12
+omnivisionesx    4395/tcp # OmniVision communication for Virtual environments [Vacquier_Serge] [Vacquier_Serge] 2009-02-12
+omnivisionesx    4395/udp # OmniVision communication for Virtual environments [Vacquier_Serge] [Vacquier_Serge] 2009-02-12
+fly              4396/tcp # Fly Object Space [Nigel_Warren] [Nigel_Warren] 2009-02-12
+ds-srv           4400/tcp # ASIGRA Services [David_Farajun] [David_Farajun] 2004-11
+ds-srv           4400/udp # ASIGRA Services [David_Farajun] [David_Farajun] 2004-11
+ds-srvr          4401/tcp # ASIGRA Televaulting DS-System Service
+ds-srvr          4401/udp # ASIGRA Televaulting DS-System Service
+ds-clnt          4402/tcp # ASIGRA Televaulting DS-Client Service
+ds-clnt          4402/udp # ASIGRA Televaulting DS-Client Service
+ds-user          4403/tcp # ASIGRA Televaulting DS-Client Monitoring/Management
+ds-user          4403/udp # ASIGRA Televaulting DS-Client Monitoring/Management
+ds-admin         4404/tcp # ASIGRA Televaulting DS-System Monitoring/Management
+ds-admin         4404/udp # ASIGRA Televaulting DS-System Monitoring/Management
+ds-mail          4405/tcp # ASIGRA Televaulting Message Level Restore service
+ds-mail          4405/udp # ASIGRA Televaulting Message Level Restore service
+ds-slp           4406/tcp # ASIGRA Televaulting DS-Sleeper Service [Andrei_Litvinn] [Andrei_Litvinn] 2005-01
+ds-slp           4406/udp # ASIGRA Televaulting DS-Sleeper Service [Andrei_Litvinn] [Andrei_Litvinn] 2005-01
+nacagent         4407/tcp # Network Access Control Agent [ITGroup] [ITGroup] 2008-06-30
+slscc            4408/tcp # SLS Technology Control Centre [Steven_Sweeting] [Steven_Sweeting] 2008-01-28
+netcabinet-com   4409/tcp # Net-Cabinet comunication [Ian_Manning_2] [Ian_Manning_2] 2009-12-16
+itwo-server      4410/tcp # RIB iTWO Application Server [Kristean_Heisler_2] [Kristean_Heisler_2] 2009-12-16
+found            4411/tcp # Found Messaging Protocol [Found_Software] [John_Mitchell] 2012-04-11 Defined TXT keys: id, key
+netrockey6       4425/tcp # NetROCKEY6 SMART Plus Service [Feitian_Technologies] [Feitian_Technologies] 2010-09-15
+netrockey6       4425/udp # NetROCKEY6 SMART Plus Service [Feitian_Technologies] [Feitian_Technologies] 2010-09-15
+beacon-port-2    4426/tcp # SMARTS Beacon Port [Eyal_Yardeni] [Eyal_Yardeni] 2003-11
+beacon-port-2    4426/udp # SMARTS Beacon Port [Eyal_Yardeni] [Eyal_Yardeni] 2003-11
+drizzle          4427/tcp # Drizzle database server [Elliot_Murphy] [Elliot_Murphy] 2008-07-09
+omviserver       4428/tcp # OMV-Investigation Server-Client [Serge_Vacquier] [Serge_Vacquier] 2009-05-20
+omviagent        4429/tcp # OMV Investigation Agent-Server [Serge_Vacquier] [Serge_Vacquier] 2009-05-20
+rsqlserver       4430/tcp # REAL SQL Server [Marco_Bambini] [Marco_Bambini] 2008-08-28
+rsqlserver       4430/udp # REAL SQL Server [Marco_Bambini] [Marco_Bambini] 2008-08-28
+wspipe           4431/tcp # adWISE Pipe [Heikki_E] [Heikki_E] 2009-06-18
+l-acoustics      4432/tcp # L-ACOUSTICS management [L-ACOUSTICS] [Christophe_Pignon] 2012-08-13
+l-acoustics      4432/udp # L-ACOUSTICS management [L-ACOUSTICS] [Christophe_Pignon] 2012-08-13
+vop              4433/tcp # Versile Object Protocol [Versile_AS] [Tore_Skaug] 2012-02-01
+netblox          4441/udp # Netblox Protocol [Brian_S_Locke] [Brian_S_Locke] 2008-07-10
+saris            4442/tcp # Saris
+saris            4442/udp # Saris
+pharos           4443/tcp # Pharos [TeleConsult] [TeleConsult]
+pharos           4443/udp # Pharos [TeleConsult] [TeleConsult]
+krb524           4444/tcp # KRB524 [B_Clifford_Neuman] [B_Clifford_Neuman] krb524 assigned the port, nv used it without an assignment
+krb524           4444/udp # KRB524 [B_Clifford_Neuman] [B_Clifford_Neuman] krb524 assigned the port, nv used it without an assignment
+nv-video         4444/tcp # NV Video default [Ron_Frederick] [Ron_Frederick] krb524 assigned the port, nv used it without an assignment
+nv-video         4444/udp # NV Video default [Ron_Frederick] [Ron_Frederick] krb524 assigned the port, nv used it without an assignment
+upnotifyp        4445/tcp # UPNOTIFYP [Mark_Fox] [Mark_Fox]
+upnotifyp        4445/udp # UPNOTIFYP [Mark_Fox] [Mark_Fox]
+n1-fwp           4446/tcp # N1-FWP
+n1-fwp           4446/udp # N1-FWP
+n1-rmgmt         4447/tcp # N1-RMGMT [Lori_Tassin] [Lori_Tassin]
+n1-rmgmt         4447/udp # N1-RMGMT [Lori_Tassin] [Lori_Tassin]
+asc-slmd         4448/tcp # ASC Licence Manager [Casper_Stoel] [Casper_Stoel]
+asc-slmd         4448/udp # ASC Licence Manager [Casper_Stoel] [Casper_Stoel]
+privatewire      4449/tcp # PrivateWire [Uri_Resnitzky] [Uri_Resnitzky]
+privatewire      4449/udp # PrivateWire [Uri_Resnitzky] [Uri_Resnitzky]
+camp             4450/tcp # Common ASCII Messaging Protocol [Control_Technology_Inc] [Clint_Eskew] 2011-10-28
+camp             4450/udp # Common ASCII Messaging Protocol [Control_Technology_Inc] [Clint_Eskew] 2011-10-28
+ctisystemmsg     4451/tcp # CTI System Msg [Control_Technology_Inc] [Clint_Eskew] 2011-10-28
+ctisystemmsg     4451/udp # CTI System Msg [Control_Technology_Inc] [Clint_Eskew] 2011-10-28
+ctiprogramload   4452/tcp # CTI Program Load [Control_Technology_Inc] [Clint_Eskew] 2011-10-28
+ctiprogramload   4452/udp # CTI Program Load [Control_Technology_Inc] [Clint_Eskew] 2011-10-28
+nssalertmgr      4453/tcp # NSS Alert Manager
+nssalertmgr      4453/udp # NSS Alert Manager
+nssagentmgr      4454/tcp # NSS Agent Manager [Jim_Hill] [Jim_Hill]
+nssagentmgr      4454/udp # NSS Agent Manager [Jim_Hill] [Jim_Hill]
+prchat-user      4455/tcp # PR Chat User
+prchat-user      4455/udp # PR Chat User
+prchat-server    4456/tcp # PR Chat Server
+prchat-server    4456/udp # PR Chat Server
+prRegister       4457/tcp # PR Register [Donny_Gilor] [Donny_Gilor]
+prRegister       4457/udp # PR Register [Donny_Gilor] [Donny_Gilor]
+mcp              4458/tcp # Matrix Configuration Protocol [Tim_DeBaillie] [Tim_DeBaillie] 2006-12
+mcp              4458/udp # Matrix Configuration Protocol [Tim_DeBaillie] [Tim_DeBaillie] 2006-12
+hpssmgmt         4484/tcp # hpssmgmt service [David_Straw] [David_Straw] 2005-11
+hpssmgmt         4484/udp # hpssmgmt service [David_Straw] [David_Straw] 2005-11
+assyst-dr        4485/tcp # Assyst Data Repository Service [Albert_Cester] [Albert_Cester] 2008-08-26
+icms             4486/tcp # Integrated Client Message Service [Resource_Allocation] [Resource_Allocation] 2010-09-27
+icms             4486/udp # Integrated Client Message Service [Resource_Allocation] [Resource_Allocation] 2010-09-27
+prex-tcp         4487/tcp # Protocol for Remote Execution over TCP [Daniel_Ruppert] [Daniel_Ruppert] 2010-09-16
+awacs-ice        4488/tcp # Apple Wide Area Connectivity Service ICE Bootstrap [Rory_McGuire] [Rory_McGuire] 2010-09-24
+awacs-ice        4488/udp # Apple Wide Area Connectivity Service ICE Bootstrap [Rory_McGuire] [Rory_McGuire] 2010-09-24
+ipsec-nat-t      4500/tcp # IPsec NAT-Traversal [RFC3947]
+ipsec-nat-t      4500/udp # IPsec NAT-Traversal [RFC3947]
+a25-fap-fgw      4502/sctp # A25 (FAP-FGW) [ThreeGPP2] [Zhiming_Li] 2012-01-11
+armagetronad     4534/udp # Armagetron Advanced Game Server [Manuel_Moos] [Yann_Kaiser] 2012-11-02
+ehs              4535/tcp # Event Heap Server
+ehs              4535/udp # Event Heap Server
+ehs-ssl          4536/tcp # Event Heap Server SSL [Brad_Johanson] [Brad_Johanson] 2005-08
+ehs-ssl          4536/udp # Event Heap Server SSL [Brad_Johanson] [Brad_Johanson] 2005-08
+wssauthsvc       4537/tcp # WSS Security Service [Mark_Tirschwell] [Mark_Tirschwell] 2006-01
+wssauthsvc       4537/udp # WSS Security Service [Mark_Tirschwell] [Mark_Tirschwell] 2006-01
+swx-gate         4538/tcp # Software Data Exchange Gateway [Julien_VALIENTE] [Julien_VALIENTE] 2006-05
+swx-gate         4538/udp # Software Data Exchange Gateway [Julien_VALIENTE] [Julien_VALIENTE] 2006-05
+worldscores      4545/tcp # WorldScores [Steve_Davis] [Steve_Davis]
+worldscores      4545/udp # WorldScores [Steve_Davis] [Steve_Davis]
+sf-lm            4546/tcp # SF License Manager (Sentinel) [Thomas_Koell] [Thomas_Koell]
+sf-lm            4546/udp # SF License Manager (Sentinel) [Thomas_Koell] [Thomas_Koell]
+lanner-lm        4547/tcp # Lanner License Manager [Les_Enstone] [Les_Enstone]
+lanner-lm        4547/udp # Lanner License Manager [Les_Enstone] [Les_Enstone]
+synchromesh      4548/tcp # Synchromesh [Tom_Hawkins_2] [Tom_Hawkins_2] 2006-02
+synchromesh      4548/udp # Synchromesh [Tom_Hawkins_2] [Tom_Hawkins_2] 2006-02
+aegate           4549/tcp # Aegate PMR Service [Nick_Warrington] [Nick_Warrington] 2006-03
+aegate           4549/udp # Aegate PMR Service [Nick_Warrington] [Nick_Warrington] 2006-03
+gds-adppiw-db    4550/tcp # Perman I Interbase Server [Leo_Lesage] [Leo_Lesage] 2006-04
+gds-adppiw-db    4550/udp # Perman I Interbase Server [Leo_Lesage] [Leo_Lesage] 2006-04
+ieee-mih         4551/tcp # MIH Services [RFC5677]
+ieee-mih         4551/udp # MIH Services [RFC5677]
+menandmice-mon   4552/tcp # Men and Mice Monitoring [Carsten_Strotmann] [Carsten_Strotmann] 2009-05-20
+menandmice-mon   4552/udp # Men and Mice Monitoring [Carsten_Strotmann] [Carsten_Strotmann] 2009-05-20
+icshostsvc       4553/tcp # ICS host services [Gordan_Vosicki] [Gordan_Vosicki] 2009-09-23
+msfrs            4554/tcp # MS FRS Replication [Kev_George] [Kev_George] 2006-09
+msfrs            4554/udp # MS FRS Replication [Kev_George] [Kev_George] 2006-09
+rsip             4555/tcp # RSIP Port [RFC3103]
+rsip             4555/udp # RSIP Port [RFC3103]
+dtn-bundle-tcp   4556/tcp # DTN Bundle TCP CL Protocol
+dtn-bundle-udp   4556/udp # DTN Bundle UDP CL Protocol [Michael_Demmer] [Michael_Demmer] 2006-11
+mtcevrunqss      4557/udp # Marathon everRun Quorum Service Server [David_Schwartz_2] [David_Schwartz_2] 2009-06-18
+mtcevrunqman     4558/udp # Marathon everRun Quorum Service Manager [David_Schwartz_2] [David_Schwartz_2] 2009-06-18
+hylafax          4559/tcp # HylaFAX [Lee_Howard] [Lee_Howard] 2002-03
+hylafax          4559/udp # HylaFAX [Lee_Howard] [Lee_Howard] 2002-03
+kwtc             4566/tcp # Kids Watch Time Control Service [Larry_Zarou] [Larry_Zarou] 2006-10
+kwtc             4566/udp # Kids Watch Time Control Service [Larry_Zarou] [Larry_Zarou] 2006-10
+tram             4567/tcp # TRAM [Joe_Wesley] [Joe_Wesley]
+tram             4567/udp # TRAM [Joe_Wesley] [Joe_Wesley]
+bmc-reporting    4568/tcp # BMC Reporting [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-reporting    4568/udp # BMC Reporting [Portnoy_Boxman] [Portnoy_Boxman]
+iax              4569/tcp # Inter-Asterisk eXchange [Benjamin_Kowarsch] [Benjamin_Kowarsch] [RFC5456] Defined TXT keys:  auth          plaintext | md5 | rsakeys  userid        alphanumeric, additionally '_', '+', '-'  secret        any printable ASCII characters  domain        any DNS domain name or IP address  extension     alphanumeric, additionally '*', '#', '_', '+', '-'  context       alphanumeric, additionally '_', '+', '-'  trunk         yes | no | 0 | 1  welcome       alphanumeric, additionally '*', '#', '_', '+', '-'  voicemail     alphanumeric, additionally '*', '#', '_', '+', '-'  reception     alphanumeric, additionally '*', '#', '_', '+', '-'  echotest      alphanumeric, additionally '*', '#', '_', '+', '-'  ivrtest       alphanumeric, additionally '*', '#', '_', '+', '-'All of these TXT record keys are optional, they may be omitted.Further keys may be added in the future.
+iax              4569/udp # Inter-Asterisk eXchange [Benjamin_Kowarsch] [Benjamin_Kowarsch] [RFC5456] Defined TXT keys:  auth          plaintext | md5 | rsakeys  userid        alphanumeric, additionally '_', '+', '-'  secret        any printable ASCII characters  domain        any DNS domain name or IP address  extension     alphanumeric, additionally '*', '#', '_', '+', '-'  context       alphanumeric, additionally '_', '+', '-'  trunk         yes | no | 0 | 1  welcome       alphanumeric, additionally '*', '#', '_', '+', '-'  voicemail     alphanumeric, additionally '*', '#', '_', '+', '-'  reception     alphanumeric, additionally '*', '#', '_', '+', '-'  echotest      alphanumeric, additionally '*', '#', '_', '+', '-'  ivrtest       alphanumeric, additionally '*', '#', '_', '+', '-'All of these TXT record keys are optional, they may be omitted.Further keys may be added in the future.
+rid              4590/tcp # RID over HTTP/TLS [IESG] [IETF_Chair] [RFC6546]
+l3t-at-an        4591/tcp # HRPD L3T (AT-AN) [Avi_Lior] [Avi_Lior] 2009-02-27
+l3t-at-an        4591/udp # HRPD L3T (AT-AN) [Avi_Lior] [Avi_Lior] 2009-02-27
+hrpd-ith-at-an   4592/udp # HRPD-ITH (AT-AN) [David_Ott] [David_Ott] 2008-06-05
+ipt-anri-anri    4593/tcp # IPT (ANRI-ANRI)
+ipt-anri-anri    4593/udp # IPT (ANRI-ANRI)
+ias-session      4594/tcp # IAS-Session (ANRI-ANRI)
+ias-session      4594/udp # IAS-Session (ANRI-ANRI)
+ias-paging       4595/tcp # IAS-Paging (ANRI-ANRI)
+ias-paging       4595/udp # IAS-Paging (ANRI-ANRI)
+ias-neighbor     4596/tcp # IAS-Neighbor (ANRI-ANRI) [David_Ott] [David_Ott] 2007-07-31
+ias-neighbor     4596/udp # IAS-Neighbor (ANRI-ANRI) [David_Ott] [David_Ott] 2007-07-31
+a21-an-1xbs      4597/tcp # A21 (AN-1xBS) [David_Ott] [David_Ott] 2006-02
+a21-an-1xbs      4597/udp # A21 (AN-1xBS) [David_Ott] [David_Ott] 2006-02
+a16-an-an        4598/tcp # A16 (AN-AN) [David_Ott] [David_Ott] 2005-12
+a16-an-an        4598/udp # A16 (AN-AN) [David_Ott] [David_Ott] 2005-12
+a17-an-an        4599/tcp # A17 (AN-AN) [David_Ott] [David_Ott] 2006-02
+a17-an-an        4599/udp # A17 (AN-AN) [David_Ott] [David_Ott] 2006-02
+piranha1         4600/tcp # Piranha1
+piranha1         4600/udp # Piranha1
+piranha2         4601/tcp # Piranha2 [Primark_Corporation] [Primark_Corporation]
+piranha2         4601/udp # Piranha2 [Primark_Corporation] [Primark_Corporation]
+mtsserver        4602/tcp # EAX MTS Server [Pedro_A_Rodriguez] [Pedro_A_Rodriguez] 2008-08-06
+menandmice-upg   4603/tcp # Men & Mice Upgrade Agent [Eggert_Thorlacius_2] [Eggert_Thorlacius_2] 2010-01-27
+playsta2-app     4658/tcp # PlayStation2 App Port
+playsta2-app     4658/udp # PlayStation2 App Port
+playsta2-lob     4659/tcp # PlayStation2 Lobby Port [Noam_Rimon] [Noam_Rimon] 2004-12
+playsta2-lob     4659/udp # PlayStation2 Lobby Port [Noam_Rimon] [Noam_Rimon] 2004-12
+smaclmgr         4660/tcp # smaclmgr [Hiromi_Taki] [Hiromi_Taki]
+smaclmgr         4660/udp # smaclmgr [Hiromi_Taki] [Hiromi_Taki]
+kar2ouche        4661/tcp # Kar2ouche Peer location service [Andy_Krouwel] [Andy_Krouwel]
+kar2ouche        4661/udp # Kar2ouche Peer location service [Andy_Krouwel] [Andy_Krouwel]
+oms              4662/tcp # OrbitNet Message Service [Roy_Davies] [Roy_Davies] 2005-08
+oms              4662/udp # OrbitNet Message Service [Roy_Davies] [Roy_Davies] 2005-08
+noteit           4663/tcp # Note It! Message Service [Pedro_Alpedrinha] [Pedro_Alpedrinha] 2006-02
+noteit           4663/udp # Note It! Message Service [Pedro_Alpedrinha] [Pedro_Alpedrinha] 2006-02
+ems              4664/tcp # Rimage Messaging Server [David_V_Raskin] [David_V_Raskin] 2006-02
+ems              4664/udp # Rimage Messaging Server [David_V_Raskin] [David_V_Raskin] 2006-02
+contclientms     4665/tcp # Container Client Message Service [Bruce_Thompson] [Bruce_Thompson] 2006-02
+contclientms     4665/udp # Container Client Message Service [Bruce_Thompson] [Bruce_Thompson] 2006-02
+eportcomm        4666/tcp # E-Port Message Service
+eportcomm        4666/udp # E-Port Message Service
+mmacomm          4667/tcp # MMA Comm Services
+mmacomm          4667/udp # MMA Comm Services
+mmaeds           4668/tcp # MMA EDS Service [Robert_Shaffer] [Robert_Shaffer] 2006-02
+mmaeds           4668/udp # MMA EDS Service [Robert_Shaffer] [Robert_Shaffer] 2006-02
+eportcommdata    4669/tcp # E-Port Data Service [Robert_Shaffer] [Robert_Shaffer] 2006-02
+eportcommdata    4669/udp # E-Port Data Service [Robert_Shaffer] [Robert_Shaffer] 2006-02
+light            4670/tcp # Light packets transfer protocol [Adam_Golovenko] [Adam_Golovenko] 2006-10
+light            4670/udp # Light packets transfer protocol [Adam_Golovenko] [Adam_Golovenko] 2006-10
+acter            4671/tcp # Bull RSF action server [Christian_Caudrelier] [Christian_Caudrelier] 2006-02
+acter            4671/udp # Bull RSF action server [Christian_Caudrelier] [Christian_Caudrelier] 2006-02
+rfa              4672/tcp # remote file access server
+rfa              4672/udp # remote file access server
+cxws             4673/tcp # CXWS Operations [Phil_Abercrombie] [Phil_Abercrombie] 2005-08
+cxws             4673/udp # CXWS Operations [Phil_Abercrombie] [Phil_Abercrombie] 2005-08
+appiq-mgmt       4674/tcp # AppIQ Agent Management [Phil_Abercrombie] [Phil_Abercrombie] 2005-08
+appiq-mgmt       4674/udp # AppIQ Agent Management [Phil_Abercrombie] [Phil_Abercrombie] 2005-08
+dhct-status      4675/tcp # BIAP Device Status
+dhct-status      4675/udp # BIAP Device Status
+dhct-alerts      4676/tcp # BIAP Generic Alert [Louis_Slothouber] [Louis_Slothouber] 2005-08
+dhct-alerts      4676/udp # BIAP Generic Alert [Louis_Slothouber] [Louis_Slothouber] 2005-08
+bcs              4677/tcp # Business Continuity Servi [Siew_Sim] [Siew_Sim] 2005-08
+bcs              4677/udp # Business Continuity Servi [Siew_Sim] [Siew_Sim] 2005-08
+traversal        4678/tcp # boundary traversal [Kevin_Lu] [Kevin_Lu] 2005-08
+traversal        4678/udp # boundary traversal [Kevin_Lu] [Kevin_Lu] 2005-08
+mgesupervision   4679/tcp # MGE UPS Supervision
+mgesupervision   4679/udp # MGE UPS Supervision
+mgemanagement    4680/tcp # MGE UPS Management [Lecuivre_J] [Lecuivre_J] 2005-08
+mgemanagement    4680/udp # MGE UPS Management [Lecuivre_J] [Lecuivre_J] 2005-08
+parliant         4681/tcp # Parliant Telephony System [Colin_Henein] [Colin_Henein] 2005-08
+parliant         4681/udp # Parliant Telephony System [Colin_Henein] [Colin_Henein] 2005-08
+finisar          4682/tcp # finisar [Christina_Mercier] [Christina_Mercier] 2005-08
+finisar          4682/udp # finisar [Christina_Mercier] [Christina_Mercier] 2005-08
+spike            4683/tcp # Spike Clipboard Service [Scott_Herscher] [Scott_Herscher] 2005-08
+spike            4683/udp # Spike Clipboard Service [Scott_Herscher] [Scott_Herscher] 2005-08
+rfid-rp1         4684/tcp # RFID Reader Protocol 1.0 [Michael_Mealling_2] [Michael_Mealling_2] 2005-08
+rfid-rp1         4684/udp # RFID Reader Protocol 1.0 [Michael_Mealling_2] [Michael_Mealling_2] 2005-08
+autopac          4685/tcp # Autopac Protocol [Peter_Hallenbeck] [Peter_Hallenbeck] 2005-08
+autopac          4685/udp # Autopac Protocol [Peter_Hallenbeck] [Peter_Hallenbeck] 2005-08
+msp-os           4686/tcp # Manina Service Protocol [Markus_Nix] [Markus_Nix] 2005-08
+msp-os           4686/udp # Manina Service Protocol [Markus_Nix] [Markus_Nix] 2005-08
+nst              4687/tcp # Network Scanner Tool FTP [Mala_Bhat] [Mala_Bhat] 2005-08
+nst              4687/udp # Network Scanner Tool FTP [Mala_Bhat] [Mala_Bhat] 2005-08
+mobile-p2p       4688/tcp # Mobile P2P Service [Hanz_Hager] [Hanz_Hager] 2008-12-04
+mobile-p2p       4688/udp # Mobile P2P Service [Hanz_Hager] [Hanz_Hager] 2008-12-04
+altovacentral    4689/tcp # Altova DatabaseCentral [Altova] [Altova] 2005-08
+altovacentral    4689/udp # Altova DatabaseCentral [Altova] [Altova] 2005-08
+prelude          4690/tcp # Prelude IDS message proto [Yoann_Vandoorselaere] [Yoann_Vandoorselaere] 2005-08
+prelude          4690/udp # Prelude IDS message proto [Yoann_Vandoorselaere] [Yoann_Vandoorselaere] 2005-08
+mtn              4691/tcp # monotone Netsync Protocol [Thomas_Keller] [Thomas_Keller] 2010-12-22
+mtn              4691/udp # monotone Netsync Protocol [Thomas_Keller] [Thomas_Keller] 2010-12-22
+conspiracy       4692/tcp # Conspiracy messaging [Jens_Edlund] [Jens_Edlund] 2005-08
+conspiracy       4692/udp # Conspiracy messaging [Jens_Edlund] [Jens_Edlund] 2005-08
+netxms-agent     4700/tcp # NetXMS Agent
+netxms-agent     4700/udp # NetXMS Agent
+netxms-mgmt      4701/tcp # NetXMS Management
+netxms-mgmt      4701/udp # NetXMS Management
+netxms-sync      4702/tcp # NetXMS Server Synchronization [Victor_Kirhenshtein] [Victor_Kirhenshtein] 2006-07
+netxms-sync      4702/udp # NetXMS Server Synchronization [Victor_Kirhenshtein] [Victor_Kirhenshtein] 2006-07
+npqes-test       4703/tcp # Network Performance Quality Evaluation System Test Service [Zhengli] [Zhengli] 2010-06-28
+assuria-ins      4704/tcp # Assuria Insider [Nick_Connor] [Nick_Connor] 2010-06-30
+truckstar        4725/tcp # TruckStar Service [Brian_Toothill] [Brian_Toothill] 2010-10-15
+truckstar        4725/udp # TruckStar Service [Brian_Toothill] [Brian_Toothill] 2010-10-15
+a26-fap-fgw      4726/udp # A26 (FAP-FGW) [David_Ott] [David_Ott] 2010-10-15
+fcis             4727/tcp # F-Link Client Information Service
+fcis-disc        4727/udp # F-Link Client Information Service Discovery [Makoto_Zukawa] [Makoto_Zukawa] 2010-10-15
+capmux           4728/tcp # CA Port Multiplexer [Nigel_Groves] [Nigel_Groves] 2006-06
+capmux           4728/udp # CA Port Multiplexer [Nigel_Groves] [Nigel_Groves] 2006-06
+gsmtap           4729/udp # GSM Interface Tap [Harald_Welte] [Harald_Welte] 2009-01-16
+gearman          4730/tcp # Gearman Job Queue System [Eric_Day] [Eric_Day] 2009-01-16
+gearman          4730/udp # Gearman Job Queue System [Eric_Day] [Eric_Day] 2009-01-16
+remcap           4731/tcp # Remote Capture Protocol [Marc_Donner] [Marc_Donner] 2009-01-16
+ohmtrigger       4732/udp # OHM server trigger [Franck_Lefevre] [Franck_Lefevre] 2009-11-18
+resorcs          4733/tcp # RES Orchestration Catalog Services [Bob_Janssen_2] [Bob_Janssen_2] 2009-11-18
+ipdr-sp          4737/tcp # IPDR/SP [Ken_Sarno] [Ken_Sarno] 2005-08
+ipdr-sp          4737/udp # IPDR/SP [Ken_Sarno] [Ken_Sarno] 2005-08
+solera-lpn       4738/tcp # SoleraTec Locator [Mark_Armstrong] [Mark_Armstrong] 2005-12
+solera-lpn       4738/udp # SoleraTec Locator [Mark_Armstrong] [Mark_Armstrong] 2005-12
+ipfix            4739/tcp # IP Flow Info Export [Nevil_Brownlee] [Nevil_Brownlee] 2005-08
+ipfix            4739/udp # IP Flow Info Export [Nevil_Brownlee] [Nevil_Brownlee] 2005-08
+ipfix            4739/sctp # IP Flow Info Export [Nevil_Brownlee] [Nevil_Brownlee] 2006-01
+ipfixs           4740/tcp # ipfix protocol over TLS [Nevil_Brownlee] [Nevil_Brownlee] 2006-10
+ipfixs           4740/sctp # ipfix protocol over DTLS [Nevil_Brownlee] [Nevil_Brownlee] 2006-10
+ipfixs           4740/udp # ipfix protocol over DTLS [Nevil_Brownlee] [Nevil_Brownlee] 2006-10
+lumimgrd         4741/tcp # Luminizer Manager [George_Hwa] [George_Hwa] 2007-03
+lumimgrd         4741/udp # Luminizer Manager [George_Hwa] [George_Hwa] 2007-03
+sicct            4742/tcp # SICCT
+sicct-sdp        4742/udp # SICCT Service Discovery Protocol [TeleTrusT_Deutschlan] [TeleTrusT_Deutschlan] 2006-04
+openhpid         4743/tcp # openhpi HPI service [Thomas_Kanngieser] [Thomas_Kanngieser] 2006-01
+openhpid         4743/udp # openhpi HPI service [Thomas_Kanngieser] [Thomas_Kanngieser] 2006-01
+ifsp             4744/tcp # Internet File Synchronization Protocol [Alex_White] [Alex_White] 2007-09-12
+ifsp             4744/udp # Internet File Synchronization Protocol [Alex_White] [Alex_White] 2007-09-12
+fmp              4745/tcp # Funambol Mobile Push [Andrea_Gazzaniga] [Andrea_Gazzaniga] 2007-01
+fmp              4745/udp # Funambol Mobile Push [Andrea_Gazzaniga] [Andrea_Gazzaniga] 2007-01
+buschtrommel     4747/udp # peer-to-peer file exchange protocol [None] [Tobias_Sturm] 2013-01-14
+profilemac       4749/tcp # Profile for Mac [David_Sinclair] [David_Sinclair] 2006-05
+profilemac       4749/udp # Profile for Mac [David_Sinclair] [David_Sinclair] 2006-05
+ssad             4750/tcp # Simple Service Auto Discovery [Dr_Horst_Herb] [Dr_Horst_Herb] 2005-12
+ssad             4750/udp # Simple Service Auto Discovery [Dr_Horst_Herb] [Dr_Horst_Herb] 2005-12
+spocp            4751/tcp # Simple Policy Control Protocol [Roland_Hedberg_2] [Roland_Hedberg_2] 2005-08
+spocp            4751/udp # Simple Policy Control Protocol [Roland_Hedberg_2] [Roland_Hedberg_2] 2005-08
+snap             4752/tcp # Simple Network Audio Protocol [Dameon_Wagner] [Dameon_Wagner] 2002-02
+snap             4752/udp # Simple Network Audio Protocol [Dameon_Wagner] [Dameon_Wagner] 2002-02
+simon            4753/tcp # Simple Invocation of Methods Over Network (SIMON) [Alexander_Christian] [Alexander_Christian] 2012-04-19
+simon-disc       4753/udp # Simple Invocation of Methods Over Network (SIMON) Discovery [Alexander_Christian] [Alexander_Christian] 2012-04-19
+bfd-multi-ctl    4784/tcp # BFD Multihop Control [Dave_Katz][Dave_Ward] [Dave_Katz][Dave_Ward] 2006-02
+bfd-multi-ctl    4784/udp # BFD Multihop Control [Dave_Katz][Dave_Ward] [Dave_Katz][Dave_Ward] 2006-02
+cncp             4785/udp # Cisco Nexus Control Protocol [Joseph_Swaminathan] [Joseph_Swaminathan] 2009-04-01
+smart-install    4786/tcp # Smart Install Service [Amit_Nigam] [Amit_Nigam] 2009-08-24
+sia-ctrl-plane   4787/tcp # Service Insertion Architecture (SIA) Control-Plane [Shree_Murthy] [Shree_Murthy] 2009-10-29
+xmcp             4788/tcp # eXtensible Messaging Client Protocol [Cisco] [Glenn_Matthews] 2011-05-23 2011-10-25 Defined TXT keys:     txtvers=1 (as described in the draft)      protovers=<comma-separated list of major/minor versions supported>(examples: "protovers=1.0" "protovers=1.1,2.0"
+vxlan            4789/udp # Virtual eXtensible Local Area Network (VXLAN) [Lawrence_Kreeger] [Lawrence_Kreeger] 2013-04-19
+iims             4800/tcp # Icona Instant Messenging System
+iims             4800/udp # Icona Instant Messenging System
+iwec             4801/tcp # Icona Web Embedded Chat
+iwec             4801/udp # Icona Web Embedded Chat
+ilss             4802/tcp # Icona License System Server [Paul_Stephen_Borlie] [Paul_Stephen_Borlie]
+ilss             4802/udp # Icona License System Server [Paul_Stephen_Borlie] [Paul_Stephen_Borlie]
+notateit         4803/tcp # Notateit Messaging
+notateit-disc    4803/udp # Notateit Messaging Discovery [Ean_Black] [Ean_Black] 2009-04-08
+aja-ntv4-disc    4804/udp # AJA ntv4 Video System Discovery [Mike_Bernadett] [Mike_Bernadett] 2010-06-03
+htcp             4827/tcp # HTCP [Paul_Vixie] [Paul_Vixie]
+htcp             4827/udp # HTCP [Paul_Vixie] [Paul_Vixie]
+varadero-0       4837/tcp # Varadero-0
+varadero-0       4837/udp # Varadero-0
+varadero-1       4838/tcp # Varadero-1
+varadero-1       4838/udp # Varadero-1
+varadero-2       4839/tcp # Varadero-2 [Carlos_Arteaga] [Carlos_Arteaga]
+varadero-2       4839/udp # Varadero-2 [Carlos_Arteaga] [Carlos_Arteaga]
+opcua-tcp        4840/tcp # OPC UA TCP Protocol
+opcua-udp        4840/udp # OPC UA TCP Protocol [Randy_Armstrong] [Randy_Armstrong] 2006-09
+quosa            4841/tcp # QUOSA Virtual Library Service [Uri_Blank] [Uri_Blank] 2006-09
+quosa            4841/udp # QUOSA Virtual Library Service [Uri_Blank] [Uri_Blank] 2006-09
+gw-asv           4842/tcp # nCode ICE-flow Library AppServer [Ross_Swithenbank] [Ross_Swithenbank] 2006-09
+gw-asv           4842/udp # nCode ICE-flow Library AppServer [Ross_Swithenbank] [Ross_Swithenbank] 2006-09
+opcua-tls        4843/tcp # OPC UA TCP Protocol over TLS/SSL [Randy_Armstrong] [Randy_Armstrong] 2006-09
+opcua-tls        4843/udp # OPC UA TCP Protocol over TLS/SSL [Randy_Armstrong] [Randy_Armstrong] 2006-09
+gw-log           4844/tcp # nCode ICE-flow Library LogServer [Ross_Swithenbank] [Ross_Swithenbank] 2006-09
+gw-log           4844/udp # nCode ICE-flow Library LogServer [Ross_Swithenbank] [Ross_Swithenbank] 2006-09
+wcr-remlib       4845/tcp # WordCruncher Remote Library Service [Jason_Dzubak] [Jason_Dzubak] 2008-03-17
+wcr-remlib       4845/udp # WordCruncher Remote Library Service [Jason_Dzubak] [Jason_Dzubak] 2008-03-17
+contamac-icm     4846/tcp # Contamac ICM ServiceIANA assigned this well-formed service name as a replacement for "contamac_icm". [Abdullah_Obeid] [Abdullah_Obeid] 2008-03-20
+contamac_icm     4846/tcp # Contamac ICM Service [Abdullah_Obeid] [Abdullah_Obeid] 2008-03-20 This entry is an alias to "contamac-icm".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+contamac-icm     4846/udp # Contamac ICM ServiceIANA assigned this well-formed service name as a replacement for "contamac_icm". [Abdullah_Obeid] [Abdullah_Obeid] 2008-03-20
+contamac_icm     4846/udp # Contamac ICM Service [Abdullah_Obeid] [Abdullah_Obeid] 2008-03-20 This entry is an alias to "contamac-icm".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+wfc              4847/tcp # Web Fresh Communication [Jonathan_Bastnagel] [Jonathan_Bastnagel] 2007-09-17
+wfc              4847/udp # Web Fresh Communication [Jonathan_Bastnagel] [Jonathan_Bastnagel] 2007-09-17
+appserv-http     4848/tcp # App Server - Admin HTTP
+appserv-http     4848/udp # App Server - Admin HTTP
+appserv-https    4849/tcp # App Server - Admin HTTPS [Sreeram_Duvvuru] [Sreeram_Duvvuru] 2002-04
+appserv-https    4849/udp # App Server - Admin HTTPS [Sreeram_Duvvuru] [Sreeram_Duvvuru] 2002-04
+sun-as-nodeagt   4850/tcp # Sun App Server - NA [Kedar_Mhaswade] [Kedar_Mhaswade] 2004-11
+sun-as-nodeagt   4850/udp # Sun App Server - NA [Kedar_Mhaswade] [Kedar_Mhaswade] 2004-11
+derby-repli      4851/tcp # Apache Derby Replication [Jorgen_Loland] [Jorgen_Loland] 2008-02-27
+derby-repli      4851/udp # Apache Derby Replication [Jorgen_Loland] [Jorgen_Loland] 2008-02-27
+unify-debug      4867/tcp # Unify Debugger [Daegis_Inc] [Chris_Anderson] 2006-05 2012-07-31
+unify-debug      4867/udp # Unify Debugger [Daegis_Inc] [Chris_Anderson] 2006-05 2012-07-31
+phrelay          4868/tcp # Photon Relay
+phrelay          4868/udp # Photon Relay
+phrelaydbg       4869/tcp # Photon Relay Debug [Michael_Hunter] [Michael_Hunter]
+phrelaydbg       4869/udp # Photon Relay Debug [Michael_Hunter] [Michael_Hunter]
+cc-tracking      4870/tcp # Citcom Tracking Service [Wolfgang_Weidner] [Wolfgang_Weidner] 2005-12
+cc-tracking      4870/udp # Citcom Tracking Service [Wolfgang_Weidner] [Wolfgang_Weidner] 2005-12
+wired            4871/tcp # Wired [Axel_Andersson] [Axel_Andersson] 2006-02
+wired            4871/udp # Wired [Axel_Andersson] [Axel_Andersson] 2006-02
+tritium-can      4876/tcp # Tritium CAN Bus Bridge Service [James_Kennedy] [James_Kennedy] 2011-02-15
+tritium-can      4876/udp # Tritium CAN Bus Bridge Service [James_Kennedy] [James_Kennedy] 2011-02-15
+lmcs             4877/tcp # Lighting Management Control System [Timothy_Parry] [Timothy_Parry] 2011-02-15
+lmcs             4877/udp # Lighting Management Control System [Timothy_Parry] [Timothy_Parry] 2011-02-15
+inst-discovery   4878/udp # Agilent Instrument Discovery [Charles_F_Steele] [Charles_F_Steele] 2011-02-15
+wsdl-event       4879/tcp # WSDL Event Receiver [Charles_F_Steele] [Charles_F_Steele] 2011-02-15
+hislip           4880/tcp # IVI High-Speed LAN Instrument Protocol [Joe_Mueller] [Joe_Mueller] 2010-01-11
+socp-t           4881/udp # SOCP Time Synchronization Protocol [Joe_Haver] [Joe_Haver] 2010-05-28
+socp-c           4882/udp # SOCP Control Protocol [Joe_Haver] [Joe_Haver] 2010-05-28
+wmlserver        4883/tcp # Meier-Phelps License Server [William_Phelps] [William_Phelps] 2010-03-22
+hivestor         4884/tcp # HiveStor Distributed File System [Nicholas_Young] [Nicholas_Young] 2008-07-10
+hivestor         4884/udp # HiveStor Distributed File System [Nicholas_Young] [Nicholas_Young] 2008-07-10
+abbs             4885/tcp # ABBS [Ryan_Rubley] [Ryan_Rubley]
+abbs             4885/udp # ABBS [Ryan_Rubley] [Ryan_Rubley]
+lyskom           4894/tcp # LysKOM Protocol A [Per_Cederqvist] [Per_Cederqvist]
+lyskom           4894/udp # LysKOM Protocol A [Per_Cederqvist] [Per_Cederqvist]
+radmin-port      4899/tcp # RAdmin Port [Dmitri_Znosko] [Dmitri_Znosko] 2003-03
+radmin-port      4899/udp # RAdmin Port [Dmitri_Znosko] [Dmitri_Znosko] 2003-03
+hfcs             4900/tcp # HyperFileSQL Client/Server Database Engine [Jerome_AERTS] [Jerome_AERTS] 2010-11-30
+hfcs             4900/udp # HyperFileSQL Client/Server Database Engine [Jerome_AERTS] [Jerome_AERTS] 2010-11-30
+flr-agent        4901/tcp # FileLocator Remote Search AgentIANA assigned this well-formed service name as a replacement for "flr_agent". [David_Vest] [David_Vest] 2008-11-19
+flr_agent        4901/tcp # FileLocator Remote Search Agent [David_Vest] [David_Vest] 2008-11-19 This entry is an alias to "flr-agent".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+magiccontrol     4902/tcp # magicCONROL RF and Data Interface [Andreas_Spalenski] [Andreas_Spalenski] 2008-11-24
+lutap            4912/tcp # Technicolor LUT Access Protocol [Markus_Loeffler] [Markus_Loeffler] 2009-02-17
+lutcp            4913/tcp # LUTher Control Protocol [Markus_Loeffler] [Markus_Loeffler] 2007-07-03
+bones            4914/tcp # Bones Remote Control [Andreas_Foedrowitz] [Andreas_Foedrowitz] 2008-06-18
+bones            4914/udp # Bones Remote Control [Andreas_Foedrowitz] [Andreas_Foedrowitz] 2008-06-18
+frcs             4915/tcp # Fibics Remote Control Service [Ken_Lagarec] [Ken_Lagarec] 2009-04-17
+atsc-mh-ssc      4937/udp # ATSC-M/H Service Signaling Channel [Jerry_Whitaker] [Jerry_Whitaker] 2008-10-27
+eq-office-4940   4940/tcp # Equitrac Office
+eq-office-4940   4940/udp # Equitrac Office
+eq-office-4941   4941/tcp # Equitrac Office
+eq-office-4941   4941/udp # Equitrac Office
+eq-office-4942   4942/tcp # Equitrac Office [Tom_Haapanen_2] [Tom_Haapanen_2] 2007-07-11
+eq-office-4942   4942/udp # Equitrac Office [Tom_Haapanen_2] [Tom_Haapanen_2] 2007-07-11
+munin            4949/tcp # Munin Graphing Framework [Jimmy_Olsen] [Jimmy_Olsen] 2010-12-24
+munin            4949/udp # Munin Graphing Framework [Jimmy_Olsen] [Jimmy_Olsen] 2010-12-24
+sybasesrvmon     4950/tcp # Sybase Server Monitor [Chris_Irie] [Chris_Irie] 2008-03-26
+sybasesrvmon     4950/udp # Sybase Server Monitor [Chris_Irie] [Chris_Irie] 2008-03-26
+pwgwims          4951/tcp # PWG WIMS [Ira_McDonald] [Ira_McDonald] 2005-12
+pwgwims          4951/udp # PWG WIMS [Ira_McDonald] [Ira_McDonald] 2005-12
+sagxtsds         4952/tcp # SAG Directory Server [Michael_Chirila] [Michael_Chirila] 2006-01
+sagxtsds         4952/udp # SAG Directory Server [Michael_Chirila] [Michael_Chirila] 2006-01
+dbsyncarbiter    4953/tcp # Synchronization Arbiter [Dave_Neudoerffer_2] [Dave_Neudoerffer_2] 2009-11-18
+ccss-qmm         4969/tcp # CCSS QMessageMonitor
+ccss-qmm         4969/udp # CCSS QMessageMonitor
+ccss-qsm         4970/tcp # CCSS QSystemMonitor [David_Young] [David_Young] 2006-01
+ccss-qsm         4970/udp # CCSS QSystemMonitor [David_Young] [David_Young] 2006-01
+webyast          4984/tcp # WebYast [Federico_Lucifredi] [Federico_Lucifredi] 2009-09-25
+gerhcs           4985/tcp # GER HC Standard [Roger_Ward] [Roger_Ward] 2009-09-25
+mrip             4986/tcp # Model Railway Interface Program [Howard_Amos] [Howard_Amos] 2006-04
+mrip             4986/udp # Model Railway Interface Program [Howard_Amos] [Howard_Amos] 2006-04
+smar-se-port1    4987/tcp # SMAR Ethernet Port 1
+smar-se-port1    4987/udp # SMAR Ethernet Port 1
+smar-se-port2    4988/tcp # SMAR Ethernet Port 2 [Delcio_Prizon] [Delcio_Prizon]
+smar-se-port2    4988/udp # SMAR Ethernet Port 2 [Delcio_Prizon] [Delcio_Prizon]
+parallel         4989/tcp # Parallel for GAUSS (tm) [Matthew_Ford] [Matthew_Ford] 2003-03
+parallel         4989/udp # Parallel for GAUSS (tm) [Matthew_Ford] [Matthew_Ford] 2003-03
+busycal          4990/tcp # BusySync Calendar Synch. Protocol [David_Riggle] [David_Riggle] 2008-01-07 Defined TXT keys: Proprietary
+busycal          4990/udp # BusySync Calendar Synch. Protocol [David_Riggle] [David_Riggle] 2008-01-07 Defined TXT keys: Proprietary
+vrt              4991/tcp # VITA Radio Transport [Sam_Bretheim] [Sam_Bretheim] 2009-01-08
+vrt              4991/udp # VITA Radio Transport [Sam_Bretheim] [Sam_Bretheim] 2009-01-08
+hfcs-manager     4999/tcp # HyperFileSQL Client/Server Database Engine Manager [Jerome_AERTS] [Jerome_AERTS] 2010-11-30
+hfcs-manager     4999/udp # HyperFileSQL Client/Server Database Engine Manager [Jerome_AERTS] [Jerome_AERTS] 2010-11-30
+commplex-main    5000/tcp # 
+commplex-main    5000/udp # 
+commplex-link    5001/tcp # 
+commplex-link    5001/udp # 
+rfe              5002/tcp # radio free ethernet
+rfe              5002/udp # radio free ethernet
+fmpro-internal   5003/tcp # FileMaker, Inc. - Proprietary transport [Clay_Maeckel] [Clay_Maeckel]
+fmpro-internal   5003/udp # FileMaker, Inc. - Proprietary name binding [Clay_Maeckel] [Clay_Maeckel]
+avt-profile-1    5004/tcp # RTP media data [RFC3551][RFC4571]
+avt-profile-1    5004/udp # RTP media data [RFC3551]
+avt-profile-1    5004/dccp # RTP media data [RFC3551][RFC5762]
+avt-profile-2    5005/tcp # RTP control protocol [RFC3551][RFC4571]
+avt-profile-2    5005/udp # RTP control protocol [RFC3551]
+avt-profile-2    5005/dccp # RTP control protocol [RFC3551][RFC5762]
+wsm-server       5006/tcp # wsm server [Adam_Berk] [Adam_Berk]
+wsm-server       5006/udp # wsm server [Adam_Berk] [Adam_Berk]
+wsm-server-ssl   5007/tcp # wsm server ssl [Adam_Berk] [Adam_Berk]
+wsm-server-ssl   5007/udp # wsm server ssl [Adam_Berk] [Adam_Berk]
+synapsis-edge    5008/tcp # Synapsis EDGE [Paul_Schilling] [Paul_Schilling]
+synapsis-edge    5008/udp # Synapsis EDGE [Paul_Schilling] [Paul_Schilling]
+winfs            5009/tcp # Microsoft Windows Filesystem [Simon_Skaria] [Simon_Skaria] 2006-01
+winfs            5009/udp # Microsoft Windows Filesystem [Simon_Skaria] [Simon_Skaria] 2006-01
+telelpathstart   5010/tcp # TelepathStart [Helmuth_Breitenfelln] [Helmuth_Breitenfelln]
+telelpathstart   5010/udp # TelepathStart [Helmuth_Breitenfelln] [Helmuth_Breitenfelln]
+telelpathattack  5011/tcp # TelepathAttack [Helmuth_Breitenfelln] [Helmuth_Breitenfelln]
+telelpathattack  5011/udp # TelepathAttack [Helmuth_Breitenfelln] [Helmuth_Breitenfelln]
+nsp              5012/tcp # NetOnTap Service [Kim_Hancock] [Kim_Hancock] 2007-10-24
+nsp              5012/udp # NetOnTap Service [Kim_Hancock] [Kim_Hancock] 2007-10-24
+fmpro-v6         5013/tcp # FileMaker, Inc. - Proprietary transport [Alex_Chen] [Alex_Chen] 2007-08-01
+fmpro-v6         5013/udp # FileMaker, Inc. - Proprietary transport [Alex_Chen] [Alex_Chen] 2007-08-01
+onpsocket        5014/udp # Overlay Network Protocol [Roger_Matthias] [Roger_Matthias] 2009-08-24
+fmwp             5015/tcp # FileMaker, Inc. - Web publishing [Alex_Chen] [Alex_Chen] 2009-11-25
+zenginkyo-1      5020/tcp # zenginkyo-1 [Masashi_Suzaki] [Masashi_Suzaki]
+zenginkyo-1      5020/udp # zenginkyo-1 [Masashi_Suzaki] [Masashi_Suzaki]
+zenginkyo-2      5021/tcp # zenginkyo-2 [Masashi_Suzaki] [Masashi_Suzaki]
+zenginkyo-2      5021/udp # zenginkyo-2 [Masashi_Suzaki] [Masashi_Suzaki]
+mice             5022/tcp # mice server [Alan_Clifford] [Alan_Clifford]
+mice             5022/udp # mice server [Alan_Clifford] [Alan_Clifford]
+htuilsrv         5023/tcp # Htuil Server for PLD2 [Dennis_Reinhardt] [Dennis_Reinhardt]
+htuilsrv         5023/udp # Htuil Server for PLD2 [Dennis_Reinhardt] [Dennis_Reinhardt]
+scpi-telnet      5024/tcp # SCPI-TELNET [Ryan_Columbus] [Ryan_Columbus] 2002-10
+scpi-telnet      5024/udp # SCPI-TELNET [Ryan_Columbus] [Ryan_Columbus] 2002-10
+scpi-raw         5025/tcp # SCPI-RAW [Ryan_Columbus] [Ryan_Columbus] 2002-10
+scpi-raw         5025/udp # SCPI-RAW [Ryan_Columbus] [Ryan_Columbus] 2002-10
+strexec-d        5026/tcp # Storix I/O daemon (data) [Anthony_Johnson] [Anthony_Johnson] 2005-08
+strexec-d        5026/udp # Storix I/O daemon (data) [Anthony_Johnson] [Anthony_Johnson] 2005-08
+strexec-s        5027/tcp # Storix I/O daemon (stat) [Anthony_Johnson] [Anthony_Johnson] 2005-08
+strexec-s        5027/udp # Storix I/O daemon (stat) [Anthony_Johnson] [Anthony_Johnson] 2005-08
+qvr              5028/tcp # Quiqum Virtual Relais [Philipp_Marcel_Albre] [Philipp_Marcel_Albre] 2009-07-06
+infobright       5029/tcp # Infobright Database Server [Mark_Windrim] [Mark_Windrim] 2009-07-23
+infobright       5029/udp # Infobright Database Server [Mark_Windrim] [Mark_Windrim] 2009-07-23
+surfpass         5030/tcp # SurfPass [Olivier_Guezenec] [Olivier_Guezenec] 2006-12
+surfpass         5030/udp # SurfPass [Olivier_Guezenec] [Olivier_Guezenec] 2006-12
+dmp              5031/udp # Direct Message Protocol [Gjermund_Wallenius] [Gjermund_Wallenius] 2009-09-30
+signacert-agent  5032/tcp # SignaCert Enterprise Trust Server Agent [Harris_Corporation] [Daniel_R_Somerfield] 2011-08-05
+asnaacceler8db   5042/tcp # asnaacceler8db [Walter_Goodwin] [Walter_Goodwin]
+asnaacceler8db   5042/udp # asnaacceler8db [Walter_Goodwin] [Walter_Goodwin]
+swxadmin         5043/tcp # ShopWorX Administration [Don_W_Fitzpatrick] [Don_W_Fitzpatrick] 2005-08
+swxadmin         5043/udp # ShopWorX Administration [Don_W_Fitzpatrick] [Don_W_Fitzpatrick] 2005-08
+lxi-evntsvc      5044/tcp # LXI Event Service [Nick_Barendt] [Nick_Barendt] 2005-08
+lxi-evntsvc      5044/udp # LXI Event Service [Nick_Barendt] [Nick_Barendt] 2005-08
+osp              5045/tcp # Open Settlement Protocol [Dmitry_Isakbayev] [Dmitry_Isakbayev] 2010-03-05
+vpm-udp          5046/udp # Vishay PM UDP Service [Ashley_Clarke] [Ashley_Clarke] 2010-06-17
+iscape           5047/udp # iSCAPE Data Broadcasting [Roland_van_der_Veen] [Roland_van_der_Veen] 2010-06-17
+texai            5048/tcp # Texai Message Service [Stephen_Reed_2] [Stephen_Reed_2] 2010-06-17
+ivocalize        5049/tcp # iVocalize Web Conference [Bryan_Vergato] [Bryan_Vergato] 2006-05
+ivocalize        5049/udp # iVocalize Web Conference [Bryan_Vergato] [Bryan_Vergato] 2006-05
+mmcc             5050/tcp # multimedia conference control tool [Steve_Casner] [Steve_Casner]
+mmcc             5050/udp # multimedia conference control tool [Steve_Casner] [Steve_Casner]
+ita-agent        5051/tcp # ITA Agent [Don_Merrell] [Don_Merrell]
+ita-agent        5051/udp # ITA Agent [Don_Merrell] [Don_Merrell]
+ita-manager      5052/tcp # ITA Manager [Don_Merrell] [Don_Merrell]
+ita-manager      5052/udp # ITA Manager [Don_Merrell] [Don_Merrell]
+rlm              5053/tcp # RLM License Server [Matt_Christiano_2] [Matt_Christiano_2] 2008-07-28
+rlm-disc         5053/udp # RLM Discovery Server [Reprise_Software_Inc] [Matt_Christiano_3] 2012-11-06
+rlm-admin        5054/tcp # RLM administrative interface [Matt_Christiano_2] [Matt_Christiano_2] 2008-07-28
+unot             5055/tcp # UNOT [Gordon_Mohr_2] [Gordon_Mohr_2]
+unot             5055/udp # UNOT [Gordon_Mohr_2] [Gordon_Mohr_2]
+intecom-ps1      5056/tcp # Intecom Pointspan 1 [David_Meermans] [David_Meermans]
+intecom-ps1      5056/udp # Intecom Pointspan 1 [David_Meermans] [David_Meermans]
+intecom-ps2      5057/tcp # Intecom Pointspan 2 [David_Meermans] [David_Meermans]
+intecom-ps2      5057/udp # Intecom Pointspan 2 [David_Meermans] [David_Meermans]
+locus-disc       5058/udp # Locus Discovery [Alan_King] [Alan_King] 2009-08-13
+sds              5059/tcp # SIP Directory Services [Arthur_Wilton] [Arthur_Wilton] 2006-03
+sds              5059/udp # SIP Directory Services [Arthur_Wilton] [Arthur_Wilton] 2006-03
+sip              5060/tcp # SIP [Henning_Schulzrinne] [Henning_Schulzrinne]
+sip              5060/udp # SIP [Henning_Schulzrinne] [Henning_Schulzrinne]
+sip-tls          5061/tcp # SIP-TLS [Henning_Schulzrinne] [Henning_Schulzrinne]
+sip-tls          5061/udp # SIP-TLS [Henning_Schulzrinne] [Henning_Schulzrinne]
+na-localise      5062/tcp # Localisation access [Jean_Pierre_Garcia_2] [Jean_Pierre_Garcia_2] 2009-10-28
+na-localise      5062/udp # Localisation access [Jean_Pierre_Garcia_2] [Jean_Pierre_Garcia_2] 2009-10-28
+csrpc            5063/tcp # centrify secure RPC [Paul_Moore] [Paul_Moore] 2009-10-28
+ca-1             5064/tcp # Channel Access 1 [Jeffrey_Hill] [Jeffrey_Hill] 2002-08
+ca-1             5064/udp # Channel Access 1 [Jeffrey_Hill] [Jeffrey_Hill] 2002-08
+ca-2             5065/tcp # Channel Access 2 [Jeffrey_Hill] [Jeffrey_Hill] 2002-08
+ca-2             5065/udp # Channel Access 2 [Jeffrey_Hill] [Jeffrey_Hill] 2002-08
+stanag-5066      5066/tcp # STANAG-5066-SUBNET-INTF [Donald_G_Kallgren] [Donald_G_Kallgren]
+stanag-5066      5066/udp # STANAG-5066-SUBNET-INTF [Donald_G_Kallgren] [Donald_G_Kallgren]
+authentx         5067/tcp # Authentx Service [Alberto_Fernandez] [Alberto_Fernandez] 2006-01
+authentx         5067/udp # Authentx Service [Alberto_Fernandez] [Alberto_Fernandez] 2006-01
+bitforestsrv     5068/tcp # Bitforest Data Service [Ville_Pekka_Vahteala] [Ville_Pekka_Vahteala] 2008-06-05
+i-net-2000-npr   5069/tcp # I/Net 2000-NPR [Chris_Megede] [Chris_Megede]
+i-net-2000-npr   5069/udp # I/Net 2000-NPR [Chris_Megede] [Chris_Megede]
+vtsas            5070/tcp # VersaTrans Server Agent Service [Christopher_Miller] [Christopher_Miller] 2006-02
+vtsas            5070/udp # VersaTrans Server Agent Service [Christopher_Miller] [Christopher_Miller] 2006-02
+powerschool      5071/tcp # PowerSchool [Greg_Porter] [Greg_Porter]
+powerschool      5071/udp # PowerSchool [Greg_Porter] [Greg_Porter]
+ayiya            5072/tcp # Anything In Anything [Jeroen_Massar] [Jeroen_Massar] 2005-08
+ayiya            5072/udp # Anything In Anything [Jeroen_Massar] [Jeroen_Massar] 2005-08
+tag-pm           5073/tcp # Advantage Group Port Mgr [James_Goddard] [James_Goddard] 2005-08
+tag-pm           5073/udp # Advantage Group Port Mgr [James_Goddard] [James_Goddard] 2005-08
+alesquery        5074/tcp # ALES Query [Tim_Maloney] [Tim_Maloney] 2005-08
+alesquery        5074/udp # ALES Query [Tim_Maloney] [Tim_Maloney] 2005-08
+pvaccess         5075/tcp # Experimental Physics and Industrial Control System [Matej_Sekoranja] [Matej_Sekoranja] 2012-03-23
+cp-spxrpts       5079/udp # Cambridge Pixel SPx Reports [Richard_Warren] [Richard_Warren] 2008-09-17
+onscreen         5080/tcp # OnScreen Data Collection Service [Christopher_Miller_2] [Christopher_Miller_2] 2008-01-14
+onscreen         5080/udp # OnScreen Data Collection Service [Christopher_Miller_2] [Christopher_Miller_2] 2008-01-14
+sdl-ets          5081/tcp # SDL - Ent Trans Server [Marc_Morin] [Marc_Morin] 2002-04
+sdl-ets          5081/udp # SDL - Ent Trans Server [Marc_Morin] [Marc_Morin] 2002-04
+qcp              5082/tcp # Qpur Communication Protocol [Joachim_Kluemper] [Joachim_Kluemper] 2008-03-19
+qcp              5082/udp # Qpur Communication Protocol [Joachim_Kluemper] [Joachim_Kluemper] 2008-03-19
+qfp              5083/tcp # Qpur File Protocol [Joachim_Kluemper] [Joachim_Kluemper] 2008-03-19
+qfp              5083/udp # Qpur File Protocol [Joachim_Kluemper] [Joachim_Kluemper] 2008-03-19
+llrp             5084/tcp # EPCglobal Low-Level Reader Protocol [Margaret_Wasserman][Paul_Dietrich] [Margaret_Wasserman][Paul_Dietrich] 2006-11 Defined TXT keys: None. RFID reader Low Level Reader Protocol
+llrp             5084/udp # EPCglobal Low-Level Reader Protocol [Margaret_Wasserman][Paul_Dietrich] [Margaret_Wasserman][Paul_Dietrich] 2006-11 Defined TXT keys: None. RFID reader Low Level Reader Protocol
+encrypted-llrp   5085/tcp # EPCglobal Encrypted LLRP [Margaret_Wasserman] [Margaret_Wasserman] 2006-11
+encrypted-llrp   5085/udp # EPCglobal Encrypted LLRP [Margaret_Wasserman] [Margaret_Wasserman] 2006-11
+aprigo-cs        5086/tcp # Aprigo Collection Service [Ron_Zalkind] [Ron_Zalkind] 2010-05-28
+car              5090/sctp # Candidate AR
+cxtp             5091/sctp # Context Transfer Protocol 2005-07 [RFC4065]
+magpie           5092/udp # Magpie Binary [Phil_Maker] [Phil_Maker] 2008-06-18
+sentinel-lm      5093/tcp # Sentinel LM [Derick_Snyder] [Derick_Snyder]
+sentinel-lm      5093/udp # Sentinel LM [Derick_Snyder] [Derick_Snyder]
+hart-ip          5094/tcp # HART-IP [Wally_Pratt_Jr] [Wally_Pratt_Jr] 2010-03-02
+hart-ip          5094/udp # HART-IP [Wally_Pratt_Jr] [Wally_Pratt_Jr] 2010-03-02
+sentlm-srv2srv   5099/tcp # SentLM Srv2Srv [Derick_Snyder] [Derick_Snyder]
+sentlm-srv2srv   5099/udp # SentLM Srv2Srv [Derick_Snyder] [Derick_Snyder]
+socalia          5100/tcp # Socalia service mux [Alberto_Raydan_2] [Alberto_Raydan_2] 2005-08
+socalia          5100/udp # Socalia service mux [Alberto_Raydan_2] [Alberto_Raydan_2] 2005-08
+talarian-tcp     5101/tcp # Talarian_TCP [Leo_Martins] [Leo_Martins]
+talarian-udp     5101/udp # Talarian_UDP [Leo_Martins] [Leo_Martins]
+oms-nonsecure    5102/tcp # Oracle OMS non-secure [Todd_Guay] [Todd_Guay] 2005-08
+oms-nonsecure    5102/udp # Oracle OMS non-secure [Todd_Guay] [Todd_Guay] 2005-08
+actifio-c2c      5103/tcp # Actifio C2C [Ravi_Kollipara] [Ravi_Kollipara] 2010-06-18
+tinymessage      5104/udp # TinyMessage [Josip_Medved] [Josip_Medved] 2010-10-20
+hughes-ap        5105/udp # Hughes Association Protocol [Varun_Santosh] [Varun_Santosh] 2010-10-20
+taep-as-svc      5111/tcp # TAEP AS service [Liu_Changchun] [Liu_Changchun] 2008-11-05
+taep-as-svc      5111/udp # TAEP AS service [Liu_Changchun] [Liu_Changchun] 2008-11-05
+pm-cmdsvr        5112/tcp # PeerMe Msg Cmd Service [Marcos_Della] [Marcos_Della] 2005-08
+pm-cmdsvr        5112/udp # PeerMe Msg Cmd Service [Marcos_Della] [Marcos_Della] 2005-08
+ev-services      5114/tcp # Enterprise Vault Services [Richard_Jones_2] [Richard_Jones_2] 2009-05-26
+autobuild        5115/tcp # Symantec Autobuild Service [David_Warden] [David_Warden] 2008-11-17
+emb-proj-cmd     5116/udp # EPSON Projecter Image Transfer [SEIKO_EPSON_4] [SEIKO_EPSON_4] 2008-11-17
+gradecam         5117/tcp # GradeCam Image Processing [Robert_Porter] [Robert_Porter] 2009-09-24
+barracuda-bbs    5120/tcp # Barracuda Backup Protocol [Barracuda_Networks] [Andrew_Blyler] 2013-04-05
+barracuda-bbs    5120/udp # Barracuda Backup Protocol [Barracuda_Networks] [Andrew_Blyler] 2013-04-05
+nbt-pc           5133/tcp # Policy Commander [Emily_Harris] [Emily_Harris] 2004-11
+nbt-pc           5133/udp # Policy Commander [Emily_Harris] [Emily_Harris] 2004-11
+ppactivation     5134/tcp # PP ActivationServer [Ian_Bradley] [Ian_Bradley] 2009-10-14
+erp-scale        5135/tcp # ERP-Scale [Ian_Bradley] [Ian_Bradley] 2009-10-14 Defined TXT keys:  RFC=<RFC destination and status>  Device=<Scale device and status>
+minotaur-sa      5136/udp # Minotaur SA [Kenneth_Flynn] [Kenneth_Flynn] 2009-10-14
+ctsd             5137/tcp # MyCTS server port [Jilles_Oldenbeuving] [Jilles_Oldenbeuving] 2002-06
+ctsd             5137/udp # MyCTS server port [Jilles_Oldenbeuving] [Jilles_Oldenbeuving] 2002-06
+rmonitor-secure  5145/tcp # RMONITOR SECUREIANA assigned this well-formed service name as a replacement for "rmonitor_secure". [Kory_Hamzeh] [Kory_Hamzeh]
+rmonitor_secure  5145/tcp # RMONITOR SECURE [Kory_Hamzeh] [Kory_Hamzeh] This entry is an alias to "rmonitor-secure".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+rmonitor-secure  5145/udp # RMONITOR SECUREIANA assigned this well-formed service name as a replacement for "rmonitor_secure". [Kory_Hamzeh] [Kory_Hamzeh]
+rmonitor_secure  5145/udp # RMONITOR SECURE [Kory_Hamzeh] [Kory_Hamzeh] This entry is an alias to "rmonitor-secure".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+social-alarm     5146/tcp # Social Alarm Service [Shaun_Byrne] [Shaun_Byrne] 2009-08-18
+atmp             5150/tcp # Ascend Tunnel Management Protocol [Kory_Hamzeh] [Kory_Hamzeh]
+atmp             5150/udp # Ascend Tunnel Management Protocol [Kory_Hamzeh] [Kory_Hamzeh]
+esri-sde         5151/tcp # ESRI SDE Instance    IANA assigned this well-formed service name as a replacement for "esri_sde". [Peter_Aronson] [Peter_Aronson] Unauthorized Use Known on ports 5151 and 5152
+esri_sde         5151/tcp # ESRI SDE Instance [Peter_Aronson] [Peter_Aronson] This entry is an alias to "esri-sde".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+esri-sde         5151/udp # ESRI SDE Remote Start    IANA assigned this well-formed service name as a replacement for "esri_sde". [Peter_Aronson] [Peter_Aronson] Unauthorized Use Known on ports 5151 and 5152
+esri_sde         5151/udp # ESRI SDE Remote Start [Peter_Aronson] [Peter_Aronson] This entry is an alias to "esri-sde".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+sde-discovery    5152/tcp # ESRI SDE Instance Discovery [Peter_Aronson] [Peter_Aronson] Unauthorized Use Known on ports 5151 and 5152
+sde-discovery    5152/udp # ESRI SDE Instance Discovery [Peter_Aronson] [Peter_Aronson] Unauthorized Use Known on ports 5151 and 5152
+toruxserver      5153/tcp # ToruX Game Server [Josse_van_Dobben_de] [Josse_van_Dobben_de] 2009-07-01
+bzflag           5154/tcp # BZFlag game server [Tim_Riker] [Tim_Riker] 2003-07
+bzflag           5154/udp # BZFlag game server [Tim_Riker] [Tim_Riker] 2003-07
+asctrl-agent     5155/tcp # Oracle asControl Agent [Todd_Guay] [Todd_Guay] 2005-08
+asctrl-agent     5155/udp # Oracle asControl Agent [Todd_Guay] [Todd_Guay] 2005-08
+rugameonline     5156/tcp # Russian Online Game [Andrey_Mohov] [Andrey_Mohov] 2010-08-17
+mediat           5157/tcp # Mediat Remote Object Exchange [Oliver_Anan] [Oliver_Anan] 2010-09-02
+snmpssh          5161/tcp # SNMP over SSH Transport Model [RFC5592]
+snmpssh-trap     5162/tcp # SNMP Notification over SSH Transport Model [RFC5592]
+sbackup          5163/tcp # Shadow Backup [Glenn_Allen] [Glenn_Allen] 2009-08-05
+vpa              5164/tcp # Virtual Protocol Adapter [Douglas_Goodall] [Douglas_Goodall] 2009-08-05
+vpa-disc         5164/udp # Virtual Protocol Adapter Discovery [Douglas_Goodall] [Douglas_Goodall] 2009-08-05
+ife-icorp        5165/tcp # ife_1corpIANA assigned this well-formed service name as a replacement for "ife_icorp". [Paul_Annala] [Paul_Annala]
+ife_icorp        5165/tcp # ife_1corp [Paul_Annala] [Paul_Annala] This entry is an alias to "ife-icorp".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+ife-icorp        5165/udp # ife_1corpIANA assigned this well-formed service name as a replacement for "ife_icorp". [Paul_Annala] [Paul_Annala]
+ife_icorp        5165/udp # ife_1corp [Paul_Annala] [Paul_Annala] This entry is an alias to "ife-icorp".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+winpcs           5166/tcp # WinPCS Service Connection [Complan_Network_AS] [Complan_Network_AS] 2006-02
+winpcs           5166/udp # WinPCS Service Connection [Complan_Network_AS] [Complan_Network_AS] 2006-02
+scte104          5167/tcp # SCTE104 Connection [Thomas_Russell] [Thomas_Russell] 2005-05
+scte104          5167/udp # SCTE104 Connection [Thomas_Russell] [Thomas_Russell] 2005-05
+scte30           5168/tcp # SCTE30 Connection [Thomas_Russell] [Thomas_Russell] 2005-05
+scte30           5168/udp # SCTE30 Connection [Thomas_Russell] [Thomas_Russell] 2005-05
+aol              5190/tcp # America-Online [Marty_Lyons] [Marty_Lyons]
+aol              5190/udp # America-Online [Marty_Lyons] [Marty_Lyons]
+aol-1            5191/tcp # AmericaOnline1 [Bruce_Mackey] [Bruce_Mackey]
+aol-1            5191/udp # AmericaOnline1 [Bruce_Mackey] [Bruce_Mackey]
+aol-2            5192/tcp # AmericaOnline2 [Bruce_Mackey] [Bruce_Mackey]
+aol-2            5192/udp # AmericaOnline2 [Bruce_Mackey] [Bruce_Mackey]
+aol-3            5193/tcp # AmericaOnline3 [Bruce_Mackey] [Bruce_Mackey]
+aol-3            5193/udp # AmericaOnline3 [Bruce_Mackey] [Bruce_Mackey]
+cpscomm          5194/tcp # CipherPoint Config Service [CipherPoint] [CipherPoint] 2010-03-03
+ampl-lic         5195/tcp # The protocol is used by a license server and client programs to control use of program licenses that float to networked machines [AMPL_Optimization] [David_M_Gay] 2012-05-25
+ampl-tableproxy  5196/tcp # The protocol is used by two programs that exchange "table" data used in the AMPL modeling language [AMPL_Optimization] [David_M_Gay] 2012-05-25
+targus-getdata   5200/tcp # TARGUS GetData [John_Keaveney] [John_Keaveney]
+targus-getdata   5200/udp # TARGUS GetData [John_Keaveney] [John_Keaveney]
+targus-getdata1  5201/tcp # TARGUS GetData 1 [John_Keaveney] [John_Keaveney]
+targus-getdata1  5201/udp # TARGUS GetData 1 [John_Keaveney] [John_Keaveney]
+targus-getdata2  5202/tcp # TARGUS GetData 2 [John_Keaveney] [John_Keaveney]
+targus-getdata2  5202/udp # TARGUS GetData 2 [John_Keaveney] [John_Keaveney]
+targus-getdata3  5203/tcp # TARGUS GetData 3 [John_Keaveney] [John_Keaveney]
+targus-getdata3  5203/udp # TARGUS GetData 3 [John_Keaveney] [John_Keaveney]
+nomad            5209/tcp # Nomad Device Video Transfer [Morega_System] [Ashraf_Tahir] 2012-08-20
+3exmp            5221/tcp # 3eTI Extensible Management Protocol for OAMP [Bill_Rettig] [Bill_Rettig] 2010-05-19
+xmpp-client      5222/tcp # XMPP Client Connection [RFC6120]
+hpvirtgrp        5223/tcp # HP Virtual Machine Group Management [John_Williams] [John_Williams] 2007-06
+hpvirtgrp        5223/udp # HP Virtual Machine Group Management [John_Williams] [John_Williams] 2007-06
+hpvirtctrl       5224/tcp # HP Virtual Machine Console Operations [John_Williams] [John_Williams] 2007-06
+hpvirtctrl       5224/udp # HP Virtual Machine Console Operations [John_Williams] [John_Williams] 2007-06
+hp-server        5225/tcp # HP Server [Brett_Green_2] [Brett_Green_2]
+hp-server        5225/udp # HP Server [Brett_Green_2] [Brett_Green_2]
+hp-status        5226/tcp # HP Status [Brett_Green_2] [Brett_Green_2]
+hp-status        5226/udp # HP Status [Brett_Green_2] [Brett_Green_2]
+perfd            5227/tcp # HP System Performance Metric Service [Chris_Bertin] [Chris_Bertin] 2009-05-19
+perfd            5227/udp # HP System Performance Metric Service [Chris_Bertin] [Chris_Bertin] 2009-05-19
+hpvroom          5228/tcp # HP Virtual Room Service [Scott_Levin] [Scott_Levin] 2009-03-19
+csedaemon        5232/tcp # Cruse Scanning System Service [Christof_J_Reetz] [Christof_J_Reetz] 2011-03-09
+enfs             5233/tcp # Etinnae Network File Service [Chris_Peel] [Chris_Peel] 2011-03-09
+eenet            5234/tcp # EEnet communications [Helmut_Giritzer] [Helmut_Giritzer] 2005-11
+eenet            5234/udp # EEnet communications [Helmut_Giritzer] [Helmut_Giritzer] 2005-11
+galaxy-network   5235/tcp # Galaxy Network Service [Michael_Andre_2] [Michael_Andre_2] 2007-10-04
+galaxy-network   5235/udp # Galaxy Network Service [Michael_Andre_2] [Michael_Andre_2] 2007-10-04
+padl2sim         5236/tcp # 
+padl2sim         5236/udp # 
+mnet-discovery   5237/tcp # m-net discovery [Andy_Crick] [Andy_Crick] 2007-11-13
+mnet-discovery   5237/udp # m-net discovery [Andy_Crick] [Andy_Crick] 2007-11-13
+downtools        5245/tcp # DownTools Control Protocol [Jarrod_Sayers] [Jarrod_Sayers] 2009-04-07
+downtools-disc   5245/udp # DownTools Discovery Protocol [Jarrod_Sayers] [Jarrod_Sayers] 2009-04-07
+capwap-control   5246/udp # CAPWAP Control Protocol [RFC5415]
+capwap-data      5247/udp # CAPWAP Data Protocol [RFC5415]
+caacws           5248/tcp # CA Access Control Web Service [Gabriel_Kalmar] [Gabriel_Kalmar] 2008-03-06
+caacws           5248/udp # CA Access Control Web Service [Gabriel_Kalmar] [Gabriel_Kalmar] 2008-03-06
+caaclang2        5249/tcp # CA AC Lang Service [Gabriel_Kalmar] [Gabriel_Kalmar] 2008-02-19
+caaclang2        5249/udp # CA AC Lang Service [Gabriel_Kalmar] [Gabriel_Kalmar] 2008-02-19
+soagateway       5250/tcp # soaGateway [Greg_Bodine] [Greg_Bodine] 2002-02
+soagateway       5250/udp # soaGateway [Greg_Bodine] [Greg_Bodine] 2002-02
+caevms           5251/tcp # CA eTrust VM Service [Kevin_Bond] [Kevin_Bond] 2004-11
+caevms           5251/udp # CA eTrust VM Service [Kevin_Bond] [Kevin_Bond] 2004-11
+movaz-ssc        5252/tcp # Movaz SSC [Lou_Berger] [Lou_Berger] 2004-11
+movaz-ssc        5252/udp # Movaz SSC [Lou_Berger] [Lou_Berger] 2004-11
+kpdp             5253/tcp # Kohler Power Device Protocol [Bill_Gross] [Bill_Gross] 2010-11-01
+3com-njack-1     5264/tcp # 3Com Network Jack Port 1 [Abhay_Rajaram] [Abhay_Rajaram] 2003-03
+3com-njack-1     5264/udp # 3Com Network Jack Port 1 [Abhay_Rajaram] [Abhay_Rajaram] 2003-03
+3com-njack-2     5265/tcp # 3Com Network Jack Port 2 [Abhay_Rajaram] [Abhay_Rajaram] 2003-03
+3com-njack-2     5265/udp # 3Com Network Jack Port 2 [Abhay_Rajaram] [Abhay_Rajaram] 2003-03
+xmpp-server      5269/tcp # XMPP Server Connection [RFC6120]
+cartographerxmp  5270/tcp # Cartographer XMP [Bobby_Krupczak_2] [Bobby_Krupczak_2] 2008-04-03 2011-08-31
+cartographerxmp  5270/udp # Cartographer XMP [Bobby_Krupczak_2] [Bobby_Krupczak_2] 2008-04-03 2011-08-31
+cuelink          5271/tcp # StageSoft CueLink messaging [Todd_Pichler] [Todd_Pichler] 2010-03-26
+cuelink-disc     5271/udp # StageSoft CueLink discovery [Todd_Pichler] [Todd_Pichler] 2010-03-26
+pk               5272/tcp # PK [Patrick_Kara] [Patrick_Kara]
+pk               5272/udp # PK [Patrick_Kara] [Patrick_Kara]
+xmpp-bosh        5280/tcp # Bidirectional-streams Over Synchronous HTTP (BOSH) [Peter_Saint_Andre] [Peter_Saint_Andre] 2009-11-25
+undo-lm          5281/tcp # Undo License Manager [Julian_Smith] [Julian_Smith] 2010-04-19
+transmit-port    5282/tcp # Marimba Transmitter Port [Johan_Eriksson] [Johan_Eriksson] 2002-04
+transmit-port    5282/udp # Marimba Transmitter Port [Johan_Eriksson] [Johan_Eriksson] 2002-04
+presence         5298/tcp # XMPP Link-Local Messaging [Eric_St_Onge] [Eric_St_Onge] 2008-01-14 Defined TXT keys: See http://www.xmpp.org/registrar/linklocal.html
+presence         5298/udp # XMPP Link-Local Messaging [Eric_St_Onge] [Eric_St_Onge] 2008-01-14 Defined TXT keys: See http://www.xmpp.org/registrar/linklocal.html
+nlg-data         5299/tcp # NLG Data Service [Andy_Shellam] [Andy_Shellam] 2008-02-19
+nlg-data         5299/udp # NLG Data Service [Andy_Shellam] [Andy_Shellam] 2008-02-19
+hacl-hb          5300/tcp # HA cluster heartbeat [Eric_Soderberg_2][Edward_Yim] [Eric_Soderberg_2][Edward_Yim]
+hacl-hb          5300/udp # HA cluster heartbeat [Eric_Soderberg_2][Edward_Yim] [Eric_Soderberg_2][Edward_Yim]
+hacl-gs          5301/tcp # HA cluster general services [Eric_Soderberg_2][Edward_Yim] [Eric_Soderberg_2][Edward_Yim]
+hacl-gs          5301/udp # HA cluster general services [Eric_Soderberg_2][Edward_Yim] [Eric_Soderberg_2][Edward_Yim]
+hacl-cfg         5302/tcp # HA cluster configuration [Eric_Soderberg_2][Edward_Yim] [Eric_Soderberg_2][Edward_Yim]
+hacl-cfg         5302/udp # HA cluster configuration [Eric_Soderberg_2][Edward_Yim] [Eric_Soderberg_2][Edward_Yim]
+hacl-probe       5303/tcp # HA cluster probing [Eric_Soderberg_2][Edward_Yim] [Eric_Soderberg_2][Edward_Yim]
+hacl-probe       5303/udp # HA cluster probing [Eric_Soderberg_2][Edward_Yim] [Eric_Soderberg_2][Edward_Yim]
+hacl-local       5304/tcp # HA Cluster Commands [Eric_Soderberg_2][Edward_Yim] [Eric_Soderberg_2][Edward_Yim]
+hacl-local       5304/udp # HA Cluster Commands [Eric_Soderberg_2][Edward_Yim] [Eric_Soderberg_2][Edward_Yim]
+hacl-test        5305/tcp # HA Cluster Test [Eric_Soderberg_2][Edward_Yim] [Eric_Soderberg_2][Edward_Yim]
+hacl-test        5305/udp # HA Cluster Test [Eric_Soderberg_2][Edward_Yim] [Eric_Soderberg_2][Edward_Yim]
+sun-mc-grp       5306/tcp # Sun MC Group [Michael_DeMoney] [Michael_DeMoney]
+sun-mc-grp       5306/udp # Sun MC Group [Michael_DeMoney] [Michael_DeMoney]
+sco-aip          5307/tcp # SCO AIP [Barrie_Cooper] [Barrie_Cooper]
+sco-aip          5307/udp # SCO AIP [Barrie_Cooper] [Barrie_Cooper]
+cfengine         5308/tcp # CFengine [Mark_Burgess] [Mark_Burgess]
+cfengine         5308/udp # CFengine [Mark_Burgess] [Mark_Burgess]
+jprinter         5309/tcp # J Printer [Ken_Blackwell] [Ken_Blackwell]
+jprinter         5309/udp # J Printer [Ken_Blackwell] [Ken_Blackwell]
+outlaws          5310/tcp # Outlaws [Richard_Fife] [Richard_Fife]
+outlaws          5310/udp # Outlaws [Richard_Fife] [Richard_Fife]
+permabit-cs      5312/tcp # Permabit Client-Server [Jered_Floyd] [Jered_Floyd] 2004-06
+permabit-cs      5312/udp # Permabit Client-Server [Jered_Floyd] [Jered_Floyd] 2004-06
+rrdp             5313/tcp # Real-time & Reliable Data [Ted_Hoshi] [Ted_Hoshi] 2004-06
+rrdp             5313/udp # Real-time & Reliable Data [Ted_Hoshi] [Ted_Hoshi] 2004-06
+opalis-rbt-ipc   5314/tcp # opalis-rbt-ipc [Laurent_Domenech] [Laurent_Domenech]
+opalis-rbt-ipc   5314/udp # opalis-rbt-ipc [Laurent_Domenech] [Laurent_Domenech]
+hacl-poll        5315/tcp # HA Cluster UDP Polling [Hoa_Nguyen] [Hoa_Nguyen]
+hacl-poll        5315/udp # HA Cluster UDP Polling [Hoa_Nguyen] [Hoa_Nguyen]
+hpbladems        5316/tcp # HPBladeSystem Monitor Service [Alan_Minchew] [Alan_Minchew] 2011-05-23 2011-05-16
+hpdevms          5317/tcp # HP Device Monitor Service [Alan_Minchew] [Alan_Minchew] 2011-05-16
+pkix-cmc         5318/tcp # PKIX Certificate Management using CMS (CMC) [IESG] [IETF_Chair] [RFC6402]
+bsfserver-zn     5320/tcp # Webservices-based Zn interface of BSF [Bert_Paul] [Bert_Paul] 2008-05-01
+bsfsvr-zn-ssl    5321/tcp # Webservices-based Zn interface of BSF over SSL [Bert_Paul] [Bert_Paul] 2008-07-03
+kfserver         5343/tcp # Sculptor Database Server [Keith_Ashman] [Keith_Ashman] 2005-12
+kfserver         5343/udp # Sculptor Database Server [Keith_Ashman] [Keith_Ashman] 2005-12
+xkotodrcp        5344/tcp # xkoto DRCP [Jeff_Heisz] [Jeff_Heisz] 2006-02
+xkotodrcp        5344/udp # xkoto DRCP [Jeff_Heisz] [Jeff_Heisz] 2006-02
+stuns            5349/tcp # STUN over TLS [RFC5389]
+stuns            5349/udp # Reserved for a future enhancement of STUN [RFC5389]
+turns            5349/tcp # TURN over TLS [RFC5766]
+turns            5349/udp # Reserved for a future enhancement of TURN [RFC5766]
+stun-behaviors   5349/tcp # STUN Behavior Discovery over TLS [RFC5780]
+stun-behaviors   5349/udp # Reserved for a future enhancement of STUN-BEHAVIOR [RFC5780]
+pcp-multicast    5350/udp # Port Control Protocol Multicast [IESG] [IETF_Chair] [RFC6887]
+pcp              5351/udp # Port Control Protocol [IESG] [IETF_Chair] [RFC6887]
+dns-llq          5352/tcp # DNS Long-Lived Queries [Kiren_Sekar] [Kiren_Sekar] 2005-08
+dns-llq          5352/udp # DNS Long-Lived Queries [Kiren_Sekar] [Kiren_Sekar] 2005-08
+mdns             5353/tcp # Multicast DNS [IESG] [IETF_Chair] [RFC6762]
+mdns             5353/udp # Multicast DNS [IESG] [IETF_Chair] [RFC6762]
+mdnsresponder    5354/tcp # Multicast DNS Responder IPC [Stuart_Cheshire_3] [Stuart_Cheshire_3] 2004-06
+mdnsresponder    5354/udp # Multicast DNS Responder IPC [Stuart_Cheshire_3] [Stuart_Cheshire_3] 2004-06
+llmnr            5355/tcp # LLMNR [Bernard_Aboba] [Bernard_Aboba] 2004-06
+llmnr            5355/udp # LLMNR [Bernard_Aboba] [Bernard_Aboba] 2004-06
+ms-smlbiz        5356/tcp # Microsoft Small Business [Gopikrishna_Sandra] [Gopikrishna_Sandra] 2005-02
+ms-smlbiz        5356/udp # Microsoft Small Business [Gopikrishna_Sandra] [Gopikrishna_Sandra] 2005-02
+wsdapi           5357/tcp # Web Services for Devices [Henry_Rawas] [Henry_Rawas] 2005-08
+wsdapi           5357/udp # Web Services for Devices [Henry_Rawas] [Henry_Rawas] 2005-08
+wsdapi-s         5358/tcp # WS for Devices Secured [Henry_Rawas] [Henry_Rawas] 2005-08
+wsdapi-s         5358/udp # WS for Devices Secured [Henry_Rawas] [Henry_Rawas] 2005-08
+ms-alerter       5359/tcp # Microsoft Alerter [Marc_McClure] [Marc_McClure] 2007-08-07
+ms-alerter       5359/udp # Microsoft Alerter [Marc_McClure] [Marc_McClure] 2007-08-07
+ms-sideshow      5360/tcp # Protocol for Windows SideShow [Dan_Polivy] [Dan_Polivy] 2008-03-12
+ms-sideshow      5360/udp # Protocol for Windows SideShow [Dan_Polivy] [Dan_Polivy] 2008-03-12
+ms-s-sideshow    5361/tcp # Secure Protocol for Windows SideShow [Dan_Polivy] [Dan_Polivy] 2008-03-12
+ms-s-sideshow    5361/udp # Secure Protocol for Windows SideShow [Dan_Polivy] [Dan_Polivy] 2008-03-12
+serverwsd2       5362/tcp # Microsoft Windows Server WSD2 Service [Erhan_Soyer_Osman] [Erhan_Soyer_Osman] 2008-03-26
+serverwsd2       5362/udp # Microsoft Windows Server WSD2 Service [Erhan_Soyer_Osman] [Erhan_Soyer_Osman] 2008-03-26
+net-projection   5363/tcp # Windows Network Projection [Rob_Williams] [Rob_Williams] 2009-02-17
+net-projection   5363/udp # Windows Network Projection [Rob_Williams] [Rob_Williams] 2009-02-17
+kdnet            5364/udp # Microsoft Kernel Debugger [Microsoft_Corporation_4] [Joe_Ballantyne] 2013-06-16
+stresstester     5397/tcp # StressTester(tm) Injector [Graham_Parsons] [Graham_Parsons] 2005-08
+stresstester     5397/udp # StressTester(tm) Injector [Graham_Parsons] [Graham_Parsons] 2005-08
+elektron-admin   5398/tcp # Elektron Administration [Chris_Hawk] [Chris_Hawk] 2005-08
+elektron-admin   5398/udp # Elektron Administration [Chris_Hawk] [Chris_Hawk] 2005-08
+securitychase    5399/tcp # SecurityChase [Daisuke_Shinomiya] [Daisuke_Shinomiya] 2005-08
+securitychase    5399/udp # SecurityChase [Daisuke_Shinomiya] [Daisuke_Shinomiya] 2005-08
+excerpt          5400/tcp # Excerpt Search [John_Hinsdale] [John_Hinsdale]
+excerpt          5400/udp # Excerpt Search [John_Hinsdale] [John_Hinsdale]
+excerpts         5401/tcp # Excerpt Search Secure [John_Hinsdale] [John_Hinsdale]
+excerpts         5401/udp # Excerpt Search Secure [John_Hinsdale] [John_Hinsdale]
+mftp             5402/tcp # OmniCast MFTP [Steve_Bannister] [Steve_Bannister]
+mftp             5402/udp # OmniCast MFTP [Steve_Bannister] [Steve_Bannister]
+hpoms-ci-lstn    5403/tcp # HPOMS-CI-LSTN [Harold_Froehling] [Harold_Froehling]
+hpoms-ci-lstn    5403/udp # HPOMS-CI-LSTN [Harold_Froehling] [Harold_Froehling]
+hpoms-dps-lstn   5404/tcp # HPOMS-DPS-LSTN [Harold_Froehling] [Harold_Froehling]
+hpoms-dps-lstn   5404/udp # HPOMS-DPS-LSTN [Harold_Froehling] [Harold_Froehling]
+netsupport       5405/tcp # NetSupport [Paul_Sanders_2] [Paul_Sanders_2]
+netsupport       5405/udp # NetSupport [Paul_Sanders_2] [Paul_Sanders_2]
+systemics-sox    5406/tcp # Systemics Sox [Gary_Howland] [Gary_Howland]
+systemics-sox    5406/udp # Systemics Sox [Gary_Howland] [Gary_Howland]
+foresyte-clear   5407/tcp # Foresyte-Clear [Jorge_Aldana] [Jorge_Aldana]
+foresyte-clear   5407/udp # Foresyte-Clear [Jorge_Aldana] [Jorge_Aldana]
+foresyte-sec     5408/tcp # Foresyte-Sec [Jorge_Aldana] [Jorge_Aldana]
+foresyte-sec     5408/udp # Foresyte-Sec [Jorge_Aldana] [Jorge_Aldana]
+salient-dtasrv   5409/tcp # Salient Data Server [Richard_Farnham] [Richard_Farnham]
+salient-dtasrv   5409/udp # Salient Data Server [Richard_Farnham] [Richard_Farnham]
+salient-usrmgr   5410/tcp # Salient User Manager [Richard_Farnham] [Richard_Farnham]
+salient-usrmgr   5410/udp # Salient User Manager [Richard_Farnham] [Richard_Farnham]
+actnet           5411/tcp # ActNet [Simon_Robillard] [Simon_Robillard]
+actnet           5411/udp # ActNet [Simon_Robillard] [Simon_Robillard]
+continuus        5412/tcp # Continuus [Steven_Holtsberg] [Steven_Holtsberg]
+continuus        5412/udp # Continuus [Steven_Holtsberg] [Steven_Holtsberg]
+wwiotalk         5413/tcp # WWIOTALK [Roger_Knobbe] [Roger_Knobbe]
+wwiotalk         5413/udp # WWIOTALK [Roger_Knobbe] [Roger_Knobbe]
+statusd          5414/tcp # StatusD [Stephen_Misel_2] [Stephen_Misel_2]
+statusd          5414/udp # StatusD [Stephen_Misel_2] [Stephen_Misel_2]
+ns-server        5415/tcp # NS Server [Jeffrey_Chiao] [Jeffrey_Chiao]
+ns-server        5415/udp # NS Server [Jeffrey_Chiao] [Jeffrey_Chiao]
+sns-gateway      5416/tcp # SNS Gateway [Mary_Holstage] [Mary_Holstage]
+sns-gateway      5416/udp # SNS Gateway [Mary_Holstage] [Mary_Holstage]
+sns-agent        5417/tcp # SNS Agent [Mary_Holstage] [Mary_Holstage]
+sns-agent        5417/udp # SNS Agent [Mary_Holstage] [Mary_Holstage]
+mcntp            5418/tcp # MCNTP [Heiko_Rupp] [Heiko_Rupp]
+mcntp            5418/udp # MCNTP [Heiko_Rupp] [Heiko_Rupp]
+dj-ice           5419/tcp # DJ-ICE [Don_Tyson_2] [Don_Tyson_2]
+dj-ice           5419/udp # DJ-ICE [Don_Tyson_2] [Don_Tyson_2]
+cylink-c         5420/tcp # Cylink-C [John_Jobe] [John_Jobe]
+cylink-c         5420/udp # Cylink-C [John_Jobe] [John_Jobe]
+netsupport2      5421/tcp # Net Support 2 [Paul_Sanders] [Paul_Sanders]
+netsupport2      5421/udp # Net Support 2 [Paul_Sanders] [Paul_Sanders]
+salient-mux      5422/tcp # Salient MUX [Richard_Farnham] [Richard_Farnham]
+salient-mux      5422/udp # Salient MUX [Richard_Farnham] [Richard_Farnham]
+virtualuser      5423/tcp # VIRTUALUSER [Chad_Williams] [Chad_Williams]
+virtualuser      5423/udp # VIRTUALUSER [Chad_Williams] [Chad_Williams]
+beyond-remote    5424/tcp # Beyond Remote [Michael_Berg] [Michael_Berg] 2004-11
+beyond-remote    5424/udp # Beyond Remote [Michael_Berg] [Michael_Berg] 2004-11
+br-channel       5425/tcp # Beyond Remote Command Channel [Michael_Berg] [Michael_Berg] 2005-08
+br-channel       5425/udp # Beyond Remote Command Channel [Michael_Berg] [Michael_Berg] 2005-08
+devbasic         5426/tcp # DEVBASIC [Curtis_Smith] [Curtis_Smith]
+devbasic         5426/udp # DEVBASIC [Curtis_Smith] [Curtis_Smith]
+sco-peer-tta     5427/tcp # SCO-PEER-TTA [Andrew_Shire] [Andrew_Shire]
+sco-peer-tta     5427/udp # SCO-PEER-TTA [Andrew_Shire] [Andrew_Shire]
+telaconsole      5428/tcp # TELACONSOLE [Joseph_M_Newcomer] [Joseph_M_Newcomer]
+telaconsole      5428/udp # TELACONSOLE [Joseph_M_Newcomer] [Joseph_M_Newcomer]
+base             5429/tcp # Billing and Accounting System Exchange [Odo_Maletzki] [Odo_Maletzki]
+base             5429/udp # Billing and Accounting System Exchange [Odo_Maletzki] [Odo_Maletzki]
+radec-corp       5430/tcp # RADEC CORP [David_Chell] [David_Chell]
+radec-corp       5430/udp # RADEC CORP [David_Chell] [David_Chell]
+park-agent       5431/tcp # PARK AGENT [John_Clifford] [John_Clifford]
+park-agent       5431/udp # PARK AGENT [John_Clifford] [John_Clifford]
+postgresql       5432/tcp # PostgreSQL Database [Tom_Lane] [Tom_Lane]
+postgresql       5432/udp # PostgreSQL Database [Tom_Lane] [Tom_Lane]
+pyrrho           5433/tcp # Pyrrho DBMS [Malcolm_Crowe] [Malcolm_Crowe] 2005-11
+pyrrho           5433/udp # Pyrrho DBMS [Malcolm_Crowe] [Malcolm_Crowe] 2005-11
+sgi-arrayd       5434/tcp # SGI Array Services Daemon [Karl_Feind] [Karl_Feind] 2005-10
+sgi-arrayd       5434/udp # SGI Array Services Daemon [Karl_Feind] [Karl_Feind] 2005-10
+sceanics         5435/tcp # SCEANICS situation and action notification [Richard_Olsen] [Richard_Olsen]
+sceanics         5435/udp # SCEANICS situation and action notification [Richard_Olsen] [Richard_Olsen]
+pmip6-cntl       5436/udp # pmip6-cntl [RFC5844]
+pmip6-data       5437/udp # pmip6-data [RFC5844]
+spss             5443/tcp # Pearson HTTPS [Pearson] [Pearson] 2008-01-17
+spss             5443/udp # Pearson HTTPS [Pearson] [Pearson] 2008-01-17
+smbdirect        5445/tcp # Server Message Block over Remote Direct Memory Access [Microsoft_Corporation_2] [Tom_Talpey] 2012-03-15
+smbdirect        5445/sctp # Server Message Block over Remote Direct Memory Access [Microsoft_Corporation_2] [Tom_Talpey] 2012-03-15
+surebox          5453/tcp # SureBox [Emin_BORU] [Emin_BORU] 2004-11
+surebox          5453/udp # SureBox [Emin_BORU] [Emin_BORU] 2004-11
+apc-5454         5454/tcp # APC 5454 [American_Power_Conve] [American_Power_Conve]
+apc-5454         5454/udp # APC 5454 [American_Power_Conve] [American_Power_Conve]
+apc-5455         5455/tcp # APC 5455 [American_Power_Conve] [American_Power_Conve]
+apc-5455         5455/udp # APC 5455 [American_Power_Conve] [American_Power_Conve]
+apc-5456         5456/tcp # APC 5456 [American_Power_Conve] [American_Power_Conve]
+apc-5456         5456/udp # APC 5456 [American_Power_Conve] [American_Power_Conve]
+silkmeter        5461/tcp # SILKMETER [Klaus_Fellner] [Klaus_Fellner]
+silkmeter        5461/udp # SILKMETER [Klaus_Fellner] [Klaus_Fellner]
+ttl-publisher    5462/tcp # TTL Publisher [Peter_Jacobs] [Peter_Jacobs]
+ttl-publisher    5462/udp # TTL Publisher [Peter_Jacobs] [Peter_Jacobs]
+ttlpriceproxy    5463/tcp # TTL Price Proxy [Peter_Jacobs] [Peter_Jacobs]
+ttlpriceproxy    5463/udp # TTL Price Proxy [Peter_Jacobs] [Peter_Jacobs]
+quailnet         5464/tcp # Quail Networks Object Broker [Craig_N_Bissell] [Craig_N_Bissell] 2006-04
+quailnet         5464/udp # Quail Networks Object Broker [Craig_N_Bissell] [Craig_N_Bissell] 2006-04
+netops-broker    5465/tcp # NETOPS-BROKER [John_R_Deuel] [John_R_Deuel]
+netops-broker    5465/udp # NETOPS-BROKER [John_R_Deuel] [John_R_Deuel]
+fcp-addr-srvr1   5500/tcp # fcp-addr-srvr1 [Ken_Wittmer] [Ken_Wittmer]
+fcp-addr-srvr1   5500/udp # fcp-addr-srvr1 [Ken_Wittmer] [Ken_Wittmer]
+fcp-addr-srvr2   5501/tcp # fcp-addr-srvr2 [Ken_Wittmer] [Ken_Wittmer]
+fcp-addr-srvr2   5501/udp # fcp-addr-srvr2 [Ken_Wittmer] [Ken_Wittmer]
+fcp-srvr-inst1   5502/tcp # fcp-srvr-inst1 [Ken_Wittmer] [Ken_Wittmer]
+fcp-srvr-inst1   5502/udp # fcp-srvr-inst1 [Ken_Wittmer] [Ken_Wittmer]
+fcp-srvr-inst2   5503/tcp # fcp-srvr-inst2 [Ken_Wittmer] [Ken_Wittmer]
+fcp-srvr-inst2   5503/udp # fcp-srvr-inst2 [Ken_Wittmer] [Ken_Wittmer]
+fcp-cics-gw1     5504/tcp # fcp-cics-gw1 [Ken_Wittmer] [Ken_Wittmer]
+fcp-cics-gw1     5504/udp # fcp-cics-gw1 [Ken_Wittmer] [Ken_Wittmer]
+checkoutdb       5505/tcp # Checkout Database [Dirk_Stoop] [Dirk_Stoop] 2007-04
+checkoutdb       5505/udp # Checkout Database [Dirk_Stoop] [Dirk_Stoop] 2007-04
+amc              5506/tcp # Amcom Mobile Connect [Aaron_Fracht_Monroe] [Aaron_Fracht_Monroe] 2010-06-03
+amc              5506/udp # Amcom Mobile Connect [Aaron_Fracht_Monroe] [Aaron_Fracht_Monroe] 2010-06-03
+sgi-eventmond    5553/tcp # SGI Eventmond Port [Andrei_Vilkotski] [Andrei_Vilkotski] 2003-06
+sgi-eventmond    5553/udp # SGI Eventmond Port [Andrei_Vilkotski] [Andrei_Vilkotski] 2003-06
+sgi-esphttp      5554/tcp # SGI ESP HTTP [Vladimir_Legalov] [Vladimir_Legalov]
+sgi-esphttp      5554/udp # SGI ESP HTTP [Vladimir_Legalov] [Vladimir_Legalov]
+personal-agent   5555/tcp # Personal Agent [Jackie_Wu] [Jackie_Wu] Known UNAUTHORIZED USEs on port 5555
+personal-agent   5555/udp # Personal Agent [Jackie_Wu] [Jackie_Wu] Known UNAUTHORIZED USEs on port 5555
+freeciv          5556/tcp # Freeciv gameplay [Reinier_Post_and_Pau] [Reinier_Post_and_Pau] 2006-01
+freeciv          5556/udp # Freeciv gameplay [Reinier_Post_and_Pau] [Reinier_Post_and_Pau] 2006-01
+farenet          5557/tcp # Sandlab FARENET [Kay_T_Labinsky] [Kay_T_Labinsky] 2010-05-03
+westec-connect   5566/tcp # Westec Connect [Jon_Bolen] [Jon_Bolen] 2009-03-18
+enc-eps-mc-sec   5567/tcp # EMIT protocol stack multicast/secure transport [Panasonic_Intranet_Panasonic_North_America_PEWLA] [Bryant_Eastham] 2004-11 2012-11-12
+enc-eps-mc-sec   5567/udp # EMIT protocol stack multicast/secure transport [Panasonic_Intranet_Panasonic_North_America_PEWLA] [Bryant_Eastham] 2004-11 2012-11-12
+sdt              5568/tcp # Session Data Transport Multicast [Daniel_W_Antonuk] [Daniel_W_Antonuk] 2006-05
+sdt              5568/udp # Session Data Transport Multicast [Daniel_W_Antonuk] [Daniel_W_Antonuk] 2006-05
+rdmnet-ctrl      5569/tcp # PLASA E1.33, Remote Device Management (RDM) controller status notifications [PLASA] [Simon_Newton] 2012-06-01
+rdmnet-device    5569/udp # PLASA E1.33, Remote Device Management (RDM) messages [PLASA] [Simon_Newton] 2012-06-01
+sdmmp            5573/tcp # SAS Domain Management Messaging Protocol [Ron_Zuckerman] [Ron_Zuckerman] 2007-08-30
+sdmmp            5573/udp # SAS Domain Management Messaging Protocol [Ron_Zuckerman] [Ron_Zuckerman] 2007-08-30
+lsi-bobcat       5574/tcp # SAS IO Forwarding [Mandar_Joshi] [Mandar_Joshi] 2009-02-09
+ora-oap          5575/tcp # Oracle Access Protocol [Peter_Povinec] [Peter_Povinec] 2010-04-13
+fdtracks         5579/tcp # FleetDisplay Tracking Service [Henrik_Woffinden] [Henrik_Woffinden] 2008-09-22
+tmosms0          5580/tcp # T-Mobile SMS Protocol Message 0 [Ezinne_Oji] [Ezinne_Oji] 2006-06
+tmosms0          5580/udp # T-Mobile SMS Protocol Message 0 [Ezinne_Oji] [Ezinne_Oji] 2006-06
+tmosms1          5581/tcp # T-Mobile SMS Protocol Message 1 [Ezinne_Oji] [Ezinne_Oji] 2006-06
+tmosms1          5581/udp # T-Mobile SMS Protocol Message 1 [Ezinne_Oji] [Ezinne_Oji] 2006-06
+fac-restore      5582/tcp # T-Mobile SMS Protocol Message 3 [Jessica_Yan] [Jessica_Yan] 2008-02-19
+fac-restore      5582/udp # T-Mobile SMS Protocol Message 3 [Jessica_Yan] [Jessica_Yan] 2008-02-19
+tmo-icon-sync    5583/tcp # T-Mobile SMS Protocol Message 2 [Donghwan_Lim] [Donghwan_Lim] 2008-01-22
+tmo-icon-sync    5583/udp # T-Mobile SMS Protocol Message 2 [Donghwan_Lim] [Donghwan_Lim] 2008-01-22
+bis-web          5584/tcp # BeInSync-Web [Adi_Ruppin] [Adi_Ruppin] 2005-08
+bis-web          5584/udp # BeInSync-Web [Adi_Ruppin] [Adi_Ruppin] 2005-08
+bis-sync         5585/tcp # BeInSync-sync [Adi_Ruppin] [Adi_Ruppin] 2005-08
+bis-sync         5585/udp # BeInSync-sync [Adi_Ruppin] [Adi_Ruppin] 2005-08
+ininmessaging    5597/tcp # inin secure messaging [Mike_Gagle_2] [Mike_Gagle_2] 2006-05
+ininmessaging    5597/udp # inin secure messaging [Mike_Gagle_2] [Mike_Gagle_2] 2006-05
+mctfeed          5598/tcp # MCT Market Data Feed [Stephane_Touizer] [Stephane_Touizer] 2006-05
+mctfeed          5598/udp # MCT Market Data Feed [Stephane_Touizer] [Stephane_Touizer] 2006-05
+esinstall        5599/tcp # Enterprise Security Remote Install [Kimberly_Gibbs] [Kimberly_Gibbs]
+esinstall        5599/udp # Enterprise Security Remote Install [Kimberly_Gibbs] [Kimberly_Gibbs]
+esmmanager       5600/tcp # Enterprise Security Manager [Kimberly_Gibbs] [Kimberly_Gibbs]
+esmmanager       5600/udp # Enterprise Security Manager [Kimberly_Gibbs] [Kimberly_Gibbs]
+esmagent         5601/tcp # Enterprise Security Agent [Kimberly_Gibbs] [Kimberly_Gibbs]
+esmagent         5601/udp # Enterprise Security Agent [Kimberly_Gibbs] [Kimberly_Gibbs]
+a1-msc           5602/tcp # A1-MSC [Mike_Dolan] [Mike_Dolan]
+a1-msc           5602/udp # A1-MSC [Mike_Dolan] [Mike_Dolan]
+a1-bs            5603/tcp # A1-BS [Mike_Dolan] [Mike_Dolan]
+a1-bs            5603/udp # A1-BS [Mike_Dolan] [Mike_Dolan]
+a3-sdunode       5604/tcp # A3-SDUNode [Mike_Dolan] [Mike_Dolan]
+a3-sdunode       5604/udp # A3-SDUNode [Mike_Dolan] [Mike_Dolan]
+a4-sdunode       5605/tcp # A4-SDUNode [Mike_Dolan] [Mike_Dolan]
+a4-sdunode       5605/udp # A4-SDUNode [Mike_Dolan] [Mike_Dolan]
+efr              5618/tcp # Fiscal Registering Protocol [efsta] [Alois_Reisinger] 2013-08-13
+ninaf            5627/tcp # Node Initiated Network Association Forma [Thomas_Scholl] [Thomas_Scholl] 2006-03
+ninaf            5627/udp # Node Initiated Network Association Forma [Thomas_Scholl] [Thomas_Scholl] 2006-03
+htrust           5628/tcp # HTrust API [Karl_Olafsson] [Karl_Olafsson] 2008-10-24
+htrust           5628/udp # HTrust API [Karl_Olafsson] [Karl_Olafsson] 2008-10-24
+symantec-sfdb    5629/tcp # Symantec Storage Foundation for Database [Quang_Thoi] [Quang_Thoi] 2006-11
+symantec-sfdb    5629/udp # Symantec Storage Foundation for Database [Quang_Thoi] [Quang_Thoi] 2006-11
+precise-comm     5630/tcp # PreciseCommunication [Alon_Tamir] [Alon_Tamir] 2006-04
+precise-comm     5630/udp # PreciseCommunication [Alon_Tamir] [Alon_Tamir] 2006-04
+pcanywheredata   5631/tcp # pcANYWHEREdata [Jon_Rosarky] [Jon_Rosarky]
+pcanywheredata   5631/udp # pcANYWHEREdata [Jon_Rosarky] [Jon_Rosarky]
+pcanywherestat   5632/tcp # pcANYWHEREstat [Jon_Rosarky] [Jon_Rosarky]
+pcanywherestat   5632/udp # pcANYWHEREstat [Jon_Rosarky] [Jon_Rosarky]
+beorl            5633/tcp # BE Operations Request Listener [Chirag_Desai] [Chirag_Desai] 2006-02
+beorl            5633/udp # BE Operations Request Listener [Chirag_Desai] [Chirag_Desai] 2006-02
+xprtld           5634/tcp # SF Message Service [VR_Satish] [VR_Satish] 2007-08-16
+xprtld           5634/udp # SF Message Service [VR_Satish] [VR_Satish] 2007-08-16
+sfmsso           5635/tcp # SFM Authentication Subsystem [De_Chih_Chien] [De_Chih_Chien] 2008-09-15
+sfm-db-server    5636/tcp # SFMdb - SFM DB server [De_Chih_Chien] [De_Chih_Chien] 2008-10-06
+cssc             5637/tcp # Symantec CSSC [Amol_P_Tambe] [Amol_P_Tambe] 2011-02-02
+flcrs            5638/tcp # Symantec Fingerprint Lookup and Container Reference Service [Symantec_Corp] [Neel_A_Bhatt] 2012-01-03
+ics              5639/tcp # Symantec Integrity Checking Service [Symantec_Corp2] [Danzhou_Liu] 2012-05-07
+vfmobile         5646/tcp # Ventureforth Mobile [Ventureforth_Inc] [Blakely_Snyder] 2011-11-03
+filemq           5670/tcp # ZeroMQ file publish-subscribe protocol [Pieter_Hintjens2] [Pieter_Hintjens2] 2012-11-01 2013-02-25
+zre-disc         5670/udp # Local area discovery and messaging over ZeroMQ [Pieter_Hintjens_3] [Pieter_Hintjens_3] 2012-12-17
+amqps            5671/tcp # amqp protocol over TLS/SSL [Ted_Ross_2] [Ted_Ross_2] 2008-03-26
+amqps            5671/udp # amqp protocol over TLS/SSL [Ted_Ross_2] [Ted_Ross_2] 2008-03-26
+amqp             5672/tcp # AMQP [Pieter_Hintjens] [Pieter_Hintjens] 2006-01
+amqp             5672/udp # AMQP [Pieter_Hintjens] [Pieter_Hintjens] 2006-01
+amqp             5672/sctp # AMQP [Martin_Sustrik] [Martin_Sustrik] 2007-03
+jms              5673/tcp # JACL Message Server [Stuart_Allen] [Stuart_Allen] 2002-02
+jms              5673/udp # JACL Message Server [Stuart_Allen] [Stuart_Allen] 2002-02
+hyperscsi-port   5674/tcp # HyperSCSI Port [Data_Storage_Institu] [Data_Storage_Institu] 2002-02
+hyperscsi-port   5674/udp # HyperSCSI Port [Data_Storage_Institu] [Data_Storage_Institu] 2002-02
+v5ua             5675/tcp # V5UA application port [RFC3807]
+v5ua             5675/udp # V5UA application port [RFC3807]
+v5ua             5675/sctp # V5UA application port [RFC3807]
+raadmin          5676/tcp # RA Administration [Sergei_Zjaikin] [Sergei_Zjaikin] 2002-02
+raadmin          5676/udp # RA Administration [Sergei_Zjaikin] [Sergei_Zjaikin] 2002-02
+questdb2-lnchr   5677/tcp # Quest Central DB2 Launchr [Robert_M_Mackowiak] [Robert_M_Mackowiak] 2002-02
+questdb2-lnchr   5677/udp # Quest Central DB2 Launchr [Robert_M_Mackowiak] [Robert_M_Mackowiak] 2002-02
+rrac             5678/tcp # Remote Replication Agent Connection
+rrac             5678/udp # Remote Replication Agent Connection
+dccm             5679/tcp # Direct Cable Connect Manager [Mark_Miller_2] [Mark_Miller_2]
+dccm             5679/udp # Direct Cable Connect Manager [Mark_Miller_2] [Mark_Miller_2]
+auriga-router    5680/tcp # Auriga Router Service [Vincent_Gaudeul] [Vincent_Gaudeul] 2006-02
+auriga-router    5680/udp # Auriga Router Service [Vincent_Gaudeul] [Vincent_Gaudeul] 2006-02
+ncxcp            5681/tcp # Net-coneX Control Protocol [Ryan_Werber] [Ryan_Werber] 2006-06
+ncxcp            5681/udp # Net-coneX Control Protocol [Ryan_Werber] [Ryan_Werber] 2006-06
+brightcore       5682/udp # BrightCore control & data transfer exchange [Marko_Bjelac] [Marko_Bjelac] 2010-06-10
+coap             5683/udp # Constrained Application Protocol [IESG] [IETF_Chair] 2011-06-13 2013-07-25 [RFC-ietf-core-coap-18]
+coaps            5684/udp # DTLS-secured CoAP [IESG] [IETF_Chair] 2013-07-25 [RFC-ietf-core-coap-18]
+ggz              5688/tcp # GGZ Gaming Zone [Josef_Spillner] [Josef_Spillner] 2003-01
+ggz              5688/udp # GGZ Gaming Zone [Josef_Spillner] [Josef_Spillner] 2003-01
+qmvideo          5689/tcp # QM video network management protocol [Jamie_Lokier] [Jamie_Lokier] 2006-05
+qmvideo          5689/udp # QM video network management protocol [Jamie_Lokier] [Jamie_Lokier] 2006-05
+rbsystem         5693/tcp # Robert Bosch Data Transfer [Robert_Bosch_GmbH] [Klaus_Warth] 2011-08-01 2012-07-17
+kmip             5696/tcp # Key Management Interoperability Protocol [OASIS_KMIP_Technical_Committee] [Robin_Cover] 2011-07-25
+proshareaudio    5713/tcp # proshare conf audio [gunner] [gunner]
+proshareaudio    5713/udp # proshare conf audio [gunner] [gunner]
+prosharevideo    5714/tcp # proshare conf video [gunner] [gunner]
+prosharevideo    5714/udp # proshare conf video [gunner] [gunner]
+prosharedata     5715/tcp # proshare conf data [gunner] [gunner]
+prosharedata     5715/udp # proshare conf data [gunner] [gunner]
+prosharerequest  5716/tcp # proshare conf request [gunner] [gunner]
+prosharerequest  5716/udp # proshare conf request [gunner] [gunner]
+prosharenotify   5717/tcp # proshare conf notify [gunner] [gunner]
+prosharenotify   5717/udp # proshare conf notify
+dpm              5718/tcp # DPM Communication Server [Sundar_Srinivasan][Vinay_Badami] [Sundar_Srinivasan][Vinay_Badami]
+dpm              5718/udp # DPM Communication Server [Sundar_Srinivasan][Vinay_Badami] [Sundar_Srinivasan][Vinay_Badami]
+dpm-agent        5719/tcp # DPM Agent Coordinator [Sundar_Srinivasan][Vinay_Badami] [Sundar_Srinivasan][Vinay_Badami] 2006-05
+dpm-agent        5719/udp # DPM Agent Coordinator [Sundar_Srinivasan][Vinay_Badami] [Sundar_Srinivasan][Vinay_Badami] 2006-05
+ms-licensing     5720/tcp # MS-Licensing [Thomas_Lindeman] [Thomas_Lindeman] 2002-11
+ms-licensing     5720/udp # MS-Licensing [Thomas_Lindeman] [Thomas_Lindeman] 2002-11
+dtpt             5721/tcp # Desktop Passthru Service [Dan_Leising] [Dan_Leising] 2005-01
+dtpt             5721/udp # Desktop Passthru Service [Dan_Leising] [Dan_Leising] 2005-01
+msdfsr           5722/tcp # Microsoft DFS Replication Service [Guhan_Suriyanarayana] [Guhan_Suriyanarayana] 2006-03
+msdfsr           5722/udp # Microsoft DFS Replication Service [Guhan_Suriyanarayana] [Guhan_Suriyanarayana] 2006-03
+omhs             5723/tcp # Operations Manager - Health Service [Gerardo_Dilillo] [Gerardo_Dilillo] 2006-08
+omhs             5723/udp # Operations Manager - Health Service [Gerardo_Dilillo] [Gerardo_Dilillo] 2006-08
+omsdk            5724/tcp # Operations Manager - SDK Service [Gerardo_Dilillo] [Gerardo_Dilillo] 2006-08
+omsdk            5724/udp # Operations Manager - SDK Service [Gerardo_Dilillo] [Gerardo_Dilillo] 2006-08
+ms-ilm           5725/tcp # Microsoft Identity Lifecycle Manager [Rob_Ward] [Rob_Ward]
+ms-ilm-sts       5726/tcp # Microsoft Lifecycle Manager Secure Token Service [Rob_Ward] [Rob_Ward]
+asgenf           5727/tcp # ASG Event Notification Framework [Arman_Bedonian] [Arman_Bedonian] 2009-07-15
+io-dist-data     5728/tcp # Dist. I/O Comm. Service Data and Control [Harish_Kuttan] [Harish_Kuttan] 2010-03-22
+io-dist-group    5728/udp # Dist. I/O Comm. Service Group Membership [Harish_Kuttan] [Harish_Kuttan] 2010-03-22
+openmail         5729/tcp # Openmail User Agent Layer [OpenMail_Encyclopedi][Don_Loughry] [OpenMail_Encyclopedi][Don_Loughry]
+openmail         5729/udp # Openmail User Agent Layer [OpenMail_Encyclopedi][Don_Loughry] [OpenMail_Encyclopedi][Don_Loughry]
+unieng           5730/tcp # Steltor's calendar access [Bernard_Desruisseaux] [Bernard_Desruisseaux]
+unieng           5730/udp # Steltor's calendar access [Bernard_Desruisseaux] [Bernard_Desruisseaux]
+ida-discover1    5741/tcp # IDA Discover Port 1 [MPITech_Support] [MPITech_Support]
+ida-discover1    5741/udp # IDA Discover Port 1 [MPITech_Support] [MPITech_Support]
+ida-discover2    5742/tcp # IDA Discover Port 2 [MPITech_Support] [MPITech_Support]
+ida-discover2    5742/udp # IDA Discover Port 2 [MPITech_Support] [MPITech_Support]
+watchdoc-pod     5743/tcp # Watchdoc NetPOD Protocol [Christophe_Chevalier] [Christophe_Chevalier] 2005-08
+watchdoc-pod     5743/udp # Watchdoc NetPOD Protocol [Christophe_Chevalier] [Christophe_Chevalier] 2005-08
+watchdoc         5744/tcp # Watchdoc Server [Christophe_Chevalier] [Christophe_Chevalier] 2004-11
+watchdoc         5744/udp # Watchdoc Server [Christophe_Chevalier] [Christophe_Chevalier] 2004-11
+fcopy-server     5745/tcp # fcopy-server [Moshe_Leibovitch] [Moshe_Leibovitch]
+fcopy-server     5745/udp # fcopy-server [Moshe_Leibovitch] [Moshe_Leibovitch]
+fcopys-server    5746/tcp # fcopys-server [Moshe_Leibovitch] [Moshe_Leibovitch]
+fcopys-server    5746/udp # fcopys-server [Moshe_Leibovitch] [Moshe_Leibovitch]
+tunatic          5747/tcp # Wildbits Tunatic [Sylvain_Demongeot] [Sylvain_Demongeot] 2005-08
+tunatic          5747/udp # Wildbits Tunatic [Sylvain_Demongeot] [Sylvain_Demongeot] 2005-08
+tunalyzer        5748/tcp # Wildbits Tunalyzer [Sylvain_Demongeot] [Sylvain_Demongeot] 2005-08
+tunalyzer        5748/udp # Wildbits Tunalyzer [Sylvain_Demongeot] [Sylvain_Demongeot] 2005-08
+rscd             5750/tcp # Bladelogic Agent Service [Brian_Trevor] [Brian_Trevor] 2008-10-24
+rscd             5750/udp # Bladelogic Agent Service [Brian_Trevor] [Brian_Trevor] 2008-10-24
+openmailg        5755/tcp # OpenMail Desk Gateway server [OpenMail_Encyclopedi][Don_Loughry] [OpenMail_Encyclopedi][Don_Loughry]
+openmailg        5755/udp # OpenMail Desk Gateway server [OpenMail_Encyclopedi][Don_Loughry] [OpenMail_Encyclopedi][Don_Loughry]
+x500ms           5757/tcp # OpenMail X.500 Directory Server [OpenMail_Encyclopedi][Don_Loughry] [OpenMail_Encyclopedi][Don_Loughry]
+x500ms           5757/udp # OpenMail X.500 Directory Server [OpenMail_Encyclopedi][Don_Loughry] [OpenMail_Encyclopedi][Don_Loughry]
+openmailns       5766/tcp # OpenMail NewMail Server [OpenMail_Encyclopedi][Don_Loughry] [OpenMail_Encyclopedi][Don_Loughry]
+openmailns       5766/udp # OpenMail NewMail Server [OpenMail_Encyclopedi][Don_Loughry] [OpenMail_Encyclopedi][Don_Loughry]
+s-openmail       5767/tcp # OpenMail Suer Agent Layer (Secure) [OpenMail_Encyclopedi][Don_Loughry] [OpenMail_Encyclopedi][Don_Loughry]
+s-openmail       5767/udp # OpenMail Suer Agent Layer (Secure) [OpenMail_Encyclopedi][Don_Loughry] [OpenMail_Encyclopedi][Don_Loughry]
+openmailpxy      5768/tcp # OpenMail CMTS Server [OpenMail_Encyclopedi][Don_Loughry] [OpenMail_Encyclopedi][Don_Loughry]
+openmailpxy      5768/udp # OpenMail CMTS Server [OpenMail_Encyclopedi][Don_Loughry] [OpenMail_Encyclopedi][Don_Loughry]
+spramsca         5769/tcp # x509solutions Internal CA [Brendan_Fay] [Brendan_Fay] 2006-02
+spramsca         5769/udp # x509solutions Internal CA [Brendan_Fay] [Brendan_Fay] 2006-02
+spramsd          5770/tcp # x509solutions Secure Data [Brendan_Fay] [Brendan_Fay] 2006-02
+spramsd          5770/udp # x509solutions Secure Data [Brendan_Fay] [Brendan_Fay] 2006-02
+netagent         5771/tcp # NetAgent [Bradley_Birnbaum] [Bradley_Birnbaum]
+netagent         5771/udp # NetAgent [Bradley_Birnbaum] [Bradley_Birnbaum]
+dali-port        5777/tcp # DALI Port [Wayne_Morrow][Michael_Melio] [Wayne_Morrow][Michael_Melio] 2003-10
+dali-port        5777/udp # DALI Port [Wayne_Morrow][Michael_Melio] [Wayne_Morrow][Michael_Melio] 2003-10
+vts-rpc          5780/tcp # Visual Tag System RPC [Graham_Bloice] [Graham_Bloice] 2009-09-17
+3par-evts        5781/tcp # 3PAR Event Reporting Service [Sushil_Thomas] [Sushil_Thomas] 2008-03-10
+3par-evts        5781/udp # 3PAR Event Reporting Service [Sushil_Thomas] [Sushil_Thomas] 2008-03-10
+3par-mgmt        5782/tcp # 3PAR Management Service [Don_Marselle] [Don_Marselle] 2008-04-09
+3par-mgmt        5782/udp # 3PAR Management Service [Don_Marselle] [Don_Marselle] 2008-04-09
+3par-mgmt-ssl    5783/tcp # 3PAR Management Service with SSL [Don_Marselle] [Don_Marselle] 2008-03-19
+3par-mgmt-ssl    5783/udp # 3PAR Management Service with SSL [Don_Marselle] [Don_Marselle] 2008-03-19
+ibar             5784/udp # Cisco Interbox Application Redundancy [Cullen_Jennings] [Cullen_Jennings] 2010-02-03
+3par-rcopy       5785/tcp # 3PAR Inform Remote Copy [Don_Marselle] [Don_Marselle] 2010-02-03
+3par-rcopy       5785/udp # 3PAR Inform Remote Copy [Don_Marselle] [Don_Marselle] 2008-04-09
+cisco-redu       5786/udp # redundancy notification [Ming_Zhang] [Ming_Zhang] 2010-02-04
+waascluster      5787/udp # Cisco WAAS Cluster Protocol [Winston_Chou] [Winston_Chou] 2011-02-08
+xtreamx          5793/tcp # XtreamX Supervised Peer message [Ahmad_Tajuddin_Samsu] [Ahmad_Tajuddin_Samsu] 2007-02
+xtreamx          5793/udp # XtreamX Supervised Peer message [Ahmad_Tajuddin_Samsu] [Ahmad_Tajuddin_Samsu] 2007-02
+spdp             5794/udp # Simple Peered Discovery Protocol [Dave_Lindquist] [Dave_Lindquist] 2010-05-27
+icmpd            5813/tcp # ICMPD [Shane_O_Donnell] [Shane_O_Donnell]
+icmpd            5813/udp # ICMPD [Shane_O_Donnell] [Shane_O_Donnell]
+spt-automation   5814/tcp # Support Automation [Joshua_Hawkins] [Joshua_Hawkins] 2003-11
+spt-automation   5814/udp # Support Automation [Joshua_Hawkins] [Joshua_Hawkins] 2003-11
+reversion        5842/tcp # Reversion Backup/Restore [Cameo_Systems_Inc] [Craig_Nelson] 2011-09-26
+wherehoo         5859/tcp # WHEREHOO [Jim_Youll] [Jim_Youll]
+wherehoo         5859/udp # WHEREHOO [Jim_Youll] [Jim_Youll]
+ppsuitemsg       5863/tcp # PlanetPress Suite Messeng [Yannick_Fortin] [Yannick_Fortin] 2006-02
+ppsuitemsg       5863/udp # PlanetPress Suite Messeng [Yannick_Fortin] [Yannick_Fortin] 2006-02
+diameters        5868/tcp # Diameter over TLS/TCP [IESG] [IETF_Chair] [RFC6733]
+diameters        5868/sctp # Diameter over DTLS/SCTP [IESG] [IETF_Chair] [RFC6733]
+jute             5883/tcp # Javascript Unit Test Environment [Mark_Ethan_Trostler] [Mark_Ethan_Trostler] 2011-11-23
+rfb              5900/tcp # Remote Framebuffer [Tristan_Richardson] [Tristan_Richardson] 2006-03 [RFC6143]
+rfb              5900/udp # Remote Framebuffer [Tristan_Richardson] [Tristan_Richardson] 2006-03 [RFC6143]
+cm               5910/tcp # Context Management [Eivan_Cerasi] [Eivan_Cerasi] 2008-10-10
+cm               5910/udp # Context Management [Eivan_Cerasi] [Eivan_Cerasi] 2008-10-10
+cm               5910/sctp # Context Management [Justin_Yu] [Justin_Yu] 2011-05-19
+cpdlc            5911/tcp # Controller Pilot Data Link Communication [Eivan_Cerasi] [Eivan_Cerasi] 2008-10-10
+cpdlc            5911/udp # Controller Pilot Data Link Communication [Eivan_Cerasi] [Eivan_Cerasi] 2008-10-10
+cpdlc            5911/sctp # Controller Pilot Data Link Communication [Justin_Yu] [Justin_Yu] 2011-05-18
+fis              5912/tcp # Flight Information Services [Eivan_Cerasi] [Eivan_Cerasi] 2008-10-10
+fis              5912/udp # Flight Information Services [Eivan_Cerasi] [Eivan_Cerasi] 2008-10-10
+fis              5912/sctp # Flight Information Services [Justin_Yu] [Justin_Yu] 2011-05-25
+ads-c            5913/tcp # Automatic Dependent Surveillance [Eivan_Cerasi] [Eivan_Cerasi] 2008-10-10
+ads-c            5913/udp # Automatic Dependent Surveillance [Eivan_Cerasi] [Eivan_Cerasi] 2008-10-10
+ads-c            5913/sctp # Automatic Dependent Surveillance [Justin_Yu] [Justin_Yu] 2011-05-25
+indy             5963/tcp # Indy Application Server [Bjorn_Lantz] [Bjorn_Lantz] 2004-11
+indy             5963/udp # Indy Application Server [Bjorn_Lantz] [Bjorn_Lantz] 2004-11
+mppolicy-v5      5968/tcp # mppolicy-v5 [Yutaka_Ono] [Yutaka_Ono]
+mppolicy-v5      5968/udp # mppolicy-v5 [Yutaka_Ono] [Yutaka_Ono]
+mppolicy-mgr     5969/tcp # mppolicy-mgr [Yutaka_Ono] [Yutaka_Ono]
+mppolicy-mgr     5969/udp # mppolicy-mgr [Yutaka_Ono] [Yutaka_Ono]
+couchdb          5984/tcp # CouchDB [Noah_Slater] [Noah_Slater] 2007-11-27
+couchdb          5984/udp # CouchDB [Noah_Slater] [Noah_Slater] 2007-11-27
+wsman            5985/tcp # WBEM WS-Management HTTP [Jim_Davis] [Jim_Davis] 2006-11
+wsman            5985/udp # WBEM WS-Management HTTP [Jim_Davis] [Jim_Davis] 2006-11
+wsmans           5986/tcp # WBEM WS-Management HTTP over TLS/SSL [Jim_Davis] [Jim_Davis] 2006-11
+wsmans           5986/udp # WBEM WS-Management HTTP over TLS/SSL [Jim_Davis] [Jim_Davis] 2006-11
+wbem-rmi         5987/tcp # WBEM RMI [Jim_Davis] [Jim_Davis]
+wbem-rmi         5987/udp # WBEM RMI [Jim_Davis] [Jim_Davis]
+wbem-http        5988/tcp # WBEM CIM-XML (HTTP) [Jim_Davis] [Jim_Davis]
+wbem-http        5988/udp # WBEM CIM-XML (HTTP) [Jim_Davis] [Jim_Davis]
+wbem-https       5989/tcp # WBEM CIM-XML (HTTPS) [Jim_Davis] [Jim_Davis]
+wbem-https       5989/udp # WBEM CIM-XML (HTTPS) [Jim_Davis] [Jim_Davis]
+wbem-exp-https   5990/tcp # WBEM Export HTTPS [Denise_Eckstein] [Denise_Eckstein] 2004-11
+wbem-exp-https   5990/udp # WBEM Export HTTPS [Denise_Eckstein] [Denise_Eckstein] 2004-11
+nuxsl            5991/tcp # NUXSL [Kai_Kretschmann] [Kai_Kretschmann] 2002-03
+nuxsl            5991/udp # NUXSL [Kai_Kretschmann] [Kai_Kretschmann] 2002-03
+consul-insight   5992/tcp # Consul InSight Security [Arthur_Hillenaar] [Arthur_Hillenaar] 2006-01
+consul-insight   5992/udp # Consul InSight Security [Arthur_Hillenaar] [Arthur_Hillenaar] 2006-01
+cvsup            5999/tcp # CVSup [Randall_Atkinson_2] [Randall_Atkinson_2]
+cvsup            5999/udp # CVSup [Randall_Atkinson_2] [Randall_Atkinson_2]
+x11             6000-6063/tcp # X Window System [Stephen_Gildea] [Stephen_Gildea]
+x11             6000-6063/udp # X Window System [Stephen_Gildea] [Stephen_Gildea]
+ndl-ahp-svc      6064/tcp # NDL-AHP-SVC [John_Richmond_2] [John_Richmond_2]
+ndl-ahp-svc      6064/udp # NDL-AHP-SVC [John_Richmond_2] [John_Richmond_2]
+winpharaoh       6065/tcp # WinPharaoh [Basil_Lee] [Basil_Lee]
+winpharaoh       6065/udp # WinPharaoh [Basil_Lee] [Basil_Lee]
+ewctsp           6066/tcp # EWCTSP [Mark_Bailon] [Mark_Bailon]
+ewctsp           6066/udp # EWCTSP [Mark_Bailon] [Mark_Bailon]
+gsmp-ancp        6068/tcp # GSMP/ANCP [Avri_Doria] [Avri_Doria] [RFC6320]
+trip             6069/tcp # TRIP [Hussein_F_Salama] [Hussein_F_Salama]
+trip             6069/udp # TRIP [Hussein_F_Salama] [Hussein_F_Salama]
+messageasap      6070/tcp # Messageasap [Murray_Freeman] [Murray_Freeman]
+messageasap      6070/udp # Messageasap [Murray_Freeman] [Murray_Freeman]
+ssdtp            6071/tcp # SSDTP [Michael_Shearson_2] [Michael_Shearson_2]
+ssdtp            6071/udp # SSDTP [Michael_Shearson_2] [Michael_Shearson_2]
+diagnose-proc    6072/tcp # DIAGNOSE-PROC [Allan_Miller] [Allan_Miller]
+diagnose-proc    6072/udp # DIAGNOSE-PROC [Allan_Miller] [Allan_Miller]
+directplay8      6073/tcp # DirectPlay8 [John_Kane] [John_Kane]
+directplay8      6073/udp # DirectPlay8 [John_Kane] [John_Kane]
+max              6074/tcp # Microsoft Max [Jay_Beavers] [Jay_Beavers] 2006-02
+max              6074/udp # Microsoft Max [Jay_Beavers] [Jay_Beavers] 2006-02
+dpm-acm          6075/tcp # Microsoft DPM Access Control Manager [Prabu_Ambravaneswara] [Prabu_Ambravaneswara] 2009-10-29
+msft-dpm-cert    6076/tcp # Microsoft DPM WCF Certificates [Microsoft_Corporation] [Prateek_Sharma] 2011-08-04
+iconstructsrv    6077/tcp # iConstruct Server [iConstruct_Aus_Pty_Ltd] [Afshin_Jafari] 2012-12-21
+p25cai           6082/udp # APCO Project 25 Common Air Interface - UDP encapsulation [APCO_Project] [APCO_Project] 2011-05-13
+miami-bcast      6083/udp # telecomsoftware miami broadcast [Peter_Steiner] [Peter_Steiner] 2011-02-22
+reload-config    6084/tcp # Peer to Peer Infrastructure [IESG] [IETF_Chair] 2009-01-29 2013-03-26 [RFC-ietf-p2psip-base-26]
+konspire2b       6085/tcp # konspire2b p2p network [Jason_Rohrer] [Jason_Rohrer] 2002-10
+konspire2b       6085/udp # konspire2b p2p network [Jason_Rohrer] [Jason_Rohrer] 2002-10
+pdtp             6086/tcp # PDTP P2P [Tony_Arcieri] [Tony_Arcieri] 2006-03
+pdtp             6086/udp # PDTP P2P [Tony_Arcieri] [Tony_Arcieri] 2006-03
+ldss             6087/tcp # Local Download Sharing Service [Clifford_Heath] [Clifford_Heath] 2006-05
+ldss             6087/udp # Local Download Sharing Service [Clifford_Heath] [Clifford_Heath] 2006-05
+doglms           6088/tcp # SuperDog License Manager [SafeNet] [Rob_Tao] 2012-07-26
+doglms-notify    6088/udp # SuperDog License Manager Notifier [SafeNet] [Rob_Tao] 2012-07-26
+raxa-mgmt        6099/tcp # RAXA Management [Sukanta_Ganguly] [Sukanta_Ganguly]
+synchronet-db    6100/tcp # SynchroNet-db [Arne_Haugland] [Arne_Haugland]
+synchronet-db    6100/udp # SynchroNet-db [Arne_Haugland] [Arne_Haugland]
+synchronet-rtc   6101/tcp # SynchroNet-rtc [Arne_Haugland] [Arne_Haugland]
+synchronet-rtc   6101/udp # SynchroNet-rtc [Arne_Haugland] [Arne_Haugland]
+synchronet-upd   6102/tcp # SynchroNet-upd [Arne_Haugland] [Arne_Haugland]
+synchronet-upd   6102/udp # SynchroNet-upd [Arne_Haugland] [Arne_Haugland]
+rets             6103/tcp # RETS [Bruce_Toback] [Bruce_Toback]
+rets             6103/udp # RETS [Bruce_Toback] [Bruce_Toback]
+dbdb             6104/tcp # DBDB [Aaron_Brick] [Aaron_Brick]
+dbdb             6104/udp # DBDB [Aaron_Brick] [Aaron_Brick]
+primaserver      6105/tcp # Prima Server [Prima_Designs_System] [Prima_Designs_System]
+primaserver      6105/udp # Prima Server [Prima_Designs_System] [Prima_Designs_System]
+mpsserver        6106/tcp # MPS Server [Prima_Designs_System] [Prima_Designs_System]
+mpsserver        6106/udp # MPS Server [Prima_Designs_System] [Prima_Designs_System]
+etc-control      6107/tcp # ETC Control [Steve_Polishinski] [Steve_Polishinski]
+etc-control      6107/udp # ETC Control [Steve_Polishinski] [Steve_Polishinski]
+sercomm-scadmin  6108/tcp # Sercomm-SCAdmin [Melinda_Tsao_2] [Melinda_Tsao_2]
+sercomm-scadmin  6108/udp # Sercomm-SCAdmin [Melinda_Tsao_2] [Melinda_Tsao_2]
+globecast-id     6109/tcp # GLOBECAST-ID [Piers_Scannell_2] [Piers_Scannell_2]
+globecast-id     6109/udp # GLOBECAST-ID [Piers_Scannell_2] [Piers_Scannell_2]
+softcm           6110/tcp # HP SoftBench CM [Scott_A_Kramer] [Scott_A_Kramer]
+softcm           6110/udp # HP SoftBench CM [Scott_A_Kramer] [Scott_A_Kramer]
+spc              6111/tcp # HP SoftBench Sub-Process Control [Scott_A_Kramer] [Scott_A_Kramer]
+spc              6111/udp # HP SoftBench Sub-Process Control [Scott_A_Kramer] [Scott_A_Kramer]
+dtspcd           6112/tcp # Desk-Top Sub-Process Control Daemon [Doug_Royer] [Doug_Royer] 2010-12-08
+dtspcd           6112/udp # Desk-Top Sub-Process Control Daemon [Doug_Royer] [Doug_Royer] 2010-12-08
+dayliteserver    6113/tcp # Daylite Server [Brent_Gulanowski] [Brent_Gulanowski] 2009-08-26
+wrspice          6114/tcp # WRspice IPC Service [Stephen_R_Whiteley] [Stephen_R_Whiteley] 2010-10-07
+xic              6115/tcp # Xic IPC Service [Stephen_R_Whiteley] [Stephen_R_Whiteley] 2010-10-07
+xtlserv          6116/tcp # XicTools License Manager Service [Stephen_R_Whiteley] [Stephen_R_Whiteley] 2010-10-07
+daylitetouch     6117/tcp # Daylite Touch Sync [Brent_Gulanowski] [Brent_Gulanowski] 2009-08-26
+tipc             6118/udp # Transparent Inter Process Communication [Ericsson] [Erik_Hugne] 2012-09-05
+spdy             6121/tcp # SPDY for a faster web [Matthew_Lloyd] [Matthew_Lloyd] 2010-04-26
+bex-webadmin     6122/tcp # Backup Express Web Server [Chi_Shih_Chang] [Chi_Shih_Chang] 2008-03-19
+bex-webadmin     6122/udp # Backup Express Web Server [Chi_Shih_Chang] [Chi_Shih_Chang] 2008-03-19
+backup-express   6123/tcp # Backup Express [Chi_Shih_Chang] [Chi_Shih_Chang] 2008-03-19
+backup-express   6123/udp # Backup Express [Chi_Shih_Chang] [Chi_Shih_Chang] 2008-03-19
+pnbs             6124/tcp # Phlexible Network Backup Service [William_R_Lear_2] [William_R_Lear_2] 2008-10-23
+pnbs             6124/udp # Phlexible Network Backup Service [William_R_Lear_2] [William_R_Lear_2] 2008-10-23
+damewaremobgtwy  6130/tcp # The DameWare Mobile Gateway Service [SolarWinds] [David_Gayler] 2013-05-29
+nbt-wol          6133/tcp # New Boundary Tech WOL [Elizabeth_Zilen] [Elizabeth_Zilen] 2004-11
+nbt-wol          6133/udp # New Boundary Tech WOL [Elizabeth_Zilen] [Elizabeth_Zilen] 2004-11
+pulsonixnls      6140/tcp # Pulsonix Network License Service [David_Manns] [David_Manns] 2008-02-28
+pulsonixnls      6140/udp # Pulsonix Network License Service [David_Manns] [David_Manns] 2008-02-28
+meta-corp        6141/tcp # Meta Corporation License Manager [Osamu_Masuda] [Osamu_Masuda]
+meta-corp        6141/udp # Meta Corporation License Manager [Osamu_Masuda] [Osamu_Masuda]
+aspentec-lm      6142/tcp # Aspen Technology License Manager [Kevin_Massey] [Kevin_Massey]
+aspentec-lm      6142/udp # Aspen Technology License Manager [Kevin_Massey] [Kevin_Massey]
+watershed-lm     6143/tcp # Watershed License Manager [David_Ferrero] [David_Ferrero]
+watershed-lm     6143/udp # Watershed License Manager [David_Ferrero] [David_Ferrero]
+statsci1-lm      6144/tcp # StatSci License Manager - 1 [Scott_Blachowicz] [Scott_Blachowicz]
+statsci1-lm      6144/udp # StatSci License Manager - 1 [Scott_Blachowicz] [Scott_Blachowicz]
+statsci2-lm      6145/tcp # StatSci License Manager - 2 [Scott_Blachowicz] [Scott_Blachowicz]
+statsci2-lm      6145/udp # StatSci License Manager - 2 [Scott_Blachowicz] [Scott_Blachowicz]
+lonewolf-lm      6146/tcp # Lone Wolf Systems License Manager [Dan_Klein] [Dan_Klein]
+lonewolf-lm      6146/udp # Lone Wolf Systems License Manager [Dan_Klein] [Dan_Klein]
+montage-lm       6147/tcp # Montage License Manager [Michael_Ubell] [Michael_Ubell]
+montage-lm       6147/udp # Montage License Manager [Michael_Ubell] [Michael_Ubell]
+ricardo-lm       6148/tcp # Ricardo North America License Manager [M_Flemming] [M_Flemming]
+ricardo-lm       6148/udp # Ricardo North America License Manager [M_Flemming] [M_Flemming]
+tal-pod          6149/tcp # tal-pod [Steven_Loomis] [Steven_Loomis]
+tal-pod          6149/udp # tal-pod [Steven_Loomis] [Steven_Loomis]
+efb-aci          6159/tcp # EFB Application Control Interface [Jonathan_Schaaf] [Jonathan_Schaaf] 2010-02-10
+ecmp             6160/tcp # Emerson Extensible Control and Management Protocol [Bryce_Beeston] [Bryce_Beeston] 2011-06-23
+ecmp-data        6160/udp # Emerson Extensible Control and Management Protocol Data [Bryce_Beeston] [Bryce_Beeston] 2011-06-23
+patrol-ism       6161/tcp # PATROL Internet Srv Mgr [Portnoy_Boxman] [Portnoy_Boxman] 2005-01
+patrol-ism       6161/udp # PATROL Internet Srv Mgr [Portnoy_Boxman] [Portnoy_Boxman] 2005-01
+patrol-coll      6162/tcp # PATROL Collector [Portnoy_Boxman] [Portnoy_Boxman] 2005-01
+patrol-coll      6162/udp # PATROL Collector [Portnoy_Boxman] [Portnoy_Boxman] 2005-01
+pscribe          6163/tcp # Precision Scribe Cnx Port [Robert_W_Hodges] [Robert_W_Hodges] 2005-01
+pscribe          6163/udp # Precision Scribe Cnx Port [Robert_W_Hodges] [Robert_W_Hodges] 2005-01
+lm-x             6200/tcp # LM-X License Manager by X-Formation [Henrik_Goldman] [Henrik_Goldman] 2006-10
+lm-x             6200/udp # LM-X License Manager by X-Formation [Henrik_Goldman] [Henrik_Goldman] 2006-10
+thermo-calc      6201/udp # Management of service nodes in a processing grid for thermodynamic calculations [Thermo-Calc_Software] [Thomas_Revesz] 2012-06-28
+radmind          6222/tcp # Radmind Access Protocol [Patrick_M_McNeal] [Patrick_M_McNeal] 2006-03
+radmind          6222/udp # Radmind Access Protocol [Patrick_M_McNeal] [Patrick_M_McNeal] 2006-03
+jeol-nsdtp-1     6241/tcp # JEOL Network Services Data Transport Protocol 1 [Kevin_Wellwood] [Kevin_Wellwood] 2008-04-17
+jeol-nsddp-1     6241/udp # JEOL Network Services Dynamic Discovery Protocol 1 [Kevin_Wellwood] [Kevin_Wellwood] 2008-04-17
+jeol-nsdtp-2     6242/tcp # JEOL Network Services Data Transport Protocol 2 [Kevin_Wellwood] [Kevin_Wellwood] 2008-04-17
+jeol-nsddp-2     6242/udp # JEOL Network Services Dynamic Discovery Protocol 2 [Kevin_Wellwood] [Kevin_Wellwood] 2008-04-17
+jeol-nsdtp-3     6243/tcp # JEOL Network Services Data Transport Protocol 3 [Kevin_Wellwood] [Kevin_Wellwood] 2008-04-17
+jeol-nsddp-3     6243/udp # JEOL Network Services Dynamic Discovery Protocol 3 [Kevin_Wellwood] [Kevin_Wellwood] 2008-04-17
+jeol-nsdtp-4     6244/tcp # JEOL Network Services Data Transport Protocol 4 [Kevin_Wellwood] [Kevin_Wellwood] 2008-04-17
+jeol-nsddp-4     6244/udp # JEOL Network Services Dynamic Discovery Protocol 4 [Kevin_Wellwood] [Kevin_Wellwood] 2008-04-17
+tl1-raw-ssl      6251/tcp # TL1 Raw Over SSL/TLS [Jim_Humphreys] [Jim_Humphreys] 2008-01-29
+tl1-raw-ssl      6251/udp # TL1 Raw Over SSL/TLS [Jim_Humphreys] [Jim_Humphreys] 2008-01-29
+tl1-ssh          6252/tcp # TL1 over SSH [Jim_Humphreys] [Jim_Humphreys] 2008-01-25
+tl1-ssh          6252/udp # TL1 over SSH [Jim_Humphreys] [Jim_Humphreys] 2008-01-25
+crip             6253/tcp # CRIP [Mike_Rodbell] [Mike_Rodbell]
+crip             6253/udp # CRIP [Mike_Rodbell] [Mike_Rodbell]
+gld              6267/tcp # GridLAB-D User Interface [David_Chassin] [David_Chassin] 2010-12-10
+grid             6268/tcp # Grid Authentication [Jason_Hamilton] [Jason_Hamilton] 2006-06
+grid             6268/udp # Grid Authentication [Jason_Hamilton] [Jason_Hamilton] 2006-06
+grid-alt         6269/tcp # Grid Authentication Alt [Jason_Hamilton] [Jason_Hamilton] 2006-06
+grid-alt         6269/udp # Grid Authentication Alt [Jason_Hamilton] [Jason_Hamilton] 2006-06
+bmc-grx          6300/tcp # BMC GRX [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-grx          6300/udp # BMC GRX [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-ctd-ldap     6301/tcp # BMC CONTROL-D LDAP SERVERIANA assigned this well-formed service name as a replacement for "bmc_ctd_ldap". [Portnoy_Boxman_2] [Portnoy_Boxman_2] 2006-09
+bmc_ctd_ldap     6301/tcp # BMC CONTROL-D LDAP SERVER [Portnoy_Boxman_2] [Portnoy_Boxman_2] 2006-09 This entry is an alias to "bmc-ctd-ldap".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+bmc-ctd-ldap     6301/udp # BMC CONTROL-D LDAP SERVERIANA assigned this well-formed service name as a replacement for "bmc_ctd_ldap". [Portnoy_Boxman_2] [Portnoy_Boxman_2] 2006-09
+bmc_ctd_ldap     6301/udp # BMC CONTROL-D LDAP SERVER [Portnoy_Boxman_2] [Portnoy_Boxman_2] 2006-09 This entry is an alias to "bmc-ctd-ldap".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+ufmp             6306/tcp # Unified Fabric Management Protocol [Albert_Berlovitch] [Albert_Berlovitch] 2009-12-17
+ufmp             6306/udp # Unified Fabric Management Protocol [Albert_Berlovitch] [Albert_Berlovitch] 2009-12-17
+scup             6315/tcp # Sensor Control Unit Protocol [Sven_Kopacz] [Sven_Kopacz] 2010-09-01
+scup-disc        6315/udp # Sensor Control Unit Protocol Discovery Protocol [Sven_Kopacz] [Sven_Kopacz] 2010-09-01
+abb-escp         6316/tcp # Ethernet Sensor Communications Protocol [Jaime_Antolin] [Jaime_Antolin] 2008-09-25
+abb-escp         6316/udp # Ethernet Sensor Communications Protocol [Jaime_Antolin] [Jaime_Antolin] 2008-09-25
+nav-data-cmd     6317/tcp # Navtech Radar Sensor Data Command [Navtech_Radar_Ltd] [Guy_Avery] 2013-02-20
+nav-data         6317/udp # Navtech Radar Sensor Data [Navtech_Radar_Ltd] [Guy_Avery] 2013-02-20
+repsvc           6320/tcp # Double-Take Replication Service [James_Wilkinson] [James_Wilkinson] 2006-04
+repsvc           6320/udp # Double-Take Replication Service [James_Wilkinson] [James_Wilkinson] 2006-04
+emp-server1      6321/tcp # Empress Software Connectivity Server 1 [Srdjan_Holovac] [Srdjan_Holovac]
+emp-server1      6321/udp # Empress Software Connectivity Server 1 [Srdjan_Holovac] [Srdjan_Holovac]
+emp-server2      6322/tcp # Empress Software Connectivity Server 2 [Srdjan_Holovac] [Srdjan_Holovac]
+emp-server2      6322/udp # Empress Software Connectivity Server 2 [Srdjan_Holovac] [Srdjan_Holovac]
+hrd-ncs          6324/tcp # HR Device Network Configuration Service [Hall_Research] [Vishal_Dharmadhikari] 2011-11-29
+hrd-ns-disc      6324/udp # HR Device Network service [Hall_Research] [Vishal_Dharmadhikari] 2011-11-29
+dt-mgmtsvc       6325/tcp # Double-Take Management Service [Vision_Solutions] [James_Wilkinson2] 2012-06-06
+dt-vra           6326/tcp # Double-Take Virtual Recovery Assistant [Vision_Solutions] [James_Wilkinson2] 2012-10-08
+sflow            6343/tcp # sFlow traffic monitoring [Peter_Phaal] [Peter_Phaal] 2003-06
+sflow            6343/udp # sFlow traffic monitoring [Peter_Phaal] [Peter_Phaal] 2003-06
+gnutella-svc     6346/tcp # gnutella-svc [Serguei_Osokine] [Serguei_Osokine]
+gnutella-svc     6346/udp # gnutella-svc [Serguei_Osokine] [Serguei_Osokine]
+gnutella-rtr     6347/tcp # gnutella-rtr [Serguei_Osokine] [Serguei_Osokine]
+gnutella-rtr     6347/udp # gnutella-rtr [Serguei_Osokine] [Serguei_Osokine]
+adap             6350/tcp # App Discovery and Access Protocol [Thomas_Kjoernes] [Thomas_Kjoernes] 2010-06-22
+adap             6350/udp # App Discovery and Access Protocol [Thomas_Kjoernes] [Thomas_Kjoernes] 2010-06-22
+pmcs             6355/tcp # PMCS applications [Pavel_Mendl] [Pavel_Mendl] 2007-03
+pmcs             6355/udp # PMCS applications [Pavel_Mendl] [Pavel_Mendl] 2007-03
+metaedit-mu      6360/tcp # MetaEdit+ Multi-User [Steven_Kelly] [Steven_Kelly] 2007-11-12
+metaedit-mu      6360/udp # MetaEdit+ Multi-User [Steven_Kelly] [Steven_Kelly] 2007-11-12
+metaedit-se      6370/tcp # MetaEdit+ Server Administration [Steven_Kelly] [Steven_Kelly] 2007-11-12
+metaedit-se      6370/udp # MetaEdit+ Server Administration [Steven_Kelly] [Steven_Kelly] 2007-11-12
+metatude-mds     6382/tcp # Metatude Dialogue Server [Menno_Zweistra] [Menno_Zweistra]
+metatude-mds     6382/udp # Metatude Dialogue Server [Menno_Zweistra] [Menno_Zweistra]
+clariion-evr01   6389/tcp # clariion-evr01 [Dave_DesRoches] [Dave_DesRoches]
+clariion-evr01   6389/udp # clariion-evr01 [Dave_DesRoches] [Dave_DesRoches]
+metaedit-ws      6390/tcp # MetaEdit+ WebService API [Steven_Kelly] [Steven_Kelly] 2007-11-12
+metaedit-ws      6390/udp # MetaEdit+ WebService API [Steven_Kelly] [Steven_Kelly] 2007-11-12
+faxcomservice    6417/tcp # Faxcom Message Service [Albert_Leung] [Albert_Leung] 2006-04
+faxcomservice    6417/udp # Faxcom Message Service [Albert_Leung] [Albert_Leung] 2006-04
+syserverremote   6418/tcp # SYserver remote commands [David_Ashkenazi] [David_Ashkenazi] 2010-03-23
+svdrp            6419/tcp # Simple VDR Protocol [Klaus_Schmidinger] [Klaus_Schmidinger] 2010-03-31
+nim-vdrshell     6420/tcp # NIM_VDRShell [Rik_Ditter] [Rik_Ditter] 2006-02
+nim-vdrshell     6420/udp # NIM_VDRShell [Rik_Ditter] [Rik_Ditter] 2006-02
+nim-wan          6421/tcp # NIM_WAN [Rik_Ditter] [Rik_Ditter] 2006-02
+nim-wan          6421/udp # NIM_WAN [Rik_Ditter] [Rik_Ditter] 2006-02
+pgbouncer        6432/tcp # PgBouncer [Marko_Kreen] [Marko_Kreen] 2009-02-13
+sun-sr-https     6443/tcp # Service Registry Default HTTPS Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-https     6443/udp # Service Registry Default HTTPS Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sge-qmaster      6444/tcp # Grid Engine Qmaster ServiceIANA assigned this well-formed service name as a replacement for "sge_qmaster". [Andreas_Haas] [Andreas_Haas] 2006-08
+sge_qmaster      6444/tcp # Grid Engine Qmaster Service [Andreas_Haas] [Andreas_Haas] 2006-08 This entry is an alias to "sge-qmaster".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+sge-qmaster      6444/udp # Grid Engine Qmaster ServiceIANA assigned this well-formed service name as a replacement for "sge_qmaster". [Andreas_Haas] [Andreas_Haas] 2006-08
+sge_qmaster      6444/udp # Grid Engine Qmaster Service [Andreas_Haas] [Andreas_Haas] 2006-08 This entry is an alias to "sge-qmaster".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+sge-execd        6445/tcp # Grid Engine Execution ServiceIANA assigned this well-formed service name as a replacement for "sge_execd". [Andreas_Haas] [Andreas_Haas] 2006-08
+sge_execd        6445/tcp # Grid Engine Execution Service [Andreas_Haas] [Andreas_Haas] 2006-08 This entry is an alias to "sge-execd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+sge-execd        6445/udp # Grid Engine Execution ServiceIANA assigned this well-formed service name as a replacement for "sge_execd". [Andreas_Haas] [Andreas_Haas] 2006-08
+sge_execd        6445/udp # Grid Engine Execution Service [Andreas_Haas] [Andreas_Haas] 2006-08 This entry is an alias to "sge-execd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+mysql-proxy      6446/tcp # MySQL Proxy [Kay_Roepke] [Kay_Roepke] 2009-04-22
+mysql-proxy      6446/udp # MySQL Proxy [Kay_Roepke] [Kay_Roepke] 2009-04-22
+skip-cert-recv   6455/tcp # SKIP Certificate Receive [Tom_Markson] [Tom_Markson]
+skip-cert-recv   6455/udp # SKIP Certificate Receive [Tom_Markson] [Tom_Markson]
+skip-cert-send   6456/tcp # SKIP Certificate Send [Tom_Markson] [Tom_Markson]
+skip-cert-send   6456/udp # SKIP Certificate Send [Tom_Markson] [Tom_Markson]
+lvision-lm       6471/tcp # LVision License Manager [Brian_McKinnon] [Brian_McKinnon]
+lvision-lm       6471/udp # LVision License Manager [Brian_McKinnon] [Brian_McKinnon]
+sun-sr-http      6480/tcp # Service Registry Default HTTP Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-http      6480/udp # Service Registry Default HTTP Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+servicetags      6481/tcp # Service Tags [Peter_Schow] [Peter_Schow] 2007-01
+servicetags      6481/udp # Service Tags [Peter_Schow] [Peter_Schow] 2007-01
+ldoms-mgmt       6482/tcp # Logical Domains Management Interface [Eric_Sharakan] [Eric_Sharakan] 2008-02-14
+ldoms-mgmt       6482/udp # Logical Domains Management Interface [Eric_Sharakan] [Eric_Sharakan] 2008-02-14
+SunVTS-RMI       6483/tcp # SunVTS RMI [Sumit_Arora] [Sumit_Arora] 2007-06
+SunVTS-RMI       6483/udp # SunVTS RMI [Sumit_Arora] [Sumit_Arora] 2007-06
+sun-sr-jms       6484/tcp # Service Registry Default JMS Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-jms       6484/udp # Service Registry Default JMS Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-iiop      6485/tcp # Service Registry Default IIOP Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-iiop      6485/udp # Service Registry Default IIOP Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-iiops     6486/tcp # Service Registry Default IIOPS Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-iiops     6486/udp # Service Registry Default IIOPS Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-iiop-aut  6487/tcp # Service Registry Default IIOPAuth Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-iiop-aut  6487/udp # Service Registry Default IIOPAuth Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-jmx       6488/tcp # Service Registry Default JMX Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-jmx       6488/udp # Service Registry Default JMX Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-admin     6489/tcp # Service Registry Default Admin Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+sun-sr-admin     6489/udp # Service Registry Default Admin Domain [Paul_Sterk] [Paul_Sterk] 2006-03
+boks             6500/tcp # BoKS Master [Magnus_Nystrom] [Magnus_Nystrom]
+boks             6500/udp # BoKS Master [Magnus_Nystrom] [Magnus_Nystrom]
+boks-servc       6501/tcp # BoKS ServcIANA assigned this well-formed service name as a replacement for "boks_servc". [Magnus_Nystrom] [Magnus_Nystrom]
+boks_servc       6501/tcp # BoKS Servc [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "boks-servc".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+boks-servc       6501/udp # BoKS ServcIANA assigned this well-formed service name as a replacement for "boks_servc". [Magnus_Nystrom] [Magnus_Nystrom]
+boks_servc       6501/udp # BoKS Servc [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "boks-servc".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+boks-servm       6502/tcp # BoKS ServmIANA assigned this well-formed service name as a replacement for "boks_servm". [Magnus_Nystrom] [Magnus_Nystrom]
+boks_servm       6502/tcp # BoKS Servm [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "boks-servm".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+boks-servm       6502/udp # BoKS ServmIANA assigned this well-formed service name as a replacement for "boks_servm". [Magnus_Nystrom] [Magnus_Nystrom]
+boks_servm       6502/udp # BoKS Servm [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "boks-servm".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+boks-clntd       6503/tcp # BoKS ClntdIANA assigned this well-formed service name as a replacement for "boks_clntd". [Magnus_Nystrom] [Magnus_Nystrom]
+boks_clntd       6503/tcp # BoKS Clntd [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "boks-clntd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+boks-clntd       6503/udp # BoKS ClntdIANA assigned this well-formed service name as a replacement for "boks_clntd". [Magnus_Nystrom] [Magnus_Nystrom]
+boks_clntd       6503/udp # BoKS Clntd [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "boks-clntd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+badm-priv        6505/tcp # BoKS Admin Private PortIANA assigned this well-formed service name as a replacement for "badm_priv". [Magnus_Nystrom] [Magnus_Nystrom]
+badm_priv        6505/tcp # BoKS Admin Private Port [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "badm-priv".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+badm-priv        6505/udp # BoKS Admin Private PortIANA assigned this well-formed service name as a replacement for "badm_priv". [Magnus_Nystrom] [Magnus_Nystrom]
+badm_priv        6505/udp # BoKS Admin Private Port [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "badm-priv".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+badm-pub         6506/tcp # BoKS Admin Public PortIANA assigned this well-formed service name as a replacement for "badm_pub". [Magnus_Nystrom] [Magnus_Nystrom]
+badm_pub         6506/tcp # BoKS Admin Public Port [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "badm-pub".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+badm-pub         6506/udp # BoKS Admin Public PortIANA assigned this well-formed service name as a replacement for "badm_pub". [Magnus_Nystrom] [Magnus_Nystrom]
+badm_pub         6506/udp # BoKS Admin Public Port [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "badm-pub".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+bdir-priv        6507/tcp # BoKS Dir Server, Private PortIANA assigned this well-formed service name as a replacement for "bdir_priv". [Magnus_Nystrom] [Magnus_Nystrom]
+bdir_priv        6507/tcp # BoKS Dir Server, Private Port [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "bdir-priv".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+bdir-priv        6507/udp # BoKS Dir Server, Private PortIANA assigned this well-formed service name as a replacement for "bdir_priv". [Magnus_Nystrom] [Magnus_Nystrom]
+bdir_priv        6507/udp # BoKS Dir Server, Private Port [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "bdir-priv".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+bdir-pub         6508/tcp # BoKS Dir Server, Public PortIANA assigned this well-formed service name as a replacement for "bdir_pub". [Magnus_Nystrom] [Magnus_Nystrom]
+bdir_pub         6508/tcp # BoKS Dir Server, Public Port [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "bdir-pub".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+bdir-pub         6508/udp # BoKS Dir Server, Public PortIANA assigned this well-formed service name as a replacement for "bdir_pub". [Magnus_Nystrom] [Magnus_Nystrom]
+bdir_pub         6508/udp # BoKS Dir Server, Public Port [Magnus_Nystrom] [Magnus_Nystrom] This entry is an alias to "bdir-pub".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+mgcs-mfp-port    6509/tcp # MGCS-MFP Port [Minoru_Ozaki] [Minoru_Ozaki]
+mgcs-mfp-port    6509/udp # MGCS-MFP Port [Minoru_Ozaki] [Minoru_Ozaki]
+mcer-port        6510/tcp # MCER Port [Portnoy_Boxman] [Portnoy_Boxman]
+mcer-port        6510/udp # MCER Port [Portnoy_Boxman] [Portnoy_Boxman]
+dccp-udp         6511/udp # Datagram Congestion Control Protocol Encapsulation for NAT Traversal [IESG] [IETF_Chair] [RFC6773]
+netconf-tls      6513/tcp # NETCONF over TLS [RFC5539]
+syslog-tls       6514/tcp # Syslog over TLS [RFC5425]
+syslog-tls       6514/udp # syslog over DTLS [RFC6012]
+syslog-tls       6514/dccp # syslog over DTLS [RFC6012]
+elipse-rec       6515/tcp # Elipse RPC Protocol [F_Englert] [F_Englert] 2007-09-17
+elipse-rec       6515/udp # Elipse RPC Protocol [F_Englert] [F_Englert] 2007-09-17
+lds-distrib      6543/tcp # lds_distrib [Jack_Baker] [Jack_Baker] 2003-06
+lds-distrib      6543/udp # lds_distrib [Jack_Baker] [Jack_Baker] 2003-06
+lds-dump         6544/tcp # LDS Dump Service [Jack_Baker] [Jack_Baker] 2006-02
+lds-dump         6544/udp # LDS Dump Service [Jack_Baker] [Jack_Baker] 2006-02
+apc-6547         6547/tcp # APC 6547 [American_Power_Conve] [American_Power_Conve]
+apc-6547         6547/udp # APC 6547 [American_Power_Conve] [American_Power_Conve]
+apc-6548         6548/tcp # APC 6548 [American_Power_Conve] [American_Power_Conve]
+apc-6548         6548/udp # APC 6548 [American_Power_Conve] [American_Power_Conve]
+apc-6549         6549/tcp # APC 6549 [American_Power_Conve] [American_Power_Conve]
+apc-6549         6549/udp # APC 6549 [American_Power_Conve] [American_Power_Conve]
+fg-sysupdate     6550/tcp # fg-sysupdate [Mark_Beyer] [Mark_Beyer]
+fg-sysupdate     6550/udp # fg-sysupdate [Mark_Beyer] [Mark_Beyer]
+sum              6551/tcp # Software Update Manager [Jan_Dirven] [Jan_Dirven] 2007-12-13
+sum              6551/udp # Software Update Manager [Jan_Dirven] [Jan_Dirven] 2007-12-13
+xdsxdm           6558/tcp # [Brian_Tackett] [Brian_Tackett] possible contact
+xdsxdm           6558/udp # [Brian_Tackett] [Brian_Tackett] possible contact
+sane-port        6566/tcp # SANE Control Port [Henning_Meier_Geinit] [Henning_Meier_Geinit] 2002-10
+sane-port        6566/udp # SANE Control Port [Henning_Meier_Geinit] [Henning_Meier_Geinit] 2002-10
+canit-store      6568/tcp # CanIt Storage ManagerIANA assigned this well-formed service name as a replacement for "canit_store". [David_F_Skoll] [David_F_Skoll] 2009-04-22
+canit_store      6568/tcp # CanIt Storage Manager [David_F_Skoll] [David_F_Skoll] 2009-04-22 This entry is an alias to "canit-store".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+rp-reputation    6568/udp # Roaring Penguin IP Address Reputation Collection [David_F_Skoll] [David_F_Skoll] 2010-02-05
+affiliate        6579/tcp # Affiliate [David_Catmull] [David_Catmull] 2006-01
+affiliate        6579/udp # Affiliate [David_Catmull] [David_Catmull] 2006-01
+parsec-master    6580/tcp # Parsec Masterserver [Andreas_Varga] [Andreas_Varga]
+parsec-master    6580/udp # Parsec Masterserver [Andreas_Varga] [Andreas_Varga]
+parsec-peer      6581/tcp # Parsec Peer-to-Peer [Andreas_Varga] [Andreas_Varga]
+parsec-peer      6581/udp # Parsec Peer-to-Peer [Andreas_Varga] [Andreas_Varga]
+parsec-game      6582/tcp # Parsec Gameserver [Andreas_Varga] [Andreas_Varga]
+parsec-game      6582/udp # Parsec Gameserver [Andreas_Varga] [Andreas_Varga]
+joaJewelSuite    6583/tcp # JOA Jewel Suite [Bob_Rundle] [Bob_Rundle] 2005-11
+joaJewelSuite    6583/udp # JOA Jewel Suite [Bob_Rundle] [Bob_Rundle] 2005-11
+mshvlm           6600/tcp # Microsoft Hyper-V Live Migration [Rajesh_D] [Rajesh_D] 2009-02-03
+mstmg-sstp       6601/tcp # Microsoft Threat Management Gateway SSTP [Ori_Yosefi] [Ori_Yosefi] 2009-05-04
+wsscomfrmwk      6602/tcp # Windows WSS Communication Framework [Rong_Yu] [Rong_Yu] 2010-08-10
+odette-ftps      6619/tcp # ODETTE-FTP over TLS/SSL [Ieuan_Friend] [Ieuan_Friend] 2006-03 [RFC5024]
+odette-ftps      6619/udp # ODETTE-FTP over TLS/SSL [Ieuan_Friend] [Ieuan_Friend] 2006-03 [RFC5024]
+kftp-data        6620/tcp # Kerberos V5 FTP Data [Robert_J_Scott] [Robert_J_Scott] 2005-08
+kftp-data        6620/udp # Kerberos V5 FTP Data [Robert_J_Scott] [Robert_J_Scott] 2005-08
+kftp             6621/tcp # Kerberos V5 FTP Control [Robert_J_Scott] [Robert_J_Scott] 2005-08
+kftp             6621/udp # Kerberos V5 FTP Control [Robert_J_Scott] [Robert_J_Scott] 2005-08
+mcftp            6622/tcp # Multicast FTP [Bruce_Lueckenhoff_2] [Bruce_Lueckenhoff_2] 2006-02
+mcftp            6622/udp # Multicast FTP [Bruce_Lueckenhoff_2] [Bruce_Lueckenhoff_2] 2006-02
+ktelnet          6623/tcp # Kerberos V5 Telnet [Robert_J_Scott] [Robert_J_Scott] 2005-08
+ktelnet          6623/udp # Kerberos V5 Telnet [Robert_J_Scott] [Robert_J_Scott] 2005-08
+datascaler-db    6624/tcp # DataScaler database [Vasu_Murthy] [Vasu_Murthy] 2010-02-08
+datascaler-ctl   6625/tcp # DataScaler control [Vasu_Murthy] [Vasu_Murthy] 2010-02-08
+wago-service     6626/tcp # WAGO Service and Update [Wolfgang_Adler] [Wolfgang_Adler] 2006-04
+wago-service     6626/udp # WAGO Service and Update [Wolfgang_Adler] [Wolfgang_Adler] 2006-04
+nexgen           6627/tcp # Allied Electronics NeXGen [Lou_Seitchik] [Lou_Seitchik] 2005-08
+nexgen           6627/udp # Allied Electronics NeXGen [Lou_Seitchik] [Lou_Seitchik] 2005-08
+afesc-mc         6628/tcp # AFE Stock Channel M/C [K_K_Ho] [K_K_Ho] 2004-04
+afesc-mc         6628/udp # AFE Stock Channel M/C [K_K_Ho] [K_K_Ho] 2004-04
+mxodbc-connect   6632/tcp # eGenix mxODBC Connect [Marc_Andre_Lemburg] [Marc_Andre_Lemburg] 2009-11-13 Unauthorized Use Known on port 6632
+cisco-vpath-tun  6633/udp # Cisco vPath Services Overlay [Cisco2] [Surendra_Kumar] 2012-06-11
+ovsdb            6640/tcp # Open vSwitch Database protocol [Bruce_Davie_2] [Bruce_Davie_2] 2013-07-31 [draft-pfaff-ovsdb-proto-02]
+openflow         6653/tcp # OpenFlow [Open_Networking_Foundation] [Puneet_Agarwal] 2013-07-18
+openflow         6653/udp # OpenFlow [Open_Networking_Foundation] [Puneet_Agarwal] 2013-07-18
+pcs-sf-ui-man    6655/tcp # PC SOFT - Software factory UI/manager [Jerome_AERTS] [Jerome_AERTS] 2010-11-30
+emgmsg           6656/tcp # Emergency Message Control Service [Gerry_Gorman] [Gerry_Gorman] 2010-12-06
+palcom-disc      6657/udp # PalCom Discovery [Boris_Magnusson] [Boris_Magnusson] 2010-12-06
+ircu            6665-6669/tcp # IRCU [Brian_Tackett] [Brian_Tackett]
+vocaltec-gold    6670/tcp # Vocaltec Global Online Directory [Scott_Petrack] [Scott_Petrack]
+vocaltec-gold    6670/udp # Vocaltec Global Online Directory [Scott_Petrack] [Scott_Petrack]
+p4p-portal       6671/tcp # P4P Portal Service [Chris_Griffiths] [Chris_Griffiths] 2008-07-28
+p4p-portal       6671/udp # P4P Portal Service [Chris_Griffiths] [Chris_Griffiths] 2008-07-28
+vision-server    6672/tcp # vision_serverIANA assigned this well-formed service name as a replacement for "vision_server". [Chris_Kramer] [Chris_Kramer]
+vision_server    6672/tcp # vision_server [Chris_Kramer] [Chris_Kramer] This entry is an alias to "vision-server".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+vision-server    6672/udp # vision_serverIANA assigned this well-formed service name as a replacement for "vision_server". [Chris_Kramer] [Chris_Kramer]
+vision_server    6672/udp # vision_server [Chris_Kramer] [Chris_Kramer] This entry is an alias to "vision-server".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+vision-elmd      6673/tcp # vision_elmdIANA assigned this well-formed service name as a replacement for "vision_elmd". [Chris_Kramer] [Chris_Kramer]
+vision_elmd      6673/tcp # vision_elmd [Chris_Kramer] [Chris_Kramer] This entry is an alias to "vision-elmd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+vision-elmd      6673/udp # vision_elmdIANA assigned this well-formed service name as a replacement for "vision_elmd". [Chris_Kramer] [Chris_Kramer]
+vision_elmd      6673/udp # vision_elmd [Chris_Kramer] [Chris_Kramer] This entry is an alias to "vision-elmd".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+vfbp             6678/tcp # Viscount Freedom Bridge Protocol [Chris_MacDonald] [Chris_MacDonald] 2011-03-16
+vfbp-disc        6678/udp # Viscount Freedom Bridge Discovery [Chris_MacDonald] [Chris_MacDonald] 2011-03-16
+osaut            6679/tcp # Osorno Automation [Peter_Hombach] [Peter_Hombach] 2011-03-16
+osaut            6679/udp # Osorno Automation [Peter_Hombach] [Peter_Hombach] 2011-03-16
+clever-ctrace    6687/tcp # CleverView for cTrace Message Service [David_Cheng] [David_Cheng] 2010-02-01
+clever-tcpip     6688/tcp # CleverView for TCP/IP Message Service [David_Cheng] [David_Cheng] 2009-10-13
+tsa              6689/tcp # Tofino Security Appliance [Scott_Howard] [Scott_Howard] 2009-10-13
+tsa              6689/udp # Tofino Security Appliance [Scott_Howard] [Scott_Howard] 2009-10-13
+babel            6696/udp # Babel Routing Protocol 2011-08-15 [RFC6126]
+kti-icad-srvr    6701/tcp # KTI/ICAD Nameserver [Stanley_Knutson] [Stanley_Knutson]
+kti-icad-srvr    6701/udp # KTI/ICAD Nameserver [Stanley_Knutson] [Stanley_Knutson]
+e-design-net     6702/tcp # e-Design network [Janos_Lerch] [Janos_Lerch] 2006-02
+e-design-net     6702/udp # e-Design network [Janos_Lerch] [Janos_Lerch] 2006-02
+e-design-web     6703/tcp # e-Design web [Janos_Lerch] [Janos_Lerch] 2006-02
+e-design-web     6703/udp # e-Design web [Janos_Lerch] [Janos_Lerch] 2006-02
+frc-hp           6704/sctp # ForCES HP (High Priority) channel [RFC5811]
+frc-mp           6705/sctp # ForCES MP (Medium Priority) channel [RFC5811]
+frc-lp           6706/sctp # ForCES LP (Low priority) channel [RFC5811]
+ibprotocol       6714/tcp # Internet Backplane Protocol [Alessandro_Bassi] [Alessandro_Bassi]
+ibprotocol       6714/udp # Internet Backplane Protocol [Alessandro_Bassi] [Alessandro_Bassi]
+fibotrader-com   6715/tcp # Fibotrader Communications [Robert_Wetzold] [Robert_Wetzold] 2006-01
+fibotrader-com   6715/udp # Fibotrader Communications [Robert_Wetzold] [Robert_Wetzold] 2006-01
+bmc-perf-agent   6767/tcp # BMC PERFORM AGENT [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-perf-agent   6767/udp # BMC PERFORM AGENT [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-perf-mgrd    6768/tcp # BMC PERFORM MGRD [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-perf-mgrd    6768/udp # BMC PERFORM MGRD [Portnoy_Boxman] [Portnoy_Boxman]
+adi-gxp-srvprt   6769/tcp # ADInstruments GxP Server [Mathew_Pitchforth] [Mathew_Pitchforth] 2005-08
+adi-gxp-srvprt   6769/udp # ADInstruments GxP Server [Mathew_Pitchforth] [Mathew_Pitchforth] 2005-08
+plysrv-http      6770/tcp # PolyServe http [Mike_Spitzer] [Mike_Spitzer] 2005-08
+plysrv-http      6770/udp # PolyServe http [Mike_Spitzer] [Mike_Spitzer] 2005-08
+plysrv-https     6771/tcp # PolyServe https [Mike_Spitzer] [Mike_Spitzer] 2005-08
+plysrv-https     6771/udp # PolyServe https [Mike_Spitzer] [Mike_Spitzer] 2005-08
+ntz-tracker      6777/tcp # netTsunami Tracker [Tomahawk_Holdings] [Sagara_Wijetunga] 2013-05-01
+ntz-p2p-storage  6778/tcp # netTsunami p2p storage system [Tomahawk_Holdings] [Sagara_Wijetunga] 2013-05-01
+bfd-lag          6784/udp # Bidirectional Forwarding Detection (BFD) on Link Aggregation Group (LAG) Interfaces [IESG] [IETF_Chair] 2012-11-08 [draft-mmm-bfd-on-lags-05]
+dgpf-exchg       6785/tcp # DGPF Individual Exchange [Thomas_Weise] [Thomas_Weise] 2006-04
+dgpf-exchg       6785/udp # DGPF Individual Exchange [Thomas_Weise] [Thomas_Weise] 2006-04
+smc-jmx          6786/tcp # Sun Java Web Console JMX [Bill_Edwards] [Bill_Edwards] 2005-08
+smc-jmx          6786/udp # Sun Java Web Console JMX [Bill_Edwards] [Bill_Edwards] 2005-08
+smc-admin        6787/tcp # Sun Web Console Admin [Bill_Edwards] [Bill_Edwards] 2005-08
+smc-admin        6787/udp # Sun Web Console Admin [Bill_Edwards] [Bill_Edwards] 2005-08
+smc-http         6788/tcp # SMC-HTTP [Ratnadeep_Bhattachar] [Ratnadeep_Bhattachar] 2002-11
+smc-http         6788/udp # SMC-HTTP [Ratnadeep_Bhattachar] [Ratnadeep_Bhattachar] 2002-11
+smc-https        6789/tcp # SMC-HTTPS [Ratnadeep_Bhattachar] [Ratnadeep_Bhattachar] 2002-08
+smc-https        6789/udp # SMC-HTTPS [Ratnadeep_Bhattachar] [Ratnadeep_Bhattachar] 2002-08
+hnmp             6790/tcp # HNMP [Jude_George] [Jude_George]
+hnmp             6790/udp # HNMP [Jude_George] [Jude_George]
+hnm              6791/tcp # Halcyon Network Manager [Richard_Harriss] [Richard_Harriss] 2005-05
+hnm              6791/udp # Halcyon Network Manager [Richard_Harriss] [Richard_Harriss] 2005-05
+acnet            6801/tcp # ACNET Control System Protocol [Rich_Neswold] [Rich_Neswold] 2007-02
+acnet            6801/udp # ACNET Control System Protocol [Rich_Neswold] [Rich_Neswold] 2007-02
+pentbox-sim      6817/tcp # PenTBox Secure IM Protocol [Alberto_Ortega_Llama] [Alberto_Ortega_Llama] 2009-11-04
+ambit-lm         6831/tcp # ambit-lm [Don_Hejna] [Don_Hejna]
+ambit-lm         6831/udp # ambit-lm [Don_Hejna] [Don_Hejna]
+netmo-default    6841/tcp # Netmo Default [Urs_Bertschinger] [Urs_Bertschinger]
+netmo-default    6841/udp # Netmo Default [Urs_Bertschinger] [Urs_Bertschinger]
+netmo-http       6842/tcp # Netmo HTTP [Urs_Bertschinger] [Urs_Bertschinger]
+netmo-http       6842/udp # Netmo HTTP [Urs_Bertschinger] [Urs_Bertschinger]
+iccrushmore      6850/tcp # ICCRUSHMORE [Dave_Hubbard] [Dave_Hubbard]
+iccrushmore      6850/udp # ICCRUSHMORE [Dave_Hubbard] [Dave_Hubbard]
+acctopus-cc      6868/tcp # Acctopus Command Channel [Stefan_Auweiler] [Stefan_Auweiler] 2009-11-16
+acctopus-st      6868/udp # Acctopus Status [Stefan_Auweiler] [Stefan_Auweiler] 2009-11-16
+muse             6888/tcp # MUSE [Muse_Communications] [Muse_Communications]
+muse             6888/udp # MUSE [Muse_Communications] [Muse_Communications]
+jetstream        6901/tcp # Novell Jetstream messaging protocol [Anil_Tyagi] [Anil_Tyagi] 2010-06-11
+ethoscan         6935/tcp # EthoScan Service [Marty_Campbell] [Marty_Campbell] 2011-06-10
+ethoscan         6935/udp # EthoScan Service [Marty_Campbell] [Marty_Campbell] 2011-06-10
+xsmsvc           6936/tcp # XenSource Management Service [Roger_Klorese] [Roger_Klorese] 2006-06
+xsmsvc           6936/udp # XenSource Management Service [Roger_Klorese] [Roger_Klorese] 2006-06
+bioserver        6946/tcp # Biometrics Server [ISHII_AKIO] [ISHII_AKIO] 2006-01
+bioserver        6946/udp # Biometrics Server [ISHII_AKIO] [ISHII_AKIO] 2006-01
+otlp             6951/tcp # OTLP [Brent_Foster] [Brent_Foster] 2006-04
+otlp             6951/udp # OTLP [Brent_Foster] [Brent_Foster] 2006-04
+jmact3           6961/tcp # JMACT3 [Yutaka_Ono] [Yutaka_Ono]
+jmact3           6961/udp # JMACT3 [Yutaka_Ono] [Yutaka_Ono]
+jmevt2           6962/tcp # jmevt2 [Yutaka_Ono] [Yutaka_Ono]
+jmevt2           6962/udp # jmevt2 [Yutaka_Ono] [Yutaka_Ono]
+swismgr1         6963/tcp # swismgr1 [Yutaka_Ono] [Yutaka_Ono]
+swismgr1         6963/udp # swismgr1 [Yutaka_Ono] [Yutaka_Ono]
+swismgr2         6964/tcp # swismgr2 [Yutaka_Ono] [Yutaka_Ono]
+swismgr2         6964/udp # swismgr2 [Yutaka_Ono] [Yutaka_Ono]
+swistrap         6965/tcp # swistrap [Yutaka_Ono] [Yutaka_Ono]
+swistrap         6965/udp # swistrap [Yutaka_Ono] [Yutaka_Ono]
+swispol          6966/tcp # swispol [Yutaka_Ono] [Yutaka_Ono]
+swispol          6966/udp # swispol [Yutaka_Ono] [Yutaka_Ono]
+acmsoda          6969/tcp # acmsoda [Daniel_Simms] [Daniel_Simms]
+acmsoda          6969/udp # acmsoda [Daniel_Simms] [Daniel_Simms]
+MobilitySrv      6997/tcp # Mobility XE Protocol [Joseph_T_Savarese] [Joseph_T_Savarese] 2007-06
+MobilitySrv      6997/udp # Mobility XE Protocol [Joseph_T_Savarese] [Joseph_T_Savarese] 2007-06
+iatp-highpri     6998/tcp # IATP-highPri [John_Murphy] [John_Murphy]
+iatp-highpri     6998/udp # IATP-highPri [John_Murphy] [John_Murphy]
+iatp-normalpri   6999/tcp # IATP-normalPri [John_Murphy] [John_Murphy]
+iatp-normalpri   6999/udp # IATP-normalPri [John_Murphy] [John_Murphy]
+afs3-fileserver  7000/tcp # file server itself
+afs3-fileserver  7000/udp # file server itself
+afs3-callback    7001/tcp # callbacks to cache managers
+afs3-callback    7001/udp # callbacks to cache managers
+afs3-prserver    7002/tcp # users & groups database
+afs3-prserver    7002/udp # users & groups database
+afs3-vlserver    7003/tcp # volume location database
+afs3-vlserver    7003/udp # volume location database
+afs3-kaserver    7004/tcp # AFS/Kerberos authentication service
+afs3-kaserver    7004/udp # AFS/Kerberos authentication service
+afs3-volser      7005/tcp # volume managment server
+afs3-volser      7005/udp # volume managment server
+afs3-errors      7006/tcp # error interpretation service
+afs3-errors      7006/udp # error interpretation service
+afs3-bos         7007/tcp # basic overseer process
+afs3-bos         7007/udp # basic overseer process
+afs3-update      7008/tcp # server-to-server updater
+afs3-update      7008/udp # server-to-server updater
+afs3-rmtsys      7009/tcp # remote cache manager service
+afs3-rmtsys      7009/udp # remote cache manager service
+ups-onlinet      7010/tcp # onlinet uninterruptable power supplies [Jim_Thompson] [Jim_Thompson]
+ups-onlinet      7010/udp # onlinet uninterruptable power supplies [Jim_Thompson] [Jim_Thompson]
+talon-disc       7011/tcp # Talon Discovery Port [Jim_Thompson] [Jim_Thompson] Known Unauthorized Use on 7011
+talon-disc       7011/udp # Talon Discovery Port [Jim_Thompson] [Jim_Thompson] Known Unauthorized Use on 7011
+talon-engine     7012/tcp # Talon Engine [Jim_Thompson] [Jim_Thompson] Known Unauthorized Use on 7011
+talon-engine     7012/udp # Talon Engine [Jim_Thompson] [Jim_Thompson] Known Unauthorized Use on 7011
+microtalon-dis   7013/tcp # Microtalon Discovery [Jim_Thompson] [Jim_Thompson]
+microtalon-dis   7013/udp # Microtalon Discovery [Jim_Thompson] [Jim_Thompson]
+microtalon-com   7014/tcp # Microtalon Communications [Jim_Thompson] [Jim_Thompson]
+microtalon-com   7014/udp # Microtalon Communications [Jim_Thompson] [Jim_Thompson]
+talon-webserver  7015/tcp # Talon Webserver [Jim_Thompson] [Jim_Thompson]
+talon-webserver  7015/udp # Talon Webserver [Jim_Thompson] [Jim_Thompson]
+fisa-svc         7018/tcp # FISA Service [FAUCONNET_Ingenierie] [FAUCONNET_Ingenierie] 2011-05-19
+doceri-ctl       7019/tcp # doceri drawing service control [Paul_Brown] [Paul_Brown] 2011-04-27
+doceri-view      7019/udp # doceri drawing service screen view [Paul_Brown] [Paul_Brown] 2011-04-27
+dpserve          7020/tcp # DP Serve [Allan_Stanley] [Allan_Stanley]
+dpserve          7020/udp # DP Serve [Allan_Stanley] [Allan_Stanley]
+dpserveadmin     7021/tcp # DP Serve Admin [Allan_Stanley] [Allan_Stanley]
+dpserveadmin     7021/udp # DP Serve Admin [Allan_Stanley] [Allan_Stanley]
+ctdp             7022/tcp # CT Discovery Protocol [James_Kirkwood] [James_Kirkwood] 2005-06
+ctdp             7022/udp # CT Discovery Protocol [James_Kirkwood] [James_Kirkwood] 2005-06
+ct2nmcs          7023/tcp # Comtech T2 NMCS [Bryan_Wilcutt] [Bryan_Wilcutt] 2005-06
+ct2nmcs          7023/udp # Comtech T2 NMCS [Bryan_Wilcutt] [Bryan_Wilcutt] 2005-06
+vmsvc            7024/tcp # Vormetric service [Tom_Boyle] [Tom_Boyle] 2005-06
+vmsvc            7024/udp # Vormetric service [Tom_Boyle] [Tom_Boyle] 2005-06
+vmsvc-2          7025/tcp # Vormetric Service II [Tom_Boyle] [Tom_Boyle] 2005-06
+vmsvc-2          7025/udp # Vormetric Service II [Tom_Boyle] [Tom_Boyle] 2005-06
+op-probe         7030/tcp # ObjectPlanet probe [Bjorn_Jarle_Kvande] [Bjorn_Jarle_Kvande] 2002-04
+op-probe         7030/udp # ObjectPlanet probe [Bjorn_Jarle_Kvande] [Bjorn_Jarle_Kvande] 2002-04
+iposplanet       7031/tcp # IPOSPLANET retailing multi devices protocol [Fabrice_Paget] [Fabrice_Paget] 2012-10-23
+quest-disc       7040/udp # Quest application level network service discovery [Quest_Software] [Henrik_Johnson] 2012-04-09
+arcp             7070/tcp # ARCP [Jude_George] [Jude_George]
+arcp             7070/udp # ARCP [Jude_George] [Jude_George]
+iwg1             7071/tcp # IWGADTS Aircraft Housekeeping Message [Don_Sullivan] [Don_Sullivan] 2010-02-16
+iwg1             7071/udp # IWGADTS Aircraft Housekeeping Message [Don_Sullivan] [Don_Sullivan] 2010-02-16
+martalk          7073/tcp # MarTalk protocol [Mahr_GmbH_Göttingen] [Kevin_Bube] 2013-09-02
+empowerid        7080/tcp # EmpowerID Communication [Matthew_Whited] [Matthew_Whited] 2008-01-16
+empowerid        7080/udp # EmpowerID Communication [Matthew_Whited] [Matthew_Whited] 2008-01-16
+jdp-disc         7095/udp # Java Discovery Protocol [OpenJDK] [Florian_Weimer] 2013-03-12
+lazy-ptop        7099/tcp # lazy-ptop [Guy_Keren] [Guy_Keren]
+lazy-ptop        7099/udp # lazy-ptop [Guy_Keren] [Guy_Keren]
+font-service     7100/tcp # X Font Service [Stephen_Gildea] [Stephen_Gildea]
+font-service     7100/udp # X Font Service [Stephen_Gildea] [Stephen_Gildea]
+elcn             7101/tcp # Embedded Light Control Network [Michael_Scarito] [Michael_Scarito] 2007-02
+elcn             7101/udp # Embedded Light Control Network [Michael_Scarito] [Michael_Scarito] 2007-02
+aes-x170         7107/udp # AES-X170 [Richard_Foss] [Richard_Foss] 2011-02-10
+virprot-lm       7121/tcp # Virtual Prototypes License Manager [Victor_Galis] [Victor_Galis]
+virprot-lm       7121/udp # Virtual Prototypes License Manager [Victor_Galis] [Victor_Galis]
+scenidm          7128/tcp # intelligent data manager [Paul_Ignatius] [Paul_Ignatius] 2006-03
+scenidm          7128/udp # intelligent data manager [Paul_Ignatius] [Paul_Ignatius] 2006-03
+scenccs          7129/tcp # Catalog Content Search [Anil_Sharma] [Anil_Sharma] 2006-04
+scenccs          7129/udp # Catalog Content Search [Anil_Sharma] [Anil_Sharma] 2006-04
+cabsm-comm       7161/tcp # CA BSM Comm [Chun_Ho_Chang] [Chun_Ho_Chang] 2004-11
+cabsm-comm       7161/udp # CA BSM Comm [Chun_Ho_Chang] [Chun_Ho_Chang] 2004-11
+caistoragemgr    7162/tcp # CA Storage Manager [Emre_Tunar] [Emre_Tunar] 2004-11
+caistoragemgr    7162/udp # CA Storage Manager [Emre_Tunar] [Emre_Tunar] 2004-11
+cacsambroker     7163/tcp # CA Connection Broker [David_Roberts] [David_Roberts] 2005-05
+cacsambroker     7163/udp # CA Connection Broker [David_Roberts] [David_Roberts] 2005-05
+fsr              7164/tcp # File System Repository Agent [Micha_Ben_Efraim] [Micha_Ben_Efraim] 2007-07-19
+fsr              7164/udp # File System Repository Agent [Micha_Ben_Efraim] [Micha_Ben_Efraim] 2007-07-19
+doc-server       7165/tcp # Document WCF Server [Micha_Ben_Efraim] [Micha_Ben_Efraim] 2008-01-07
+doc-server       7165/udp # Document WCF Server [Micha_Ben_Efraim] [Micha_Ben_Efraim] 2008-01-07
+aruba-server     7166/tcp # Aruba eDiscovery Server [Micha_Ben_Efraim] [Micha_Ben_Efraim] 2008-01-07
+aruba-server     7166/udp # Aruba eDiscovery Server [Micha_Ben_Efraim] [Micha_Ben_Efraim] 2008-01-07
+casrmagent       7167/tcp # CA SRM Agent [Venkata_Krishna] [Venkata_Krishna] 2010-02-24
+cnckadserver     7168/tcp # cncKadServer DB & Inventory Services [Micha_Ben_Efraim_2] [Micha_Ben_Efraim_2] 2011-01-31
+ccag-pib         7169/tcp # Consequor Consulting Process Integration Bridge [Frank_Goenninger] [Frank_Goenninger] 2010-02-22
+ccag-pib         7169/udp # Consequor Consulting Process Integration Bridge [Frank_Goenninger] [Frank_Goenninger] 2010-02-22
+nsrp             7170/tcp # Adaptive Name/Service Resolution [Geoff_Back_2] [Geoff_Back_2] 2010-02-01
+nsrp             7170/udp # Adaptive Name/Service Resolution [Geoff_Back_2] [Geoff_Back_2] 2010-02-01
+drm-production   7171/tcp # Discovery and Retention Mgt Production [Micha_Ben_Efraim_3] [Micha_Ben_Efraim_3] 2010-02-18
+drm-production   7171/udp # Discovery and Retention Mgt Production [Micha_Ben_Efraim_3] [Micha_Ben_Efraim_3] 2010-02-18
+metalbend        7172/tcp # Port used for MetalBend programmable interface [Micha_Ben_Efraim_4] [Micha_Ben_Efraim_4] 2012-11-27
+zsecure          7173/tcp # zSecure Server [Hans_Schoone] [Hans_Schoone] 2010-10-01
+clutild          7174/tcp # Clutild [Cheryl_Stoutenburg] [Cheryl_Stoutenburg]
+clutild          7174/udp # Clutild [Cheryl_Stoutenburg] [Cheryl_Stoutenburg]
+fodms            7200/tcp # FODMS FLIP [David_Anthony] [David_Anthony]
+fodms            7200/udp # FODMS FLIP [David_Anthony] [David_Anthony]
+dlip             7201/tcp # DLIP [Albert_Manfredi] [Albert_Manfredi]
+dlip             7201/udp # DLIP [Albert_Manfredi] [Albert_Manfredi]
+ramp             7227/tcp # Registry A & M Protocol [John_Havard] [John_Havard] 2003-11
+ramp             7227/udp # Registry A $ M Protocol [John_Havard] [John_Havard] 2003-11
+citrixupp        7228/tcp # Citrix Universal Printing Port [Gary_Barton] [Gary_Barton] 2011-02-24
+citrixuppg       7229/tcp # Citrix UPP Gateway [Gary_Barton] [Gary_Barton] 2011-02-24
+display          7236/tcp # Wi-Fi Alliance Wi-Fi Display Protocol [Wi-Fi_Alliance] [Thomas_Sciorilli] 2012-04-09 Defined TXT keys: _display.tcp. Display Protocol
+pads             7237/tcp # PADS (Public Area Display System) Server [Willie_Jan_Bons] [Willie_Jan_Bons] 2011-03-10
+cnap             7262/tcp # Calypso Network Access Protocol [Scott_Halberg] [Scott_Halberg] 2009-06-02
+cnap             7262/udp # Calypso Network Access Protocol [Scott_Halberg] [Scott_Halberg] 2009-06-02
+watchme-7272     7272/tcp # WatchMe Monitoring 7272 [Oliver_Heinz] [Oliver_Heinz] 2005-08
+watchme-7272     7272/udp # WatchMe Monitoring 7272 [Oliver_Heinz] [Oliver_Heinz] 2005-08
+oma-rlp          7273/tcp # OMA Roaming Location [Larry_A_Young] [Larry_A_Young] 2005-08
+oma-rlp          7273/udp # OMA Roaming Location [Larry_A_Young] [Larry_A_Young] 2005-08
+oma-rlp-s        7274/tcp # OMA Roaming Location SEC [Larry_A_Young] [Larry_A_Young] 2005-08
+oma-rlp-s        7274/udp # OMA Roaming Location SEC [Larry_A_Young] [Larry_A_Young] 2005-08
+oma-ulp          7275/tcp # OMA UserPlane Location [Larry_A_Young_2] [Larry_A_Young_2] 2006-02
+oma-ulp          7275/udp # OMA UserPlane Location [Larry_A_Young_2] [Larry_A_Young_2] 2006-02
+oma-ilp          7276/tcp # OMA Internal Location Protocol [Khiem_Tran] [Khiem_Tran] 2007-11-06
+oma-ilp          7276/udp # OMA Internal Location Protocol [Khiem_Tran] [Khiem_Tran] 2007-11-06
+oma-ilp-s        7277/tcp # OMA Internal Location Secure Protocol [Khiem_Tran] [Khiem_Tran] 2007-11-06
+oma-ilp-s        7277/udp # OMA Internal Location Secure Protocol [Khiem_Tran] [Khiem_Tran] 2007-11-06
+oma-dcdocbs      7278/tcp # OMA Dynamic Content Delivery over CBS [Avi_Primo] [Avi_Primo] 2008-01-29
+oma-dcdocbs      7278/udp # OMA Dynamic Content Delivery over CBS [Avi_Primo] [Avi_Primo] 2008-01-29
+ctxlic           7279/tcp # Citrix Licensing [Marc_Binstock] [Marc_Binstock] 2008-01-29
+ctxlic           7279/udp # Citrix Licensing [Marc_Binstock] [Marc_Binstock] 2008-01-29
+itactionserver1  7280/tcp # ITACTIONSERVER 1 [Brian_Taylor] [Brian_Taylor]
+itactionserver1  7280/udp # ITACTIONSERVER 1 [Brian_Taylor] [Brian_Taylor]
+itactionserver2  7281/tcp # ITACTIONSERVER 2 [Brian_Taylor] [Brian_Taylor]
+itactionserver2  7281/udp # ITACTIONSERVER 2 [Brian_Taylor] [Brian_Taylor]
+mzca-action      7282/tcp # eventACTION/ussACTION (MZCA) server [Gord_Tomlin] [Gord_Tomlin] 2009-01-30
+mzca-alert       7282/udp # eventACTION/ussACTION (MZCA) alert [Gord_Tomlin] [Gord_Tomlin] 2010-01-21
+genstat          7283/tcp # General Statistics Rendezvous Protocol [VSN_International_Ltd] [Sean_D_Sollé] 2011-09-28
+lcm-server       7365/tcp # LifeKeeper Communications [James_Bottomley] [James_Bottomley] 2006-02
+lcm-server       7365/udp # LifeKeeper Communications [James_Bottomley] [James_Bottomley] 2006-02
+mindfilesys      7391/tcp # mind-file system server [Dave_Porter] [Dave_Porter]
+mindfilesys      7391/udp # mind-file system server [Dave_Porter] [Dave_Porter]
+mrssrendezvous   7392/tcp # mrss-rendezvous server [Dave_Porter] [Dave_Porter]
+mrssrendezvous   7392/udp # mrss-rendezvous server [Dave_Porter] [Dave_Porter]
+nfoldman         7393/tcp # nFoldMan Remote Publish [Richard_McDonald] [Richard_McDonald] 2006-01
+nfoldman         7393/udp # nFoldMan Remote Publish [Richard_McDonald] [Richard_McDonald] 2006-01
+fse              7394/tcp # File system export of backup images [Weibao_Wu] [Weibao_Wu] 2006-04
+fse              7394/udp # File system export of backup images [Weibao_Wu] [Weibao_Wu] 2006-04
+winqedit         7395/tcp # winqedit [David_Greer] [David_Greer]
+winqedit         7395/udp # winqedit [David_Greer] [David_Greer]
+hexarc           7397/tcp # Hexarc Command Language [George_Moromisato] [George_Moromisato] 2004-11
+hexarc           7397/udp # Hexarc Command Language [George_Moromisato] [George_Moromisato] 2004-11
+rtps-discovery   7400/tcp # RTPS Discovery [Gerardo_Pardo_Castel] [Gerardo_Pardo_Castel] 2005-10
+rtps-discovery   7400/udp # RTPS Discovery [Gerardo_Pardo_Castel] [Gerardo_Pardo_Castel] 2005-10
+rtps-dd-ut       7401/tcp # RTPS Data-Distribution User-Traffic [Gerardo_Pardo_Castel] [Gerardo_Pardo_Castel] 2005-10
+rtps-dd-ut       7401/udp # RTPS Data-Distribution User-Traffic [Gerardo_Pardo_Castel] [Gerardo_Pardo_Castel] 2005-10
+rtps-dd-mt       7402/tcp # RTPS Data-Distribution Meta-Traffic [Gerardo_Pardo_Castel] [Gerardo_Pardo_Castel] 2005-10
+rtps-dd-mt       7402/udp # RTPS Data-Distribution Meta-Traffic [Gerardo_Pardo_Castel] [Gerardo_Pardo_Castel] 2005-10
+ionixnetmon      7410/tcp # Ionix Network Monitor [Maxime_Deputter] [Maxime_Deputter] 2006-04
+ionixnetmon      7410/udp # Ionix Network Monitor [Maxime_Deputter] [Maxime_Deputter] 2006-04
+daqstream        7411/tcp # Streaming of measurement data [Hottinger_Baldwin_Messtechnik_GmbH] [Stephan_Gatzka] 2013-03-15
+daqstream        7411/udp # Streaming of measurement data [Hottinger_Baldwin_Messtechnik_GmbH] [Stephan_Gatzka] 2013-03-15
+mtportmon        7421/tcp # Matisse Port Monitor [Didier_Cabannes] [Didier_Cabannes] 2004-11
+mtportmon        7421/udp # Matisse Port Monitor [Didier_Cabannes] [Didier_Cabannes] 2004-11
+pmdmgr           7426/tcp # OpenView DM Postmaster Manager [Dave_Lamb] [Dave_Lamb]
+pmdmgr           7426/udp # OpenView DM Postmaster Manager [Dave_Lamb] [Dave_Lamb]
+oveadmgr         7427/tcp # OpenView DM Event Agent Manager [Dave_Lamb] [Dave_Lamb]
+oveadmgr         7427/udp # OpenView DM Event Agent Manager [Dave_Lamb] [Dave_Lamb]
+ovladmgr         7428/tcp # OpenView DM Log Agent Manager [Dave_Lamb] [Dave_Lamb]
+ovladmgr         7428/udp # OpenView DM Log Agent Manager [Dave_Lamb] [Dave_Lamb]
+opi-sock         7429/tcp # OpenView DM rqt communication [Dave_Lamb] [Dave_Lamb]
+opi-sock         7429/udp # OpenView DM rqt communication [Dave_Lamb] [Dave_Lamb]
+xmpv7            7430/tcp # OpenView DM xmpv7 api pipe [Dave_Lamb] [Dave_Lamb]
+xmpv7            7430/udp # OpenView DM xmpv7 api pipe [Dave_Lamb] [Dave_Lamb]
+pmd              7431/tcp # OpenView DM ovc/xmpv3 api pipe [Dave_Lamb] [Dave_Lamb]
+pmd              7431/udp # OpenView DM ovc/xmpv3 api pipe [Dave_Lamb] [Dave_Lamb]
+faximum          7437/tcp # Faximum [George_Pajari] [George_Pajari]
+faximum          7437/udp # Faximum [George_Pajari] [George_Pajari]
+oracleas-https   7443/tcp # Oracle Application Server HTTPS [David_McMarlin] [David_McMarlin] 2006-08
+oracleas-https   7443/udp # Oracle Application Server HTTPS [David_McMarlin] [David_McMarlin] 2006-08
+rise             7473/tcp # Rise: The Vieneo Province [Jason_Reskin] [Jason_Reskin] 2007-03
+rise             7473/udp # Rise: The Vieneo Province [Jason_Reskin] [Jason_Reskin] 2007-03
+neo4j            7474/tcp # Neo4j Graph Database [Neo_Technology_Inc] [Julian_Simpson] 2013-02-08
+telops-lmd       7491/tcp # telops-lmd [David_Spencer] [David_Spencer]
+telops-lmd       7491/udp # telops-lmd [David_Spencer] [David_Spencer]
+silhouette       7500/tcp # Silhouette User [Anthony_Payne] [Anthony_Payne] 2004-02
+silhouette       7500/udp # Silhouette User [Anthony_Payne] [Anthony_Payne] 2004-02
+ovbus            7501/tcp # HP OpenView Bus Daemon [David_M_Rhodes] [David_M_Rhodes]
+ovbus            7501/udp # HP OpenView Bus Daemon [David_M_Rhodes] [David_M_Rhodes]
+adcp             7508/tcp # Automation Device Configuration Protocol [Festo_AG] [Joerg_Ullmann] 2011-05-27 2012-07-26
+acplt            7509/tcp # ACPLT - process automation service [Chair_for_Process_Control_Engineering] [Ulrich_Epple] 2010-12-07 2012-08-07
+ovhpas           7510/tcp # HP OpenView Application Server [Jeff_Conrad] [Jeff_Conrad]
+ovhpas           7510/udp # HP OpenView Application Server [Jeff_Conrad] [Jeff_Conrad]
+pafec-lm         7511/tcp # pafec-lm [Billy_Dhillon] [Billy_Dhillon]
+pafec-lm         7511/udp # pafec-lm [Billy_Dhillon] [Billy_Dhillon]
+saratoga         7542/tcp # Saratoga Transfer Protocol [Lloyd_Wood] [Lloyd_Wood] 2007-05
+saratoga         7542/udp # Saratoga Transfer Protocol [Lloyd_Wood] [Lloyd_Wood] 2007-05
+atul             7543/tcp # atul server [Mark_Stapp] [Mark_Stapp] 2006-01
+atul             7543/udp # atul server [Mark_Stapp] [Mark_Stapp] 2006-01
+nta-ds           7544/tcp # FlowAnalyzer DisplayServer [Fred_Messinger] [Fred_Messinger]
+nta-ds           7544/udp # FlowAnalyzer DisplayServer [Fred_Messinger] [Fred_Messinger]
+nta-us           7545/tcp # FlowAnalyzer UtilityServer [Fred_Messinger] [Fred_Messinger]
+nta-us           7545/udp # FlowAnalyzer UtilityServer [Fred_Messinger] [Fred_Messinger]
+cfs              7546/tcp # Cisco Fabric service [Rituparna_Agrawal] [Rituparna_Agrawal] 2005-09
+cfs              7546/udp # Cisco Fabric service [Rituparna_Agrawal] [Rituparna_Agrawal] 2005-09
+cwmp             7547/tcp # DSL Forum CWMP [Anton_Okmianski] [Anton_Okmianski] 2006-01
+cwmp             7547/udp # DSL Forum CWMP [Anton_Okmianski] [Anton_Okmianski] 2006-01
+tidp             7548/tcp # Threat Information Distribution Protocol [Chui_Tin_Yen] [Chui_Tin_Yen] 2006-02
+tidp             7548/udp # Threat Information Distribution Protocol [Chui_Tin_Yen] [Chui_Tin_Yen] 2006-02
+nls-tl           7549/tcp # Network Layer Signaling Transport Layer [Melinda_Shore] [Melinda_Shore] 2006-05
+nls-tl           7549/udp # Network Layer Signaling Transport Layer [Melinda_Shore] [Melinda_Shore] 2006-05
+cloudsignaling   7550/udp # Cloud Signaling Service [Scott_Dawson] [Scott_Dawson] 2011-07-01
+sncp             7560/tcp # Sniffer Command Protocol [Dominick_Cafarelli] [Dominick_Cafarelli] 2005-08
+sncp             7560/udp # Sniffer Command Protocol [Dominick_Cafarelli] [Dominick_Cafarelli] 2005-08
+cfw              7563/tcp # Control Framework [RFC6230]
+vsi-omega        7566/tcp # VSI Omega [Curtis_Smith] [Curtis_Smith]
+vsi-omega        7566/udp # VSI Omega [Curtis_Smith] [Curtis_Smith]
+dell-eql-asm     7569/tcp # Dell EqualLogic Host Group Management [James_E_King_III] [James_E_King_III]
+aries-kfinder    7570/tcp # Aries Kfinder [James_King_III] [James_King_III]
+aries-kfinder    7570/udp # Aries Kfinder [James_King_III] [James_King_III]
+sun-lm           7588/tcp # Sun License Manager [Sophie_Deng] [Sophie_Deng]
+sun-lm           7588/udp # Sun License Manager [Sophie_Deng] [Sophie_Deng]
+indi             7624/tcp # Instrument Neutral Distributed Interface [Elwood_Downey] [Elwood_Downey] 2002-04
+indi             7624/udp # Instrument Neutral Distributed Interface [Elwood_Downey] [Elwood_Downey] 2002-04
+simco            7626/tcp # SImple Middlebox COnfiguration (SIMCO) Server [RFC4540]
+simco            7626/sctp # SImple Middlebox COnfiguration (SIMCO) [Sebastian_Kiesel] [Sebastian_Kiesel] 2006-01
+soap-http        7627/tcp # SOAP Service Port [Donald_Dylla] [Donald_Dylla] 2004-12
+soap-http        7627/udp # SOAP Service Port [Donald_Dylla] [Donald_Dylla] 2004-12
+zen-pawn         7628/tcp # Primary Agent Work Notification [Ty_Ellis] [Ty_Ellis] 2006-05
+zen-pawn         7628/udp # Primary Agent Work Notification [Ty_Ellis] [Ty_Ellis] 2006-05
+xdas             7629/tcp # OpenXDAS Wire Protocol [John_Calcote_2] [John_Calcote_2] 2006-10
+xdas             7629/udp # OpenXDAS Wire Protocol [John_Calcote_2] [John_Calcote_2] 2006-10
+hawk             7630/tcp # HA Web Konsole [Tim_Serong] [Tim_Serong] 2010-03-31
+tesla-sys-msg    7631/tcp # TESLA System Messaging [Andy_Perreault] [Andy_Perreault] 2010-03-31
+pmdfmgt          7633/tcp # PMDF Management [Hunter_Goatley] [Hunter_Goatley]
+pmdfmgt          7633/udp # PMDF Management [Hunter_Goatley] [Hunter_Goatley]
+cuseeme          7648/tcp # bonjour-cuseeme [Marc_Manthey] [Marc_Manthey] 2006-07
+cuseeme          7648/udp # bonjour-cuseeme [Marc_Manthey] [Marc_Manthey] 2006-07
+imqstomp         7672/tcp # iMQ STOMP Server [Amy_Kang] [Amy_Kang] 2009-03-10
+imqstomps        7673/tcp # iMQ STOMP Server over SSL [Amy_Kang] [Amy_Kang] 2009-03-10
+imqtunnels       7674/tcp # iMQ SSL tunnel [Shailesh_S_Bavadeka] [Shailesh_S_Bavadeka] 2002-04
+imqtunnels       7674/udp # iMQ SSL tunnel [Shailesh_S_Bavadeka] [Shailesh_S_Bavadeka] 2002-04
+imqtunnel        7675/tcp # iMQ Tunnel [Shailesh_S_Bavadeka] [Shailesh_S_Bavadeka] 2002-04
+imqtunnel        7675/udp # iMQ Tunnel [Shailesh_S_Bavadeka] [Shailesh_S_Bavadeka] 2002-04
+imqbrokerd       7676/tcp # iMQ Broker Rendezvous [Joseph_Di_Pol] [Joseph_Di_Pol] 2002-04
+imqbrokerd       7676/udp # iMQ Broker Rendezvous [Joseph_Di_Pol] [Joseph_Di_Pol] 2002-04
+sun-user-https   7677/tcp # Sun App Server - HTTPS [Abhijit_Kumar] [Abhijit_Kumar] 2005-11
+sun-user-https   7677/udp # Sun App Server - HTTPS [Abhijit_Kumar] [Abhijit_Kumar] 2005-11
+pando-pub        7680/tcp # Pando Media Public Distribution [Laird_Popkin] [Laird_Popkin] 2008-02-27
+pando-pub        7680/udp # Pando Media Public Distribution [Laird_Popkin] [Laird_Popkin] 2008-02-27
+collaber         7689/tcp # Collaber Network Service [Rajesh_Akkineni] [Rajesh_Akkineni] 2007-01
+collaber         7689/udp # Collaber Network Service [Rajesh_Akkineni] [Rajesh_Akkineni] 2007-01
+klio             7697/tcp # KLIO communications [Helmut_Giritzer_2] [Helmut_Giritzer_2] 2005-08
+klio             7697/udp # KLIO communications [Helmut_Giritzer_2] [Helmut_Giritzer_2] 2005-08
+em7-secom        7700/tcp # EM7 Secure Communications [Christopher_Cordray] [Christopher_Cordray] 2008-06-05
+sync-em7         7707/tcp # EM7 Dynamic Updates [Christopher_Cordray] [Christopher_Cordray] 2004-11
+sync-em7         7707/udp # EM7 Dynamic Updates [Christopher_Cordray] [Christopher_Cordray] 2004-11
+scinet           7708/tcp # scientia.net [Christoph_Anton_Mitt] [Christoph_Anton_Mitt] 2006-01
+scinet           7708/udp # scientia.net [Christoph_Anton_Mitt] [Christoph_Anton_Mitt] 2006-01
+medimageportal   7720/tcp # MedImage Portal [Robert_Helton] [Robert_Helton] 2003-10
+medimageportal   7720/udp # MedImage Portal [Robert_Helton] [Robert_Helton] 2003-10
+nsdeepfreezectl  7724/tcp # Novell Snap-in Deep Freeze Control [David_Crowe] [David_Crowe] 2008-01-07
+nsdeepfreezectl  7724/udp # Novell Snap-in Deep Freeze Control [David_Crowe] [David_Crowe] 2008-01-07
+nitrogen         7725/tcp # Nitrogen Service [Randy_Lomnes] [Randy_Lomnes] 2004-11
+nitrogen         7725/udp # Nitrogen Service [Randy_Lomnes] [Randy_Lomnes] 2004-11
+freezexservice   7726/tcp # FreezeX Console Service [David_Crowe] [David_Crowe] 2005-06
+freezexservice   7726/udp # FreezeX Console Service [David_Crowe] [David_Crowe] 2005-06
+trident-data     7727/tcp # Trident Systems Data [Jeremy_McClintock] [Jeremy_McClintock] 2005-08
+trident-data     7727/udp # Trident Systems Data [Jeremy_McClintock] [Jeremy_McClintock] 2005-08
+smip             7734/tcp # Smith Protocol over IP [Jim_Pettinato] [Jim_Pettinato] 2007-04
+smip             7734/udp # Smith Protocol over IP [Jim_Pettinato] [Jim_Pettinato] 2007-04
+aiagent          7738/tcp # HP Enterprise Discovery Agent [Matthew_Darwin] [Matthew_Darwin] 2005-08
+aiagent          7738/udp # HP Enterprise Discovery Agent [Matthew_Darwin] [Matthew_Darwin] 2005-08
+scriptview       7741/tcp # ScriptView Network [Reinhard_Wolf] [Reinhard_Wolf] 2010-08-19
+scriptview       7741/udp # ScriptView Network [Reinhard_Wolf] [Reinhard_Wolf] 2010-08-19
+msss             7742/tcp # Mugginsoft Script Server Service [Jonathan_Mitchell] [Jonathan_Mitchell] 2008-09-08
+sstp-1           7743/tcp # Sakura Script Transfer Protocol [Kouichi_Takeda] [Kouichi_Takeda]
+sstp-1           7743/udp # Sakura Script Transfer Protocol [Kouichi_Takeda] [Kouichi_Takeda]
+raqmon-pdu       7744/tcp # RAQMON PDU [RFC4712]
+raqmon-pdu       7744/udp # RAQMON PDU [RFC4712]
+prgp             7747/tcp # Put/Run/Get Protocol [Jayasooriah] [Jayasooriah] 2008-02-22
+prgp             7747/udp # Put/Run/Get Protocol [Jayasooriah] [Jayasooriah] 2008-02-22
+cbt              7777/tcp # cbt [Tony_Ballardie] [Tony_Ballardie]
+cbt              7777/udp # cbt [Tony_Ballardie] [Tony_Ballardie]
+interwise        7778/tcp # Interwise [Joseph_Gray] [Joseph_Gray]
+interwise        7778/udp # Interwise [Joseph_Gray] [Joseph_Gray]
+vstat            7779/tcp # VSTAT [Vinh_Nguyn] [Vinh_Nguyn]
+vstat            7779/udp # VSTAT [Vinh_Nguyn] [Vinh_Nguyn]
+accu-lmgr        7781/tcp # accu-lmgr [Moises_E_Hernandez] [Moises_E_Hernandez]
+accu-lmgr        7781/udp # accu-lmgr [Moises_E_Hernandez] [Moises_E_Hernandez]
+minivend         7786/tcp # MINIVEND [Mike_Heins] [Mike_Heins]
+minivend         7786/udp # MINIVEND [Mike_Heins] [Mike_Heins]
+popup-reminders  7787/tcp # Popup Reminders Receive [Robert_Harvey] [Robert_Harvey] 2006-01
+popup-reminders  7787/udp # Popup Reminders Receive [Robert_Harvey] [Robert_Harvey] 2006-01
+office-tools     7789/tcp # Office Tools Pro Receive [Robert_Harvey] [Robert_Harvey] 2006-01
+office-tools     7789/udp # Office Tools Pro Receive [Robert_Harvey] [Robert_Harvey] 2006-01
+q3ade            7794/tcp # Q3ADE Cluster Service [Uffe_Harksen] [Uffe_Harksen] 2005-08
+q3ade            7794/udp # Q3ADE Cluster Service [Uffe_Harksen] [Uffe_Harksen] 2005-08
+pnet-conn        7797/tcp # Propel Connector port
+pnet-conn        7797/udp # Propel Connector port
+pnet-enc         7798/tcp # Propel Encoder port [Leif_Hedstrom] [Leif_Hedstrom] 2002-04
+pnet-enc         7798/udp # Propel Encoder port [Leif_Hedstrom] [Leif_Hedstrom] 2002-04
+altbsdp          7799/tcp # Alternate BSDP Service [Dieter_Siegmund] [Dieter_Siegmund] 2007-10-22
+altbsdp          7799/udp # Alternate BSDP Service [Dieter_Siegmund] [Dieter_Siegmund] 2007-10-22
+asr              7800/tcp # Apple Software Restore [Jim_Kateley][Shantonu_Sen] [Jim_Kateley][Shantonu_Sen] 2006-01 Defined TXT keys: image=<HTTP URL of disk image>
+asr              7800/udp # Apple Software Restore [Jim_Kateley][Shantonu_Sen] [Jim_Kateley][Shantonu_Sen] 2006-01 Defined TXT keys: image=<HTTP URL of disk image>
+ssp-client       7801/tcp # Secure Server Protocol - client [Rick_Macchio] [Rick_Macchio] 2006-11
+ssp-client       7801/udp # Secure Server Protocol - client [Rick_Macchio] [Rick_Macchio] 2006-11
+vns-tp           7802/udp # Virtualized Network Services Tunnel Protocol [Juniper_Networks] [Bruno_Rijsman] 2013-02-01
+rbt-wanopt       7810/tcp # Riverbed WAN Optimization Protocol [Vladimir_Legalov_2] [Vladimir_Legalov_2] 2007-09-04
+rbt-wanopt       7810/udp # Riverbed WAN Optimization Protocol [Vladimir_Legalov_2] [Vladimir_Legalov_2] 2007-09-04
+apc-7845         7845/tcp # APC 7845 [American_Power_Conve] [American_Power_Conve]
+apc-7845         7845/udp # APC 7845 [American_Power_Conve] [American_Power_Conve]
+apc-7846         7846/tcp # APC 7846 [American_Power_Conve] [American_Power_Conve]
+apc-7846         7846/udp # APC 7846 [American_Power_Conve] [American_Power_Conve]
+csoauth          7847/tcp # A product key authentication protocol made by CSO [Jeff_Wamsley] [Jacob_Kiesel] 2013-09-04
+mobileanalyzer   7869/tcp # MobileAnalyzer& MobileMonitor [Jonas_Gyllensvaan] [Jonas_Gyllensvaan] 2009-04-27
+rbt-smc          7870/tcp # Riverbed Steelhead Mobile Service [Gabriel_Levy] [Gabriel_Levy] 2008-08-29
+mdm              7871/tcp # Mobile Device Management [Dan_Harkins] [Dan_Harkins] 2011-08-15
+mipv6tls         7872/udp # TLS-based Mobile IPv6 Security [IESG] [IETF_Chair] 2012-04-12 [RFC6618]
+owms             7878/tcp # Opswise Message Service [Stonebranch_Inc] [Nathan_Hammond_2] 2013-06-25
+pss              7880/tcp # Pearson [Pearson] [Pearson] 2008-01-17
+pss              7880/udp # Pearson [Pearson] [Pearson] 2008-01-17
+ubroker          7887/tcp # Universal Broker [Nathan_Hammond] [Nathan_Hammond] 2005-10
+ubroker          7887/udp # Universal Broker [Nathan_Hammond] [Nathan_Hammond] 2005-10
+mevent           7900/tcp # Multicast Event [YoonSoo_Kim] [YoonSoo_Kim] 2006-05
+mevent           7900/udp # Multicast Event [YoonSoo_Kim] [YoonSoo_Kim] 2006-05
+tnos-sp          7901/tcp # TNOS Service Protocol [Rene_Kurt] [Rene_Kurt] 2005-08
+tnos-sp          7901/udp # TNOS Service Protocol [Rene_Kurt] [Rene_Kurt] 2005-08
+tnos-dp          7902/tcp # TNOS shell Protocol [Rene_Kurt] [Rene_Kurt] 2005-08
+tnos-dp          7902/udp # TNOS shell Protocol [Rene_Kurt] [Rene_Kurt] 2005-08
+tnos-dps         7903/tcp # TNOS Secure DiaguardProtocol [Rene_Kurt] [Rene_Kurt] 2005-08
+tnos-dps         7903/udp # TNOS Secure DiaguardProtocol [Rene_Kurt] [Rene_Kurt] 2005-08
+qo-secure        7913/tcp # QuickObjects secure port [Jonas_Bovin] [Jonas_Bovin]
+qo-secure        7913/udp # QuickObjects secure port [Jonas_Bovin] [Jonas_Bovin]
+t2-drm           7932/tcp # Tier 2 Data Resource Manager [Peter_Carlson] [Peter_Carlson]
+t2-drm           7932/udp # Tier 2 Data Resource Manager [Peter_Carlson] [Peter_Carlson]
+t2-brm           7933/tcp # Tier 2 Business Rules Manager [Peter_Carlson] [Peter_Carlson]
+t2-brm           7933/udp # Tier 2 Business Rules Manager [Peter_Carlson] [Peter_Carlson]
+supercell        7967/tcp # Supercell [Kevin_Nakagawa] [Kevin_Nakagawa]
+supercell        7967/udp # Supercell [Kevin_Nakagawa] [Kevin_Nakagawa]
+micromuse-ncps   7979/tcp # Micromuse-ncps [Hing_Wing_To] [Hing_Wing_To]
+micromuse-ncps   7979/udp # Micromuse-ncps [Hing_Wing_To] [Hing_Wing_To]
+quest-vista      7980/tcp # Quest Vista [Preston_Bannister] [Preston_Bannister]
+quest-vista      7980/udp # Quest Vista [Preston_Bannister] [Preston_Bannister]
+sossd-collect    7981/tcp # Spotlight on SQL Server Desktop Collect [Rob_Griffin_2] [Rob_Griffin_2] 2010-08-30
+sossd-agent      7982/tcp # Spotlight on SQL Server Desktop Agent [Rob_Griffin_2] [Rob_Griffin_2] 2010-09-13
+sossd-disc       7982/udp # Spotlight on SQL Server Desktop Agent Discovery [Rob_Griffin_2] [Rob_Griffin_2] 2010-09-13
+pushns           7997/tcp # PUSH Notification Service [Tristan_Seifert] [Tristan_Seifert] 2011-01-31
+usicontentpush   7998/udp # USI Content Push Service [Prakash_Iyer] [Prakash_Iyer] 2009-08-10
+irdmi2           7999/tcp # iRDMI2
+irdmi2           7999/udp # iRDMI2
+irdmi            8000/tcp # iRDMI [Gil_Shafriri] [Gil_Shafriri]
+irdmi            8000/udp # iRDMI [Gil_Shafriri] [Gil_Shafriri]
+vcom-tunnel      8001/tcp # VCOM Tunnel [Mark_Lewandowski] [Mark_Lewandowski]
+vcom-tunnel      8001/udp # VCOM Tunnel [Mark_Lewandowski] [Mark_Lewandowski]
+teradataordbms   8002/tcp # Teradata ORDBMS [Curt_Ellmann] [Curt_Ellmann]
+teradataordbms   8002/udp # Teradata ORDBMS [Curt_Ellmann] [Curt_Ellmann]
+mcreport         8003/tcp # Mulberry Connect Reporting Service [Dave_Stoneham] [Dave_Stoneham] 2008-03-10
+mcreport         8003/udp # Mulberry Connect Reporting Service [Dave_Stoneham] [Dave_Stoneham] 2008-03-10
+mxi              8005/tcp # MXI Generation II for z/OS [Rob_Scott] [Rob_Scott] 2007-05
+mxi              8005/udp # MXI Generation II for z/OS [Rob_Scott] [Rob_Scott] 2007-05
+http-alt         8008/tcp # HTTP Alternate [James_Gettys] [James_Gettys]
+http-alt         8008/udp # HTTP Alternate [James_Gettys] [James_Gettys]
+qbdb             8019/tcp # QB DB Dynamic Port [Sridhar_Krishnamurth] [Sridhar_Krishnamurth] 2008-02-15
+qbdb             8019/udp # QB DB Dynamic Port [Sridhar_Krishnamurth] [Sridhar_Krishnamurth] 2008-02-15
+intu-ec-svcdisc  8020/tcp # Intuit Entitlement Service and Discovery [Daniel_C_McGloin] [Daniel_C_McGloin] 2005-05
+intu-ec-svcdisc  8020/udp # Intuit Entitlement Service and Discovery [Daniel_C_McGloin] [Daniel_C_McGloin] 2005-05
+intu-ec-client   8021/tcp # Intuit Entitlement Client [Daniel_C_McGloin] [Daniel_C_McGloin] 2005-05
+intu-ec-client   8021/udp # Intuit Entitlement Client [Daniel_C_McGloin] [Daniel_C_McGloin] 2005-05
+oa-system        8022/tcp # oa-system [Marie_France_Dubreui] [Marie_France_Dubreui]
+oa-system        8022/udp # oa-system [Marie_France_Dubreui] [Marie_France_Dubreui]
+ca-audit-da      8025/tcp # CA Audit Distribution Agent [Henning_Smith] [Henning_Smith] 2006-07
+ca-audit-da      8025/udp # CA Audit Distribution Agent [Henning_Smith] [Henning_Smith] 2006-07
+ca-audit-ds      8026/tcp # CA Audit Distribution Server [Henning_Smith] [Henning_Smith] 2006-07
+ca-audit-ds      8026/udp # CA Audit Distribution Server [Henning_Smith] [Henning_Smith] 2006-07
+pro-ed           8032/tcp # ProEd
+pro-ed           8032/udp # ProEd
+mindprint        8033/tcp # MindPrint [Larry_Tusoni] [Larry_Tusoni]
+mindprint        8033/udp # MindPrint [Larry_Tusoni] [Larry_Tusoni]
+vantronix-mgmt   8034/tcp # .vantronix Management [Reyk_Floeter] [Reyk_Floeter] 2008-02-27
+vantronix-mgmt   8034/udp # .vantronix Management [Reyk_Floeter] [Reyk_Floeter] 2008-02-27
+ampify           8040/tcp # Ampify Messaging Protocol [Tav_Espian] [Tav_Espian] 2010-08-10
+ampify           8040/udp # Ampify Messaging Protocol [Tav_Espian] [Tav_Espian] 2010-08-10
+fs-agent         8042/tcp # FireScope Agent [Matt_Rogers] [Matt_Rogers] 2008-10-16
+fs-server        8043/tcp # FireScope Server [Matt_Rogers] [Matt_Rogers] 2008-10-16
+fs-mgmt          8044/tcp # FireScope Management Interface [Matt_Rogers] [Matt_Rogers] 2008-10-16
+rocrail          8051/tcp # Rocrail Client Service [Rob_Versluis] [Rob_Versluis] 2011-05-23
+senomix01        8052/tcp # Senomix Timesheets Server [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix01        8052/udp # Senomix Timesheets Server [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix02        8053/tcp # Senomix Timesheets Client [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix02        8053/udp # Senomix Timesheets Client [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix03        8054/tcp # Senomix Timesheets Server [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix03        8054/udp # Senomix Timesheets Server [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix04        8055/tcp # Senomix Timesheets Server [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix04        8055/udp # Senomix Timesheets Server [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix05        8056/tcp # Senomix Timesheets Server [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix05        8056/udp # Senomix Timesheets Server [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix06        8057/tcp # Senomix Timesheets Client [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix06        8057/udp # Senomix Timesheets Client [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix07        8058/tcp # Senomix Timesheets Client [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix07        8058/udp # Senomix Timesheets Client [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix08        8059/tcp # Senomix Timesheets Client [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+senomix08        8059/udp # Senomix Timesheets Client [1 year assignment] [Charles_O_Dale] [Charles_O_Dale] 2006-07
+aero             8060/udp # Asymmetric Extended Route Optimization (AERO) [IESG] [IETF_Chair] [RFC6706]
+toad-bi-appsrvr  8066/tcp # Toad BI Application Server [Quest_Software_2] [Greg_Cottman_3] 2013-04-19
+gadugadu         8074/tcp # Gadu-Gadu [Marcin_Gozdalik] [Marcin_Gozdalik] 2006-05
+gadugadu         8074/udp # Gadu-Gadu [Marcin_Gozdalik] [Marcin_Gozdalik] 2006-05
+http-alt         8080/tcp # HTTP Alternate (see port 80) [Stephen_Casner] [Stephen_Casner]
+http-alt         8080/udp # HTTP Alternate (see port 80) [Stephen_Casner] [Stephen_Casner]
+sunproxyadmin    8081/tcp # Sun Proxy Admin Service [Arvind_Srinivasan] [Arvind_Srinivasan] 2005-08
+sunproxyadmin    8081/udp # Sun Proxy Admin Service [Arvind_Srinivasan] [Arvind_Srinivasan] 2005-08
+us-cli           8082/tcp # Utilistor (Client) [Andy_Brewerton] [Andy_Brewerton] 2005-08
+us-cli           8082/udp # Utilistor (Client) [Andy_Brewerton] [Andy_Brewerton] 2005-08
+us-srv           8083/tcp # Utilistor (Server) [Andy_Brewerton] [Andy_Brewerton] 2005-08
+us-srv           8083/udp # Utilistor (Server) [Andy_Brewerton] [Andy_Brewerton] 2005-08
+d-s-n            8086/tcp # Distributed SCADA Networking Rendezvous Port [Gary_Hampton] [Gary_Hampton] 2008-02-27
+d-s-n            8086/udp # Distributed SCADA Networking Rendezvous Port [Gary_Hampton] [Gary_Hampton] 2008-02-27
+simplifymedia    8087/tcp # Simplify Media SPP Protocol [Emmanuel_Saint_Loube] [Emmanuel_Saint_Loube] 2008-08-08
+simplifymedia    8087/udp # Simplify Media SPP Protocol [Emmanuel_Saint_Loube] [Emmanuel_Saint_Loube] 2008-08-08
+radan-http       8088/tcp # Radan HTTP [Steve_Hay] [Steve_Hay] 2008-06-13
+radan-http       8088/udp # Radan HTTP [Steve_Hay] [Steve_Hay] 2008-06-13
+jamlink          8091/tcp # Jam Link Framework [Evgeniy_Filatov] [Evgeniy_Filatov] 2009-11-25
+sac              8097/tcp # SAC Port Id [Girish_Bhat] [Girish_Bhat] 2006-04
+sac              8097/udp # SAC Port Id [Girish_Bhat] [Girish_Bhat] 2006-04
+xprint-server    8100/tcp # Xprint Server [John_McKernan] [John_McKernan]
+xprint-server    8100/udp # Xprint Server [John_McKernan] [John_McKernan]
+ldoms-migr       8101/tcp # Logical Domains Migration [Liam_Merwick] [Liam_Merwick] 2009-01-16
+mtl8000-matrix   8115/tcp # MTL8000 Matrix [David_Pinch] [David_Pinch] 2002-04
+mtl8000-matrix   8115/udp # MTL8000 Matrix [David_Pinch] [David_Pinch] 2002-04
+cp-cluster       8116/tcp # Check Point Clustering [Roni_Moshitzky] [Roni_Moshitzky]
+cp-cluster       8116/udp # Check Point Clustering [Roni_Moshitzky] [Roni_Moshitzky]
+purityrpc        8117/tcp # Purity replication clustering and remote management [Pure_Storage] [Steve_Hodgson] 2013-08-13
+privoxy          8118/tcp # Privoxy HTTP proxy [Andreas_Oesterhelt] [Andreas_Oesterhelt] 2002-06
+privoxy          8118/udp # Privoxy HTTP proxy [Andreas_Oesterhelt] [Andreas_Oesterhelt] 2002-06
+apollo-data      8121/tcp # Apollo Data Port [Anthony_Carrabino] [Anthony_Carrabino] 2003-08
+apollo-data      8121/udp # Apollo Data Port [Anthony_Carrabino] [Anthony_Carrabino] 2003-08
+apollo-admin     8122/tcp # Apollo Admin Port [Anthony_Carrabino] [Anthony_Carrabino] 2003-08
+apollo-admin     8122/udp # Apollo Admin Port [Anthony_Carrabino] [Anthony_Carrabino] 2003-08
+paycash-online   8128/tcp # PayCash Online Protocol [MegaZone] [MegaZone] 2005-08
+paycash-online   8128/udp # PayCash Online Protocol [MegaZone] [MegaZone] 2005-08
+paycash-wbp      8129/tcp # PayCash Wallet-Browser [MegaZone] [MegaZone] 2005-08
+paycash-wbp      8129/udp # PayCash Wallet-Browser [MegaZone] [MegaZone] 2005-08
+indigo-vrmi      8130/tcp # INDIGO-VRMI [Colin_Caughie] [Colin_Caughie]
+indigo-vrmi      8130/udp # INDIGO-VRMI [Colin_Caughie] [Colin_Caughie]
+indigo-vbcp      8131/tcp # INDIGO-VBCP [Colin_Caughie] [Colin_Caughie]
+indigo-vbcp      8131/udp # INDIGO-VBCP [Colin_Caughie] [Colin_Caughie]
+dbabble          8132/tcp # dbabble [Chris_Pugmire] [Chris_Pugmire]
+dbabble          8132/udp # dbabble [Chris_Pugmire] [Chris_Pugmire]
+isdd             8148/tcp # i-SDD file transfer [Frank_Waarsenburg] [Frank_Waarsenburg] 2004-11
+isdd             8148/udp # i-SDD file transfer [Frank_Waarsenburg] [Frank_Waarsenburg] 2004-11
+eor-game         8149/udp # Edge of Reality game data [Sky_Schulz] [Sky_Schulz] 2011-05-09
+quantastor       8153/tcp # QuantaStor Management Interface [OS_NEXUS] [Steven_Umbehocker] 2012-09-21
+patrol           8160/tcp # Patrol [Portnoy_Boxman] [Portnoy_Boxman]
+patrol           8160/udp # Patrol [Portnoy_Boxman] [Portnoy_Boxman]
+patrol-snmp      8161/tcp # Patrol SNMP [Portnoy_Boxman] [Portnoy_Boxman]
+patrol-snmp      8161/udp # Patrol SNMP [Portnoy_Boxman] [Portnoy_Boxman]
+lpar2rrd         8162/tcp # LPAR2RRD client server communication [LPAR2RRD_project] [Pavel_Hampl] 2013-08-14
+intermapper      8181/tcp # Intermapper network management system [William_Fisher] [William_Fisher] 2011-05-09
+vmware-fdm       8182/tcp # VMware Fault Domain Manager [Ron_Passerini] [Ron_Passerini] 2010-04-27
+vmware-fdm       8182/udp # VMware Fault Domain Manager [Ron_Passerini] [Ron_Passerini] 2010-04-27
+proremote        8183/tcp # ProRemote [Alex_Lelievre] [Alex_Lelievre] 2009-08-18
+itach            8184/tcp # Remote iTach Connection [Barend_Jacobus_van_d] [Barend_Jacobus_van_d] 2010-04-27
+itach            8184/udp # Remote iTach Connection [Barend_Jacobus_van_d] [Barend_Jacobus_van_d] 2010-04-27
+spytechphone     8192/tcp # SpyTech Phone Service [Bill_Kay] [Bill_Kay] 2006-04
+spytechphone     8192/udp # SpyTech Phone Service [Bill_Kay] [Bill_Kay] 2006-04
+blp1             8194/tcp # Bloomberg data API [Albert_Hou] [Albert_Hou] 2006-05
+blp1             8194/udp # Bloomberg data API [Albert_Hou] [Albert_Hou] 2006-05
+blp2             8195/tcp # Bloomberg feed [Albert_Hou] [Albert_Hou] 2006-05
+blp2             8195/udp # Bloomberg feed [Albert_Hou] [Albert_Hou] 2006-05
+vvr-data         8199/tcp # VVR DATA [Ming_Xu] [Ming_Xu]
+vvr-data         8199/udp # VVR DATA [Ming_Xu] [Ming_Xu]
+trivnet1         8200/tcp # TRIVNET [Saar_Wilf] [Saar_Wilf]
+trivnet1         8200/udp # TRIVNET [Saar_Wilf] [Saar_Wilf]
+trivnet2         8201/tcp # TRIVNET [Saar_Wilf] [Saar_Wilf]
+trivnet2         8201/udp # TRIVNET [Saar_Wilf] [Saar_Wilf]
+aesop            8202/udp # Audio+Ethernet Standard Open Protocol [POWERSOFT_SRL] [Paolo_Desii][Claudio_Lastrucci] 2012-01-03
+lm-perfworks     8204/tcp # LM Perfworks [Chris_Flynn] [Chris_Flynn]
+lm-perfworks     8204/udp # LM Perfworks [Chris_Flynn] [Chris_Flynn]
+lm-instmgr       8205/tcp # LM Instmgr [Chris_Flynn] [Chris_Flynn]
+lm-instmgr       8205/udp # LM Instmgr [Chris_Flynn] [Chris_Flynn]
+lm-dta           8206/tcp # LM Dta [Chris_Flynn] [Chris_Flynn]
+lm-dta           8206/udp # LM Dta [Chris_Flynn] [Chris_Flynn]
+lm-sserver       8207/tcp # LM SServer [Chris_Flynn] [Chris_Flynn]
+lm-sserver       8207/udp # LM SServer [Chris_Flynn] [Chris_Flynn]
+lm-webwatcher    8208/tcp # LM Webwatcher [Chris_Flynn] [Chris_Flynn]
+lm-webwatcher    8208/udp # LM Webwatcher [Chris_Flynn] [Chris_Flynn]
+rexecj           8230/tcp # RexecJ Server [Curtiss_Howard] [Curtiss_Howard] 2004-11
+rexecj           8230/udp # RexecJ Server [Curtiss_Howard] [Curtiss_Howard] 2004-11
+synapse-nhttps   8243/tcp # Synapse Non Blocking HTTPS [Ruwan_Linton] [Ruwan_Linton] 2008-07-10
+synapse-nhttps   8243/udp # Synapse Non Blocking HTTPS [Ruwan_Linton] [Ruwan_Linton] 2008-07-10
+pando-sec        8276/tcp # Pando Media Controlled Distribution [Laird_Popkin] [Laird_Popkin] 2008-02-27
+pando-sec        8276/udp # Pando Media Controlled Distribution [Laird_Popkin] [Laird_Popkin] 2008-02-27
+synapse-nhttp    8280/tcp # Synapse Non Blocking HTTP [Ruwan_Linton] [Ruwan_Linton] 2008-06-05
+synapse-nhttp    8280/udp # Synapse Non Blocking HTTP [Ruwan_Linton] [Ruwan_Linton] 2008-06-05
+blp3             8292/tcp # Bloomberg professional [Albert_Hou] [Albert_Hou] 2006-05
+blp3             8292/udp # Bloomberg professional [Albert_Hou] [Albert_Hou] 2006-05
+hiperscan-id     8293/tcp # Hiperscan Identification Service [Thomas_Klose] [Thomas_Klose] 2009-12-15
+blp4             8294/tcp # Bloomberg intelligent client [Albert_Hou] [Albert_Hou] 2006-05
+blp4             8294/udp # Bloomberg intelligent client [Albert_Hou] [Albert_Hou] 2006-05
+tmi              8300/tcp # Transport Management Interface [Steve_Kneizys] [Steve_Kneizys] 2006-11
+tmi              8300/udp # Transport Management Interface [Steve_Kneizys] [Steve_Kneizys] 2006-11
+amberon          8301/tcp # Amberon PPC/PPS [Ronald_Snyder] [Ronald_Snyder] 2006-03
+amberon          8301/udp # Amberon PPC/PPS [Ronald_Snyder] [Ronald_Snyder] 2006-03
+hub-open-net     8313/tcp # Hub Open Network [Grexie] [Tim_Behrsin] 2012-06-13 Defined TXT keys: _hub._tcp.host.example.com
+tnp-discover     8320/tcp # Thin(ium) Network Protocol [Aly_Orady] [Aly_Orady] 2007-08-07
+tnp-discover     8320/udp # Thin(ium) Network Protocol [Aly_Orady] [Aly_Orady] 2007-08-07
+tnp              8321/tcp # Thin(ium) Network Protocol [Aly_Orady] [Aly_Orady] 2007-08-07
+tnp              8321/udp # Thin(ium) Network Protocol [Aly_Orady] [Aly_Orady] 2007-08-07
+server-find      8351/tcp # Server Find [Chris_Brown] [Chris_Brown]
+server-find      8351/udp # Server Find [Chris_Brown] [Chris_Brown]
+cruise-enum      8376/tcp # Cruise ENUM [Steve_Husak] [Steve_Husak]
+cruise-enum      8376/udp # Cruise ENUM [Steve_Husak] [Steve_Husak]
+cruise-swroute   8377/tcp # Cruise SWROUTE [Steve_Husak] [Steve_Husak]
+cruise-swroute   8377/udp # Cruise SWROUTE [Steve_Husak] [Steve_Husak]
+cruise-config    8378/tcp # Cruise CONFIG [Steve_Husak] [Steve_Husak]
+cruise-config    8378/udp # Cruise CONFIG [Steve_Husak] [Steve_Husak]
+cruise-diags     8379/tcp # Cruise DIAGS [Steve_Husak] [Steve_Husak]
+cruise-diags     8379/udp # Cruise DIAGS [Steve_Husak] [Steve_Husak]
+cruise-update    8380/tcp # Cruise UPDATE [Steve_Husak] [Steve_Husak]
+cruise-update    8380/udp # Cruise UPDATE [Steve_Husak] [Steve_Husak]
+m2mservices      8383/tcp # M2m Services [Carlos_Arteaga_2] [Carlos_Arteaga_2] 2004-11
+m2mservices      8383/udp # M2m Services [Carlos_Arteaga_2] [Carlos_Arteaga_2] 2004-11
+cvd              8400/tcp # cvd [Aaron_Bilbrey] [Aaron_Bilbrey]
+cvd              8400/udp # cvd [Aaron_Bilbrey] [Aaron_Bilbrey]
+sabarsd          8401/tcp # sabarsd [Aaron_Bilbrey] [Aaron_Bilbrey]
+sabarsd          8401/udp # sabarsd [Aaron_Bilbrey] [Aaron_Bilbrey]
+abarsd           8402/tcp # abarsd [Aaron_Bilbrey] [Aaron_Bilbrey]
+abarsd           8402/udp # abarsd [Aaron_Bilbrey] [Aaron_Bilbrey]
+admind           8403/tcp # admind [Aaron_Bilbrey] [Aaron_Bilbrey]
+admind           8403/udp # admind [Aaron_Bilbrey] [Aaron_Bilbrey]
+svcloud          8404/tcp # SuperVault Cloud [Nine_Technology_LLC] [Alex_Stoev] 2009-09-14 2011-08-01
+svbackup         8405/tcp # SuperVault Backup [Nine_Technology_LLC] [Alex_Stoev] 2009-09-14 2011-08-01
+dlpx-sp          8415/tcp # Delphix Session Protocol [Delphix_Corp] [Peng_Dai] 2012-11-01
+espeech          8416/tcp # eSpeech Session Protocol [Scott_Tarone] [Scott_Tarone] 2002-11
+espeech          8416/udp # eSpeech Session Protocol [Scott_Tarone] [Scott_Tarone] 2002-11
+espeech-rtp      8417/tcp # eSpeech RTP Protocol [Scott_Tarone] [Scott_Tarone] 2003-04
+espeech-rtp      8417/udp # eSpeech RTP Protocol [Scott_Tarone] [Scott_Tarone] 2003-04
+cybro-a-bus      8442/tcp # CyBro A-bus Protocol [Damir_Skrjanec] [Damir_Skrjanec] 2007-05
+cybro-a-bus      8442/udp # CyBro A-bus Protocol [Damir_Skrjanec] [Damir_Skrjanec] 2007-05
+pcsync-https     8443/tcp # PCsync HTTPS
+pcsync-https     8443/udp # PCsync HTTPS
+pcsync-http      8444/tcp # PCsync HTTP [Katy_Lynn_McCullough] [Katy_Lynn_McCullough]
+pcsync-http      8444/udp # PCsync HTTP [Katy_Lynn_McCullough] [Katy_Lynn_McCullough]
+copy             8445/tcp # Port for copy peer sync feature [Copy] [Jason_Dictos] 2012-09-19
+copy-disc        8445/udp # Port for copy discovery [Copy] [Jason_Dictos] 2012-09-19
+npmp             8450/tcp # npmp [Ian_Chard] [Ian_Chard]
+npmp             8450/udp # npmp [Ian_Chard] [Ian_Chard]
+nexentamv        8457/tcp # Nexenta Management GUI [Nexenta] [Andrew_Galloway] 2012-12-07
+cisco-avp        8470/tcp # Cisco Address Validation Protocol [Cullen_Jennings] [Cullen_Jennings] 2009-02-13
+pim-port         8471/tcp # PIM over Reliable Transport [IESG] [IETF_Chair] 2008-08-21 [RFC6559]
+pim-port         8471/sctp # PIM over Reliable Transport [IESG] [IETF_Chair] 2008-08-21 [RFC6559]
+otv              8472/tcp # Overlay Transport Virtualization (OTV) [Dino_Farinacci] [Dino_Farinacci] 2008-01-07
+otv              8472/udp # Overlay Transport Virtualization (OTV) [Dino_Farinacci] [Dino_Farinacci] 2008-01-07
+vp2p             8473/tcp # Virtual Point to Point [Jerome_Grimbert] [Jerome_Grimbert]
+vp2p             8473/udp # Virtual Point to Point [Jerome_Grimbert] [Jerome_Grimbert]
+noteshare        8474/tcp # AquaMinds NoteShare [Michael_McNabb] [Michael_McNabb] 2005-10
+noteshare        8474/udp # AquaMinds NoteShare [Michael_McNabb] [Michael_McNabb] 2005-10
+fmtp             8500/tcp # Flight Message Transfer Protocol [Eivan_Cerasi] [Eivan_Cerasi] 2003-12
+fmtp             8500/udp # Flight Message Transfer Protocol [Eivan_Cerasi] [Eivan_Cerasi] 2003-12
+cmtp-mgt         8501/tcp # CYTEL Message Transfer Management
+cmtp-av          8501/udp # CYTEL Message Transfer Audio and Video [Frank_Jakel] [Frank_Jakel] 2011-04-29
+rtsp-alt         8554/tcp # RTSP Alternate (see port 554) [Stephen_Casner_2] [Stephen_Casner_2]
+rtsp-alt         8554/udp # RTSP Alternate (see port 554) [Stephen_Casner_2] [Stephen_Casner_2]
+d-fence          8555/tcp # SYMAX D-FENCE [Thomas_Geisel] [Thomas_Geisel] 2003-01
+d-fence          8555/udp # SYMAX D-FENCE [Thomas_Geisel] [Thomas_Geisel] 2003-01
+enc-tunnel       8567/tcp # EMIT tunneling protocol [Panasonic_Intranet_Panasonic_North_America_PEWLA] [Bryant_Eastham] 2005-08 2012-11-12
+enc-tunnel       8567/udp # EMIT tunneling protocol [Panasonic_Intranet_Panasonic_North_America_PEWLA] [Bryant_Eastham] 2005-08 2012-11-12
+asterix          8600/tcp # Surveillance Data [Eivan_Cerasi] [Eivan_Cerasi] 2005-11
+asterix          8600/udp # Surveillance Data [Eivan_Cerasi] [Eivan_Cerasi] 2005-11
+canon-cpp-disc   8609/udp # Canon Compact Printer Protocol Discovery [Canon_Inc] [Ryusuke_Okuhara] 2012-06-08 2012-06-15
+canon-mfnp       8610/tcp # Canon MFNP Service [Ritsuto_Sako] [Ritsuto_Sako] 2009-05-04
+canon-mfnp       8610/udp # Canon MFNP Service [Ritsuto_Sako] [Ritsuto_Sako] 2009-05-04
+canon-bjnp1      8611/tcp # Canon BJNP Port 1 [Atsushi_Nakamura] [Atsushi_Nakamura] 2003-11
+canon-bjnp1      8611/udp # Canon BJNP Port 1 [Atsushi_Nakamura] [Atsushi_Nakamura] 2003-11
+canon-bjnp2      8612/tcp # Canon BJNP Port 2 [Atsushi_Nakamura] [Atsushi_Nakamura] 2003-11
+canon-bjnp2      8612/udp # Canon BJNP Port 2 [Atsushi_Nakamura] [Atsushi_Nakamura] 2003-11
+canon-bjnp3      8613/tcp # Canon BJNP Port 3 [Atsushi_Nakamura] [Atsushi_Nakamura] 2003-11
+canon-bjnp3      8613/udp # Canon BJNP Port 3 [Atsushi_Nakamura] [Atsushi_Nakamura] 2003-11
+canon-bjnp4      8614/tcp # Canon BJNP Port 4 [Atsushi_Nakamura] [Atsushi_Nakamura] 2003-11
+canon-bjnp4      8614/udp # Canon BJNP Port 4 [Atsushi_Nakamura] [Atsushi_Nakamura] 2003-11
+imink            8615/tcp # Imink Service Control [Canon_Inc] [KEN_ICHI_FUJII] 2011-10-10
+monetra          8665/tcp # Monetra [Main_Street_Softworks] [Brad_House] 2013-04-02
+monetra-admin    8666/tcp # Monetra Administrative Access [Main_Street_Softworks] [Brad_House] 2013-04-02
+msi-cps-rm       8675/tcp # Motorola Solutions Customer Programming Software for Radio Management [Motorola_Solutions_Inc] [Jenish_Amin] 2012-03-14
+msi-cps-rm-disc  8675/udp # Motorola Solutions Customer Programming Software for Radio Management Discovery [Motorola_Solutions_Inc] [Jenish_Amin] 2012-03-14
+sun-as-jmxrmi    8686/tcp # Sun App Server - JMX/RMI [Abhijit_Kumar] [Abhijit_Kumar] 2005-11
+sun-as-jmxrmi    8686/udp # Sun App Server - JMX/RMI [Abhijit_Kumar] [Abhijit_Kumar] 2005-11
+openremote-ctrl  8688/tcp # OpenRemote Controller HTTP/REST [OpenRemote_Inc] [Juha_Lindfors] 2012-12-18
+vnyx             8699/tcp # VNYX Primary Port [Gregg_Green] [Gregg_Green] 2004-11
+nvc              8711/tcp # Nuance Voice Control [Nuance_Communications_Inc2] [Diego_Negre] 2012-10-05
+dtp-net          8732/udp # DASGIP Net Services [Dr_Matthias_Arnold] [Dr_Matthias_Arnold] 2009-03-23
+ibus             8733/tcp # iBus [Silvano_Maffeis] [Silvano_Maffeis]
+ibus             8733/udp # iBus [Silvano_Maffeis] [Silvano_Maffeis]
+dey-keyneg       8750/tcp # DEY Storage Key Negotiation [DEY_Storage_Systems_Inc] [Garrett_D_Amore] 2013-03-01
+mc-appserver     8763/tcp # MC-APPSERVER [Romeo_Kasanwidjojo] [Romeo_Kasanwidjojo]
+mc-appserver     8763/udp # MC-APPSERVER [Romeo_Kasanwidjojo] [Romeo_Kasanwidjojo]
+openqueue        8764/tcp # OPENQUEUE [Matt_Jensen] [Matt_Jensen]
+openqueue        8764/udp # OPENQUEUE [Matt_Jensen] [Matt_Jensen]
+ultraseek-http   8765/tcp # Ultraseek HTTP [Walter_Underwood] [Walter_Underwood]
+ultraseek-http   8765/udp # Ultraseek HTTP [Walter_Underwood] [Walter_Underwood]
+amcs             8766/tcp # Agilent Connectivity Service [Agilent_Technologies_Inc] [Tom_Fay] 2013-01-16
+amcs             8766/udp # Agilent Connectivity Service [Agilent_Technologies_Inc] [Tom_Fay] 2013-01-16
+dpap             8770/tcp # Digital Photo Access Protocol (iPhoto) [Amandeep_Jawa_2] [Amandeep_Jawa_2] 2004-11 Defined TXT keys: txtvers, Version, iPSh Version, Machine ID, Machine Name, Password
+dpap             8770/udp # Digital Photo Access Protocol (iPhoto) [Amandeep_Jawa_2] [Amandeep_Jawa_2] 2004-11 Defined TXT keys: txtvers, Version, iPSh Version, Machine ID, Machine Name, Password
+uec              8778/tcp # Stonebranch Universal Enterprise Controller [Stonebranch_Inc] [Nathan_Hammond_2] 2013-06-25
+msgclnt          8786/tcp # Message Client
+msgclnt          8786/udp # Message Client
+msgsrvr          8787/tcp # Message Server [Michael_O_Brien] [Michael_O_Brien] 2003-03
+msgsrvr          8787/udp # Message Server [Michael_O_Brien] [Michael_O_Brien] 2003-03
+acd-pm           8793/tcp # Accedian Performance Measurement [Marco_Mascitto] [Marco_Mascitto]
+acd-pm           8793/udp # Accedian Performance Measurement [Marco_Mascitto] [Marco_Mascitto]
+sunwebadmin      8800/tcp # Sun Web Server Admin Service [Jyri_J_Virkki] [Jyri_J_Virkki] 2005-12
+sunwebadmin      8800/udp # Sun Web Server Admin Service [Jyri_J_Virkki] [Jyri_J_Virkki] 2005-12
+truecm           8804/tcp # truecm [Scott_Kramer] [Scott_Kramer]
+truecm           8804/udp # truecm [Scott_Kramer] [Scott_Kramer]
+dxspider         8873/tcp # dxspider linking protocol [Dirk_Koopman] [Dirk_Koopman] 2005-08
+dxspider         8873/udp # dxspider linking protocol [Dirk_Koopman] [Dirk_Koopman] 2005-08
+cddbp-alt        8880/tcp # CDDBP [Steve_Scherf] [Steve_Scherf]
+cddbp-alt        8880/udp # CDDBP [Steve_Scherf] [Steve_Scherf]
+galaxy4d         8881/tcp # Galaxy4D Online Game Engine [Galaxy4D] [Olivier_St-Laurent] 2012-06-18
+secure-mqtt      8883/tcp # Secure MQTT [Arthur_Barr] [Arthur_Barr] 2008-02-27
+secure-mqtt      8883/udp # Secure MQTT [Arthur_Barr] [Arthur_Barr] 2008-02-27
+ddi-tcp-1        8888/tcp # NewsEDGE server TCP (TCP 1) [Fred_Yao] [Fred_Yao]
+ddi-udp-1        8888/udp # NewsEDGE server UDP (UDP 1) [Fred_Yao] [Fred_Yao]
+ddi-tcp-2        8889/tcp # Desktop Data TCP 1 [Fred_Yao] [Fred_Yao]
+ddi-udp-2        8889/udp # NewsEDGE server broadcast [Fred_Yao] [Fred_Yao]
+ddi-tcp-3        8890/tcp # Desktop Data TCP 2 [Fred_Yao] [Fred_Yao]
+ddi-udp-3        8890/udp # NewsEDGE client broadcast [Fred_Yao] [Fred_Yao]
+ddi-tcp-4        8891/tcp # Desktop Data TCP 3: NESS application [Fred_Yao] [Fred_Yao]
+ddi-udp-4        8891/udp # Desktop Data UDP 3: NESS application [Fred_Yao] [Fred_Yao]
+ddi-tcp-5        8892/tcp # Desktop Data TCP 4: FARM product [Fred_Yao] [Fred_Yao]
+ddi-udp-5        8892/udp # Desktop Data UDP 4: FARM product [Fred_Yao] [Fred_Yao]
+ddi-tcp-6        8893/tcp # Desktop Data TCP 5: NewsEDGE/Web application [Fred_Yao] [Fred_Yao]
+ddi-udp-6        8893/udp # Desktop Data UDP 5: NewsEDGE/Web application [Fred_Yao] [Fred_Yao]
+ddi-tcp-7        8894/tcp # Desktop Data TCP 6: COAL application [Fred_Yao] [Fred_Yao]
+ddi-udp-7        8894/udp # Desktop Data UDP 6: COAL application [Fred_Yao] [Fred_Yao]
+ospf-lite        8899/tcp # ospf-lite [Matthew_Thomas] [Matthew_Thomas] 2008-01-07
+ospf-lite        8899/udp # ospf-lite [Matthew_Thomas] [Matthew_Thomas] 2008-01-07
+jmb-cds1         8900/tcp # JMB-CDS 1 [Curtis_Bray] [Curtis_Bray]
+jmb-cds1         8900/udp # JMB-CDS 1 [Curtis_Bray] [Curtis_Bray]
+jmb-cds2         8901/tcp # JMB-CDS 2 [Curtis_Bray] [Curtis_Bray]
+jmb-cds2         8901/udp # JMB-CDS 2 [Curtis_Bray] [Curtis_Bray]
+manyone-http     8910/tcp # manyone-http [Matt_King] [Matt_King] 2002-04
+manyone-http     8910/udp # manyone-http [Matt_King] [Matt_King] 2002-04
+manyone-xml      8911/tcp # manyone-xml [Matt_King] [Matt_King] 2002-04
+manyone-xml      8911/udp # manyone-xml [Matt_King] [Matt_King] 2002-04
+wcbackup         8912/tcp # Windows Client Backup [Jim_Lyon] [Jim_Lyon] 2005-11
+wcbackup         8912/udp # Windows Client Backup [Jim_Lyon] [Jim_Lyon] 2005-11
+dragonfly        8913/tcp # Dragonfly System Service [Paul_Hodara] [Paul_Hodara] 2005-11
+dragonfly        8913/udp # Dragonfly System Service [Paul_Hodara] [Paul_Hodara] 2005-11
+twds             8937/tcp # Transaction Warehouse Data Service [Lance_M_Steenson] [Lance_M_Steenson] 2009-09-18
+ub-dns-control   8953/tcp # unbound dns nameserver control [NLnet_Labs_Support] [NLnet_Labs_Support] 2011-05-10 2011-07-11
+cumulus-admin    8954/tcp # Cumulus Admin Port [Thomas_Schleu] [Thomas_Schleu]
+cumulus-admin    8954/udp # Cumulus Admin Port [Thomas_Schleu] [Thomas_Schleu]
+sunwebadmins     8989/tcp # Sun Web Server SSL Admin Service [Jyri_J_Virkki] [Jyri_J_Virkki] 2005-12
+sunwebadmins     8989/udp # Sun Web Server SSL Admin Service [Jyri_J_Virkki] [Jyri_J_Virkki] 2005-12
+http-wmap        8990/tcp # webmail HTTP service [Fred_Batty] [Fred_Batty] 2007-12-03
+http-wmap        8990/udp # webmail HTTP service [Fred_Batty] [Fred_Batty] 2007-12-03
+https-wmap       8991/tcp # webmail HTTPS service [Fred_Batty] [Fred_Batty] 2007-12-03
+https-wmap       8991/udp # webmail HTTPS service [Fred_Batty] [Fred_Batty] 2007-12-03
+bctp             8999/tcp # Brodos Crypto Trade Protocol [Alexander_Sahler] [Alexander_Sahler] 2002-02
+bctp             8999/udp # Brodos Crypto Trade Protocol [Alexander_Sahler] [Alexander_Sahler] 2002-02
+cslistener       9000/tcp # CSlistener [David_Jones] [David_Jones]
+cslistener       9000/udp # CSlistener [David_Jones] [David_Jones]
+etlservicemgr    9001/tcp # ETL Service Manager [Stephen_McCrea] [Stephen_McCrea] 2002-03
+etlservicemgr    9001/udp # ETL Service Manager [Stephen_McCrea] [Stephen_McCrea] 2002-03
+dynamid          9002/tcp # DynamID authentication [Jerome_Dusautois] [Jerome_Dusautois] 2002-03
+dynamid          9002/udp # DynamID authentication [Jerome_Dusautois] [Jerome_Dusautois] 2002-03
+ogs-client       9007/udp # Open Grid Services Client [Gareth_Nelson_2] [Gareth_Nelson_2] 2008-08-22
+ogs-server       9008/tcp # Open Grid Services Server [Gareth_Nelson_2] [Gareth_Nelson_2] 2008-08-22
+pichat           9009/tcp # Pichat Server [Mark_Seuffert] [Mark_Seuffert] 2004-11
+pichat           9009/udp # Pichat Server [Mark_Seuffert] [Mark_Seuffert] 2004-11
+sdr              9010/tcp # Secure Data Replicator Protocol [Sufyan_Almajali] [Sufyan_Almajali] 2008-06-27
+tambora          9020/tcp # TAMBORA [Jason_van_Zyl] [Jason_van_Zyl] 2002-03
+tambora          9020/udp # TAMBORA [Jason_van_Zyl] [Jason_van_Zyl] 2002-03
+panagolin-ident  9021/tcp # Pangolin Identification [William_Benner_2] [William_Benner_2] 2002-03
+panagolin-ident  9021/udp # Pangolin Identification [William_Benner_2] [William_Benner_2] 2002-03
+paragent         9022/tcp # PrivateArk Remote Agent [Gal_Cucuy] [Gal_Cucuy] 2002-03
+paragent         9022/udp # PrivateArk Remote Agent [Gal_Cucuy] [Gal_Cucuy] 2002-03
+swa-1            9023/tcp # Secure Web Access - 1 [Tim_McGranaghan] [Tim_McGranaghan]
+swa-1            9023/udp # Secure Web Access - 1 [Tim_McGranaghan] [Tim_McGranaghan]
+swa-2            9024/tcp # Secure Web Access - 2 [Tim_McGranaghan] [Tim_McGranaghan]
+swa-2            9024/udp # Secure Web Access - 2 [Tim_McGranaghan] [Tim_McGranaghan]
+swa-3            9025/tcp # Secure Web Access - 3 [Tim_McGranaghan] [Tim_McGranaghan]
+swa-3            9025/udp # Secure Web Access - 3 [Tim_McGranaghan] [Tim_McGranaghan]
+swa-4            9026/tcp # Secure Web Access - 4 [Tim_McGranaghan] [Tim_McGranaghan]
+swa-4            9026/udp # Secure Web Access - 4 [Tim_McGranaghan] [Tim_McGranaghan]
+versiera         9050/tcp # Versiera Agent Listener [Frank_Pikelner] [Frank_Pikelner] 2010-01-15
+fio-cmgmt        9051/tcp # Fusion-io Central Manager Service [Jim_Sermersheim] [Jim_Sermersheim] 2010-01-15
+glrpc            9080/tcp # Groove GLRPC [Adrian_Popescu] [Adrian_Popescu] 2002-09
+glrpc            9080/udp # Groove GLRPC [Adrian_Popescu] [Adrian_Popescu] 2002-09
+lcs-ap           9082/sctp # LCS Application Protocol [Kimmo_Kymalainen] [Kimmo_Kymalainen] 2010-06-04
+emc-pp-mgmtsvc   9083/tcp # EMC PowerPath Mgmt Service [Jim_Perreault] [Jim_Perreault] 2010-06-04
+aurora           9084/tcp # IBM AURORA Performance Visualizer [Jeroen_Massar_2] [Jeroen_Massar_2] 2008-08-21
+aurora           9084/udp # IBM AURORA Performance Visualizer [Jeroen_Massar_2] [Jeroen_Massar_2] 2008-08-21
+aurora           9084/sctp # IBM AURORA Performance Visualizer [Jeroen_Massar_2] [Jeroen_Massar_2] 2008-08-21
+ibm-rsyscon      9085/tcp # IBM Remote System Console [William_LePera] [William_LePera] 2008-06-18
+ibm-rsyscon      9085/udp # IBM Remote System Console [William_LePera] [William_LePera] 2008-06-18
+net2display      9086/tcp # Vesa Net2Display [Kenneth_B_Ocheltree] [Kenneth_B_Ocheltree] 2008-01-07
+net2display      9086/udp # Vesa Net2Display [Kenneth_B_Ocheltree] [Kenneth_B_Ocheltree] 2008-01-07
+classic          9087/tcp # Classic Data Server [Paul_Cadarette] [Paul_Cadarette] 2007-01
+classic          9087/udp # Classic Data Server [Paul_Cadarette] [Paul_Cadarette] 2007-01
+sqlexec          9088/tcp # IBM Informix SQL Interface [Jonathan_Leffler] [Jonathan_Leffler] 2005-12
+sqlexec          9088/udp # IBM Informix SQL Interface [Jonathan_Leffler] [Jonathan_Leffler] 2005-12
+sqlexec-ssl      9089/tcp # IBM Informix SQL Interface - Encrypted [Jonathan_Leffler] [Jonathan_Leffler] 2005-12
+sqlexec-ssl      9089/udp # IBM Informix SQL Interface - Encrypted [Jonathan_Leffler] [Jonathan_Leffler] 2005-12
+websm            9090/tcp # WebSM [I_Hsing_Tsao] [I_Hsing_Tsao]
+websm            9090/udp # WebSM [I_Hsing_Tsao] [I_Hsing_Tsao]
+xmltec-xmlmail   9091/tcp # xmltec-xmlmail [Mitch_Kaufman] [Mitch_Kaufman]
+xmltec-xmlmail   9091/udp # xmltec-xmlmail [Mitch_Kaufman] [Mitch_Kaufman]
+XmlIpcRegSvc     9092/tcp # Xml-Ipc Server Reg [Casey_Harrington] [Casey_Harrington] 2006-01
+XmlIpcRegSvc     9092/udp # Xml-Ipc Server Reg [Casey_Harrington] [Casey_Harrington] 2006-01
+copycat          9093/tcp # Copycat database replication service [Microtec_Informatique] [Raphael_Neve] 2012-03-15
+hp-pdl-datastr   9100/tcp # PDL Data Streaming Port [Shivaun_Albright] [Shivaun_Albright] 2002-04
+hp-pdl-datastr   9100/udp # PDL Data Streaming Port [Shivaun_Albright] [Shivaun_Albright] 2002-04
+pdl-datastream   9100/tcp # Printer PDL Data Stream [Stuart_Cheshire_4] [Stuart_Cheshire_4] 2002-09 The protocol name "pdl-datastream" is primarily registered for usein DNS SRV records (RFC 2782). DNS SRV records allow a protocol to run onany port number, but the default port for this protocol is 9100.
+pdl-datastream   9100/udp # Printer PDL Data Stream [Stuart_Cheshire_4] [Stuart_Cheshire_4] 2002-09 The protocol name "pdl-datastream" is primarily registered for usein DNS SRV records (RFC 2782). DNS SRV records allow a protocol to run onany port number, but the default port for this protocol is 9100.
+bacula-dir       9101/tcp # Bacula Director [Kern_Sibbald] [Kern_Sibbald] 2002-01
+bacula-dir       9101/udp # Bacula Director [Kern_Sibbald] [Kern_Sibbald] 2002-01
+bacula-fd        9102/tcp # Bacula File Daemon [Kern_Sibbald] [Kern_Sibbald] 2002-01
+bacula-fd        9102/udp # Bacula File Daemon [Kern_Sibbald] [Kern_Sibbald] 2002-01
+bacula-sd        9103/tcp # Bacula Storage Daemon [Kern_Sibbald] [Kern_Sibbald] 2002-01
+bacula-sd        9103/udp # Bacula Storage Daemon [Kern_Sibbald] [Kern_Sibbald] 2002-01
+peerwire         9104/tcp # PeerWire [Steven_Gerhardt] [Steven_Gerhardt] 2004-02
+peerwire         9104/udp # PeerWire [Steven_Gerhardt] [Steven_Gerhardt] 2004-02
+xadmin           9105/tcp # Xadmin Control Service [Ari√´n Huisken <xadmin&huisken-systems.nl> 15 June 2009]
+xadmin           9105/udp # Xadmin Control Service [Ari√´n Huisken <xadmin&huisken-systems.nl> 15 June 2009]
+astergate        9106/tcp # Astergate Control Service [Ari_Huisken] [Ari_Huisken] 2010-01-04
+astergate-disc   9106/udp # Astergate Discovery Service [Ari_Huisken] [Ari_Huisken] 2010-01-04
+astergatefax     9107/tcp # AstergateFax Control Service [Gijs_Middelkamp] [Gijs_Middelkamp] 2010-02-03
+mxit             9119/tcp # MXit Instant Messaging [Marnus_Freeman] [Marnus_Freeman] 2006-02
+mxit             9119/udp # MXit Instant Messaging [Marnus_Freeman] [Marnus_Freeman] 2006-02
+grcmp            9122/tcp # Global Relay compliant mobile instant messaging protocol [Global_Relay] [Mike_Sample] 2012-11-28
+grcp             9123/tcp # Global Relay compliant instant messaging protocol [Global_Relay] [Mike_Sample] 2012-11-28
+dddp             9131/tcp # Dynamic Device Discovery [Shane_Dick] [Shane_Dick] 2005-08
+dddp             9131/udp # Dynamic Device Discovery [Shane_Dick] [Shane_Dick] 2005-08
+apani1           9160/tcp # apani1 [Neal_Taylor] [Neal_Taylor]
+apani1           9160/udp # apani1 [Neal_Taylor] [Neal_Taylor]
+apani2           9161/tcp # apani2 [Neal_Taylor] [Neal_Taylor]
+apani2           9161/udp # apani2 [Neal_Taylor] [Neal_Taylor]
+apani3           9162/tcp # apani3 [Neal_Taylor] [Neal_Taylor]
+apani3           9162/udp # apani3 [Neal_Taylor] [Neal_Taylor]
+apani4           9163/tcp # apani4 [Neal_Taylor] [Neal_Taylor]
+apani4           9163/udp # apani4 [Neal_Taylor] [Neal_Taylor]
+apani5           9164/tcp # apani5 [Neal_Taylor] [Neal_Taylor]
+apani5           9164/udp # apani5 [Neal_Taylor] [Neal_Taylor]
+sun-as-jpda      9191/tcp # Sun AppSvr JPDA [Abhijit_Kumar] [Abhijit_Kumar] 2005-11
+sun-as-jpda      9191/udp # Sun AppSvr JPDA [Abhijit_Kumar] [Abhijit_Kumar] 2005-11
+wap-wsp          9200/tcp # WAP connectionless session service [WAP_Forum] [WAP_Forum]
+wap-wsp          9200/udp # WAP connectionless session service [WAP_Forum] [WAP_Forum]
+wap-wsp-wtp      9201/tcp # WAP session service [WAP_Forum] [WAP_Forum]
+wap-wsp-wtp      9201/udp # WAP session service [WAP_Forum] [WAP_Forum]
+wap-wsp-s        9202/tcp # WAP secure connectionless session service [WAP_Forum] [WAP_Forum]
+wap-wsp-s        9202/udp # WAP secure connectionless session service [WAP_Forum] [WAP_Forum]
+wap-wsp-wtp-s    9203/tcp # WAP secure session service [WAP_Forum] [WAP_Forum]
+wap-wsp-wtp-s    9203/udp # WAP secure session service [WAP_Forum] [WAP_Forum]
+wap-vcard        9204/tcp # WAP vCard [WAP_Forum] [WAP_Forum]
+wap-vcard        9204/udp # WAP vCard [WAP_Forum] [WAP_Forum]
+wap-vcal         9205/tcp # WAP vCal [WAP_Forum] [WAP_Forum]
+wap-vcal         9205/udp # WAP vCal [WAP_Forum] [WAP_Forum]
+wap-vcard-s      9206/tcp # WAP vCard Secure [WAP_Forum] [WAP_Forum]
+wap-vcard-s      9206/udp # WAP vCard Secure [WAP_Forum] [WAP_Forum]
+wap-vcal-s       9207/tcp # WAP vCal Secure [WAP_Forum] [WAP_Forum]
+wap-vcal-s       9207/udp # WAP vCal Secure [WAP_Forum] [WAP_Forum]
+rjcdb-vcards     9208/tcp # rjcdb vCard [Robert_John_Churchil] [Robert_John_Churchil] 2006-01
+rjcdb-vcards     9208/udp # rjcdb vCard [Robert_John_Churchil] [Robert_John_Churchil] 2006-01
+almobile-system  9209/tcp # ALMobile System Service [Rob_Graber] [Rob_Graber] 2006-01
+almobile-system  9209/udp # ALMobile System Service [Rob_Graber] [Rob_Graber] 2006-01
+oma-mlp          9210/tcp # OMA Mobile Location Protocol [Hans_Rohnert] [Hans_Rohnert] 2002-04
+oma-mlp          9210/udp # OMA Mobile Location Protocol [Hans_Rohnert] [Hans_Rohnert] 2002-04
+oma-mlp-s        9211/tcp # OMA Mobile Location Protocol Secure [Hans_Rohnert] [Hans_Rohnert] 2002-04
+oma-mlp-s        9211/udp # OMA Mobile Location Protocol Secure [Hans_Rohnert] [Hans_Rohnert] 2002-04
+serverviewdbms   9212/tcp # Server View dbms access [Detlef_Rothe] [Detlef_Rothe] 2009-05-15
+serverviewdbms   9212/udp # Server View dbms access [Detlef_Rothe] [Detlef_Rothe] 2009-05-15
+serverstart      9213/tcp # ServerStart RemoteControl [Detlef_Rothe] [Detlef_Rothe] 2009-05-15
+serverstart      9213/udp # ServerStart RemoteControl [Detlef_Rothe] [Detlef_Rothe] 2009-05-15
+ipdcesgbs        9214/tcp # IPDC ESG BootstrapService [Joerg_Heuer] [Joerg_Heuer] 2006-02
+ipdcesgbs        9214/udp # IPDC ESG BootstrapService [Joerg_Heuer] [Joerg_Heuer] 2006-02
+insis            9215/tcp # Integrated Setup and Install Service [Markus_Treinen] [Markus_Treinen] 2006-02
+insis            9215/udp # Integrated Setup and Install Service [Markus_Treinen] [Markus_Treinen] 2006-02
+acme             9216/tcp # Aionex Communication Management Engine [Mark_Sapp] [Mark_Sapp] 2006-04
+acme             9216/udp # Aionex Communication Management Engine [Mark_Sapp] [Mark_Sapp] 2006-04
+fsc-port         9217/tcp # FSC Communication Port [Teijo_Mustonen] [Teijo_Mustonen] 2002-03
+fsc-port         9217/udp # FSC Communication Port [Teijo_Mustonen] [Teijo_Mustonen] 2002-03
+teamcoherence    9222/tcp # QSC Team Coherence [Ewan_McNab] [Ewan_McNab] 2004-11
+teamcoherence    9222/udp # QSC Team Coherence [Ewan_McNab] [Ewan_McNab] 2004-11
+mon              9255/tcp # Manager On Network [David_Rouchet] [David_Rouchet] 2007-05
+mon              9255/udp # Manager On Network [David_Rouchet] [David_Rouchet] 2007-05
+traingpsdata     9277/udp # GPS Data transmitted from train to ground network [Alstom_Transport_Preston] [Paul_Steane] 2012-12-14
+pegasus          9278/tcp # Pegasus GPS Platform [Nestor_A_Diaz] [Nestor_A_Diaz] 2009-05-12
+pegasus          9278/udp # Pegasus GPS Platform [Nestor_A_Diaz] [Nestor_A_Diaz] 2009-05-12
+pegasus-ctl      9279/tcp # Pegaus GPS System Control Interface [Nestor_A_Diaz] [Nestor_A_Diaz] 2009-05-12
+pegasus-ctl      9279/udp # Pegaus GPS System Control Interface [Nestor_A_Diaz] [Nestor_A_Diaz] 2009-05-12
+pgps             9280/tcp # Predicted GPS [Jeremy_Freeman] [Jeremy_Freeman] 2008-02-14
+pgps             9280/udp # Predicted GPS [Jeremy_Freeman] [Jeremy_Freeman] 2008-02-14
+swtp-port1       9281/tcp # SofaWare transport port 1 [Amir_Rapson] [Amir_Rapson] 2002-02
+swtp-port1       9281/udp # SofaWare transport port 1 [Amir_Rapson] [Amir_Rapson] 2002-02
+swtp-port2       9282/tcp # SofaWare transport port 2 [Amir_Rapson] [Amir_Rapson] 2002-02
+swtp-port2       9282/udp # SofaWare transport port 2 [Amir_Rapson] [Amir_Rapson] 2002-02
+callwaveiam      9283/tcp # CallWaveIAM [Colin_Kelley] [Colin_Kelley]
+callwaveiam      9283/udp # CallWaveIAM [Colin_Kelley] [Colin_Kelley]
+visd             9284/tcp # VERITAS Information Serve [Ravi_Tavakely] [Ravi_Tavakely] 2002-02
+visd             9284/udp # VERITAS Information Serve [Ravi_Tavakely] [Ravi_Tavakely] 2002-02
+n2h2server       9285/tcp # N2H2 Filter Service Port [Jim_Irwin] [Jim_Irwin] 2002-02
+n2h2server       9285/udp # N2H2 Filter Service Port [Jim_Irwin] [Jim_Irwin] 2002-02
+n2receive        9286/udp # n2 monitoring receiver [Peter_van_Dijk] [Peter_van_Dijk] 2011-01-10
+cumulus          9287/tcp # Cumulus [Thomas_Schleu] [Thomas_Schleu]
+cumulus          9287/udp # Cumulus [Thomas_Schleu] [Thomas_Schleu]
+armtechdaemon    9292/tcp # ArmTech Daemon [Rohan_Story] [Rohan_Story]
+armtechdaemon    9292/udp # ArmTech Daemon [Rohan_Story] [Rohan_Story]
+storview         9293/tcp # StorView Client [Ryan_Smith] [Ryan_Smith] 2006-07
+storview         9293/udp # StorView Client [Ryan_Smith] [Ryan_Smith] 2006-07
+armcenterhttp    9294/tcp # ARMCenter http Service [Eric_Thiebaut_George] [Eric_Thiebaut_George] 2006-04
+armcenterhttp    9294/udp # ARMCenter http Service [Eric_Thiebaut_George] [Eric_Thiebaut_George] 2006-04
+armcenterhttps   9295/tcp # ARMCenter https Service [Eric_Thiebaut_George] [Eric_Thiebaut_George] 2006-04
+armcenterhttps   9295/udp # ARMCenter https Service [Eric_Thiebaut_George] [Eric_Thiebaut_George] 2006-04
+vrace            9300/tcp # Virtual Racing Service [Pete_Loeffen] [Pete_Loeffen] 2006-10
+vrace            9300/udp # Virtual Racing Service [Pete_Loeffen] [Pete_Loeffen] 2006-10
+sphinxql         9306/tcp # Sphinx search server (MySQL listener) [Andrew_Aksyonoff] [Andrew_Aksyonoff] 2009-10-20
+sphinxapi        9312/tcp # Sphinx search server [Andrew_Aksyonoff] [Andrew_Aksyonoff] 2009-10-20
+secure-ts        9318/tcp # PKIX TimeStamp over TLS [Niklas_Weiss] [Niklas_Weiss] 2004-11
+secure-ts        9318/udp # PKIX TimeStamp over TLS [Niklas_Weiss] [Niklas_Weiss] 2004-11
+guibase          9321/tcp # guibase [Yutaka_Ono] [Yutaka_Ono]
+guibase          9321/udp # guibase [Yutaka_Ono] [Yutaka_Ono]
+mpidcmgr         9343/tcp # MpIdcMgr [Yutaka_Ono] [Yutaka_Ono]
+mpidcmgr         9343/udp # MpIdcMgr [Yutaka_Ono] [Yutaka_Ono]
+mphlpdmc         9344/tcp # Mphlpdmc [Yutaka_Ono] [Yutaka_Ono]
+mphlpdmc         9344/udp # Mphlpdmc [Yutaka_Ono] [Yutaka_Ono]
+ctechlicensing   9346/tcp # C Tech Licensing [Reed_Copsey_Jr] [Reed_Copsey_Jr]
+ctechlicensing   9346/udp # C Tech Licensing [Reed_Copsey_Jr] [Reed_Copsey_Jr]
+fjdmimgr         9374/tcp # fjdmimgr [Yutaka_Ono] [Yutaka_Ono]
+fjdmimgr         9374/udp # fjdmimgr [Yutaka_Ono] [Yutaka_Ono]
+boxp             9380/tcp # Brivs! Open Extensible Protocol [Danko_Alexeyev] [Danko_Alexeyev] 2007-08-08
+boxp             9380/udp # Brivs! Open Extensible Protocol [Danko_Alexeyev] [Danko_Alexeyev] 2007-08-08
+d2dconfig        9387/tcp # D2D Configuration Service [Pete_Camble] [Pete_Camble] 2008-12-24
+d2ddatatrans     9388/tcp # D2D Data Transfer Service [Pete_Camble] [Pete_Camble] 2008-12-24
+adws             9389/tcp # Active Directory Web Services [Nitin_Gupta] [Nitin_Gupta] 2008-12-24
+otp              9390/tcp # OpenVAS Transfer Protocol [Tim_Brown] [Tim_Brown] 2008-12-24
+fjinvmgr         9396/tcp # fjinvmgr [Yutaka_Ono] [Yutaka_Ono]
+fjinvmgr         9396/udp # fjinvmgr [Yutaka_Ono] [Yutaka_Ono]
+mpidcagt         9397/tcp # MpIdcAgt [Yutaka_Ono] [Yutaka_Ono]
+mpidcagt         9397/udp # MpIdcAgt [Yutaka_Ono] [Yutaka_Ono]
+sec-t4net-srv    9400/tcp # Samsung Twain for Network Server [Dongkeun_Kim] [Dongkeun_Kim] 2007-02
+sec-t4net-srv    9400/udp # Samsung Twain for Network Server [Dongkeun_Kim] [Dongkeun_Kim] 2007-02
+sec-t4net-clt    9401/tcp # Samsung Twain for Network Client [Dongkeun_Kim] [Dongkeun_Kim] 2007-02
+sec-t4net-clt    9401/udp # Samsung Twain for Network Client [Dongkeun_Kim] [Dongkeun_Kim] 2007-02
+sec-pc2fax-srv   9402/tcp # Samsung PC2FAX for Network Server [HyeongBae_Yu] [HyeongBae_Yu] 2008-07-31
+sec-pc2fax-srv   9402/udp # Samsung PC2FAX for Network Server [HyeongBae_Yu] [HyeongBae_Yu] 2008-07-31
+git              9418/tcp # git pack transfer service [Linus_Torvalds] [Linus_Torvalds] 2005-09
+git              9418/udp # git pack transfer service [Linus_Torvalds] [Linus_Torvalds] 2005-09
+tungsten-https   9443/tcp # WSO2 Tungsten HTTPS [Afkham_Azeez] [Afkham_Azeez] 2006-06
+tungsten-https   9443/udp # WSO2 Tungsten HTTPS [Afkham_Azeez] [Afkham_Azeez] 2006-06
+wso2esb-console  9444/tcp # WSO2 ESB Administration Console HTTPS [Ruwan_Linton] [Ruwan_Linton] 2008-08-20
+wso2esb-console  9444/udp # WSO2 ESB Administration Console HTTPS [Ruwan_Linton] [Ruwan_Linton] 2008-08-20
+mindarray-ca     9445/tcp # MindArray Systems Console Agent [MINDARRAY_SYSTEMS] [ALPESH_DHAMELIA] 2011-10-25
+sntlkeyssrvr     9450/tcp # Sentinel Keys Server [Martin_Ziskind] [Martin_Ziskind] 2008-08-21
+sntlkeyssrvr     9450/udp # Sentinel Keys Server [Martin_Ziskind] [Martin_Ziskind] 2008-08-21
+ismserver        9500/tcp # ismserver [Ian_Gordon_3] [Ian_Gordon_3]
+ismserver        9500/udp # ismserver [Ian_Gordon_3] [Ian_Gordon_3]
+sma-spw          9522/udp # SMA Speedwire [SMA_Solar_Techology] [SMA_Solar_Techology] 2011-03-08
+mngsuite         9535/tcp # Management Suite Remote Control [Trevor_Perkes] [Trevor_Perkes] 2010-02-01
+mngsuite         9535/udp # Management Suite Remote Control [Trevor_Perkes] [Trevor_Perkes] 2010-02-01
+laes-bf          9536/tcp # Surveillance buffering function [Glen_Myers] [Glen_Myers] 2007-05
+laes-bf          9536/udp # Surveillance buffering function [Glen_Myers] [Glen_Myers] 2007-05
+trispen-sra      9555/tcp # Trispen Secure Remote Access [Jaco_Botha] [Jaco_Botha] 2004-11
+trispen-sra      9555/udp # Trispen Secure Remote Access [Jaco_Botha] [Jaco_Botha] 2004-11
+ldgateway        9592/tcp # LANDesk Gateway [Alan_Butt] [Alan_Butt] 2006-03
+ldgateway        9592/udp # LANDesk Gateway [Alan_Butt] [Alan_Butt] 2006-03
+cba8             9593/tcp # LANDesk Management Agent (cba8) [Trevor_Perkes] [Trevor_Perkes] 2010-02-01
+cba8             9593/udp # LANDesk Management Agent (cba8) [Trevor_Perkes] [Trevor_Perkes] 2010-02-01
+msgsys           9594/tcp # Message System [Alan_Butt] [Alan_Butt]
+msgsys           9594/udp # Message System [Alan_Butt] [Alan_Butt]
+pds              9595/tcp # Ping Discovery Service [Alan_Butt] [Alan_Butt]
+pds              9595/udp # Ping Discovery Service [Alan_Butt] [Alan_Butt]
+mercury-disc     9596/tcp # Mercury Discovery [Paul_Mclachlan] [Paul_Mclachlan] 2005-11
+mercury-disc     9596/udp # Mercury Discovery [Paul_Mclachlan] [Paul_Mclachlan] 2005-11
+pd-admin         9597/tcp # PD Administration [Duk_Loi] [Duk_Loi] 2005-11
+pd-admin         9597/udp # PD Administration [Duk_Loi] [Duk_Loi] 2005-11
+vscp             9598/tcp # Very Simple Ctrl Protocol [Ake_Hedman] [Ake_Hedman] 2005-11
+vscp             9598/udp # Very Simple Ctrl Protocol [Ake_Hedman] [Ake_Hedman] 2005-11
+robix            9599/tcp # Robix [Evan_Rosen] [Evan_Rosen] 2005-11
+robix            9599/udp # Robix [Evan_Rosen] [Evan_Rosen] 2005-11
+micromuse-ncpw   9600/tcp # MICROMUSE-NCPW [Hing_Wing_To_2] [Hing_Wing_To_2]
+micromuse-ncpw   9600/udp # MICROMUSE-NCPW [Hing_Wing_To_2] [Hing_Wing_To_2]
+streamcomm-ds    9612/tcp # StreamComm User Directory [Brian_C_Wiles] [Brian_C_Wiles]
+streamcomm-ds    9612/udp # StreamComm User Directory [Brian_C_Wiles] [Brian_C_Wiles]
+iadt-tls         9614/tcp # iADT Protocol over TLS [Paul_A_Suhler] [Paul_A_Suhler] 2009-02-05
+erunbook-agent   9616/tcp # eRunbook AgentIANA assigned this well-formed service name as a replacement for "erunbook_agent". [Gerhard_Wagner] [Gerhard_Wagner] 2009-03-10
+erunbook_agent   9616/tcp # eRunbook Agent [Gerhard_Wagner] [Gerhard_Wagner] 2009-03-10 This entry is an alias to "erunbook-agent".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+erunbook-server  9617/tcp # eRunbook ServerIANA assigned this well-formed service name as a replacement for "erunbook_server". [Gerhard_Wagner] [Gerhard_Wagner] 2009-03-10
+erunbook_server  9617/tcp # eRunbook Server [Gerhard_Wagner] [Gerhard_Wagner] 2009-03-10 This entry is an alias to "erunbook-server".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+condor           9618/tcp # Condor Collector Service [Todd_Tannenbaum] [Todd_Tannenbaum] 2008-04-03
+condor           9618/udp # Condor Collector Service [Todd_Tannenbaum] [Todd_Tannenbaum] 2008-04-03
+odbcpathway      9628/tcp # ODBC Pathway Service [Adrian_Hungate] [Adrian_Hungate] 2007-05
+odbcpathway      9628/udp # ODBC Pathway Service [Adrian_Hungate] [Adrian_Hungate] 2007-05
+uniport          9629/tcp # UniPort SSO Controller [Adrian_Hungate] [Adrian_Hungate] 2007-09-05
+uniport          9629/udp # UniPort SSO Controller [Adrian_Hungate] [Adrian_Hungate] 2007-09-05
+peoctlr          9630/tcp # Peovica Controller [Adrian_Hungate] [Adrian_Hungate] 2009-09-14
+peocoll          9631/tcp # Peovica Collector [Adrian_Hungate] [Adrian_Hungate] 2009-09-14
+mc-comm          9632/udp # Mobile-C Communications [David_Ko_2] [David_Ko_2] 2009-09-14
+pqsflows         9640/tcp # ProQueSys Flows Service [Sarene_Caiazza] [Sarene_Caiazza] 2010-04-27
+xmms2            9667/tcp # Cross-platform Music Multiplexing System [Juho_Herttua] [Juho_Herttua] 2009-04-14
+xmms2            9667/udp # Cross-platform Music Multiplexing System [Juho_Herttua] [Juho_Herttua]
+tec5-sdctp       9668/tcp # tec5 Spectral Device Control Protocol [Michael_Muth] [Michael_Muth] 2009-05-11
+tec5-sdctp       9668/udp # tec5 Spectral Device Control Protocol [Michael_Muth] [Michael_Muth] 2009-05-11
+client-wakeup    9694/tcp # T-Mobile Client Wakeup Message [Michael_Schonborn] [Michael_Schonborn] 2009-09-11
+client-wakeup    9694/udp # T-Mobile Client Wakeup Message [Michael_Schonborn] [Michael_Schonborn] 2009-09-11
+ccnx             9695/tcp # Content Centric Networking [Van_Jacobson_2][Simon_Barber] [Van_Jacobson_2][Simon_Barber] 2009-09-29
+ccnx             9695/udp # Content Centric Networking [Van_Jacobson_2][Simon_Barber] [Van_Jacobson_2][Simon_Barber] 2009-09-29
+board-roar       9700/tcp # Board M.I.T. Service [Francesco_Rosi] [Francesco_Rosi] 2006-01
+board-roar       9700/udp # Board M.I.T. Service [Francesco_Rosi] [Francesco_Rosi] 2006-01
+l5nas-parchan    9747/tcp # L5NAS Parallel Channel [Lawrence_J_Dickson] [Lawrence_J_Dickson] 2002-03
+l5nas-parchan    9747/udp # L5NAS Parallel Channel [Lawrence_J_Dickson] [Lawrence_J_Dickson] 2002-03
+board-voip       9750/tcp # Board M.I.T. Synchronous Collaboration [Francesco_Rosi] [Francesco_Rosi] 2006-01
+board-voip       9750/udp # Board M.I.T. Synchronous Collaboration [Francesco_Rosi] [Francesco_Rosi] 2006-01
+rasadv           9753/tcp # rasadv [Dave_Thaler_2] [Dave_Thaler_2]
+rasadv           9753/udp # rasadv [Dave_Thaler_2] [Dave_Thaler_2]
+tungsten-http    9762/tcp # WSO2 Tungsten HTTP [Afkham_Azeez] [Afkham_Azeez] 2006-06
+tungsten-http    9762/udp # WSO2 Tungsten HTTP [Afkham_Azeez] [Afkham_Azeez] 2006-06
+davsrc           9800/tcp # WebDav Source Port [Ethan_Fremen] [Ethan_Fremen]
+davsrc           9800/udp # WebDav Source Port [Ethan_Fremen] [Ethan_Fremen]
+sstp-2           9801/tcp # Sakura Script Transfer Protocol-2 [Kouichi_Takeda_2] [Kouichi_Takeda_2]
+sstp-2           9801/udp # Sakura Script Transfer Protocol-2 [Kouichi_Takeda_2] [Kouichi_Takeda_2]
+davsrcs          9802/tcp # WebDAV Source TLS/SSL [Rob_Isaac] [Rob_Isaac] 2003-07
+davsrcs          9802/udp # WebDAV Source TLS/SSL [Rob_Isaac] [Rob_Isaac] 2003-07
+sapv1            9875/tcp # Session Announcement v1 [RFC2974]
+sapv1            9875/udp # Session Announcement v1 [RFC2974]
+sd               9876/tcp # Session Director [Van_Jacobson] [Van_Jacobson]
+kca-service      9878/udp # The KX509 Kerberized Certificate Issuance Protocol in Use in 2012 [IESG] [IETF_Chair] 2012-07-12 [RFC6717] Historically, this service has been referred to as "kca_service", but this service name does not meet the registry requirements.
+cyborg-systems   9888/tcp # CYBORG Systems [Malcolm_Graham] [Malcolm_Graham]
+cyborg-systems   9888/udp # CYBORG Systems [Malcolm_Graham] [Malcolm_Graham]
+gt-proxy         9889/tcp # Port for Cable network related data proxy or repeater [Dawei_Qi] [Dawei_Qi] 2010-07-07
+gt-proxy         9889/udp # Port for Cable network related data proxy or repeater [Dawei_Qi] [Dawei_Qi] 2010-07-07
+monkeycom        9898/tcp # MonkeyCom [Yuji_Kuwabara] [Yuji_Kuwabara]
+monkeycom        9898/udp # MonkeyCom [Yuji_Kuwabara] [Yuji_Kuwabara]
+sctp-tunneling   9899/udp # SCTP TUNNELING [IESG] [IETF_Chair] 2013-04-10 [RFC6951]
+iua              9900/tcp # IUA [Lyndon_Ong_2] [Lyndon_Ong_2]
+iua              9900/udp # IUA [Lyndon_Ong_2] [Lyndon_Ong_2]
+iua              9900/sctp # IUA [Lyndon_Ong_2] [Lyndon_Ong_2]
+enrp             9901/udp # enrp server channel
+enrp-sctp        9901/sctp # enrp server channel [RFC5353]
+enrp-sctp-tls    9902/sctp # enrp/tls server channel [RFC5353]
+multicast-ping   9903/udp # Multicast Ping Protocol 2011-12-09 [RFC6450]
+domaintime       9909/tcp # domaintime [Jeffry_Dwight] [Jeffry_Dwight]
+domaintime       9909/udp # domaintime [Jeffry_Dwight] [Jeffry_Dwight]
+sype-transport   9911/tcp # SYPECom Transport Protocol [Sylvain_Pedneault] [Sylvain_Pedneault] 2003-03
+sype-transport   9911/udp # SYPECom Transport Protocol [Sylvain_Pedneault] [Sylvain_Pedneault] 2003-03
+xybrid-cloud     9925/tcp # XYBRID Cloud [Rx_Networks_Inc_2] [Drew_Davies_2] 2013-04-25
+apc-9950         9950/tcp # APC 9950 [American_Power_Conve] [American_Power_Conve]
+apc-9950         9950/udp # APC 9950 [American_Power_Conve] [American_Power_Conve]
+apc-9951         9951/tcp # APC 9951 [American_Power_Conve] [American_Power_Conve]
+apc-9951         9951/udp # APC 9951 [American_Power_Conve] [American_Power_Conve]
+apc-9952         9952/tcp # APC 9952 [American_Power_Conve] [American_Power_Conve]
+apc-9952         9952/udp # APC 9952 [American_Power_Conve] [American_Power_Conve]
+acis             9953/tcp # 9953 [Thomas_Guth] [Thomas_Guth] 2006-01
+acis             9953/udp # 9953 [Thomas_Guth] [Thomas_Guth] 2006-01
+hinp             9954/tcp # HaloteC Instrument Network Protocol [HaloteC_Instruments] [Michel_Stam] 2012-02-07
+alljoyn-stm      9955/tcp # Contact Port for AllJoyn standard messaging [Qualcomm_Innovation_Center] [Craig_Dowell] 2012-03-14
+alljoyn-mcm      9955/udp # Contact Port for AllJoyn multiplexed constrained messaging [Qualcomm_Innovation_Center] [Craig_Dowell] 2012-03-14
+alljoyn          9956/udp # Alljoyn Name Service [Qualcomm_Innovation_Center] [Craig_Dowell] 2011-12-21
+odnsp            9966/tcp # OKI Data Network Setting Protocol [Masato_Sato] [Masato_Sato] 2006-05
+odnsp            9966/udp # OKI Data Network Setting Protocol [Masato_Sato] [Masato_Sato] 2006-05
+xybrid-rt        9978/tcp # XYBRID RT Server [Rx_Networks_Inc] [Drew_Davies] 2013-01-24
+dsm-scm-target   9987/tcp # DSM/SCM Target Interface [Mike_Dyslin] [Mike_Dyslin] 2006-08
+dsm-scm-target   9987/udp # DSM/SCM Target Interface [Mike_Dyslin] [Mike_Dyslin] 2006-08
+nsesrvr          9988/tcp # Software Essentials Secure HTTP server [Narayanan_Raju] [Narayanan_Raju] 2009-02-05
+osm-appsrvr      9990/tcp # OSM Applet Server [Vinay_Gupta] [Vinay_Gupta] 2003-08
+osm-appsrvr      9990/udp # OSM Applet Server [Vinay_Gupta] [Vinay_Gupta] 2003-08
+osm-oev          9991/tcp # OSM Event Server [Vinay_Gupta] [Vinay_Gupta] 2003-08
+osm-oev          9991/udp # OSM Event Server [Vinay_Gupta] [Vinay_Gupta] 2003-08
+palace-1         9992/tcp # OnLive-1 [Douglas_Crockford] [Douglas_Crockford]
+palace-1         9992/udp # OnLive-1 [Douglas_Crockford] [Douglas_Crockford]
+palace-2         9993/tcp # OnLive-2 [Douglas_Crockford] [Douglas_Crockford]
+palace-2         9993/udp # OnLive-2 [Douglas_Crockford] [Douglas_Crockford]
+palace-3         9994/tcp # OnLive-3 [Douglas_Crockford] [Douglas_Crockford]
+palace-3         9994/udp # OnLive-3 [Douglas_Crockford] [Douglas_Crockford]
+palace-4         9995/tcp # Palace-4 [Douglas_Crockford] [Douglas_Crockford]
+palace-4         9995/udp # Palace-4 [Douglas_Crockford] [Douglas_Crockford]
+palace-5         9996/tcp # Palace-5 [Douglas_Crockford] [Douglas_Crockford]
+palace-5         9996/udp # Palace-5 [Douglas_Crockford] [Douglas_Crockford]
+palace-6         9997/tcp # Palace-6 [Douglas_Crockford] [Douglas_Crockford]
+palace-6         9997/udp # Palace-6 [Douglas_Crockford] [Douglas_Crockford]
+distinct32       9998/tcp # Distinct32 [Anoop_Tewari] [Anoop_Tewari]
+distinct32       9998/udp # Distinct32 [Anoop_Tewari] [Anoop_Tewari]
+distinct         9999/tcp # distinct [Anoop_Tewari] [Anoop_Tewari]
+distinct         9999/udp # distinct [Anoop_Tewari] [Anoop_Tewari]
+ndmp            10000/tcp # Network Data Management Protocol [Brian_Ehrmantraut] [Brian_Ehrmantraut]
+ndmp            10000/udp # Network Data Management Protocol [Brian_Ehrmantraut] [Brian_Ehrmantraut]
+scp-config      10001/tcp # SCP Configuration [Michael_Benz] [Michael_Benz] 2010-08-06
+scp-config      10001/udp # SCP Configuration [Michael_Benz] [Michael_Benz] 2010-08-06
+documentum      10002/tcp # EMC-Documentum Content Server Product [Reza_Bagherian] [Reza_Bagherian] 2007-07-19
+documentum      10002/udp # EMC-Documentum Content Server Product [Reza_Bagherian] [Reza_Bagherian] 2007-07-19
+documentum-s    10003/tcp # EMC-Documentum Content Server ProductIANA assigned this well-formed service name as a replacement for "documentum_s". [Reza_Bagherian] [Reza_Bagherian] 2007-07-19
+documentum_s    10003/tcp # EMC-Documentum Content Server Product [Reza_Bagherian] [Reza_Bagherian] 2007-07-19 This entry is an alias to "documentum-s".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+documentum-s    10003/udp # EMC-Documentum Content Server ProductIANA assigned this well-formed service name as a replacement for "documentum_s". [Reza_Bagherian] [Reza_Bagherian] 2007-07-19
+documentum_s    10003/udp # EMC-Documentum Content Server Product [Reza_Bagherian] [Reza_Bagherian] 2007-07-19 This entry is an alias to "documentum-s".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+emcrmirccd      10004/tcp # EMC Replication Manager Client [Robert_Boudrie] [Robert_Boudrie] 2008-06-09
+emcrmird        10005/tcp # EMC Replication Manager Server [Robert_Boudrie] [Robert_Boudrie] 2008-06-09
+mvs-capacity    10007/tcp # MVS Capacity [Donna_Dillenberger] [Donna_Dillenberger]
+mvs-capacity    10007/udp # MVS Capacity [Donna_Dillenberger] [Donna_Dillenberger]
+octopus         10008/tcp # Octopus Multiplexer [Chris_Koeritz_2] [Chris_Koeritz_2] 2002-10
+octopus         10008/udp # Octopus Multiplexer [Chris_Koeritz_2] [Chris_Koeritz_2] 2002-10
+swdtp-sv        10009/tcp # Systemwalker Desktop Patrol [Akira_Ide] [Akira_Ide] 2006-03
+swdtp-sv        10009/udp # Systemwalker Desktop Patrol [Akira_Ide] [Akira_Ide] 2006-03
+rxapi           10010/tcp # ooRexx rxapi services [David_Ashley] [David_Ashley] 2009-07-24
+zabbix-agent    10050/tcp # Zabbix Agent [Alexei_Vladishev] [Alexei_Vladishev] 2006-02
+zabbix-agent    10050/udp # Zabbix Agent [Alexei_Vladishev] [Alexei_Vladishev] 2006-02
+zabbix-trapper  10051/tcp # Zabbix Trapper [Alexei_Vladishev] [Alexei_Vladishev] 2006-02
+zabbix-trapper  10051/udp # Zabbix Trapper [Alexei_Vladishev] [Alexei_Vladishev] 2006-02
+qptlmd          10055/tcp # Quantapoint FLEXlm Licensing Service [Justin_Vegso] [Justin_Vegso] 2010-07-01
+amanda          10080/tcp # Amanda [John_Jackson] [John_Jackson]
+amanda          10080/udp # Amanda [John_Jackson] [John_Jackson]
+famdc           10081/tcp # FAM Archive Server [Frode_Randers] [Frode_Randers] 2006-01
+famdc           10081/udp # FAM Archive Server [Frode_Randers] [Frode_Randers] 2006-01
+itap-ddtp       10100/tcp # VERITAS ITAP DDTP [Saugata_Guha] [Saugata_Guha] 2004-05
+itap-ddtp       10100/udp # VERITAS ITAP DDTP [Saugata_Guha] [Saugata_Guha] 2004-05
+ezmeeting-2     10101/tcp # eZmeeting [Albert_C_Yang] [Albert_C_Yang] 2002-03
+ezmeeting-2     10101/udp # eZmeeting [Albert_C_Yang] [Albert_C_Yang] 2002-03
+ezproxy-2       10102/tcp # eZproxy [Albert_C_Yang] [Albert_C_Yang] 2002-03
+ezproxy-2       10102/udp # eZproxy [Albert_C_Yang] [Albert_C_Yang] 2002-03
+ezrelay         10103/tcp # eZrelay [Albert_C_Yang] [Albert_C_Yang] 2002-03
+ezrelay         10103/udp # eZrelay [Albert_C_Yang] [Albert_C_Yang] 2002-03
+swdtp           10104/tcp # Systemwalker Desktop Patrol [Akira_Ide] [Akira_Ide] 2006-09
+swdtp           10104/udp # Systemwalker Desktop Patrol [Akira_Ide] [Akira_Ide] 2006-09
+bctp-server     10107/tcp # VERITAS BCTP, server [Saugata_Guha] [Saugata_Guha] 2004-05
+bctp-server     10107/udp # VERITAS BCTP, server [Saugata_Guha] [Saugata_Guha] 2004-05
+nmea-0183       10110/tcp # NMEA-0183 Navigational Data [Meindert_Sprang] [Meindert_Sprang] 2009-02-18
+nmea-0183       10110/udp # NMEA-0183 Navigational Data [Meindert_Sprang] [Meindert_Sprang] 2009-02-18
+nmea-onenet     10111/udp # NMEA OneNet multicast messaging [National_Marine_Electronics_Association] [Steve_Spitzer] 2011-09-15
+netiq-endpoint  10113/tcp # NetIQ Endpoint [John_Wood] [John_Wood]
+netiq-endpoint  10113/udp # NetIQ Endpoint [John_Wood] [John_Wood]
+netiq-qcheck    10114/tcp # NetIQ Qcheck [Michael_Sharpe] [Michael_Sharpe] 2010-09-14
+netiq-qcheck    10114/udp # NetIQ Qcheck [Michael_Sharpe] [Michael_Sharpe] 2010-09-14
+netiq-endpt     10115/tcp # NetIQ Endpoint [Gary_Weichinger] [Gary_Weichinger]
+netiq-endpt     10115/udp # NetIQ Endpoint [Gary_Weichinger] [Gary_Weichinger]
+netiq-voipa     10116/tcp # NetIQ VoIP Assessor [Gary_Weichinger] [Gary_Weichinger]
+netiq-voipa     10116/udp # NetIQ VoIP Assessor [Gary_Weichinger] [Gary_Weichinger]
+iqrm            10117/tcp # NetIQ IQCResource Managament Svc [Michael_Sharpe] [Michael_Sharpe] 2010-09-14
+iqrm            10117/udp # NetIQ IQCResource Managament Svc [Michael_Sharpe] [Michael_Sharpe] 2010-09-14
+bmc-perf-sd     10128/tcp # BMC-PERFORM-SERVICE DAEMON [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-perf-sd     10128/udp # BMC-PERFORM-SERVICE DAEMON [Portnoy_Boxman] [Portnoy_Boxman]
+bmc-gms         10129/tcp # BMC General Manager Server [Dima_Seliverstov] [Dima_Seliverstov] 2009-07-28
+qb-db-server    10160/tcp # QB Database Server [Wei_Wang] [Wei_Wang] 2005-11
+qb-db-server    10160/udp # QB Database Server [Wei_Wang] [Wei_Wang] 2005-11
+snmptls         10161/tcp # SNMP-TLS [RFC6353]
+snmpdtls        10161/udp # SNMP-DTLS [RFC6353]
+snmptls-trap    10162/tcp # SNMP-Trap-TLS [RFC6353]
+snmpdtls-trap   10162/udp # SNMP-Trap-DTLS [RFC6353]
+trisoap         10200/tcp # Trigence AE Soap Service [Brigitte_Gagne] [Brigitte_Gagne] 2006-08
+trisoap         10200/udp # Trigence AE Soap Service [Brigitte_Gagne] [Brigitte_Gagne] 2006-08
+rsms            10201/tcp # Remote Server Management Service [Patrick_H_Piper] [Patrick_H_Piper] 2009-03-06
+rscs            10201/udp # Remote Server Control and Test Service [Patrick_H_Piper] [Patrick_H_Piper] 2009-03-06
+apollo-relay    10252/tcp # Apollo Relay Port [Anthony_Carrabino] [Anthony_Carrabino] 2003-08
+apollo-relay    10252/udp # Apollo Relay Port [Anthony_Carrabino] [Anthony_Carrabino] 2003-08
+axis-wimp-port  10260/tcp # Axis WIMP Port [Stefan_Eriksson] [Stefan_Eriksson]
+axis-wimp-port  10260/udp # Axis WIMP Port [Stefan_Eriksson] [Stefan_Eriksson]
+blocks          10288/tcp # Blocks [Carl_Malamud] [Carl_Malamud]
+blocks          10288/udp # Blocks [Carl_Malamud] [Carl_Malamud]
+cosir           10321/tcp # Computer Op System Information Report [Kevin_C_Barber] [Kevin_C_Barber] 2009-01-13
+hip-nat-t       10500/udp # HIP NAT-Traversal [Ari_Keranen] [Ari_Keranen] [RFC5770]
+MOS-lower       10540/tcp # MOS Media Object Metadata Port [Eric_Thorniley] [Eric_Thorniley] 2007-09-17
+MOS-lower       10540/udp # MOS Media Object Metadata Port [Eric_Thorniley] [Eric_Thorniley] 2007-09-17
+MOS-upper       10541/tcp # MOS Running Order Port [Eric_Thorniley] [Eric_Thorniley] 2007-09-17
+MOS-upper       10541/udp # MOS Running Order Port [Eric_Thorniley] [Eric_Thorniley] 2007-09-17
+MOS-aux         10542/tcp # MOS Low Priority Port [Eric_Thorniley] [Eric_Thorniley] 2007-09-17
+MOS-aux         10542/udp # MOS Low Priority Port [Eric_Thorniley] [Eric_Thorniley] 2007-09-17
+MOS-soap        10543/tcp # MOS SOAP Default Port [Eric_Thorniley] [Eric_Thorniley] 2007-09-17
+MOS-soap        10543/udp # MOS SOAP Default Port [Eric_Thorniley] [Eric_Thorniley] 2007-09-17
+MOS-soap-opt    10544/tcp # MOS SOAP Optional Port [Eric_Thorniley] [Eric_Thorniley] 2007-09-17
+MOS-soap-opt    10544/udp # MOS SOAP Optional Port [Eric_Thorniley] [Eric_Thorniley] 2007-09-17
+printopia       10631/tcp # Port to allow for administration and control of "Printopia" application software,      which provides printing services to mobile users [Ecamm_Network_LLC] [Chris_Kent] 2011-10-24
+gap             10800/tcp # Gestor de Acaparamiento para Pocket PCs [Juan_Carlos_Olivares] [Juan_Carlos_Olivares] 2006-03
+gap             10800/udp # Gestor de Acaparamiento para Pocket PCs [Juan_Carlos_Olivares] [Juan_Carlos_Olivares] 2006-03
+lpdg            10805/tcp # LUCIA Pareja Data Group [Alvaro_P_Dominguez] [Alvaro_P_Dominguez] 2006-02
+lpdg            10805/udp # LUCIA Pareja Data Group [Alvaro_P_Dominguez] [Alvaro_P_Dominguez] 2006-02
+nbd             10809/tcp # Linux Network Block Device [Wouter_Verhelst] [Wouter_Verhelst] 2010-08-02
+nmc-disc        10810/udp # Nuance Mobile Care Discovery [Gordon_Waddell] [Gordon_Waddell] 2011-03-21
+helix           10860/tcp # Helix Client/Server [Matthew_Strange][Larry_Atkin_2] [Matthew_Strange][Larry_Atkin_2] 2009-03-06
+helix           10860/udp # Helix Client/Server [Matthew_Strange][Larry_Atkin_2] [Matthew_Strange][Larry_Atkin_2] 2009-03-06
+bveapi          10880/tcp # BVEssentials HTTP API [Tri_Tech_Computers_Ltd] [James_Emerton] 2012-11-19
+bveapi          10880/udp # BVEssentials HTTP API [Tri_Tech_Computers_Ltd] [James_Emerton] 2012-11-19
+rmiaux          10990/tcp # Auxiliary RMI Port [Eugen_Bacic_2] [Eugen_Bacic_2]
+rmiaux          10990/udp # Auxiliary RMI Port [Eugen_Bacic_2] [Eugen_Bacic_2]
+irisa           11000/tcp # IRISA [V_A_Brauner] [V_A_Brauner]
+irisa           11000/udp # IRISA [V_A_Brauner] [V_A_Brauner]
+metasys         11001/tcp # Metasys [Tobin_Schuster] [Tobin_Schuster]
+metasys         11001/udp # Metasys [Tobin_Schuster] [Tobin_Schuster]
+origo-sync      11103/tcp # OrigoDB Server Sync Interface [Devrex_Labs] [Robert_Friberg] 2013-03-29
+netapp-icmgmt   11104/tcp # NetApp Intercluster Management [Craig_Everhart] [Craig_Everhart] 2010-07-06
+netapp-icdata   11105/tcp # NetApp Intercluster Data [Craig_Everhart] [Craig_Everhart] 2010-07-06
+sgi-lk          11106/tcp # SGI LK Licensing service [Michel_Bourget] [Michel_Bourget] 2009-01-06
+sgi-lk          11106/udp # SGI LK Licensing service [Michel_Bourget] [Michel_Bourget] 2009-01-06
+myq-termlink    11108/udp # Hardware Terminals Discovery and Low-Level Communication Protocol [JANUS_spol] [Jakub_Ahmadyar] 2013-04-23
+sgi-dmfmgr      11109/tcp # Data migration facility Manager (DMF) is a browser based interface to DMF [SGI] [John_Sygulla] 2013-01-07
+sgi-soap        11110/tcp # Data migration facility (DMF) SOAP is a web server protocol to support remote access to DMF [SGI] [John_Sygulla] 2013-01-07
+vce             11111/tcp # Viral Computing Environment (VCE) [Fred_Cohen] [Fred_Cohen]
+vce             11111/udp # Viral Computing Environment (VCE) [Fred_Cohen] [Fred_Cohen]
+dicom           11112/tcp # DICOM [David_Clunie] [David_Clunie] 2005-08
+dicom           11112/udp # DICOM [David_Clunie] [David_Clunie] 2005-08
+suncacao-snmp   11161/tcp # sun cacao snmp access point [Nick_Stephen] [Nick_Stephen] 2005-08
+suncacao-snmp   11161/udp # sun cacao snmp access point [Nick_Stephen] [Nick_Stephen] 2005-08
+suncacao-jmxmp  11162/tcp # sun cacao JMX-remoting access point [Nick_Stephen] [Nick_Stephen] 2005-08
+suncacao-jmxmp  11162/udp # sun cacao JMX-remoting access point [Nick_Stephen] [Nick_Stephen] 2005-08
+suncacao-rmi    11163/tcp # sun cacao rmi registry access point [Nick_Stephen] [Nick_Stephen] 2005-08
+suncacao-rmi    11163/udp # sun cacao rmi registry access point [Nick_Stephen] [Nick_Stephen] 2005-08
+suncacao-csa    11164/tcp # sun cacao command-streaming access point [Nick_Stephen] [Nick_Stephen] 2005-08
+suncacao-csa    11164/udp # sun cacao command-streaming access point [Nick_Stephen] [Nick_Stephen] 2005-08
+suncacao-websvc 11165/tcp # sun cacao web service access point [Nick_Stephen] [Nick_Stephen] 2005-08
+suncacao-websvc 11165/udp # sun cacao web service access point [Nick_Stephen] [Nick_Stephen] 2005-08
+snss            11171/udp # Surgical Notes Security Service Discovery (SNSS) [David_Lethe] [David_Lethe] 2010-12-24
+oemcacao-jmxmp  11172/tcp # OEM cacao JMX-remoting access point [David_Sechrest] [David_Sechrest] 2010-09-22
+t5-straton      11173/tcp # Straton Runtime Programing [COPALP] [Jerome_FOLLUT] 2012-03-01
+oemcacao-rmi    11174/tcp # OEM cacao rmi registry access point [David_Sechrest] [David_Sechrest] 2010-09-22
+oemcacao-websvc 11175/tcp # OEM cacao web service access point [David_Sechrest] [David_Sechrest] 2010-09-22
+smsqp           11201/tcp # smsqp [Andres_Seco_Hernande] [Andres_Seco_Hernande]
+smsqp           11201/udp # smsqp [Andres_Seco_Hernande] [Andres_Seco_Hernande]
+dcsl-backup     11202/tcp # DCSL Network Backup Services [John_Reynolds] [John_Reynolds] 2012-04-17 Defined TXT keys: DCSL-Service
+wifree          11208/tcp # WiFree Service [Jose_Luis_Martin_Pei] [Jose_Luis_Martin_Pei] 2006-03
+wifree          11208/udp # WiFree Service [Jose_Luis_Martin_Pei] [Jose_Luis_Martin_Pei] 2006-03
+memcache        11211/tcp # Memory cache service [Trond_Norbye] [Trond_Norbye] 2009-02-09
+memcache        11211/udp # Memory cache service [Trond_Norbye] [Trond_Norbye] 2009-02-09
+imip            11319/tcp # IMIP [Len_Zuvela] [Len_Zuvela]
+imip            11319/udp # IMIP [Len_Zuvela] [Len_Zuvela]
+imip-channels   11320/tcp # IMIP Channels Port [Len_Zuvela_2] [Len_Zuvela_2]
+imip-channels   11320/udp # IMIP Channels Port [Len_Zuvela_2] [Len_Zuvela_2]
+arena-server    11321/tcp # Arena Server Listen [Earl_Brannigan] [Earl_Brannigan]
+arena-server    11321/udp # Arena Server Listen [Earl_Brannigan] [Earl_Brannigan]
+atm-uhas        11367/tcp # ATM UHAS [Todd_Barker] [Todd_Barker]
+atm-uhas        11367/udp # ATM UHAS [Todd_Barker] [Todd_Barker]
+hkp             11371/tcp # OpenPGP HTTP Keyserver [David_Shaw] [David_Shaw] 2003-05
+hkp             11371/udp # OpenPGP HTTP Keyserver [David_Shaw] [David_Shaw] 2003-05
+asgcypresstcps  11489/tcp # ASG Cypress Secure Only [David_Luxford] [David_Luxford] 2010-07-01
+tempest-port    11600/tcp # Tempest Protocol Port [Francis_Cianfrocca] [Francis_Cianfrocca]
+tempest-port    11600/udp # Tempest Protocol Port [Francis_Cianfrocca] [Francis_Cianfrocca]
+h323callsigalt  11720/tcp # H.323 Call Control Signalling Alternate [ITU-T] [ITU-T_TSB] 2013-01-31
+h323callsigalt  11720/udp # H.323 Call Control Signalling Alternate [ITU-T] [ITU-T_TSB] 2013-01-31
+intrepid-ssl    11751/tcp # Intrepid SSL [Robert_Eden] [Robert_Eden] 2003-03
+intrepid-ssl    11751/udp # Intrepid SSL [Robert_Eden] [Robert_Eden] 2003-03
+lanschool       11796/tcp # LanSchool [Stoneware_Inc] [Dana_Doggett] 2012-05-18
+lanschool-mpt   11796/udp # Lanschool Multipoint [Stoneware_Inc] [Dana_Doggett] 2012-05-18
+xoraya          11876/tcp # X2E Xoraya Multichannel protocol [Hannes_K] [Hannes_K] 2010-09-13
+xoraya          11876/udp # X2E Xoraya Multichannel protocol [Hannes_K] [Hannes_K] 2010-09-13
+x2e-disc        11877/udp # X2E service discovery protocol [Hannes_K] [Hannes_K] 2010-09-13
+sysinfo-sp      11967/tcp # SysInfo Service Protocol [Mike_Cooper] [Mike_Cooper] 2003-03
+sysinfo-sp      11967/udp # SysInfo Sercice Protocol [Mike_Cooper] [Mike_Cooper] 2003-03
+wmereceiving    11997/sctp # WorldMailExpress [Greg_Foutz] [Greg_Foutz] 2006-03
+wmedistribution 11998/sctp # WorldMailExpress [Greg_Foutz] [Greg_Foutz] 2006-03
+wmereporting    11999/sctp # WorldMailExpress [Greg_Foutz] [Greg_Foutz] 2006-03
+entextxid       12000/tcp # IBM Enterprise Extender SNA XID Exchange [Eugene_Cox] [Eugene_Cox]
+entextxid       12000/udp # IBM Enterprise Extender SNA XID Exchange [Eugene_Cox] [Eugene_Cox]
+entextnetwk     12001/tcp # IBM Enterprise Extender SNA COS Network Priority [Eugene_Cox] [Eugene_Cox]
+entextnetwk     12001/udp # IBM Enterprise Extender SNA COS Network Priority [Eugene_Cox] [Eugene_Cox]
+entexthigh      12002/tcp # IBM Enterprise Extender SNA COS High Priority [Eugene_Cox] [Eugene_Cox]
+entexthigh      12002/udp # IBM Enterprise Extender SNA COS High Priority [Eugene_Cox] [Eugene_Cox]
+entextmed       12003/tcp # IBM Enterprise Extender SNA COS Medium Priority [Eugene_Cox] [Eugene_Cox]
+entextmed       12003/udp # IBM Enterprise Extender SNA COS Medium Priority [Eugene_Cox] [Eugene_Cox]
+entextlow       12004/tcp # IBM Enterprise Extender SNA COS Low Priority [Eugene_Cox] [Eugene_Cox]
+entextlow       12004/udp # IBM Enterprise Extender SNA COS Low Priority [Eugene_Cox] [Eugene_Cox]
+dbisamserver1   12005/tcp # DBISAM Database Server - Regular [Tim_Young] [Tim_Young] 2002-05
+dbisamserver1   12005/udp # DBISAM Database Server - Regular [Tim_Young] [Tim_Young] 2002-05
+dbisamserver2   12006/tcp # DBISAM Database Server - Admin [Tim_Young] [Tim_Young] 2002-05
+dbisamserver2   12006/udp # DBISAM Database Server - Admin [Tim_Young] [Tim_Young] 2002-05
+accuracer       12007/tcp # Accuracer Database System Server [Alexander_V_Ivanov] [Alexander_V_Ivanov] 2004-12
+accuracer       12007/udp # Accuracer Database System Server [Alexander_V_Ivanov] [Alexander_V_Ivanov] 2004-12
+accuracer-dbms  12008/tcp # Accuracer Database System Admin [Alexander_V_Ivanov] [Alexander_V_Ivanov] 2004-12
+accuracer-dbms  12008/udp # Accuracer Database System Admin [Alexander_V_Ivanov] [Alexander_V_Ivanov] 2004-12
+ghvpn           12009/udp # Green Hills VPN [Green_Hills_Software] [Tom_R_Zavisca] 2012-02-07
+edbsrvr         12010/tcp # ElevateDB Server [Tim_Young] [Tim_Young] 2009-05-06
+vipera          12012/tcp # Vipera Messaging Service [Silvano_Maffeis_2] [Silvano_Maffeis_2] 2005-08
+vipera          12012/udp # Vipera Messaging Service [Silvano_Maffeis_2] [Silvano_Maffeis_2] 2005-08
+vipera-ssl      12013/tcp # Vipera Messaging Service over SSL Communication [Silvano_Maffeis_2] [Silvano_Maffeis_2] 2008-01-16
+vipera-ssl      12013/udp # Vipera Messaging Service over SSL Communication [Silvano_Maffeis_2] [Silvano_Maffeis_2] 2008-01-16
+rets-ssl        12109/tcp # RETS over SSL [Bruce_Toback] [Bruce_Toback] 2003-02
+rets-ssl        12109/udp # RETS over SSL [Bruce_Toback] [Bruce_Toback] 2003-02
+nupaper-ss      12121/tcp # NuPaper Session Service [David_Warden_2] [David_Warden_2] 2005-11
+nupaper-ss      12121/udp # NuPaper Session Service [David_Warden_2] [David_Warden_2] 2005-11
+cawas           12168/tcp # CA Web Access Service [Jon_Press] [Jon_Press] 2005-08
+cawas           12168/udp # CA Web Access Service [Jon_Press] [Jon_Press] 2005-08
+hivep           12172/tcp # HiveP [Dick_Augustsson] [Dick_Augustsson]
+hivep           12172/udp # HiveP [Dick_Augustsson] [Dick_Augustsson]
+linogridengine  12300/tcp # LinoGrid Engine [Frans_Lundberg] [Frans_Lundberg] 2004-11
+linogridengine  12300/udp # LinoGrid Engine [Frans_Lundberg] [Frans_Lundberg] 2004-11
+rads            12302/tcp # Remote Administration Daemon (RAD) is a system service that offers secure, remote, programmatic access to Solaris system configuration and run-time state [Oracle] [Devjani_Ray] 2012-04-20
+warehouse-sss   12321/tcp # Warehouse Monitoring Syst SSS [Craig_Steffen] [Craig_Steffen] 2005-08
+warehouse-sss   12321/udp # Warehouse Monitoring Syst SSS [Craig_Steffen] [Craig_Steffen] 2005-08
+warehouse       12322/tcp # Warehouse Monitoring Syst [Craig_Steffen] [Craig_Steffen] 2005-08
+warehouse       12322/udp # Warehouse Monitoring Syst [Craig_Steffen] [Craig_Steffen] 2005-08
+italk           12345/tcp # Italk Chat System [Takayuki_Ito] [Takayuki_Ito]
+italk           12345/udp # Italk Chat System [Takayuki_Ito] [Takayuki_Ito]
+tsaf            12753/tcp # tsaf port [Andreas_Fehr] [Andreas_Fehr]
+tsaf            12753/udp # tsaf port [Andreas_Fehr] [Andreas_Fehr]
+netperf         12865/tcp # control port for the netperf benchmark [netperf.org] [rick_jones] 2013-04-05
+i-zipqd         13160/tcp # I-ZIPQD [Chuck_Runquist] [Chuck_Runquist]
+i-zipqd         13160/udp # I-ZIPQD [Chuck_Runquist] [Chuck_Runquist]
+bcslogc         13216/tcp # Black Crow Software application logging [Ramindur_Singh] [Ramindur_Singh] 2008-12-04
+bcslogc         13216/udp # Black Crow Software application logging [Ramindur_Singh] [Ramindur_Singh] 2008-12-04
+rs-pias         13217/tcp # R&S Proxy Installation Assistant Service [Guido_Kiener] [Guido_Kiener] 2008-12-04
+rs-pias         13217/udp # R&S Proxy Installation Assistant Service [Guido_Kiener] [Guido_Kiener] 2008-12-04
+emc-vcas-tcp    13218/tcp # EMC Virtual CAS Service
+emc-vcas-udp    13218/udp # EMV Virtual CAS Service Discovery [Mark_O_Connell] [Mark_O_Connell] 2008-12-04
+powwow-client   13223/tcp # PowWow Client [Paul_K_Peterson] [Paul_K_Peterson]
+powwow-client   13223/udp # PowWow Client [Paul_K_Peterson] [Paul_K_Peterson]
+powwow-server   13224/tcp # PowWow Server [Paul_K_Peterson] [Paul_K_Peterson]
+powwow-server   13224/udp # PowWow Server [Paul_K_Peterson] [Paul_K_Peterson]
+doip-data       13400/tcp # DoIP Data [Joerg_Schneider] [Joerg_Schneider] 2011-01-26
+doip-disc       13400/udp # DoIP Discovery [Joerg_Schneider] [Joerg_Schneider] 2011-01-26
+bprd            13720/tcp # BPRD Protocol (VERITAS NetBackup) [Jeff_Holmbeck] [Jeff_Holmbeck]
+bprd            13720/udp # BPRD Protocol (VERITAS NetBackup) [Jeff_Holmbeck] [Jeff_Holmbeck]
+bpdbm           13721/tcp # BPDBM Protocol (VERITAS NetBackup) [Jeff_Holmbeck] [Jeff_Holmbeck]
+bpdbm           13721/udp # BPDBM Protocol (VERITAS NetBackup) [Jeff_Holmbeck] [Jeff_Holmbeck]
+bpjava-msvc     13722/tcp # BP Java MSVC Protocol [Tim_Schmidt] [Tim_Schmidt]
+bpjava-msvc     13722/udp # BP Java MSVC Protocol [Tim_Schmidt] [Tim_Schmidt]
+vnetd           13724/tcp # Veritas Network Utility [Jeff_Holmbeck] [Jeff_Holmbeck]
+vnetd           13724/udp # Veritas Network Utility [Jeff_Holmbeck] [Jeff_Holmbeck]
+bpcd            13782/tcp # VERITAS NetBackup [Jeff_Holmbeck] [Jeff_Holmbeck]
+bpcd            13782/udp # VERITAS NetBackup [Jeff_Holmbeck] [Jeff_Holmbeck]
+vopied          13783/tcp # VOPIED Protocol [Jeff_Holmbeck] [Jeff_Holmbeck]
+vopied          13783/udp # VOPIED Protocol [Jeff_Holmbeck] [Jeff_Holmbeck]
+nbdb            13785/tcp # NetBackup Database [Pat_Tovo] [Pat_Tovo] 2004-12
+nbdb            13785/udp # NetBackup Database [Pat_Tovo] [Pat_Tovo] 2004-12
+nomdb           13786/tcp # Veritas-nomdb [Clayton_Haapala] [Clayton_Haapala] 2005-08
+nomdb           13786/udp # Veritas-nomdb [Clayton_Haapala] [Clayton_Haapala] 2005-08
+dsmcc-config    13818/tcp # DSMCC Config [Tim_Addington] [Tim_Addington] [ISO/IEC 13818-6 MPEG-2 DSM-CC]
+dsmcc-config    13818/udp # DSMCC Config [Tim_Addington] [Tim_Addington] [ISO/IEC 13818-6 MPEG-2 DSM-CC]
+dsmcc-session   13819/tcp # DSMCC Session Messages [Tim_Addington] [Tim_Addington] [ISO/IEC 13818-6 MPEG-2 DSM-CC]
+dsmcc-session   13819/udp # DSMCC Session Messages [Tim_Addington] [Tim_Addington] [ISO/IEC 13818-6 MPEG-2 DSM-CC]
+dsmcc-passthru  13820/tcp # DSMCC Pass-Thru Messages [Tim_Addington] [Tim_Addington] [ISO/IEC 13818-6 MPEG-2 DSM-CC]
+dsmcc-passthru  13820/udp # DSMCC Pass-Thru Messages [Tim_Addington] [Tim_Addington] [ISO/IEC 13818-6 MPEG-2 DSM-CC]
+dsmcc-download  13821/tcp # DSMCC Download Protocol [Tim_Addington] [Tim_Addington] [ISO/IEC 13818-6 MPEG-2 DSM-CC]
+dsmcc-download  13821/udp # DSMCC Download Protocol [Tim_Addington] [Tim_Addington] [ISO/IEC 13818-6 MPEG-2 DSM-CC]
+dsmcc-ccp       13822/tcp # DSMCC Channel Change Protocol [Tim_Addington] [Tim_Addington] [ISO/IEC 13818-6 MPEG-2 DSM-CC]
+dsmcc-ccp       13822/udp # DSMCC Channel Change Protocol [Tim_Addington] [Tim_Addington] [ISO/IEC 13818-6 MPEG-2 DSM-CC]
+bmdss           13823/tcp # Blackmagic Design Streaming Server [Sam_Vaughan] [Sam_Vaughan] 2011-03-01
+ucontrol        13894/tcp # Ultimate Control communication protocol [NEGU_Soft] [borja_lopez_urkidi] 2012-09-10
+ucontrol        13894/udp # Ultimate Control communication protocol [NEGU_Soft] [borja_lopez_urkidi] 2012-09-10
+dta-systems     13929/tcp # D-TA SYSTEMS [Alexis_Bose] [Alexis_Bose] 2008-12-08
+dta-systems     13929/udp # D-TA SYSTEMS [Alexis_Bose] [Alexis_Bose] 2008-12-08
+medevolve       13930/tcp # MedEvolve Port Requester [Jon_Robertson] [Jon_Robertson] 2008-10-24
+scotty-ft       14000/tcp # SCOTTY High-Speed Filetransfer [Patrick_Verbeek] [Patrick_Verbeek] 2007-05
+scotty-ft       14000/udp # SCOTTY High-Speed Filetransfer [Patrick_Verbeek] [Patrick_Verbeek] 2007-05
+sua             14001/tcp # SUA [Miguel_Angel_Garcia] [Miguel_Angel_Garcia]
+sua             14001/udp # De-Registered [Miguel_Angel_Garcia] [Miguel_Angel_Garcia] 2001-06-06
+sua             14001/sctp # SUA [Miguel_Angel_Garcia] [Miguel_Angel_Garcia]
+scotty-disc     14002/udp # Discovery of a SCOTTY hardware codec board [SCOTTY_Group_SE] [Patrick_Verbeek_2] 2013-01-14
+sage-best-com1  14033/tcp # sage Best! Config Server 1 [Christian_Rubach] [Christian_Rubach]
+sage-best-com1  14033/udp # sage Best! Config Server 1 [Christian_Rubach] [Christian_Rubach]
+sage-best-com2  14034/tcp # sage Best! Config Server 2 [Christian_Rubach] [Christian_Rubach]
+sage-best-com2  14034/udp # sage Best! Config Server 2 [Christian_Rubach] [Christian_Rubach]
+vcs-app         14141/tcp # VCS Application [Ming_Xu] [Ming_Xu]
+vcs-app         14141/udp # VCS Application [Ming_Xu] [Ming_Xu]
+icpp            14142/tcp # IceWall Cert Protocol [Tsutomu_Fujinami] [Tsutomu_Fujinami] 2005-08
+icpp            14142/udp # IceWall Cert Protocol [Tsutomu_Fujinami] [Tsutomu_Fujinami] 2005-08
+gcm-app         14145/tcp # GCM Application [Ming_Xu] [Ming_Xu]
+gcm-app         14145/udp # GCM Application [Ming_Xu] [Ming_Xu]
+vrts-tdd        14149/tcp # Veritas Traffic Director [Sameer_Deokule] [Sameer_Deokule] 2002-03
+vrts-tdd        14149/udp # Veritas Traffic Director [Sameer_Deokule] [Sameer_Deokule] 2002-03
+vcscmd          14150/tcp # Veritas Cluster Server Command Server [Anand_Bhalerao] [Anand_Bhalerao] 2008-10-02
+vad             14154/tcp # Veritas Application Director [Rajeev_Verma] [Rajeev_Verma] 2006-02
+vad             14154/udp # Veritas Application Director [Rajeev_Verma] [Rajeev_Verma] 2006-02
+cps             14250/tcp # Fencing Server [Mayank_Vasa] [Mayank_Vasa] 2008-04-03
+cps             14250/udp # Fencing Server [Mayank_Vasa] [Mayank_Vasa] 2008-04-03
+ca-web-update   14414/tcp # CA eTrust Web Update Service [Robert_Ciochon] [Robert_Ciochon] 2006-08
+ca-web-update   14414/udp # CA eTrust Web Update Service [Robert_Ciochon] [Robert_Ciochon] 2006-08
+hde-lcesrvr-1   14936/tcp # hde-lcesrvr-1 [Horizon_Digital_Ente] [Horizon_Digital_Ente]
+hde-lcesrvr-1   14936/udp # hde-lcesrvr-1 [Horizon_Digital_Ente] [Horizon_Digital_Ente]
+hde-lcesrvr-2   14937/tcp # hde-lcesrvr-2 [Horizon_Digital_Ente] [Horizon_Digital_Ente]
+hde-lcesrvr-2   14937/udp # hde-lcesrvr-2 [Horizon_Digital_Ente] [Horizon_Digital_Ente]
+hydap           15000/tcp # Hypack Data Aquisition [HYPACK_Inc] [Mircea_Neacsu] 2011-10-27
+hydap           15000/udp # Hypack Data Aquisition [HYPACK_Inc] [Mircea_Neacsu] 2011-10-27
+v2g-secc        15118/udp # v2g Supply Equipment Communication Controller Discovery Protocol [Holger_Lochner] [Holger_Lochner] 2011-04-06
+xpilot          15345/tcp # XPilot Contact Port [Bert_Gijsbers] [Bert_Gijsbers]
+xpilot          15345/udp # XPilot Contact Port [Bert_Gijsbers] [Bert_Gijsbers]
+3link           15363/tcp # 3Link Negotiation [Brant_Thomsen] [Brant_Thomsen] 2003-01
+3link           15363/udp # 3Link Negotiation [Brant_Thomsen] [Brant_Thomsen] 2003-01
+cisco-snat      15555/tcp # Cisco Stateful NAT [Kaushik_Biswas] [Kaushik_Biswas] 2006-03
+cisco-snat      15555/udp # Cisco Stateful NAT [Kaushik_Biswas] [Kaushik_Biswas] 2006-03
+bex-xr          15660/tcp # Backup Express Restore Server [Chi_Shih_Chang] [Chi_Shih_Chang] 2008-03-19
+bex-xr          15660/udp # Backup Express Restore Server [Chi_Shih_Chang] [Chi_Shih_Chang] 2008-03-19
+ptp             15740/tcp # Picture Transfer Protocol [Petronel_Bigioi] [Petronel_Bigioi] 2004-11 Defined TXT keys: guid=<Device guid>
+ptp             15740/udp # Picture Transfer Protocol [Petronel_Bigioi] [Petronel_Bigioi] 2004-11 Defined TXT keys: guid=<Device guid>
+2ping           15998/udp # 2ping Bi-Directional Ping Service [Ryan_Finnie] [Ryan_Finnie] 2010-10-06
+programmar      15999/tcp # ProGrammar Enterprise [Norman_Wilson] [Norman_Wilson] 2010-10-06
+fmsas           16000/tcp # Administration Server Access [Mark_Davidson] [Mark_Davidson] 2010-10-06
+fmsascon        16001/tcp # Administration Server Connector [Mark_Davidson] [Mark_Davidson] 2010-10-06
+gsms            16002/tcp # GoodSync Mediation Service [Vadim_Maslov] [Vadim_Maslov] 2010-10-06
+alfin           16003/udp # Automation and Control by REGULACE.ORG [Ing_Tomas_Halabala] [Ing_Tomas_Halabala] 2010-10-06
+jwpc            16020/tcp # Filemaker Java Web Publishing Core [Robert_Parks] [Robert_Parks] 2010-05-12
+jwpc-bin        16021/tcp # Filemaker Java Web Publishing Core Binary [Robert_Parks] [Robert_Parks] 2010-05-12
+sun-sea-port    16161/tcp # Solaris SEA Port [Dana_Porter] [Dana_Porter] 2003-10
+sun-sea-port    16161/udp # Solaris SEA Port [Dana_Porter] [Dana_Porter] 2003-10
+solaris-audit   16162/tcp # Solaris Audit - secure remote audit log [Jan_Friedel] [Jan_Friedel] 2009-05-07
+etb4j           16309/tcp # etb4j [Christopher_R_Smith] [Christopher_R_Smith] 2004-11
+etb4j           16309/udp # etb4j [Christopher_R_Smith] [Christopher_R_Smith] 2004-11
+pduncs          16310/tcp # Policy Distribute, Update Notification [Diane_I_Shannon] [Diane_I_Shannon] 2006-08
+pduncs          16310/udp # Policy Distribute, Update Notification [Diane_I_Shannon] [Diane_I_Shannon] 2006-08
+pdefmns         16311/tcp # Policy definition and update management [Diane_I_Shannon] [Diane_I_Shannon] 2007-04
+pdefmns         16311/udp # Policy definition and update management [Diane_I_Shannon] [Diane_I_Shannon] 2007-04
+netserialext1   16360/tcp # Network Serial Extension Ports One [Michael_J_Hoy] [Michael_J_Hoy]
+netserialext1   16360/udp # Network Serial Extension Ports One [Michael_J_Hoy] [Michael_J_Hoy]
+netserialext2   16361/tcp # Network Serial Extension Ports Two [Michael_J_Hoy] [Michael_J_Hoy]
+netserialext2   16361/udp # Network Serial Extension Ports Two [Michael_J_Hoy] [Michael_J_Hoy]
+netserialext3   16367/tcp # Network Serial Extension Ports Three [Michael_J_Hoy] [Michael_J_Hoy]
+netserialext3   16367/udp # Network Serial Extension Ports Three [Michael_J_Hoy] [Michael_J_Hoy]
+netserialext4   16368/tcp # Network Serial Extension Ports Four [Michael_J_Hoy] [Michael_J_Hoy]
+netserialext4   16368/udp # Network Serial Extension Ports Four [Michael_J_Hoy] [Michael_J_Hoy]
+connected       16384/tcp # Connected Corp [Nicole_C_Ouellette] [Nicole_C_Ouellette] 2004-02
+connected       16384/udp # Connected Corp [Nicole_C_Ouellette] [Nicole_C_Ouellette] 2004-02
+xoms            16619/tcp # X509 Objects Management Service [Francis_GASCHET] [Francis_GASCHET] 2008-09-08
+vtp             16666/udp # Vidder Tunnel Protocol [Vidder_Inc] [Ted_Schroeder_2] 2011-10-24
+newbay-snc-mc   16900/tcp # Newbay Mobile Client Update Service [Srinivasa_Nayudu] [Srinivasa_Nayudu] 2009-07-06
+newbay-snc-mc   16900/udp # Newbay Mobile Client Update Service [Srinivasa_Nayudu] [Srinivasa_Nayudu] 2009-07-06
+sgcip           16950/tcp # Simple Generic Client Interface Protocol [John_Aquilino] [John_Aquilino]
+sgcip           16950/udp # Simple Generic Client Interface Protocol [John_Aquilino] [John_Aquilino]
+intel-rci-mp    16991/tcp # INTEL-RCI-MP [Jane_Dashevsky] [Jane_Dashevsky]
+intel-rci-mp    16991/udp # INTEL-RCI-MP [Jane_Dashevsky] [Jane_Dashevsky]
+amt-soap-http   16992/tcp # Intel(R) AMT SOAP/HTTP [David_T_Hines] [David_T_Hines] 2005-02
+amt-soap-http   16992/udp # Intel(R) AMT SOAP/HTTP [David_T_Hines] [David_T_Hines] 2005-02
+amt-soap-https  16993/tcp # Intel(R) AMT SOAP/HTTPS [David_T_Hines] [David_T_Hines] 2005-02
+amt-soap-https  16993/udp # Intel(R) AMT SOAP/HTTPS [David_T_Hines] [David_T_Hines] 2005-02
+amt-redir-tcp   16994/tcp # Intel(R) AMT Redirection/TCP [Nimrod_Diamant] [Nimrod_Diamant] 2005-02
+amt-redir-tcp   16994/udp # Intel(R) AMT Redirection/TCP [Nimrod_Diamant] [Nimrod_Diamant] 2005-02
+amt-redir-tls   16995/tcp # Intel(R) AMT Redirection/TLS [Nimrod_Diamant] [Nimrod_Diamant] 2005-02
+amt-redir-tls   16995/udp # Intel(R) AMT Redirection/TLS [Nimrod_Diamant] [Nimrod_Diamant] 2005-02
+isode-dua       17007/tcp # 
+isode-dua       17007/udp # 
+soundsvirtual   17185/tcp # Sounds Virtual [Richard_Snider] [Richard_Snider]
+soundsvirtual   17185/udp # Sounds Virtual [Richard_Snider] [Richard_Snider]
+chipper         17219/tcp # Chipper [Ronald_Jimmink] [Ronald_Jimmink]
+chipper         17219/udp # Chipper [Ronald_Jimmink] [Ronald_Jimmink]
+avdecc          17221/tcp # IEEE 1722.1 AVB Discovery, Enumeration, Connection management, and Control [IEEE_1722_1] [Jeffrey_Daniel_Koftinoff] 2011-11-01
+avdecc          17221/udp # IEEE 1722.1 AVB Discovery, Enumeration, Connection management, and Control [IEEE_1722_1] [Jeffrey_Daniel_Koftinoff] 2011-11-01
+cpsp            17222/udp # Control Plane Synchronization Protocol (SPSP) [Randall_Stewart_2] [Randall_Stewart_2] 2011-11-10
+integrius-stp   17234/tcp # Integrius Secure Tunnel Protocol [Christian_Klemetsson] [Christian_Klemetsson] 2010-03-04
+integrius-stp   17234/udp # Integrius Secure Tunnel Protocol [Christian_Klemetsson] [Christian_Klemetsson] 2010-03-04
+ssh-mgmt        17235/tcp # SSH Tectia Manager [Ville_Laurikari] [Ville_Laurikari] 2005-08
+ssh-mgmt        17235/udp # SSH Tectia Manager [Ville_Laurikari] [Ville_Laurikari] 2005-08
+db-lsp          17500/tcp # Dropbox LanSync Protocol [Paul_Bohm] [Paul_Bohm] 2010-01-21
+db-lsp-disc     17500/udp # Dropbox LanSync Discovery [Paul_Bohm] [Paul_Bohm] 2010-01-21
+ea              17729/tcp # Eclipse Aviation [William_Schmidt] [William_Schmidt] 2006-03
+ea              17729/udp # Eclipse Aviation [William_Schmidt] [William_Schmidt] 2006-03
+zep             17754/tcp # Encap. ZigBee Packets [Fred_Fierling] [Fred_Fierling] 2006-02
+zep             17754/udp # Encap. ZigBee Packets [Fred_Fierling] [Fred_Fierling] 2006-02
+zigbee-ip       17755/tcp # ZigBee IP Transport Service [Chris_Herzog] [Chris_Herzog] 2006-05
+zigbee-ip       17755/udp # ZigBee IP Transport Service [Chris_Herzog] [Chris_Herzog] 2006-05
+zigbee-ips      17756/tcp # ZigBee IP Transport Secure Service [Chris_Herzog] [Chris_Herzog] 2006-05
+zigbee-ips      17756/udp # ZigBee IP Transport Secure Service [Chris_Herzog] [Chris_Herzog] 2006-05
+sw-orion        17777/tcp # SolarWinds Orion [Joel_Dolisy] [Joel_Dolisy] 2008-09-10
+biimenu         18000/tcp # Beckman Instruments, Inc. [R_L_Meyering] [R_L_Meyering]
+biimenu         18000/udp # Beckman Instruments, Inc. [R_L_Meyering] [R_L_Meyering]
+radpdf          18104/tcp # RAD PDF Service [Christopher_Truxaw] [Christopher_Truxaw] 2010-10-15
+racf            18136/tcp # z/OS Resource Access Control Facility [Bruce_Wells] [Bruce_Wells] 2010-10-04
+opsec-cvp       18181/tcp # OPSEC CVP [Alon_Kantor] [Alon_Kantor]
+opsec-cvp       18181/udp # OPSEC CVP [Alon_Kantor] [Alon_Kantor]
+opsec-ufp       18182/tcp # OPSEC UFP [Alon_Kantor] [Alon_Kantor]
+opsec-ufp       18182/udp # OPSEC UFP [Alon_Kantor] [Alon_Kantor]
+opsec-sam       18183/tcp # OPSEC SAM [Alon_Kantor] [Alon_Kantor]
+opsec-sam       18183/udp # OPSEC SAM [Alon_Kantor] [Alon_Kantor]
+opsec-lea       18184/tcp # OPSEC LEA [Alon_Kantor] [Alon_Kantor]
+opsec-lea       18184/udp # OPSEC LEA [Alon_Kantor] [Alon_Kantor]
+opsec-omi       18185/tcp # OPSEC OMI [Alon_Kantor] [Alon_Kantor]
+opsec-omi       18185/udp # OPSEC OMI [Alon_Kantor] [Alon_Kantor]
+ohsc            18186/tcp # Occupational Health SC [David_Fudge] [David_Fudge] 2003-08
+ohsc            18186/udp # Occupational Health Sc [David_Fudge] [David_Fudge] 2003-08
+opsec-ela       18187/tcp # OPSEC ELA [Alon_Kantor] [Alon_Kantor]
+opsec-ela       18187/udp # OPSEC ELA [Alon_Kantor] [Alon_Kantor]
+checkpoint-rtm  18241/tcp # Check Point RTM [Dudi_Hazan] [Dudi_Hazan]
+checkpoint-rtm  18241/udp # Check Point RTM [Dudi_Hazan] [Dudi_Hazan]
+iclid           18242/tcp # Checkpoint router monitoring [Check_Point_Software] [Rahul_Bahadur] 2012-06-28
+clusterxl       18243/tcp # Checkpoint router state backup [Check_Point_Software] [Rahul_Bahadur] 2012-06-28
+gv-pf           18262/tcp # GV NetConfig Service [Scott_Libert] [Scott_Libert] 2008-01-29
+gv-pf           18262/udp # GV NetConfig Service [Scott_Libert] [Scott_Libert] 2008-01-29
+ac-cluster      18463/tcp # AC Cluster [Lisa_Zhong] [Lisa_Zhong]
+ac-cluster      18463/udp # AC Cluster [Lisa_Zhong] [Lisa_Zhong]
+rds-ib          18634/tcp # Reliable Datagram Service [Andy_Grover] [Andy_Grover] 2009-02-27
+rds-ib          18634/udp # Reliable Datagram Service [Andy_Grover] [Andy_Grover] 2009-02-27
+rds-ip          18635/tcp # Reliable Datagram Service over IP [Andy_Grover] [Andy_Grover] 2009-05-20
+rds-ip          18635/udp # Reliable Datagram Service over IP [Andy_Grover] [Andy_Grover] 2009-05-20
+ique            18769/tcp # IQue Protocol [Avi_Drissman] [Avi_Drissman] 2002-07
+ique            18769/udp # IQue Protocol [Avi_Drissman] [Avi_Drissman] 2002-07
+infotos         18881/tcp # Infotos [Marcel_Dube] [Marcel_Dube] 2004-11
+infotos         18881/udp # Infotos [Marcel_Dube] [Marcel_Dube] 2004-11
+apc-necmp       18888/tcp # APCNECMP [Michael_Yip] [Michael_Yip]
+apc-necmp       18888/udp # APCNECMP [Michael_Yip] [Michael_Yip]
+igrid           19000/tcp # iGrid Server [Massimo_Cafaro] [Massimo_Cafaro] 2004-11
+igrid           19000/udp # iGrid Server [Massimo_Cafaro] [Massimo_Cafaro] 2004-11
+j-link          19020/tcp # J-Link TCP/IP Protocol [SEGGER] [SEGGER]
+opsec-uaa       19191/tcp # OPSEC UAA [Reuven_Harrison] [Reuven_Harrison]
+opsec-uaa       19191/udp # OPSEC UAA [Reuven_Harrison] [Reuven_Harrison]
+ua-secureagent  19194/tcp # UserAuthority SecureAgent [Reuven_Harrison_2] [Reuven_Harrison_2] 2003-01
+ua-secureagent  19194/udp # UserAuthority SecureAgent [Reuven_Harrison_2] [Reuven_Harrison_2] 2003-01
+keysrvr         19283/tcp # Key Server for SASSAFRAS [Mark_Valence] [Mark_Valence]
+keysrvr         19283/udp # Key Server for SASSAFRAS [Mark_Valence] [Mark_Valence]
+keyshadow       19315/tcp # Key Shadow for SASSAFRAS [Mark_Valence] [Mark_Valence]
+keyshadow       19315/udp # Key Shadow for SASSAFRAS [Mark_Valence] [Mark_Valence]
+mtrgtrans       19398/tcp # mtrgtrans [Katsuhito_Muroi] [Katsuhito_Muroi]
+mtrgtrans       19398/udp # mtrgtrans [Katsuhito_Muroi] [Katsuhito_Muroi]
+hp-sco          19410/tcp # hp-sco [Larry_Schwartz] [Larry_Schwartz]
+hp-sco          19410/udp # hp-sco [Larry_Schwartz] [Larry_Schwartz]
+hp-sca          19411/tcp # hp-sca [Larry_Schwartz] [Larry_Schwartz]
+hp-sca          19411/udp # hp-sca [Larry_Schwartz] [Larry_Schwartz]
+hp-sessmon      19412/tcp # HP-SESSMON [Gita_Murthy] [Gita_Murthy]
+hp-sessmon      19412/udp # HP-SESSMON [Gita_Murthy] [Gita_Murthy]
+fxuptp          19539/tcp # FXUPTP [Keiji_Okuma] [Keiji_Okuma] 2005-08
+fxuptp          19539/udp # FXUPTP [Keiji_Okuma] [Keiji_Okuma] 2005-08
+sxuptp          19540/tcp # SXUPTP [Keiji_Okuma] [Keiji_Okuma] 2002-08
+sxuptp          19540/udp # SXUPTP [Keiji_Okuma] [Keiji_Okuma] 2002-08
+jcp             19541/tcp # JCP Client [Yuji_Sasaki] [Yuji_Sasaki]
+jcp             19541/udp # JCP Client [Yuji_Sasaki] [Yuji_Sasaki]
+mle             19788/udp # Mesh Link Establishment [IESG] [IETF_Chair] 2012-12-18
+iec-104-sec     19998/tcp # IEC 60870-5-104 process control - secure [Grant_Gilchrist] [Grant_Gilchrist] 2010-10-18
+dnp-sec         19999/tcp # Distributed Network Protocol - Secure [Grant_Gilchrist] [Grant_Gilchrist] 2008-08-04
+dnp-sec         19999/udp # Distributed Network Protocol - Secure [Grant_Gilchrist] [Grant_Gilchrist] 2008-08-04
+dnp             20000/tcp # DNP [Michael_Thesing] [Michael_Thesing]
+dnp             20000/udp # DNP [Michael_Thesing] [Michael_Thesing]
+microsan        20001/tcp # MicroSAN [Thomas_E_Ludwig] [Thomas_E_Ludwig] 2004-02
+microsan        20001/udp # MicroSAN [Thomas_E_Ludwig] [Thomas_E_Ludwig] 2004-02
+commtact-http   20002/tcp # Commtact HTTP [Tomas_Svoboda] [Tomas_Svoboda] 2004-12
+commtact-http   20002/udp # Commtact HTTP [Tomas_Svoboda] [Tomas_Svoboda] 2004-12
+commtact-https  20003/tcp # Commtact HTTPS [Tomas_Svoboda] [Tomas_Svoboda] 2004-12
+commtact-https  20003/udp # Commtact HTTPS [Tomas_Svoboda] [Tomas_Svoboda] 2004-12
+openwebnet      20005/tcp # OpenWebNet protocol for electric network [BTicino_S_p_A] [BTicino_S_p_A] 2008-04-09
+openwebnet      20005/udp # OpenWebNet protocol for electric network [BTicino_S_p_A] [BTicino_S_p_A] 2008-04-09
+ss-idi-disc     20012/udp # Samsung Interdevice Interaction discovery [Hong_Jungkih] [Hong_Jungkih]
+ss-idi          20013/tcp # Samsung Interdevice Interaction [Hong_Jungkih] [Hong_Jungkih]
+opendeploy      20014/tcp # OpenDeploy Listener [Todd_Scallan] [Todd_Scallan] 2005-08
+opendeploy      20014/udp # OpenDeploy Listener [Todd_Scallan] [Todd_Scallan] 2005-08
+nburn-id        20034/tcp # NetBurner ID PortIANA assigned this well-formed service name as a replacement for "nburn_id". [Paul_Breed] [Paul_Breed] 2003-11
+nburn_id        20034/tcp # NetBurner ID Port [Paul_Breed] [Paul_Breed] 2003-11 This entry is an alias to "nburn-id".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+nburn-id        20034/udp # NetBurner ID PortIANA assigned this well-formed service name as a replacement for "nburn_id". [Paul_Breed] [Paul_Breed] 2003-11
+nburn_id        20034/udp # NetBurner ID Port [Paul_Breed] [Paul_Breed] 2003-11 This entry is an alias to "nburn-id".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+tmophl7mts      20046/tcp # TMOP HL7 Message Transfer Service [Tim_Riley] [Tim_Riley] 2009-07-31
+tmophl7mts      20046/udp # TMOP HL7 Message Transfer Service [Tim_Riley] [Tim_Riley] 2009-07-31
+mountd          20048/tcp # NFS mount protocol [Nicolas_Williams] [Nicolas_Williams] 2010-08-09
+mountd          20048/udp # NFS mount protocol [Nicolas_Williams] [Nicolas_Williams] 2010-08-09
+nfsrdma         20049/tcp # Network File System (NFS) over RDMA [RFC5666]
+nfsrdma         20049/udp # Network File System (NFS) over RDMA [RFC5666]
+nfsrdma         20049/sctp # Network File System (NFS) over RDMA [RFC5666]
+tolfab          20167/tcp # TOLfab Data Change [Pierre_Couderc] [Pierre_Couderc] 2006-03
+tolfab          20167/udp # TOLfab Data Change [Pierre_Couderc] [Pierre_Couderc] 2006-03
+ipdtp-port      20202/tcp # IPD Tunneling Port [Vikki_Yin_Wei] [Vikki_Yin_Wei] 2003-01
+ipdtp-port      20202/udp # IPD Tunneling Port [Vikki_Yin_Wei] [Vikki_Yin_Wei] 2003-01
+ipulse-ics      20222/tcp # iPulse-ICS [Meggie_Garica_Woodru] [Meggie_Garica_Woodru]
+ipulse-ics      20222/udp # iPulse-ICS [Meggie_Garica_Woodru] [Meggie_Garica_Woodru]
+emwavemsg       20480/tcp # emWave Message Service [Harald_Striepe] [Harald_Striepe] 2008-02-14
+emwavemsg       20480/udp # emWave Message Service [Harald_Striepe] [Harald_Striepe] 2008-02-14
+track           20670/tcp # Track [Michael_Sweet] [Michael_Sweet]
+track           20670/udp # Track [Michael_Sweet] [Michael_Sweet]
+athand-mmp      20999/tcp # At Hand MMP [Stepan_Riha] [Stepan_Riha]
+athand-mmp      20999/udp # AT Hand MMP [Stepan_Riha] [Stepan_Riha]
+irtrans         21000/tcp # IRTrans Control [Marcus_Mueller] [Marcus_Mueller] 2004-11
+irtrans         21000/udp # IRTrans Control [Marcus_Mueller] [Marcus_Mueller] 2004-11
+notezilla-lan   21010/tcp # Notezilla.Lan Server [Conceptworld_Corporation] [Gautam_Jain] 2013-08-20
+rdm-tfs         21553/tcp # Raima RDM TFS [Paul_Johnson] [Paul_Johnson] 2011-05-02
+dfserver        21554/tcp # MineScape Design File Server [Michael_Purser] [Michael_Purser] 2006-06
+dfserver        21554/udp # MineScape Design File Server [Michael_Purser] [Michael_Purser] 2006-06
+vofr-gateway    21590/tcp # VoFR Gateway [Marty_Borden] [Marty_Borden]
+vofr-gateway    21590/udp # VoFR Gateway [Marty_Borden] [Marty_Borden]
+tvpm            21800/tcp # TVNC Pro Multiplexing [Brian_Blevins] [Brian_Blevins]
+tvpm            21800/udp # TVNC Pro Multiplexing [Brian_Blevins] [Brian_Blevins]
+webphone        21845/tcp # webphone [Toby_Hosterman] [Toby_Hosterman]
+webphone        21845/udp # webphone [Toby_Hosterman] [Toby_Hosterman]
+netspeak-is     21846/tcp # NetSpeak Corp. Directory Services [Toby_Hosterman] [Toby_Hosterman]
+netspeak-is     21846/udp # NetSpeak Corp. Directory Services [Toby_Hosterman] [Toby_Hosterman]
+netspeak-cs     21847/tcp # NetSpeak Corp. Connection Services [Toby_Hosterman] [Toby_Hosterman]
+netspeak-cs     21847/udp # NetSpeak Corp. Connection Services [Toby_Hosterman] [Toby_Hosterman]
+netspeak-acd    21848/tcp # NetSpeak Corp. Automatic Call Distribution [Toby_Hosterman] [Toby_Hosterman]
+netspeak-acd    21848/udp # NetSpeak Corp. Automatic Call Distribution [Toby_Hosterman] [Toby_Hosterman]
+netspeak-cps    21849/tcp # NetSpeak Corp. Credit Processing System [Toby_Hosterman] [Toby_Hosterman]
+netspeak-cps    21849/udp # NetSpeak Corp. Credit Processing System [Toby_Hosterman] [Toby_Hosterman]
+snapenetio      22000/tcp # SNAPenetIO [Kevin_Kuhns] [Kevin_Kuhns]
+snapenetio      22000/udp # SNAPenetIO [Kevin_Kuhns] [Kevin_Kuhns]
+optocontrol     22001/tcp # OptoControl [Kevin_Kuhns] [Kevin_Kuhns]
+optocontrol     22001/udp # OptoControl [Kevin_Kuhns] [Kevin_Kuhns]
+optohost002     22002/tcp # Opto Host Port 2 [Doug_Leany] [Doug_Leany] 2006-09
+optohost002     22002/udp # Opto Host Port 2 [Doug_Leany] [Doug_Leany] 2006-09
+optohost003     22003/tcp # Opto Host Port 3 [Doug_Leany] [Doug_Leany] 2006-09
+optohost003     22003/udp # Opto Host Port 3 [Doug_Leany] [Doug_Leany] 2006-09
+optohost004     22004/tcp # Opto Host Port 4 [Doug_Leany] [Doug_Leany] 2006-09
+optohost004     22004/udp # Opto Host Port 4 [Doug_Leany] [Doug_Leany] 2006-09
+optohost004     22005/tcp # Opto Host Port 5 [Doug_Leany] [Doug_Leany] 2006-09
+optohost004     22005/udp # Opto Host Port 5 [Doug_Leany] [Doug_Leany] 2006-09
+dcap            22125/tcp # dCache Access Protocol [Christoph_Anton_Mitt] [Christoph_Anton_Mitt] 2009-03-10
+gsidcap         22128/tcp # GSI dCache Access Protocol [Christoph_Anton_Mitt] [Christoph_Anton_Mitt] 2009-03-10
+wnn6            22273/tcp # wnn6 [Yasunari_Gon_Yamasit] [Yasunari_Gon_Yamasit]
+wnn6            22273/udp # wnn6 [Yasunari_Gon_Yamasit] [Yasunari_Gon_Yamasit]
+cis             22305/tcp # CompactIS Tunnel [Justin_Paupore] [Justin_Paupore] 2007-08-16
+cis             22305/udp # CompactIS Tunnel [Justin_Paupore] [Justin_Paupore] 2007-08-16
+cis-secure      22343/tcp # CompactIS Secure Tunnel [Justin_Paupore] [Justin_Paupore] 2007-08-16
+cis-secure      22343/udp # CompactIS Secure Tunnel [Justin_Paupore] [Justin_Paupore] 2007-08-16
+wibukey         22347/tcp # WibuKey Standard WkLan [Wolfgang_Voelker] [Wolfgang_Voelker] 2007-06
+wibukey         22347/udp # WibuKey Standard WkLan [Wolfgang_Voelker] [Wolfgang_Voelker] 2007-06
+codemeter       22350/tcp # CodeMeter Standard [Wolfgang_Voelker] [Wolfgang_Voelker] 2007-06
+codemeter       22350/udp # CodeMeter Standard [Wolfgang_Voelker] [Wolfgang_Voelker] 2007-06
+codemeter-cmwan 22351/tcp # TPC/IP requests of copy protection software to a server [WIBU-SYSTEMS_AG] [Wolfgang_Völker_2] 2013-06-25
+caldsoft-backup 22537/tcp # CaldSoft Backup server file transfer [CaldSoft] [Mark_Caldwell] 2011-08-12
+vocaltec-wconf  22555/tcp # Vocaltec Web Conference [Scott_Petrack] [Scott_Petrack]
+vocaltec-phone  22555/udp # Vocaltec Internet Phone [Scott_Petrack] [Scott_Petrack]
+talikaserver    22763/tcp # Talika Main Server [Laxman_C_Marathe] [Laxman_C_Marathe] 2006-12
+talikaserver    22763/udp # Talika Main Server [Laxman_C_Marathe] [Laxman_C_Marathe] 2006-12
+aws-brf         22800/tcp # Telerate Information Platform LAN [Timo_Sivonen] [Timo_Sivonen]
+aws-brf         22800/udp # Telerate Information Platform LAN [Timo_Sivonen] [Timo_Sivonen]
+brf-gw          22951/tcp # Telerate Information Platform WAN [Timo_Sivonen] [Timo_Sivonen]
+brf-gw          22951/udp # Telerate Information Platform WAN [Timo_Sivonen] [Timo_Sivonen]
+inovaport1      23000/tcp # Inova LightLink Server Type 1 [Chris_Koeritz_3] [Chris_Koeritz_3] 2006-10
+inovaport1      23000/udp # Inova LightLink Server Type 1 [Chris_Koeritz_3] [Chris_Koeritz_3] 2006-10
+inovaport2      23001/tcp # Inova LightLink Server Type 2 [Chris_Koeritz_3] [Chris_Koeritz_3] 2006-10
+inovaport2      23001/udp # Inova LightLink Server Type 2 [Chris_Koeritz_3] [Chris_Koeritz_3] 2006-10
+inovaport3      23002/tcp # Inova LightLink Server Type 3 [Chris_Koeritz_3] [Chris_Koeritz_3] 2006-10
+inovaport3      23002/udp # Inova LightLink Server Type 3 [Chris_Koeritz_3] [Chris_Koeritz_3] 2006-10
+inovaport4      23003/tcp # Inova LightLink Server Type 4 [Chris_Koeritz_3] [Chris_Koeritz_3] 2006-10
+inovaport4      23003/udp # Inova LightLink Server Type 4 [Chris_Koeritz_3] [Chris_Koeritz_3] 2006-10
+inovaport5      23004/tcp # Inova LightLink Server Type 5 [Chris_Koeritz_3] [Chris_Koeritz_3] 2006-10
+inovaport5      23004/udp # Inova LightLink Server Type 5 [Chris_Koeritz_3] [Chris_Koeritz_3] 2006-10
+inovaport6      23005/tcp # Inova LightLink Server Type 6 [Chris_Koeritz_3] [Chris_Koeritz_3] 2006-10
+inovaport6      23005/udp # Inova LightLink Server Type 6 [Chris_Koeritz_3] [Chris_Koeritz_3] 2006-10
+gntp            23053/tcp # Generic Notification Transport Protocol [Growl_Project] [Chris_Forsythe] 2012-02-07
+s102            23272/udp # S102 application [Kimmo_Kymalainen] [Kimmo_Kymalainen] 2009-08-26
+elxmgmt         23333/tcp # Emulex HBAnyware Remote Management [Maziar_Tamadon] [Maziar_Tamadon] 2007-11-06
+elxmgmt         23333/udp # Emulex HBAnyware Remote Management [Maziar_Tamadon] [Maziar_Tamadon] 2007-11-06
+novar-dbase     23400/tcp # Novar Data [Keith_Kilroy] [Keith_Kilroy] 2006-02
+novar-dbase     23400/udp # Novar Data [Keith_Kilroy] [Keith_Kilroy] 2006-02
+novar-alarm     23401/tcp # Novar Alarm [Keith_Kilroy] [Keith_Kilroy] 2006-02
+novar-alarm     23401/udp # Novar Alarm [Keith_Kilroy] [Keith_Kilroy] 2006-02
+novar-global    23402/tcp # Novar Global [Keith_Kilroy] [Keith_Kilroy] 2006-02
+novar-global    23402/udp # Novar Global [Keith_Kilroy] [Keith_Kilroy] 2006-02
+aequus          23456/tcp # Aequus Service [James_Anson] [James_Anson] 2009-02-12
+aequus-alt      23457/tcp # Aequus Service Mgmt [James_Anson] [James_Anson] 2009-02-12
+areaguard-neo   23546/tcp # AreaGuard Neo - WebServer [SODATSW_spol] [Roman_Štěpánek] 2012-05-31
+med-ltp         24000/tcp # med-ltp [Juergen_Fischbach] [Juergen_Fischbach]
+med-ltp         24000/udp # med-ltp [Juergen_Fischbach] [Juergen_Fischbach]
+med-fsp-rx      24001/tcp # med-fsp-rx [Juergen_Fischbach] [Juergen_Fischbach]
+med-fsp-rx      24001/udp # med-fsp-rx [Juergen_Fischbach] [Juergen_Fischbach]
+med-fsp-tx      24002/tcp # med-fsp-tx [Juergen_Fischbach] [Juergen_Fischbach]
+med-fsp-tx      24002/udp # med-fsp-tx [Juergen_Fischbach] [Juergen_Fischbach]
+med-supp        24003/tcp # med-supp [Juergen_Fischbach] [Juergen_Fischbach]
+med-supp        24003/udp # med-supp [Juergen_Fischbach] [Juergen_Fischbach]
+med-ovw         24004/tcp # med-ovw [Juergen_Fischbach] [Juergen_Fischbach]
+med-ovw         24004/udp # med-ovw [Juergen_Fischbach] [Juergen_Fischbach]
+med-ci          24005/tcp # med-ci [Juergen_Fischbach] [Juergen_Fischbach]
+med-ci          24005/udp # med-ci [Juergen_Fischbach] [Juergen_Fischbach]
+med-net-svc     24006/tcp # med-net-svc [Juergen_Fischbach] [Juergen_Fischbach]
+med-net-svc     24006/udp # med-net-svc [Juergen_Fischbach] [Juergen_Fischbach]
+filesphere      24242/tcp # fileSphere [Carl_Cedergren] [Carl_Cedergren]
+filesphere      24242/udp # fileSphere [Carl_Cedergren] [Carl_Cedergren]
+vista-4gl       24249/tcp # Vista 4GL [Mark_Itzcovitz] [Mark_Itzcovitz]
+vista-4gl       24249/udp # Vista 4GL [Mark_Itzcovitz] [Mark_Itzcovitz]
+ild             24321/tcp # Isolv Local Directory [Mitchell_Bass] [Mitchell_Bass] 2005-08
+ild             24321/udp # Isolv Local Directory [Mitchell_Bass] [Mitchell_Bass] 2005-08
+hid             24322/udp # Transport of Human Interface Device data streams [Freebox_SAS] [Nicolas_Pouillon] 2012-12-14
+intel-rci       24386/tcp # Intel RCIIANA assigned this well-formed service name as a replacement for "intel_rci". [Mark_Lewis_2] [Mark_Lewis_2]
+intel_rci       24386/tcp # Intel RCI [Mark_Lewis_2] [Mark_Lewis_2] This entry is an alias to "intel-rci".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+intel-rci       24386/udp # Intel RCIIANA assigned this well-formed service name as a replacement for "intel_rci". [Mark_Lewis_2] [Mark_Lewis_2]
+intel_rci       24386/udp # Intel RCI [Mark_Lewis_2] [Mark_Lewis_2] This entry is an alias to "intel-rci".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+tonidods        24465/tcp # Tonido Domain Server [Madhan_Kanagavel] [Madhan_Kanagavel] 2008-07-18
+tonidods        24465/udp # Tonido Domain Server [Madhan_Kanagavel] [Madhan_Kanagavel] 2008-07-18
+binkp           24554/tcp # BINKP [Max_Masyutin] [Max_Masyutin]
+binkp           24554/udp # BINKP [Max_Masyutin] [Max_Masyutin]
+canditv         24676/tcp # Canditv Message Service [Gary_Aston] [Gary_Aston] 2009-03-10
+canditv         24676/udp # Canditv Message Service [Gary_Aston] [Gary_Aston] 2009-03-10
+flashfiler      24677/tcp # FlashFiler [Ben_Oram] [Ben_Oram]
+flashfiler      24677/udp # FlashFiler [Ben_Oram] [Ben_Oram]
+proactivate     24678/tcp # Turbopower Proactivate [Ben_Oram] [Ben_Oram]
+proactivate     24678/udp # Turbopower Proactivate [Ben_Oram] [Ben_Oram]
+tcc-http        24680/tcp # TCC User HTTP Service [Brian_Kennedy] [Brian_Kennedy] 2006-08
+tcc-http        24680/udp # TCC User HTTP Service [Brian_Kennedy] [Brian_Kennedy] 2006-08
+cslg            24754/tcp # Citrix StorageLink Gateway [Mark_Nijmeijer] [Mark_Nijmeijer] 2009-04-17
+assoc-disc      24850/udp # Device Association Discovery [Microsoft_Corporation_3] [Sachin_Sheth] 2012-06-27
+find            24922/tcp # Find Identification of Network Devices [Jean_Paul_Moreaux] [Jean_Paul_Moreaux]
+find            24922/udp # Find Identification of Network Devices [Jean_Paul_Moreaux] [Jean_Paul_Moreaux]
+icl-twobase1    25000/tcp # icl-twobase1 [J_A_Sever] [J_A_Sever]
+icl-twobase1    25000/udp # icl-twobase1 [J_A_Sever] [J_A_Sever]
+icl-twobase2    25001/tcp # icl-twobase2 [J_A_Sever] [J_A_Sever]
+icl-twobase2    25001/udp # icl-twobase2 [J_A_Sever] [J_A_Sever]
+icl-twobase3    25002/tcp # icl-twobase3 [J_A_Sever] [J_A_Sever]
+icl-twobase3    25002/udp # icl-twobase3 [J_A_Sever] [J_A_Sever]
+icl-twobase4    25003/tcp # icl-twobase4 [J_A_Sever] [J_A_Sever]
+icl-twobase4    25003/udp # icl-twobase4 [J_A_Sever] [J_A_Sever]
+icl-twobase5    25004/tcp # icl-twobase5 [J_A_Sever] [J_A_Sever]
+icl-twobase5    25004/udp # icl-twobase5 [J_A_Sever] [J_A_Sever]
+icl-twobase6    25005/tcp # icl-twobase6 [J_A_Sever] [J_A_Sever]
+icl-twobase6    25005/udp # icl-twobase6 [J_A_Sever] [J_A_Sever]
+icl-twobase7    25006/tcp # icl-twobase7 [J_A_Sever] [J_A_Sever]
+icl-twobase7    25006/udp # icl-twobase7 [J_A_Sever] [J_A_Sever]
+icl-twobase8    25007/tcp # icl-twobase8 [J_A_Sever] [J_A_Sever]
+icl-twobase8    25007/udp # icl-twobase8 [J_A_Sever] [J_A_Sever]
+icl-twobase9    25008/tcp # icl-twobase9 [J_A_Sever] [J_A_Sever]
+icl-twobase9    25008/udp # icl-twobase9 [J_A_Sever] [J_A_Sever]
+icl-twobase10   25009/tcp # icl-twobase10 [J_A_Sever] [J_A_Sever]
+icl-twobase10   25009/udp # icl-twobase10 [J_A_Sever] [J_A_Sever]
+rna             25471/sctp # RNSAP User Adaptation for Iurh [Dario_S_Tonesi] [Dario_S_Tonesi] 2011-02-07
+sauterdongle    25576/tcp # Sauter Dongle [Christian_Brecht] [Christian_Brecht] 2010-12-15
+idtp            25604/tcp # Identifier Tracing Protocol [Huang_Neng-geng] [Huang_Neng-geng] 2011-08-09
+vocaltec-hos    25793/tcp # Vocaltec Address Server [Scott_Petrack] [Scott_Petrack]
+vocaltec-hos    25793/udp # Vocaltec Address Server [Scott_Petrack] [Scott_Petrack]
+tasp-net        25900/tcp # TASP Network Comm [Martin_Ellis] [Martin_Ellis] 2004-11
+tasp-net        25900/udp # TASP Network Comm [Martin_Ellis] [Martin_Ellis] 2004-11
+niobserver      25901/tcp # NIObserver [Roman_Oliynyk] [Roman_Oliynyk]
+niobserver      25901/udp # NIObserver [Roman_Oliynyk] [Roman_Oliynyk]
+nilinkanalyst   25902/tcp # NILinkAnalyst [Roman_Oliynyk_2] [Roman_Oliynyk_2] 2007-08-30
+nilinkanalyst   25902/udp # NILinkAnalyst [Roman_Oliynyk_2] [Roman_Oliynyk_2] 2007-08-30
+niprobe         25903/tcp # NIProbe [Roman_Oliynyk] [Roman_Oliynyk]
+niprobe         25903/udp # NIProbe [Roman_Oliynyk] [Roman_Oliynyk]
+bf-game         25954/udp # Bitfighter game server [Christopher_Eykamp] [Christopher_Eykamp] 2012-08-16
+bf-master       25955/udp # Bitfighter master server [Christopher_Eykamp] [Christopher_Eykamp] 2012-08-16
+quake           26000/tcp # quake [Yasunari_Gon_Yamasit] [Yasunari_Gon_Yamasit]
+quake           26000/udp # quake [Yasunari_Gon_Yamasit] [Yasunari_Gon_Yamasit]
+scscp           26133/tcp # Symbolic Computation Software Composability Protocol [Alexander_Konovalov] [Alexander_Konovalov] 2007-11-27
+scscp           26133/udp # Symbolic Computation Software Composability Protocol [Alexander_Konovalov] [Alexander_Konovalov] 2007-11-27
+wnn6-ds         26208/tcp # wnn6-ds [Yasunari_Gon_Yamasit] [Yasunari_Gon_Yamasit]
+wnn6-ds         26208/udp # wnn6-ds [Yasunari_Gon_Yamasit] [Yasunari_Gon_Yamasit]
+ezproxy         26260/tcp # eZproxy [Albert_C_Yang] [Albert_C_Yang]
+ezproxy         26260/udp # eZproxy [Albert_C_Yang] [Albert_C_Yang]
+ezmeeting       26261/tcp # eZmeeting [Albert_C_Yang] [Albert_C_Yang]
+ezmeeting       26261/udp # eZmeeting [Albert_C_Yang] [Albert_C_Yang]
+k3software-svr  26262/tcp # K3 Software-Server [Jim_Baldridge] [Jim_Baldridge]
+k3software-svr  26262/udp # K3 Software-Server [Jim_Baldridge] [Jim_Baldridge]
+k3software-cli  26263/tcp # K3 Software-Client [Jim_Baldridge] [Jim_Baldridge]
+k3software-cli  26263/udp # K3 Software-Client [Jim_Baldridge] [Jim_Baldridge]
+exoline-tcp     26486/tcp # EXOline-TCP [Lars_Mattsson] [Lars_Mattsson] 2008-12-24
+exoline-udp     26486/udp # EXOline-UDP [Lars_Mattsson] [Lars_Mattsson] 2008-12-24
+exoconfig       26487/tcp # EXOconfig [Urban_Fosseus] [Urban_Fosseus] 2008-12-24
+exoconfig       26487/udp # EXOconfig [Urban_Fosseus] [Urban_Fosseus] 2008-12-24
+exonet          26489/tcp # EXOnet [Urban_Fosseus] [Urban_Fosseus] 2008-12-24
+exonet          26489/udp # EXOnet [Urban_Fosseus] [Urban_Fosseus] 2008-12-24
+imagepump       27345/tcp # ImagePump [Richard_Minner] [Richard_Minner]
+imagepump       27345/udp # ImagePump [Richard_Minner] [Richard_Minner]
+jesmsjc         27442/tcp # Job controller service [Chris_Newman] [Chris_Newman] 2010-10-15
+jesmsjc         27442/udp # Job controller service [Chris_Newman] [Chris_Newman] 2010-10-15
+kopek-httphead  27504/tcp # Kopek HTTP Head Port [Sten_H_Danielsen] [Sten_H_Danielsen] 2002-07
+kopek-httphead  27504/udp # Kopek HTTP Head Port [Sten_H_Danielsen] [Sten_H_Danielsen] 2002-07
+ars-vista       27782/tcp # ARS VISTA Application [Spencer_Teran_2] [Spencer_Teran_2] 2004-11
+ars-vista       27782/udp # ARS VISTA Application [Spencer_Teran_2] [Spencer_Teran_2] 2004-11
+astrolink       27876/tcp # Astrolink Protocol [Alanax_Technologies_Inc] [Wesley_Eddy] 2013-01-14
+tw-auth-key     27999/tcp # TW Authentication/Key Distribution and [Alex_Duncan_2] [Alex_Duncan_2]
+tw-auth-key     27999/udp # Attribute Certificate Services [Alex_Duncan_2] [Alex_Duncan_2]
+nxlmd           28000/tcp # NX License Manager [Anthony_Greatorex] [Anthony_Greatorex] 2004-11 Unauthorized Use Known on port 28000
+nxlmd           28000/udp # NX License Manager [Anthony_Greatorex] [Anthony_Greatorex] 2004-11
+pqsp            28001/tcp # PQ Service [Peter_Laschtowitz] [Peter_Laschtowitz] 2009-09-15
+a27-ran-ran     28119/udp # A27 cdma2000 RAN Management [ThreeGPP2] [Zhiming_Li] 2012-04-13
+voxelstorm      28200/tcp # VoxelStorm game server [VoxelStorm] [Eugene_Hopkinson] 2012-11-08
+voxelstorm      28200/udp # VoxelStorm game server [VoxelStorm] [Eugene_Hopkinson] 2012-11-08
+siemensgsm      28240/tcp # Siemens GSM [David_Anuszewski] [David_Anuszewski] 2004-11
+siemensgsm      28240/udp # Siemens GSM [David_Anuszewski] [David_Anuszewski] 2004-11
+sgsap           29118/sctp # SGsAP in 3GPP [GPP_Specifications] [GPP_Specifications] 2009-06-11
+otmp            29167/tcp # ObTools Message Protocol [Paul_Clark] [Paul_Clark] 2006-02
+otmp            29167/udp # ObTools Message Protocol [Paul_Clark] [Paul_Clark] 2006-02
+sbcap           29168/sctp # SBcAP in 3GPP [GPP_Specifications] [GPP_Specifications] 2009-06-11
+iuhsctpassoc    29169/sctp # HNBAP and RUA Common Association [John_Meredith] [John_Meredith] 2009-09-08
+bingbang        29999/tcp # data exchange protocol for IEC61850 in wind power plants [DEIF_AS] [Armin_Solies] 2012-10-15
+ndmps           30000/tcp # Secure Network Data Management Protocol [Alioune_Thiam] [Alioune_Thiam] 2013-02-05
+pago-services1  30001/tcp # Pago Services 1 [Balduin_Mueller_Plat] [Balduin_Mueller_Plat] 2002-03
+pago-services1  30001/udp # Pago Services 1 [Balduin_Mueller_Plat] [Balduin_Mueller_Plat] 2002-03
+pago-services2  30002/tcp # Pago Services 2 [Balduin_Mueller_Plat] [Balduin_Mueller_Plat] 2002-03
+pago-services2  30002/udp # Pago Services 2 [Balduin_Mueller_Plat] [Balduin_Mueller_Plat] 2002-03
+amicon-fpsu-ra  30003/tcp # Amicon FPSU-IP Remote Administration [Amicon_OOO] [Alexey_Novotorzhin] 2013-04-25
+amicon-fpsu-ra  30003/udp # Amicon FPSU-IP Remote Administration [Amicon_OOO] [Alexey_Novotorzhin] 2013-04-25
+amicon-fpsu-s   30004/udp # Amicon FPSU-IP VPN [Amicon_OOO] [Alexey_Novotorzhin] 2013-04-25
+kingdomsonline  30260/tcp # Kingdoms Online (CraigAvenue) [Drake_Bankston] [Drake_Bankston] 2009-08-18
+kingdomsonline  30260/udp # Kingdoms Online (CraigAvenue) [Drake_Bankston] [Drake_Bankston] 2009-08-18
+samsung-disc    30832/udp # Samsung Convergence Discovery Protocol [Samsung_2] [Young_Ki_Kim] 2013-05-29
+ovobs           30999/tcp # OpenView Service Desk Client [Service_Desk_Product] [Service_Desk_Product] 2006-05
+ovobs           30999/udp # OpenView Service Desk Client [Service_Desk_Product] [Service_Desk_Product] 2006-05
+autotrac-acp    31020/tcp # Autotrac ACP 245 [Roberto_Jorge_Dino] [Roberto_Jorge_Dino]
+yawn            31029/udp # YaWN - Yet Another Windows Notifier [David_Spivey] [David_Spivey] 2010-08-30
+xqosd           31416/tcp # XQoS network monitor [Joe_Elliott] [Joe_Elliott] 2002-06
+xqosd           31416/udp # XQoS network monitor [Joe_Elliott] [Joe_Elliott] 2002-06
+tetrinet        31457/tcp # TetriNET Protocol [Emmanuel_Bourg] [Emmanuel_Bourg] 2004-11
+tetrinet        31457/udp # TetriNET Protocol [Emmanuel_Bourg] [Emmanuel_Bourg] 2004-11
+lm-mon          31620/tcp # lm mon [System_Administrator] [System_Administrator] 2003-06
+lm-mon          31620/udp # lm mon [System_Administrator] [System_Administrator] 2003-06
+dsx-monitor     31685/tcp # DS Expert MonitorIANA assigned this well-formed service name as a replacement for "dsx_monitor". [John_Lowery] [John_Lowery] 2008-08-21
+dsx_monitor     31685/tcp # DS Expert Monitor [John_Lowery] [John_Lowery] 2008-08-21 This entry is an alias to "dsx-monitor".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+gamesmith-port  31765/tcp # GameSmith Port [Randy_Thompson] [Randy_Thompson] 2002-08
+gamesmith-port  31765/udp # GameSmith Port [Randy_Thompson] [Randy_Thompson] 2002-08
+iceedcp-tx      31948/tcp # Embedded Device Configuration Protocol TXIANA assigned this well-formed service name as a replacement for "iceedcp_tx". [Oliver_Lewis] [Oliver_Lewis] 2006-08
+iceedcp_tx      31948/tcp # Embedded Device Configuration Protocol TX [Oliver_Lewis] [Oliver_Lewis] 2006-08 This entry is an alias to "iceedcp-tx".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+iceedcp-tx      31948/udp # Embedded Device Configuration Protocol TXIANA assigned this well-formed service name as a replacement for "iceedcp_tx". [Oliver_Lewis] [Oliver_Lewis] 2006-08
+iceedcp_tx      31948/udp # Embedded Device Configuration Protocol TX [Oliver_Lewis] [Oliver_Lewis] 2006-08 This entry is an alias to "iceedcp-tx".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+iceedcp-rx      31949/tcp # Embedded Device Configuration Protocol RXIANA assigned this well-formed service name as a replacement for "iceedcp_rx". [Oliver_Lewis] [Oliver_Lewis] 2006-08
+iceedcp_rx      31949/tcp # Embedded Device Configuration Protocol RX [Oliver_Lewis] [Oliver_Lewis] 2006-08 This entry is an alias to "iceedcp-rx".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+iceedcp-rx      31949/udp # Embedded Device Configuration Protocol RXIANA assigned this well-formed service name as a replacement for "iceedcp_rx". [Oliver_Lewis] [Oliver_Lewis] 2006-08
+iceedcp_rx      31949/udp # Embedded Device Configuration Protocol RX [Oliver_Lewis] [Oliver_Lewis] 2006-08 This entry is an alias to "iceedcp-rx".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+iracinghelper   32034/tcp # iRacing helper service [Randy_Cassidy] [Randy_Cassidy] 2007-08-30
+iracinghelper   32034/udp # iRacing helper service [Randy_Cassidy] [Randy_Cassidy] 2007-08-30
+t1distproc60    32249/tcp # T1 Distributed Processor [Peter_Beahan] [Peter_Beahan] 2004-11
+t1distproc60    32249/udp # T1 Distributed Processor [Peter_Beahan] [Peter_Beahan] 2004-11
+apm-link        32483/tcp # Access Point Manager Link [Tony_Diodato] [Tony_Diodato] 2005-08
+apm-link        32483/udp # Access Point Manager Link [Tony_Diodato] [Tony_Diodato] 2005-08
+sec-ntb-clnt    32635/tcp # SecureNotebook-CLNT [Eric_Cantineau] [Eric_Cantineau] 2004-11
+sec-ntb-clnt    32635/udp # SecureNotebook-CLNT [Eric_Cantineau] [Eric_Cantineau] 2004-11
+DMExpress       32636/tcp # DMExpress [Arnie_Farrelly] [Arnie_Farrelly]
+DMExpress       32636/udp # DMExpress [Arnie_Farrelly] [Arnie_Farrelly]
+filenet-powsrm  32767/tcp # FileNet BPM WS-ReliableMessaging Client [Chris_Adkins] [Chris_Adkins] 2006-08
+filenet-powsrm  32767/udp # FileNet BPM WS-ReliableMessaging Client [Chris_Adkins] [Chris_Adkins] 2006-08
+filenet-tms     32768/tcp # Filenet TMS [Daniel_Whelan] [Daniel_Whelan]
+filenet-tms     32768/udp # Filenet TMS [Daniel_Whelan] [Daniel_Whelan]
+filenet-rpc     32769/tcp # Filenet RPC [Daniel_Whelan] [Daniel_Whelan]
+filenet-rpc     32769/udp # Filenet RPC [Daniel_Whelan] [Daniel_Whelan]
+filenet-nch     32770/tcp # Filenet NCH [Daniel_Whelan] [Daniel_Whelan]
+filenet-nch     32770/udp # Filenet NCH [Daniel_Whelan] [Daniel_Whelan]
+filenet-rmi     32771/tcp # FileNET RMI [Chris_Adkins] [Chris_Adkins]
+filenet-rmi     32771/udp # FileNet RMI [Chris_Adkins] [Chris_Adkins]
+filenet-pa      32772/tcp # FileNET Process Analyzer [Chris_Adkins] [Chris_Adkins] 2003-01
+filenet-pa      32772/udp # FileNET Process Analyzer [Chris_Adkins] [Chris_Adkins] 2003-01
+filenet-cm      32773/tcp # FileNET Component Manager [Chris_Adkins] [Chris_Adkins] 2003-08
+filenet-cm      32773/udp # FileNET Component Manager [Chris_Adkins] [Chris_Adkins] 2003-08
+filenet-re      32774/tcp # FileNET Rules Engine [Chris_Adkins] [Chris_Adkins] 2003-08
+filenet-re      32774/udp # FileNET Rules Engine [Chris_Adkins] [Chris_Adkins] 2003-08
+filenet-pch     32775/tcp # Performance Clearinghouse [Tim_Morgan_2] [Tim_Morgan_2] 2005-11
+filenet-pch     32775/udp # Performance Clearinghouse [Tim_Morgan_2] [Tim_Morgan_2] 2005-11
+filenet-peior   32776/tcp # FileNET BPM IOR [Chris_Adkins] [Chris_Adkins] 2006-05
+filenet-peior   32776/udp # FileNET BPM IOR [Chris_Adkins] [Chris_Adkins] 2006-05
+filenet-obrok   32777/tcp # FileNet BPM CORBA [Chris_Adkins] [Chris_Adkins] 2006-10
+filenet-obrok   32777/udp # FileNet BPM CORBA [Chris_Adkins] [Chris_Adkins] 2006-10
+mlsn            32801/tcp # Multiple Listing Service Network [Corey_Leong] [Corey_Leong] 2010-10-11
+mlsn            32801/udp # Multiple Listing Service Network [Corey_Leong] [Corey_Leong] 2010-10-11
+retp            32811/tcp # Real Estate Transport Protocol [Corey_Leong] [Corey_Leong] 2010-10-11
+idmgratm        32896/tcp # Attachmate ID Manager [George_Gianelos_2] [George_Gianelos_2] 2003-03
+idmgratm        32896/udp # Attachmate ID Manager [George_Gianelos_2] [George_Gianelos_2] 2003-03
+aurora-balaena  33123/tcp # Aurora (Balaena Ltd) [Andrew_Mather] [Andrew_Mather] 2008-02-14
+aurora-balaena  33123/udp # Aurora (Balaena Ltd) [Andrew_Mather] [Andrew_Mather] 2008-02-14
+diamondport     33331/tcp # DiamondCentral Interface [Edward_Browdy] [Edward_Browdy] 2002-07
+diamondport     33331/udp # DiamondCentral Interface [Edward_Browdy] [Edward_Browdy] 2002-07
+dgi-serv        33333/tcp # Digital Gaslight Service [George_Flanagin] [George_Flanagin] 2010-03-02
+speedtrace      33334/tcp # SpeedTrace TraceAgent [Holger_Heinrich] [Holger_Heinrich] 2012-02-01
+speedtrace-disc 33334/udp # SpeedTrace TraceAgent Discovery [Holger_Heinrich] [Holger_Heinrich] 2012-02-01
+traceroute      33434/tcp # traceroute use [IANA] [IANA]
+traceroute      33434/udp # traceroute use [IANA] [IANA]
+snip-slave      33656/tcp # SNIP Slave [Dr_Chris_Tucker] [Dr_Chris_Tucker] 2005-08
+snip-slave      33656/udp # SNIP Slave [Dr_Chris_Tucker] [Dr_Chris_Tucker] 2005-08
+turbonote-2     34249/tcp # TurboNote Relay Server Default Port [Peter_Hyde] [Peter_Hyde]
+turbonote-2     34249/udp # TurboNote Relay Server Default Port [Peter_Hyde] [Peter_Hyde]
+p-net-local     34378/tcp # P-Net on IP local [Kurt_Nissen] [Kurt_Nissen] 2004-02
+p-net-local     34378/udp # P-Net on IP local [Kurt_Nissen] [Kurt_Nissen] 2004-02
+p-net-remote    34379/tcp # P-Net on IP remote [Kurt_Nissen] [Kurt_Nissen] 2004-02
+p-net-remote    34379/udp # P-Net on IP remote [Kurt_Nissen] [Kurt_Nissen] 2004-02
+dhanalakshmi    34567/tcp # dhanalakshmi.org EDI Service [Girish_Gopalakrishna] [Girish_Gopalakrishna] 2010-04-20
+profinet-rt     34962/tcp # PROFInet RT Unicast [Peter_Wenzel] [Peter_Wenzel] 2004-11
+profinet-rt     34962/udp # PROFInet RT Unicast [Peter_Wenzel] [Peter_Wenzel] 2004-11
+profinet-rtm    34963/tcp # PROFInet RT Multicast [Peter_Wenzel] [Peter_Wenzel] 2004-11
+profinet-rtm    34963/udp # PROFInet RT Multicast [Peter_Wenzel] [Peter_Wenzel] 2004-11
+profinet-cm     34964/tcp # PROFInet Context Manager [Peter_Wenzel] [Peter_Wenzel] 2004-11
+profinet-cm     34964/udp # PROFInet Context Manager [Peter_Wenzel] [Peter_Wenzel] 2004-11
+ethercat        34980/tcp # EtherCAT Port [Martin_Rostan] [Martin_Rostan] 2003-11
+ethercat        34980/udp # EhterCAT Port [Martin_Rostan] [Martin_Rostan] 2003-11
+heathview       35000/tcp # HeathView [Heathwest_Systems_Limited] [Andrew_Porrer] 2013-03-21
+kitim           35354/tcp # KIT Messenger [Rudi_Visser] [Rudi_Visser] 2011-07-07
+altova-lm       35355/tcp # Altova License Management [Alexander_Falk_2] [Alexander_Falk_2] 2011-07-07
+altova-lm-disc  35355/udp # Altova License Management Discovery [Alexander_Falk_2] [Alexander_Falk_2] 2011-07-07
+guttersnex      35356/tcp # Gutters Note Exchange [Squee_Application_Development] [Tristan_Seifert_2] 2011-07-19
+openstack-id    35357/tcp # OpenStack ID Service [Rackspace_Hosting] [Ziad_Sawalha] 2011-08-15
+allpeers        36001/tcp # AllPeers Network [Cedric_Maloux] [Cedric_Maloux] 2007-04
+allpeers        36001/udp # AllPeers Network [Cedric_Maloux] [Cedric_Maloux] 2007-04
+s1-control      36412/sctp # S1-Control Plane (3GPP) [Kimmo_Kymalainen] [Kimmo_Kymalainen] 2009-09-01
+x2-control      36422/sctp # X2-Control Plane (3GPP) [Kimmo_Kymalainen] [Kimmo_Kymalainen] 2009-09-01
+m2ap            36443/sctp # M2 Application Part [Dario_S_Tonesi] [Dario_S_Tonesi] 2011-02-07
+m3ap            36444/sctp # M3 Application Part [Dario_S_Tonesi] [Dario_S_Tonesi] 2011-02-07
+febooti-aw      36524/tcp # Febooti Automation Workshop [Maris_Bormanis] [Maris_Bormanis] 2011-06-10
+observium-agent 36602/tcp # Observium statistics collection agent [Observium] [Adam_Armstrong] 2013-05-10
+kastenxpipe     36865/tcp # KastenX Pipe [Guy_Cheng] [Guy_Cheng]
+kastenxpipe     36865/udp # KastenX Pipe [Guy_Cheng] [Guy_Cheng]
+neckar          37475/tcp # science + computing's Venus Administration Port [Ralf_Allrutz] [Ralf_Allrutz] 2002-02
+neckar          37475/udp # science + computing's Venus Administration Port [Ralf_Allrutz] [Ralf_Allrutz] 2002-02
+gdrive-sync     37483/tcp # Google Drive Sync [Google] [Fil_Zembowicz] 2013-02-01
+unisys-eportal  37654/tcp # Unisys ClearPath ePortal [Sung_U_Ro] [Sung_U_Ro] 2006-01
+unisys-eportal  37654/udp # Unisys ClearPath ePortal [Sung_U_Ro] [Sung_U_Ro] 2006-01
+galaxy7-data    38201/tcp # Galaxy7 Data Tunnel [Tatham_Oddie] [Tatham_Oddie] 2002-09
+galaxy7-data    38201/udp # Galaxy7 Data Tunnel [Tatham_Oddie] [Tatham_Oddie] 2002-09
+fairview        38202/tcp # Fairview Message Service [Jim_Lyle] [Jim_Lyle] 2005-11 Defined TXT keys: DevID=<device id>, DevType=<device type>, DevStat=<device status>
+fairview        38202/udp # Fairview Message Service [Jim_Lyle] [Jim_Lyle] 2005-11 Defined TXT keys: DevID=<device id>, DevType=<device type>, DevStat=<device status>
+agpolicy        38203/tcp # AppGate Policy Server [Martin_Forssen] [Martin_Forssen] 2004-11
+agpolicy        38203/udp # AppGate Policy Server [Martin_Forssen] [Martin_Forssen] 2004-11
+sruth           38800/tcp # Sruth is a service for the distribution of routinely-      generated but arbitrary files based on a publish/subscribe      distribution model and implemented using a peer-to-peer transport      mechanism [University_Corporation_for_Atmospheric_Research] [Steven_Emmerson] 2012-05-07
+secrmmsafecopya 38865/tcp # Security approval process for use of the secRMM SafeCopy program [Squadra_Technologies] [Anthony_LaMark] 2012-03-14
+turbonote-1     39681/tcp # TurboNote Default Port [Peter_Hyde] [Peter_Hyde]
+turbonote-1     39681/udp # TurboNote Default Port [Peter_Hyde] [Peter_Hyde]
+safetynetp      40000/tcp # SafetyNET p [Roland_Rupp] [Roland_Rupp] 2006-11
+safetynetp      40000/udp # SafetyNET p [Roland_Rupp] [Roland_Rupp] 2006-11
+cscp            40841/tcp # CSCP [Michael_Dodge] [Michael_Dodge]
+cscp            40841/udp # CSCP [Michael_Dodge] [Michael_Dodge]
+csccredir       40842/tcp # CSCCREDIR [Sudhir_Menon] [Sudhir_Menon]
+csccredir       40842/udp # CSCCREDIR [Sudhir_Menon] [Sudhir_Menon]
+csccfirewall    40843/tcp # CSCCFIREWALL [Sudhir_Menon] [Sudhir_Menon]
+csccfirewall    40843/udp # CSCCFIREWALL [Sudhir_Menon] [Sudhir_Menon]
+ortec-disc      40853/udp # ORTEC Service Discovery [Jesse_Ursery] [Jesse_Ursery] 2010-11-22
+fs-qos          41111/tcp # Foursticks QoS Protocol [Chee_Kent_Lam] [Chee_Kent_Lam] 2002-04
+fs-qos          41111/udp # Foursticks QoS Protocol [Chee_Kent_Lam] [Chee_Kent_Lam] 2002-04
+tentacle        41121/tcp # Tentacle Server [Sancho_Lerena] [Sancho_Lerena] 2009-06-02
+crestron-cip    41794/tcp # Crestron Control Port [Ed_Ranney] [Ed_Ranney] 2003-01
+crestron-cip    41794/udp # Crestron Control Port [Ed_Ranney] [Ed_Ranney] 2003-01
+crestron-ctp    41795/tcp # Crestron Terminal Port [Ed_Ranney] [Ed_Ranney] 2003-01
+crestron-ctp    41795/udp # Crestron Terminal Port [Ed_Ranney] [Ed_Ranney] 2003-01
+crestron-cips   41796/tcp # Crestron Secure Control Port [Crestron_Electronics] [Manish_Talreja] 2012-06-27
+crestron-ctps   41797/tcp # Crestron Secure Terminal Port [Crestron_Electronics] [Manish_Talreja] 2012-06-27
+candp           42508/tcp # Computer Associates network discovery protocol [Jon_Press] [Jon_Press] 2005-09
+candp           42508/udp # Computer Associates network discovery protocol [Jon_Press] [Jon_Press] 2005-09
+candrp          42509/tcp # CA discovery response [Jon_Press] [Jon_Press] 2005-08
+candrp          42509/udp # CA discovery response [Jon_Press] [Jon_Press] 2005-08
+caerpc          42510/tcp # CA eTrust RPC [Jon_Press] [Jon_Press] 2005-08
+caerpc          42510/udp # CA eTrust RPC [Jon_Press] [Jon_Press] 2005-08
+recvr-rc        43000/tcp # Receiver Remote Control [Research_Electronics_International] [Ross_Binkley] 2012-12-20
+recvr-rc-disc   43000/udp # Receiver Remote Control Discovery [Research_Electronics_International] [Ross_Binkley] 2012-12-20
+reachout        43188/tcp # REACHOUT [Roman_Kriis] [Roman_Kriis]
+reachout        43188/udp # REACHOUT [Roman_Kriis] [Roman_Kriis]
+ndm-agent-port  43189/tcp # NDM-AGENT-PORT [Roman_Kriis] [Roman_Kriis]
+ndm-agent-port  43189/udp # NDM-AGENT-PORT [Roman_Kriis] [Roman_Kriis]
+ip-provision    43190/tcp # IP-PROVISION [Roman_Kriis] [Roman_Kriis]
+ip-provision    43190/udp # IP-PROVISION [Roman_Kriis] [Roman_Kriis]
+noit-transport  43191/tcp # Reconnoiter Agent Data Transport [Theo_Schlossnagle] [Theo_Schlossnagle] 2009-05-19
+shaperai        43210/tcp # Shaper Automation Server Management [Shaper_Automation] [Yohann_Sulaiman] 2012-06-22
+shaperai-disc   43210/udp # Shaper Automation Server Management Discovery [Shaper_Automation] [Yohann_Sulaiman] 2012-06-22
+eq3-update      43439/tcp # EQ3 firmware update [eQ-3_AG] [Falk_Werner] 2012-02-10
+eq3-config      43439/udp # EQ3 discovery and configuration [eQ-3_AG] [Falk_Werner] 2012-02-10
+ew-mgmt         43440/tcp # Cisco EnergyWise Management
+ew-disc-cmd     43440/udp # Cisco EnergyWise Discovery and Command Flooding [John_Parello] [John_Parello] 2009-05-19
+ciscocsdb       43441/tcp # Cisco NetMgmt DB Ports [Cisco_Systems] [Cisco_Systems] 2005-11
+ciscocsdb       43441/udp # Cisco NetMgmt DB Ports [Cisco_Systems] [Cisco_Systems] 2005-11
+z-wave-s        44123/tcp # Z-Wave Secure Tunnel [Sigma_Designs_Inc] [Anders_Brandt_3] 2012-10-12
+pmcd            44321/tcp # PCP server (pmcd) [Ken_McDonell] [Ken_McDonell] 2010-12-20
+pmcd            44321/udp # PCP server (pmcd) [Ken_McDonell] [Ken_McDonell] 2010-12-20
+pmcdproxy       44322/tcp # PCP server (pmcd) proxy [Ken_McDonell] [Ken_McDonell] 2003-07 2010-12-20
+pmcdproxy       44322/udp # PCP server (pmcd) proxy [Ken_McDonell] [Ken_McDonell] 2003-07 2010-12-20
+cognex-dataman  44444/tcp # Cognex DataMan Management Protocol [Cognex] [Mario_Joussen] 2012-08-28
+domiq           44544/udp # DOMIQ Building Automation [DOMIQ_Sp_zoo] [Filip_Zawadiak] 2011-08-29
+rbr-debug       44553/tcp # REALbasic Remote Debug [Aaron_Ballman] [Aaron_Ballman] 2004-11
+rbr-debug       44553/udp # REALbasic Remote Debug [Aaron_Ballman] [Aaron_Ballman] 2004-11
+asihpi          44600/udp # AudioScience HPI [Eliot_Blennerhassett] [Eliot_Blennerhassett] 2011-07-07
+EtherNet-IP-2   44818/tcp # EtherNet/IP messagingIANA assigned this well-formed service name as a replacement for "EtherNet/IP-2". [Brian_Batke_2] [Brian_Batke_2] New contact added for port 44818 on 2008-02-01
+EtherNet/IP-2   44818/tcp # EtherNet/IP messaging [Brian_Batke_2] [Brian_Batke_2] New contact added for port 44818 on 2008-02-01This entry is an alias to "EtherNet-IP-2".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+EtherNet-IP-2   44818/udp # EtherNet/IP messagingIANA assigned this well-formed service name as a replacement for "EtherNet/IP-2". [Brian_Batke_2] [Brian_Batke_2] New contact added for port 44818 on 2008-02-01
+EtherNet/IP-2   44818/udp # EtherNet/IP messaging [Brian_Batke_2] [Brian_Batke_2] New contact added for port 44818 on 2008-02-01This entry is an alias to "EtherNet-IP-2".This entry is now historic, not usable for use with manycommon service discovery mechanisms.
+m3da            44900/tcp # M3DA is used for efficient machine-to-machine communications [Eclipse_Foundation] [Didier_Lahay] 2013-02-22
+m3da-disc       44900/udp # M3DA Discovery is used for efficient machine-to-machine communications [Eclipse_Foundation] [Didier_Lahay] 2013-02-22
+asmp            45000/tcp # NSi AutoStore Status Monitoring Protocol data transfer [Notable_Solutions_Inc] [Andrew_Andrews] 2011-09-01
+asmp-mon        45000/udp # NSi AutoStore Status Monitoring Protocol device monitoring [Notable_Solutions_Inc] [Andrew_Andrews] 2011-09-01
+asmps           45001/tcp # NSi AutoStore Status Monitoring Protocol secure data transfer [Notable_Solutions_Inc] [Andrew_Andrews] 2011-09-01
+synctest        45045/tcp # Remote application control protocol [Eleks_Ltd] [Andriy_Skop] 2013-04-08
+invision-ag     45054/tcp # InVision AG [Matthias_Schroer] [Matthias_Schroer]
+invision-ag     45054/udp # InVision AG [Matthias_Schroer] [Matthias_Schroer]
+eba             45678/tcp # EBA PRISE [Patrick_Kara] [Patrick_Kara]
+eba             45678/udp # EBA PRISE [Patrick_Kara] [Patrick_Kara]
+dai-shell       45824/tcp # Server for the DAI family of client-server products [Data_Access_Inc] [Adam_Robinson] 2012-04-30
+qdb2service     45825/tcp # Qpuncture Data Access Service [Michael_Yun] [Michael_Yun] 2007-10-24
+qdb2service     45825/udp # Qpuncture Data Access Service [Michael_Yun] [Michael_Yun] 2007-10-24
+ssr-servermgr   45966/tcp # SSRServerMgr [Jeremy_Gilliat] [Jeremy_Gilliat]
+ssr-servermgr   45966/udp # SSRServerMgr [Jeremy_Gilliat] [Jeremy_Gilliat]
+spremotetablet  46998/tcp # Connection between a desktop computer or server and a signature tablet to capture handwritten signatures [SOFTPRO_GmbH] [Christoph_Hipp] 2012-07-19 2013-08-02
+mediabox        46999/tcp # MediaBox Server [Alexander_Graef] [Alexander_Graef] 2004-11
+mediabox        46999/udp # MediaBox Server [Alexander_Graef] [Alexander_Graef] 2004-11
+mbus            47000/tcp # Message Bus [Dirk_Kutscher] [Dirk_Kutscher]
+mbus            47000/udp # Message Bus [Dirk_Kutscher] [Dirk_Kutscher]
+winrm           47001/tcp # Windows Remote Management Service [Ryan_Mack] [Ryan_Mack] 2009-04-29
+jvl-mactalk     47100/udp # Configuration of motors connected to Industrial Ethernet [JVL_Industri_Elektronik] [Kim_Berthelsen] 2012-12-21
+dbbrowse        47557/tcp # Databeam Corporation [Cindy_Martin] [Cindy_Martin]
+dbbrowse        47557/udp # Databeam Corporation [Cindy_Martin] [Cindy_Martin]
+directplaysrvr  47624/tcp # Direct Play Server [Ajay_Jindal] [Ajay_Jindal]
+directplaysrvr  47624/udp # Direct Play Server [Ajay_Jindal] [Ajay_Jindal]
+ap              47806/tcp # ALC Protocol [Dave_Robin] [Dave_Robin]
+ap              47806/udp # ALC Protocol [Dave_Robin] [Dave_Robin]
+bacnet          47808/tcp # Building Automation and Control Networks [Coleman_Brumley] [Coleman_Brumley] 2011-02-10
+bacnet          47808/udp # Building Automation and Control Networks [Coleman_Brumley] [Coleman_Brumley] 2011-02-10
+presonus-ucnet  47809/udp # PreSonus Universal Control Network Protocol [PreSonus_Audio_Electronics_Inc] [Matthias_Juwan] 2013-07-12
+nimcontroller   48000/tcp # Nimbus Controller [Carstein_Seeberg_2] [Carstein_Seeberg_2]
+nimcontroller   48000/udp # Nimbus Controller [Carstein_Seeberg_2] [Carstein_Seeberg_2]
+nimspooler      48001/tcp # Nimbus Spooler [Carstein_Seeberg_2] [Carstein_Seeberg_2]
+nimspooler      48001/udp # Nimbus Spooler [Carstein_Seeberg_2] [Carstein_Seeberg_2]
+nimhub          48002/tcp # Nimbus Hub [Carstein_Seeberg_2] [Carstein_Seeberg_2]
+nimhub          48002/udp # Nimbus Hub [Carstein_Seeberg_2] [Carstein_Seeberg_2]
+nimgtw          48003/tcp # Nimbus Gateway [Carstein_Seeberg_2] [Carstein_Seeberg_2]
+nimgtw          48003/udp # Nimbus Gateway [Carstein_Seeberg_2] [Carstein_Seeberg_2]
+nimbusdb        48004/tcp # NimbusDB Connector [Stephen_Harrison] [Stephen_Harrison] 2011-01-24
+nimbusdbctrl    48005/tcp # NimbusDB Control [Stephen_Harrison] [Stephen_Harrison] 2011-01-24
+3gpp-cbsp       48049/tcp # 3GPP Cell Broadcast Service Protocol [Gert_Thomasen] [Gert_Thomasen] 2009-12-07
+weandsf         48050/tcp # WeFi Access Network Discovery and Selection Function [WeFi_Inc] [Eran_Naveh] 2013-07-19
+isnetserv       48128/tcp # Image Systems Network Services [Bengt_Gustafsson] [Bengt_Gustafsson] 2006-05
+isnetserv       48128/udp # Image Systems Network Services [Bengt_Gustafsson] [Bengt_Gustafsson] 2006-05
+blp5            48129/tcp # Bloomberg locator [Albert_Hou] [Albert_Hou] 2006-05
+blp5            48129/udp # Bloomberg locator [Albert_Hou] [Albert_Hou] 2006-05
+com-bardac-dw   48556/tcp # com-bardac-dw [Nicholas_J_Howes] [Nicholas_J_Howes]
+com-bardac-dw   48556/udp # com-bardac-dw [Nicholas_J_Howes] [Nicholas_J_Howes]
+iqobject        48619/tcp # iqobject [Bjorn_de_Bonnenfant] [Bjorn_de_Bonnenfant] 2003-11
+iqobject        48619/udp # iqobject [Bjorn_de_Bonnenfant] [Bjorn_de_Bonnenfant] 2003-11
+matahari        49000/tcp # Matahari Broker [Matahari_Project] [Zane_Bitter] 2011-08-31

--- a/userspace/libsinsp/servparse.cpp
+++ b/userspace/libsinsp/servparse.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 1983, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "servparse.h"
+
+// To get the installation directory
+#include "config.h"
+
+#include <unordered_map>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <string.h>
+
+#define	MAXALIASES	35
+struct servent {
+	char *s_name;     /*%< official service name */
+	char **s_aliases; /*%< alias list */
+	int s_port;       /*%< port # */
+	char *s_proto;    /*%< protocol to use */
+};
+
+static char SERVDB[] = SYSDIG_SHARE_DIR "/services";
+static FILE *servf = NULL;
+static char line[BUFSIZ+1];
+static struct servent serv;
+static char *serv_aliases[MAXALIASES];
+int _serv_stayopen, _loaded = 0;
+
+unordered_map<string,int> byName;
+unordered_map<int,string> byPortTCP;
+unordered_map<int,string> byPortUDP;
+
+void setservent(int f)
+{
+	if (servf == NULL)
+	{
+		servf = fopen(SERVDB, "r" );
+		if(!servf) 
+		{
+			throw sinsp_exception(string(SERVDB) + " can't be opened.");
+		}
+	}
+	else
+	{
+		rewind(servf);
+	}
+	_serv_stayopen |= f;
+}
+
+void endservent()
+{
+	if (servf) 
+	{
+		fclose(servf);
+		servf = NULL;
+	}
+	_serv_stayopen = 0;
+}
+
+struct servent * getservent()
+{
+	char *p;
+	register char *cp, **q;
+
+	if (servf == NULL && (servf = fopen(SERVDB, "r" )) == NULL)
+	{
+		if(!servf) 
+    	{
+			throw sinsp_exception(string(SERVDB) + " can't be opened.");
+		}
+		return (NULL);
+	}
+
+again:
+	if ((p = fgets(line, BUFSIZ, servf)) == NULL)
+	{
+		return (NULL);
+	}
+
+	if (*p == '#')
+	{
+		goto again;
+	}
+
+	cp = strpbrk(p, "#\n");
+	if (cp == NULL)
+	{
+		goto again;
+	}
+
+	*cp = '\0';
+	serv.s_name = p;
+
+	p = strpbrk(p, " \t");
+	if (p == NULL)
+	{
+		goto again;
+	}
+	*p++ = '\0';
+
+	while (*p == ' ' || *p == '\t')
+	{
+		p++;
+	}
+
+	cp = strpbrk(p, ",/");
+	if (cp == NULL)
+	{
+		goto again;
+	}
+
+	*cp++ = '\0';
+	serv.s_port = (u_short)atoi(p);
+	serv.s_proto = cp;
+	q = serv.s_aliases = serv_aliases;
+	cp = strpbrk(cp, " \t");
+
+	if (cp != NULL)
+	{
+		*cp++ = '\0';
+	}
+
+	while (cp && *cp) 
+	{
+		if (*cp == ' ' || *cp == '\t') 
+		{
+			cp++;
+			continue;
+		}
+
+		if (q < &serv_aliases[MAXALIASES - 1])
+		{
+			*q++ = cp;
+		}
+		cp = strpbrk(cp, " \t");
+		if (cp != NULL)
+		{
+			*cp++ = '\0';
+		}
+	}
+
+	*q = NULL;
+	return (&serv);
+}
+
+int insert(servent *sd) 
+{
+	if(!sd)
+	{
+		return 0;
+	}
+	if(sd->s_proto[0] == 't') 
+	{
+		byPortTCP[sd->s_port] = string(sd->s_name);
+	} 
+	else if(sd->s_proto[0] == 'u') 
+	{
+		byPortUDP[sd->s_port] = string(sd->s_name);
+	}
+
+	byName[sd->s_name] = sd->s_port;
+	return 1;
+}
+
+void loadFile() 
+{
+	if (!_loaded)
+	{
+		while(insert(getservent()));
+		_loaded = 1;
+	}
+}
+
+string service::findByPort(int port, string type = "tcp") 
+{
+	loadFile();
+
+	return ( (type[0] | 0x20) == 'u') ?
+		byPortUDP[port] :
+		byPortTCP[port];
+		
+}
+
+int service::findByName(string name) 
+{
+	loadFile();
+	int ix = byName[name];
+
+	if (ix == 0)
+	{
+		throw sinsp_exception(string(name) + " can't be translated to a port using " + string(SERVDB) + ". Manually add it and try again.");
+	}
+
+	return ix;
+}
+
+string service::toName(string in)
+{
+	return ( !in.empty() && strspn( in.c_str(), "0123456789" ) == in.size() ) 
+		?  loadFile(), byPortTCP[stoi(in)]
+		:  in;
+}
+
+int service::toPort(string in)
+{
+	return in.empty() ? 0 : (
+		( strspn( in.c_str(), "0123456789" ) == in.size() )
+			? stoi(in)
+			: service::findByName(in)
+		);
+}
+

--- a/userspace/libsinsp/servparse.cpp
+++ b/userspace/libsinsp/servparse.cpp
@@ -56,7 +56,13 @@ struct servent {
 	static char SERVDB[] = "services";
 	static char SERVDBUSER[] = "services-user";
 #endif
-static char SERVDBOS[] = "/etc/services";
+
+#ifdef _WIN32
+	// TODO: There is a better way of doing this, I'm sure
+	static char SERVDBOS[] = "\\windows\\system32\\drivers\\etc\\services";
+#else
+	static char SERVDBOS[] = "/etc/services";
+#endif
 
 static FILE *servf = NULL;
 static char line[BUFSIZ+1];

--- a/userspace/libsinsp/servparse.h
+++ b/userspace/libsinsp/servparse.h
@@ -1,0 +1,22 @@
+#pragma once
+/*
+ * BSD license by inclusion of servparse.cpp from NetBSD,
+ * see the file servparse.cpp for details.  This file
+ * assumes the most permissive available and applicable 
+ * license given the restrictions therein.
+ */
+
+#include "sinsp.h"
+#include <string>
+using namespace std;
+
+class service {
+	public:
+		static string findByPort(int port, string type/* = "tcp"*/);
+		static int findByName(string name);
+
+		// These will typecheck whats coming in and return a
+		// name (either what came in or converted)
+		static string toName(string in);
+		static int toPort(string in);
+};

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -55,6 +55,7 @@ using namespace std;
 #include "stats.h"
 #include "ifinfo.h"
 #include "chisel.h"
+#include "servparse.h"
 
 #ifndef VISIBILITY_PRIVATE
 #define VISIBILITY_PRIVATE private:


### PR DESCRIPTION
This commit modifies the type PT_PORT to accept both a numeric
value and a string value specified in a services file.

It adds a services file from wireshark and code to parse it from
NetBSD.  The code that does this is being maintained with tests
outside of this repository at

git@github.com:kristopolous/services-parser.git

It introduces a config.h inside of libsinsp in order to find
where the services file will live during runtime.  The copying is
done inside libsinsp's Cmakefile.

The servparse.h and .cpp introduce 4 functions to convert to and
from numeric ports and string values.