### PR TITLE
use json.h from the include path instead of hardcoding third-party

### DIFF
--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -17,7 +17,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #pragma once
-#include "third-party/jsoncpp/json/json.h"
+#include <json/json.h>
 
 #ifndef VISIBILITY_PRIVATE
 #define VISIBILITY_PRIVATE private:

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -17,7 +17,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #pragma once
-#include "third-party/jsoncpp/json/json.h"
+#include <json/json.h>
 
 class sinsp_filter_check;
 

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -17,7 +17,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #pragma once
-#include "third-party/jsoncpp/json/json.h"
+#include <json/json.h>
 
 #ifdef HAS_FILTERING
 

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -1,3 +1,4 @@
+include_directories("${JSONCPP_INCLUDE}")
 include_directories("${PROJECT_SOURCE_DIR}/common")
 include_directories("${PROJECT_SOURCE_DIR}/userspace/libscap")
 include_directories("${PROJECT_SOURCE_DIR}/userspace/libsinsp")


### PR DESCRIPTION
this allows using the proper header files while linking to the system
jsoncpp when using -DUSE_BUNDLED_JSONCPP=NO
