### PR TITLE
[9] resolve IP addresses into host names with asynch DNS lookups

### DIFF
--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -237,6 +237,14 @@ public:
 	const sinsp_evt_param* get_param_value_raw(const char* name);
 
 	/*!
+	  \brief Get a hostname from a binary ipv4 string
+
+	  \param binary_adress The 32 bit binary address to use
+	  \param buf The hostname container, of size NI_MAXHOST
+ 	*/
+	char* get_binary_ipv4_as_host(void* binary_address, char* buf);
+
+	/*!
 	  \brief Get a parameter as a C++ string.
 
 	  \param name The parameter name.

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -56,6 +56,9 @@ sinsp::sinsp() :
 	m_thread_timeout_ns = DEFAULT_THREAD_TIMEOUT_S * ONE_SECOND_IN_NS;
 	m_inactive_thread_scan_time_ns = DEFAULT_INACTIVE_THREAD_SCAN_TIME_S * ONE_SECOND_IN_NS;
 
+	// Turn off DNS resolution by default
+	m_usedns = false;
+
 #ifdef HAS_ANALYZER
 	m_analyzer = NULL;
 #endif
@@ -773,4 +776,15 @@ sinsp_evt::param_fmt sinsp::get_buffer_format()
 bool sinsp::is_live()
 {
 	return m_islive;
+}
+
+bool sinsp::use_dns()
+{
+	return this->m_usedns;
+}
+
+bool sinsp::use_dns(bool flag)
+{
+	this->m_usedns = flag;
+	return flag;
 }

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -426,6 +426,8 @@ public:
 	  \brief Returns true if the current capture is live.
 	*/
 	bool is_live();
+	bool use_dns(bool flag);
+	bool use_dns();
 
 	//
 	// Misc internal stuff 
@@ -457,6 +459,7 @@ private:
 
 	scap_t* m_h;
 	bool m_islive;
+	bool m_usedns;
 	string m_filename;
 	sinsp_evt m_evt;
 	string m_lasterr;

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -119,6 +119,7 @@ static void usage()
 "                    h for human-readable string, a for abosulte timestamp from\n" 
 "                    epoch, r for relative time from the beginning of the\n" 
 "                    capture, and d for delta between event enter and exit.\n" 
+" -u, --url          Show ips as urls (host names)\n"
 " -v, --verbose      Verbose output.\n"
 " -w <writefile>, --write=<writefile>\n"
 "                    Write the captured events to <writefile>.\n"
@@ -419,6 +420,7 @@ int main(int argc, char **argv)
 		{"snaplen", required_argument, 0, 's' },
 		{"summary", no_argument, 0, 'S' },
 		{"timetype", required_argument, 0, 't' },
+		{"url", no_argument, 0, 'u' },
 		{"verbose", no_argument, 0, 'v' },
 		{"writefile", required_argument, 0, 'w' },
 		{"print-hex", no_argument, 0, 'x'},
@@ -438,7 +440,7 @@ int main(int argc, char **argv)
 		//
 		// Parse the args
 		//
-		while((op = getopt_long(argc, argv, "Aac:dhi:jlLn:p:qr:Ss:t:vw:xX", long_options, &long_index)) != -1)
+		while((op = getopt_long(argc, argv, "Aac:dhi:jlLn:p:qr:Ss:t:uvw:xX", long_options, &long_index)) != -1)
 		{
 			switch(op)
 			{
@@ -627,6 +629,9 @@ int main(int argc, char **argv)
 						timefmt = "%evt.latency.s.%evt.latency.ns";
 					}
 				}
+				break;
+	  		case 'u':
+				inspector->use_dns(true);
 				break;
 			case 'v':
 				verbose = true;


### PR DESCRIPTION
This candidate branch has the following changes:

Inclusion of netdb.h in event.cpp for gethostname resolution

Introduction of char\* sinsp_evt::get_binary_ipv4_as_host(void*
binary_address, char\* buf) to do what it says on the tin.

A code split at PT_SOCKADDR to use the above parameter is a flag
is set at runtime (see below)

An introduction of a (currently unused) PF_DNS param_fmt (which loris
thinks is the way to go, but I can't see a reason for it, hence the
candidate status of the PR).

An introduction of a bool m_usedns (initialized to false in the
constructor) inside of sinsp with a getter and setter.

An addition of a -u short and --url long opt (the flag referred to
above) to turn on the feature of doing DNS resolution.

Currently, the code to enable it is in line 633:

```
inspector->use_dns(true);
```

Which utilizes the function referred to above.
