### PR TITLE
make building the driver optional

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -1,20 +1,38 @@
+option(BUILD_DRIVER "Build the driver on Linux" ON)
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 	set(KBUILD_FLAGS "${SYSDIG_DEBUG_FLAGS} ${SYSDIG_FEATURE_FLAGS}")
 else()
 	set(KBUILD_FLAGS "${SYSDIG_FEATURE_FLAGS}")
 endif()
 
-add_custom_target(driver ALL
+add_custom_target(prepare ALL
 	COMMAND sed -i 's/^PACKAGE_VERSION=.*/PACKAGE_VERSION="${SYSDIG_VERSION}"/g' dkms.conf
 	COMMAND sed -i 's/^DKMS_VERSION=.*/DKMS_VERSION="${SYSDIG_VERSION}"/g' ../scripts/debian/postinst
 	COMMAND sed -i 's/^DKMS_VERSION=.*/DKMS_VERSION="${SYSDIG_VERSION}"/g' ../scripts/debian/prerm
 	COMMAND sed -i 's/^ccflags-y := .*/ccflags-y := ${KBUILD_FLAGS}/g' Makefile
-	COMMAND make
-	COMMAND cp -f sysdig-probe.ko "${CMAKE_CURRENT_BINARY_DIR}"
 	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# This if/else is needed because you currently cannot manipulate dependencies
+# of built-in targets like "all" in CMake:
+# http://public.kitware.com/Bug/view.php?id=8438
+if(BUILD_DRIVER)
+	add_custom_target(driver ALL
+		COMMAND make
+		COMMAND cp -f sysdig-probe.ko "${CMAKE_CURRENT_BINARY_DIR}"
+		DEPENDS prepare
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+else()
+	add_custom_target(driver
+		COMMAND make
+		COMMAND cp -f sysdig-probe.ko "${CMAKE_CURRENT_BINARY_DIR}"
+		DEPENDS prepare
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+endif()
 
 add_custom_target(install_driver
 	COMMAND make install
+	DEPENDS driver
 	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
 install(FILES


### PR DESCRIPTION
this allows package maintainers to build only the userspace binary and let the user build the driver module for their specific kernel which is not available in the build environment of the maintainer.
