### PR TITLE
fix format string for size_t params

### DIFF
--- a/userspace/libscap/examples/02-validatebuffer/test.c
+++ b/userspace/libscap/examples/02-validatebuffer/test.c
@@ -99,7 +99,7 @@ int32_t g_check_integrity(uint32_t* cur_event, char* copy_buffer, int buf_len, O
 		
 		if(sentinel_begin != sentinel_end)
 		{
-			fprintf(stderr, "Error: sentinel begin %d, sentinel end %d, evt_type %u, evt_size %u, cnt %u, offset %x, remaining %u\n",
+			fprintf(stderr, "Error: sentinel begin %d, sentinel end %d, evt_type %u, evt_size %zu, cnt %u, offset %x, remaining %u\n",
 			        sentinel_begin,
 			        sentinel_end,
 			        (uint32_t)hdr->type,


### PR DESCRIPTION
warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘size_t’ [-Wformat=]

when printing size_t, one has to use %zu instead of pure %u, as size_t's size can vary depending on the architecture.

this was only partly fixed in 37be1398520db8d51d3e1b20b0cd21dc70b5cada
