### PR TITLE
remove 'register' usage

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1041,8 +1041,8 @@ const filtercheck_field_info* sinsp_filter_check_event::get_field_info()
 
 int32_t sinsp_filter_check_event::gmt2local(time_t t)
 {
-	register int dt, dir;
-	register struct tm *gmt, *loc;
+	int dt, dir;
+	struct tm *gmt, *loc;
 	struct tm sgmt;
 
 	if(t == 0)
@@ -1064,7 +1064,7 @@ int32_t sinsp_filter_check_event::gmt2local(time_t t)
 
 	dt += dir * 24 * 60 * 60;
 
-	return (dt);
+	return dt;
 }
 
 void sinsp_filter_check_event::ts_to_string(uint64_t ts, OUT string* res, bool date, bool ns)


### PR DESCRIPTION
I don't think we need to add register modifier to variables right now for this
piece of code. Otherwise it has following compile warnings:

/Users/lgq/sysdig/userspace/libsinsp/filterchecks.cpp:1044:2: warning: 'register' storage class specifier is deprecated
      [-Wdeprecated-register]
        register int dt, dir;
        ^~~~~~~~~
/Users/lgq/sysdig/userspace/libsinsp/filterchecks.cpp:1044:2: warning: 'register' storage class specifier is deprecated
      [-Wdeprecated-register]
        register int dt, dir;
        ^~~~~~~~~
/Users/lgq/sysdig/userspace/libsinsp/filterchecks.cpp:1045:2: warning: 'register' storage class specifier is deprecated
      [-Wdeprecated-register]
        register struct tm *gmt, *loc;
        ^~~~~~~~~
/Users/lgq/sysdig/userspace/libsinsp/filterchecks.cpp:1045:2: warning: 'register' storage class specifier is deprecated
      [-Wdeprecated-register]
        register struct tm *gmt, *loc;
        ^~~~~~~~~
