### PR TITLE
only include linux includes on linux

### DIFF
--- a/userspace/common/sysdig_types.h
+++ b/userspace/common/sysdig_types.h
@@ -34,7 +34,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Import/typedef in userspace the kernel types
 //
-#if !defined(_WIN32) && !defined(__APPLE__) && !defined (__sun)
+#if defined(__linux__)
 #include <linux/types.h>
 #else 
 typedef uint64_t __u64;

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -43,7 +43,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <errno.h>
 #include <netinet/tcp.h>
-#if !defined __sun
+#if defined(__linux__)
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 //#include <linux/sock_diag.h>


### PR DESCRIPTION
let's be honest: there are so many different OS out there. so let's not test against a blacklist of OSes but just include linux headers when **linux** is defined.

current fail: FreeBSD :)
