### PR TITLE
fix error message so that it is reachable

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -1068,9 +1068,9 @@ int init_module(void)
 	g_ppm_numdevs = num_cpus;
 	g_ppm_devs = kmalloc(g_ppm_numdevs * sizeof(struct ppm_device), GFP_KERNEL);
 	if (!g_ppm_devs) {
+		pr_err("can't allocate devices\n");
 		ret = -ENOMEM;
 		goto init_module_err;
-		pr_err("can't allocate devices\n");
 	}
 
 	/*


### PR DESCRIPTION
Noticed there was a "goto" before printing out the error message. Moved it around so that it matched the other checks in the same section.
