### PR TITLE
Replaced tuple<bool,string,string> with named struct in chisel.cpp

### DIFF
--- a/userspace/libsinsp/chisel.cpp
+++ b/userspace/libsinsp/chisel.cpp
@@ -18,8 +18,6 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <iostream>
 #include <fstream>
-#include <algorithm> 
-#include <functional> 
 #include <cctype>
 #include <locale>
 #ifndef _WIN32


### PR DESCRIPTION
This change fixes compilation with GCC 4.4 and improves readability of code.
