### PR TITLE
fileslower tool for investigating latency outliers

### DIFF
--- a/userspace/sysdig/chisels/fileslower.lua
+++ b/userspace/sysdig/chisels/fileslower.lua
@@ -1,0 +1,79 @@
+--[[
+fileslower.lua - trace file I/O slower than a given threshold.
+
+USAGE: sysdig -c fileslower min_ms
+   eg,
+       sysdig -c fileslower 10		# show file I/O slower than 10 ms
+       sysdig -c fileslower 0		# show all file I/O
+
+By default this skips file I/O to /dev. Modify the skip_dev variable in this
+chisel to change this behavior.
+
+Note: The file I/O traced is those matched by the sysdig filter:
+"evt.is_io=true and fd.type=file".
+
+Copyright (C) 2014 Brendan Gregg.
+ 
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+--]]
+
+description = "Trace file I/O slower than a threshold, or all file I/O";
+short_description = "Trace slow file I/O";
+category = "misc";
+
+skip_dev = true		-- skip /dev/... files
+
+args =
+{
+    {
+        name = "min_ms",
+        description = "minimum millisecond threshold for showing file I/O",
+        argtype = "int"
+    },
+}
+
+function on_set_arg(name, val)
+    min_ms = tonumber(val)
+    return true
+end
+
+function on_init()
+    -- set these fields on_event()
+    etype = chisel.request_field("evt.type")
+    dir = chisel.request_field("evt.dir")  
+    datetime = chisel.request_field("evt.datetime")
+    fname = chisel.request_field("fd.name")
+    pname = chisel.request_field("proc.name")
+    latency = chisel.request_field("evt.latency")
+
+    -- filter for file I/O
+    chisel.set_filter("evt.is_io=true and fd.type=file")
+
+    print(string.format("%-23.23s %-12.12s %-8s %7s %s", "TIME",
+        "PROCESS", "TYPE", "LAT(ms)", "FILE"))
+    return true
+end
+
+function on_event()
+    lat = evt.field(latency) / 1000000
+    fn = evt.field(fname)
+    if evt.field(dir) == "<" and lat > min_ms then
+        -- filter /dev files if needed
+        if skip_dev == false or string.sub(fn, 0, 5) ~= "/dev/" then
+            print(string.format("%-23.23s %-12.12s %-8s %7d %s",
+                evt.field(datetime), evt.field(pname), evt.field(etype), lat, fn))
+        end
+    end
+
+    return true
+end


### PR DESCRIPTION
This chisel allows quick analysis of file I/O latency outliers. For example, those latency greater than 1ms:

```
# sysdig -c fileslower 1
TIME                    PROCESS      TYPE     LAT(ms) FILE
2014-04-13 20:40:43.973 cksum        read           2 /mnt/partial.0.0
2014-04-13 20:40:44.187 cksum        read           1 /mnt/partial.0.0
2014-04-13 20:40:44.689 cksum        read           2 /mnt/partial.0.0
2014-04-13 20:40:45.005 cksum        read           2 /mnt/partial.0.0
2014-04-13 20:40:45.193 cksum        read           1 /mnt/partial.0.0
[...]
```

Typical use will be checking for latency greater than 10s or 100s of ms. This is particularly useful for exonerating file system and storage devices, proving that file I/O (of the type traced) has not exceeded expected latencies.

A minimum latency of 0 will show all file I/O:

```
# sysdig -c fileslower 0
TIME                    PROCESS      TYPE     LAT(ms) FILE
2014-04-13 20:59:04.414 ls           read           0 /lib/x86_64-linux-gnu/libselinux.so.1
2014-04-13 20:59:04.414 ls           read           0 /lib/x86_64-linux-gnu/librt.so.1
2014-04-13 20:59:04.414 ls           read           0 /lib/x86_64-linux-gnu/libacl.so.1
2014-04-13 20:59:04.414 ls           read           0 /lib/x86_64-linux-gnu/libc.so.6
2014-04-13 20:59:04.414 ls           read           0 /lib/x86_64-linux-gnu/libdl.so.2
2014-04-13 20:59:04.414 ls           read           0 /lib/x86_64-linux-gnu/libpthread.so.0
2014-04-13 20:59:04.414 ls           read           0 /lib/x86_64-linux-gnu/libattr.so.1
2014-04-13 20:59:04.415 ls           read           0 /proc/filesystems
2014-04-13 20:59:04.415 ls           read           0 /proc/filesystems
2014-04-13 20:59:04.418 date         read           0 /lib/x86_64-linux-gnu/librt.so.1
2014-04-13 20:59:04.418 date         read           0 /lib/x86_64-linux-gnu/libc.so.6
2014-04-13 20:59:04.418 date         read           0 /lib/x86_64-linux-gnu/libpthread.so.0
2014-04-13 20:59:04.418 date         read           0 /etc/localtime
2014-04-13 20:59:04.418 date         read           0 /etc/localtime
```

The latency for these reads were all 0 milliseconds (rounded), due to caching in the file system. The tool can be easily modified to show microseconds or nanoseconds, but given the role -- analyzing latency outliers -- using milliseconds is most effective in this case.
