### PR TITLE
Add fix for install OpenVZ kernel headers correctly

### DIFF
--- a/scripts/install-sysdig.in
+++ b/scripts/install-sysdig.in
@@ -38,7 +38,12 @@ function install_rpm {
 	if [[ $KERNEL_VERSION == *PAE* ]]; then
 		yum -q -y install kernel-PAE-devel-${KERNEL_VERSION%.PAE} || kernel_warning
 	else
-		yum -q -y install kernel-devel-$KERNEL_VERSION || kernel_warning
+		if [[ $KERNEL_VERSION == *stab* ]]; then
+			# It's OpenVZ kernel and we should install another package
+			yum -q -y install vzkernel-devel-$KERNEL_VERSION || kernel_warning
+		else
+			yum -q -y install kernel-devel-$KERNEL_VERSION || kernel_warning
+		fi
 	fi
 	echo "* Installing Sysdig"
 	yum -q -y install sysdig


### PR DESCRIPTION
Hello!

I wish support for OpenVZ kernel on CentOS 6. It uses standard CentOS distro with few custom packages with tools (vzctl/ploop) and kernel (vzkernel). It preservers RH kernel ABI and will be used without original kernel. 

OpenVZ is so widespread technology http://stats.openvz.org/ :)
