### PR TITLE
CMake 2.8.1 cannot build bundled LuaJIT because of bug #10346.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(EXISTS CMakeLists.txt)
 		"The following wiki page has more information on manually building sysdig: http://bit.ly/1oJ84UI")
 endif()
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.2)
 
 project(sysdig) 
 


### PR DESCRIPTION
http://public.kitware.com/Bug/view.php?id=10346
