### PR TITLE
[53] Build for Solaris

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,12 @@ if(NOT WIN32)
 		add_subdirectory(driver)
 	endif()
 
+	if(CMAKE_SYSTEM_NAME MATCHES "SunOS")
+		set(CMD_MAKE gmake)
+	else()
+		set(CMD_MAKE make)
+	endif()
+
 	if (LUAJIT_PREFIX)
 		find_path (LUAJIT_INCLUDE luajit.h ${LUAJIT_PREFIX} NO_DEFAULT_PATH)
 		find_library (LUAJIT_LIB NAMES luajit luajit-5.1 PATHS ${LUAJIT_PREFIX} NO_DEFAULT_PATH)
@@ -89,7 +95,7 @@ if(NOT WIN32)
 		ExternalProject_Add(luajit
 			SOURCE_DIR ${LUAJIT_SRC}
 			CONFIGURE_COMMAND ""
-			BUILD_COMMAND make
+			BUILD_COMMAND ${CMD_MAKE}
 			BUILD_IN_SOURCE 1
 			INSTALL_COMMAND "")
 	endif()

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -19,6 +19,10 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef EVENTS_PUBLIC_H_
 #define EVENTS_PUBLIC_H_
 
+#if defined (__sun)
+#include <sys/ioccom.h>
+#endif
+
 #ifdef __KERNEL__
 #include <linux/types.h>
 #endif
@@ -848,6 +852,8 @@ struct ppm_event_info {
 #if defined _MSC_VER
 #pragma pack(push)
 #pragma pack(1)
+#elif defined __sun
+#pragma pack(1)
 #else
 #pragma pack(push, 1)
 #endif
@@ -861,7 +867,11 @@ struct ppm_evt_hdr {
 	uint16_t type; /* the event type */
 /* uint16_t cpuid; the cpu that generated the event */
 };
+#if defined __sun
+#pragma pack()
+#else
 #pragma pack(pop)
+#endif
 
 /*
  * IOCTL codes

--- a/userspace/common/sysdig_types.h
+++ b/userspace/common/sysdig_types.h
@@ -34,7 +34,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Import/typedef in userspace the kernel types
 //
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32) && !defined(__APPLE__) && !defined (__sun)
 #include <linux/types.h>
 #else 
 typedef uint64_t __u64;

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -12,7 +12,11 @@ add_library(scap STATIC
 	event_table.c
 	syscall_info_table.c)
 
-if (WIN32)
+if (CMAKE_SYSTEM_NAME MATCHES "SunOS")
+	target_link_libraries(scap
+		socket nsl)
+
+elseif (WIN32)
 	target_link_libraries(scap
 		Ws2_32.lib)
 endif()

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -204,6 +204,8 @@ typedef struct scap_threadinfo
 #if defined _MSC_VER
 #pragma pack(push)
 #pragma pack(1)
+#elif defined __sun
+#pragma pack(1)
 #else
 #pragma pack(push, 1)
 #endif
@@ -292,7 +294,11 @@ typedef struct scap_ifinfo_ipv6_nolinkspeed
 	char ifname[SCAP_MAX_PATH_SIZE];
 }scap_ifinfo_ipv6_nolinkspeed;
 
+#if defined __sun
+#pragma pack()
+#else
 #pragma pack(pop)
+#endif
 
 /*!
   \brief List of the machine network interfaces

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -41,12 +41,14 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
+#include <errno.h>
 #include <netinet/tcp.h>
+#if !defined __sun
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 //#include <linux/sock_diag.h>
 //#include <linux/unix_diag.h>
-#include <errno.h>
+#endif
 #endif
 
 #define SOCKET_SCAN_BUFFER_SIZE 1024 * 1024

--- a/userspace/libscap/scap_savefile.h
+++ b/userspace/libscap/scap_savefile.h
@@ -20,6 +20,8 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #if defined _MSC_VER
 #pragma pack(push)
 #pragma pack(1)
+#elif defined __sun
+#pragma pack(1)
 #else
 #pragma pack(push, 1)
 #endif
@@ -102,4 +104,8 @@ typedef struct _section_header_block
 										// library release. We'll keep him for a while for
 										// backward compatibility
 
+#if defined __sun
+#pragma pack()
+#else
 #pragma pack(pop)
+#endif


### PR DESCRIPTION
Adds the necessary code splits for GNU make and SunOS -l flags into
the CMakeLists.

Changes the pragma rules for SunOS g++ (which do not support pop)

Also adds some minor include file preprocessor branches with __sun
tests.
