### PR TITLE
consider ppm_print_format for numeric param

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -513,7 +513,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 	//
 	// Get the parameter information
 	//
-	ppm_print_format param_fmt = get_param_info(id)->fmt;
+	ppm_print_format param_fmt = m_info->params[id].fmt;
 
 	switch(m_info->params[id].type)
 	{


### PR DESCRIPTION
Unless i have missed something, i think we don't consider the print format defined in event_table.c when we print evt.args and evt.arg.*
