### PR TITLE
correct the pos's size and then fix the following two compile warnings:

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -205,7 +205,7 @@ uint8_t* sinsp_filter_check_fd::extract_from_null_fd(sinsp_evt *evt, OUT uint32_
 		{
 			m_tstr.erase(remove_if(m_tstr.begin(), m_tstr.end(), g_invalidchar()), m_tstr.end());
 
-			uint32_t pos = m_tstr.rfind('/');
+			size_t pos = m_tstr.rfind('/');
 			if(pos != string::npos)
 			{
 				if(pos < m_tstr.size() - 1)
@@ -311,7 +311,7 @@ uint8_t* sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT uint32_t* len)
 			m_tstr = m_fdinfo->m_name;
 			m_tstr.erase(remove_if(m_tstr.begin(), m_tstr.end(), g_invalidchar()), m_tstr.end());
 
-			uint32_t pos = m_tstr.rfind('/');
+			size_t pos = m_tstr.rfind('/');
 			if(pos != string::npos)
 			{
 				if(pos < m_tstr.size() - 1)


### PR DESCRIPTION
/Users/lgq/github/sysdig/userspace/libsinsp/filterchecks.cpp:209:11: warning: comparison of constant 18446744073709551615
      with expression of type 'uint32_t' (aka 'unsigned int') is always true [-Wtautological-constant-out-of-range-compare]
                        if(pos != string::npos)
                           ~~~ ^  ~~~~~~~~~~~~
/Users/lgq/github/sysdig/userspace/libsinsp/filterchecks.cpp:315:11: warning: comparison of constant 18446744073709551615
      with expression of type 'uint32_t' (aka 'unsigned int') is always true [-Wtautological-constant-out-of-range-compare]
                        if(pos != string::npos)
                           ~~~ ^  ~~~~~~~~~~~~
