### PR TITLE
install-sysdig should support oracle linux

### DIFF
--- a/scripts/install-sysdig
+++ b/scripts/install-sysdig
@@ -113,7 +113,7 @@ elif [ -f /etc/system-release-cpe ]; then
 	DISTRO=$(cat /etc/system-release-cpe | cut -d':' -f3)
 	VERSION=$(cat /etc/system-release-cpe | cut -d':' -f5)
 
-	if [ $DISTRO = "centos" ] || [ $DISTRO = "redhat" ]; then
+	if [ $DISTRO = "oracle" ] || [ $DISTRO = "centos" ] || [ $DISTRO = "redhat" ]; then
 		if echo $VERSION | grep -q ^6; then
 			install_rpm
 		else


### PR DESCRIPTION
Oracle Linux is a distribution based on RHEL.  sysdig is installable on
Oracle Linux in the same way it is installable on CentOS or RHEL
