### PR TITLE
define PATH_MAX for platforms who have no PATH_MAX

### DIFF
--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -29,6 +29,10 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include "filter.h"
 #include "filterchecks.h"
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 #ifdef HAS_CHISELS
 const chiseldir_info g_chisel_dirs_array[] =
 {


### PR DESCRIPTION
Hurd has no PATH_MAX and the proper solution would be dynamically
allocating a big enough `char *s`, but defining PATH_MAX as 4096
when it isn't defined yet is good enough too ;)
