### PR TITLE
Remove use of 'goto' in chisels to improve Lua 5.2 compat (issue #148)

### DIFF
--- a/userspace/sysdig/chisels/ansiterminal.lua
+++ b/userspace/sysdig/chisels/ansiterminal.lua
@@ -74,7 +74,7 @@ function ansiterminal.clearscreen()
     io.write(schar(27) .. '[' .. "2J")
 end
 
-function ansiterminal.goto(x, y)
+function ansiterminal.moveto(x, y)
     io.write(schar(27) .. '[' .. tostring(x) .. ";" .. tostring(y) .. 'H')
 end
 

--- a/userspace/sysdig/chisels/table_generator.lua
+++ b/userspace/sysdig/chisels/table_generator.lua
@@ -179,7 +179,7 @@ end
 function on_interval(ts_s, ts_ns, delta)	
 	if vizinfo.output_format ~= "json" then
 		terminal.clearscreen()
-		terminal.goto(0, 0)
+		terminal.moveto(0, 0)
 	end
 	
 	print_sorted_table(grtable, ts_s, 0, delta, vizinfo)
@@ -193,7 +193,7 @@ end
 function on_capture_end(ts_s, ts_ns, delta)
 	if islive and vizinfo.output_format ~= "json" then
 		terminal.clearscreen()
-		terminal.goto(0 ,0)
+		terminal.moveto(0 ,0)
 		terminal.showcursor()
 		return true
 	end

--- a/userspace/sysdig/chisels/topprocs_cpu.lua
+++ b/userspace/sysdig/chisels/topprocs_cpu.lua
@@ -109,7 +109,7 @@ end
 function on_interval(ts_s, ts_ns, delta)
 	if vizinfo.output_format ~= "json" then
 		terminal.clearscreen()
-		terminal.goto(0, 0)
+		terminal.moveto(0, 0)
 	end
 	
 	for cpuid = 1, ncpus do
@@ -139,7 +139,7 @@ end
 function on_capture_end(ts_s, ts_ns, delta)
 	if islive and vizinfo.output_format ~= "json" then
 		terminal.clearscreen()
-		terminal.goto(0 ,0)
+		terminal.moveto(0 ,0)
 		terminal.showcursor()
 		return true
 	end


### PR DESCRIPTION
Not claiming this is all that needs to be done (or that it isn't), but it's a start, and should fix the reporter's syntax error harmlessly.

If you're worried about compatibility with user-created chisels not in the repo, we could do something like:

```
ansiterminal["goto"] = ansiterminal.moveto
```

however I'm not that much inclined to backwards-compatibility cruft, especially for such a young project :)
