### PR TITLE
Fixes MSVC 12 warnings for JSON implementation

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -830,7 +830,7 @@ Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_
 		{
 			if(param->m_len == 1 + 4 + 2)
 			{
-				int ipv4_len = (3 + 1) * 4 + 1;
+				const int ipv4_len = (3 + 1) * 4 + 1;
 				char ipv4_addr[ ipv4_len ];
 
 				snprintf(
@@ -871,7 +871,7 @@ Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_
 				Json::Value source;
 				Json::Value dest;
 
-				int ipv4_len = (3 + 1) * 4 + 1;
+				const int ipv4_len = (3 + 1) * 4 + 1;
 				char ipv4_addr[ ipv4_len ];
 
 				snprintf(
@@ -924,7 +924,7 @@ Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_
 					Json::Value source;
 					Json::Value dest;
 
-					int ipv4_len = (3 + 1) * 4 + 1;
+					const int ipv4_len = (3 + 1) * 4 + 1;
 					char ipv4_addr[ ipv4_len ];
 
 					snprintf(

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1488,69 +1488,10 @@ Json::Value sinsp_filter_check_event::extract_as_js(sinsp_evt *evt, OUT uint32_t
 			return root;
 		}
 		break;
-	case TYPE_RESRAW:
-		{
-			const sinsp_evt_param* pi = evt->get_param_value_raw("res");
 
-			if(pi != NULL)
-			{
-				*len = pi->m_len;
-				return (uint8_t*)pi->m_val;
-			}
-
-			if((evt->get_flags() & EF_CREATES_FD) && PPME_IS_EXIT(evt->get_type()))
-			{
-				pi = evt->get_param_value_raw("fd");
-
-				if(pi != NULL)
-				{
-					*len = pi->m_len;
-					return (uint8_t*)pi->m_val;
-				}
-			}
-
-			return Json::Value::null;
-		}
-		break;
 	case TYPE_RESSTR:
-		{
-			const char* resolved_argstr;
-			const char* argstr;
-
-			argstr = evt->get_param_value_str("res", &resolved_argstr);
-
-			if(resolved_argstr != NULL && resolved_argstr[0] != 0)
-			{
-				return (uint8_t*)resolved_argstr;
-			}
-			else
-			{
-				if(argstr == NULL)
-				{
-					if((evt->get_flags() & EF_CREATES_FD) && PPME_IS_EXIT(evt->get_type()))
-					{
-						argstr = evt->get_param_value_str("fd", &resolved_argstr);
-
-						if(resolved_argstr != NULL && resolved_argstr[0] != 0)
-						{
-							return (uint8_t*)resolved_argstr;
-						}
-						else
-						{
-							return (uint8_t*)argstr;
-						}
-					}
-					else
-					{
-						return Json::Value::null;
-					}
-				}
-				else
-				{
-					return (uint8_t*)argstr;
-				}
-			}
-		}
+	case TYPE_RESRAW:
+		return Json::Value::null;
 		break;
 
 	case TYPE_COUNT:


### PR DESCRIPTION
This commit fixes two groups of warning messages in MSVC 12:
- event.cpp: a char was declared with an int size which was not explicitly declared const - VS didn't like that so the const modifier is now there.
- filtercheck.cpp: two blocks representing types with no JSON representation were cleared out to return nulls given a warning in MSVC 12.
