### PR TITLE
Support splice

### DIFF
--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -188,4 +188,6 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_SYSCALL_MMAP2_X */{"mmap2", EC_MEMORY, EF_NONE, 4, {{"res", PT_UINT64, PF_HEX}, {"vm_size", PT_UINT32, PF_DEC}, {"vm_rss", PT_UINT32, PF_DEC}, {"vm_swap", PT_UINT32, PF_DEC} } },
 	/* PPME_SYSCALL_MUNMAP_E */{"munmap", EC_MEMORY, EF_NONE, 2, {{"addr", PT_UINT64, PF_HEX}, {"length", PT_UINT64, PF_DEC} } },
 	/* PPME_SYSCALL_MUNMAP_X */{"munmap", EC_MEMORY, EF_NONE, 4, {{"res", PT_ERRNO, PF_DEC}, {"vm_size", PT_UINT32, PF_DEC}, {"vm_rss", PT_UINT32, PF_DEC}, {"vm_swap", PT_UINT32, PF_DEC} } },
+	/* PPME_SYSCALL_SPLICE_E */{"splice", EC_IO_OTHER, EF_USES_FD, 4, {{"fd_in", PT_FD, PF_DEC}, {"fd_out", PT_FD, PF_DEC}, {"size", PT_UINT64, PF_DEC}, {"flags", PT_FLAGS32, PF_HEX, splice_flags} } },
+	/* PPME_SYSCALL_SPLICE_X */{"splice", EC_IO_OTHER, EF_USES_FD, 1, {{"res", PT_ERRNO, PF_DEC}} }
 };

--- a/driver/flags_table.c
+++ b/driver/flags_table.c
@@ -233,3 +233,11 @@ const struct ppm_name_value mmap_flags[] = {
 	{"MAP_LOCKED", PPM_MAP_LOCKED},
 	{ },
 };
+
+const struct ppm_name_value splice_flags[] = {
+	{"SPLICE_F_MOVE", PPM_SPLICE_F_MOVE},
+	{"SPLICE_F_NONBLOCK", PPM_SPLICE_F_NONBLOCK},
+	{"SPLICE_F_MORE", PPM_SPLICE_F_MORE},
+	{"SPLICE_F_GIFT", PPM_SPLICE_F_GIFT},
+	{ },
+};

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -259,6 +259,14 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #define PPM_MAP_LOCKED		(1 << 14)
 
 /*
+ * splice flags
+ */
+#define PPM_SPLICE_F_MOVE		(1 << 0)
+#define PPM_SPLICE_F_NONBLOCK	(1 << 1)
+#define PPM_SPLICE_F_MORE		(1 << 2)
+#define PPM_SPLICE_F_GIFT		(1 << 3)
+
+/*
  * SuS says limits have to be unsigned.
  * Which makes a ton more sense anyway.
  *
@@ -457,7 +465,9 @@ enum ppm_event_type {
 	PPME_SYSCALL_MMAP2_X = 163,
 	PPME_SYSCALL_MUNMAP_E = 164,
 	PPME_SYSCALL_MUNMAP_X = 165,
-	PPM_EVENT_MAX = 166
+	PPME_SYSCALL_SPLICE_E = 166,
+	PPME_SYSCALL_SPLICE_X = 167,
+	PPM_EVENT_MAX = 168
 };
 /*@}*/
 
@@ -951,5 +961,6 @@ extern const struct ppm_name_value rlimit_resources[];
 extern const struct ppm_name_value fcntl_commands[];
 extern const struct ppm_name_value prot_flags[];
 extern const struct ppm_name_value mmap_flags[];
+extern const struct ppm_name_value splice_flags[];
 
 #endif /* EVENTS_PUBLIC_H_ */

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -266,7 +266,9 @@ const struct ppm_event_entry g_ppm_events[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_MMAP2_E] = {f_sys_mmap_e},
 	[PPME_SYSCALL_MMAP2_X] = {f_sys_brk_munmap_mmap_x},
 	[PPME_SYSCALL_MUNMAP_E] = {PPM_AUTOFILL, 2, APT_REG, {{0}, {1} } },
-	[PPME_SYSCALL_MUNMAP_X] = {f_sys_brk_munmap_mmap_x}
+	[PPME_SYSCALL_MUNMAP_X] = {f_sys_brk_munmap_mmap_x},
+	[PPME_SYSCALL_SPLICE_E] = {PPM_AUTOFILL, 4, APT_REG, {{0}, {2}, {4}, {5}} },
+	[PPME_SYSCALL_SPLICE_X] = {PPM_AUTOFILL, 1, APT_REG, {{AF_ID_RETVAL}} }
 };
 
 /*

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -162,7 +162,8 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 #ifdef __NR_mmap2
 	[__NR_mmap2 - SYSCALL_TABLE_ID0] =                    	{UF_USED, PPME_SYSCALL_MMAP2_E, PPME_SYSCALL_MMAP2_X},
 #endif
-	[__NR_munmap - SYSCALL_TABLE_ID0] =						{UF_USED, PPME_SYSCALL_MUNMAP_E, PPME_SYSCALL_MUNMAP_X}
+	[__NR_munmap - SYSCALL_TABLE_ID0] =						{UF_USED, PPME_SYSCALL_MUNMAP_E, PPME_SYSCALL_MUNMAP_X},
+	[__NR_splice - SYSCALL_TABLE_ID0] =                     {UF_USED, PPME_SYSCALL_SPLICE_E, PPME_SYSCALL_SPLICE_X},
 };
 
 /*

--- a/userspace/libscap/event_table.c
+++ b/userspace/libscap/event_table.c
@@ -188,4 +188,6 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_SYSCALL_MMAP2_X */{"mmap2", EC_MEMORY, EF_NONE, 4, {{"res", PT_UINT64, PF_HEX}, {"vm_size", PT_UINT32, PF_DEC}, {"vm_rss", PT_UINT32, PF_DEC}, {"vm_swap", PT_UINT32, PF_DEC} } },
 	/* PPME_SYSCALL_MUNMAP_E */{"munmap", EC_MEMORY, EF_NONE, 2, {{"addr", PT_UINT64, PF_HEX}, {"length", PT_UINT64, PF_DEC} } },
 	/* PPME_SYSCALL_MUNMAP_X */{"munmap", EC_MEMORY, EF_NONE, 4, {{"res", PT_ERRNO, PF_DEC}, {"vm_size", PT_UINT32, PF_DEC}, {"vm_rss", PT_UINT32, PF_DEC}, {"vm_swap", PT_UINT32, PF_DEC} } },
+	/* PPME_SYSCALL_SPLICE_E */{"splice", EC_IO_OTHER, EF_USES_FD, 4, {{"fd_in", PT_FD, PF_DEC}, {"fd_out", PT_FD, PF_DEC}, {"size", PT_UINT64, PF_DEC}, {"flags", PT_FLAGS32, PF_HEX, splice_flags} } },
+	/* PPME_SYSCALL_SPLICE_X */{"splice", EC_IO_OTHER, EF_USES_FD, 1, {{"res", PT_ERRNO, PF_DEC}} }
 };

--- a/userspace/libscap/flags_table.c
+++ b/userspace/libscap/flags_table.c
@@ -234,3 +234,11 @@ const struct ppm_name_value mmap_flags[] = {
 	{"MAP_LOCKED", PPM_MAP_LOCKED},
 	{0, 0},
 };
+
+const struct ppm_name_value splice_flags[] = {
+	{"SPLICE_F_MOVE", PPM_SPLICE_F_MOVE},
+	{"SPLICE_F_NONBLOCK", PPM_SPLICE_F_NONBLOCK},
+	{"SPLICE_F_MORE", PPM_SPLICE_F_MORE},
+	{"SPLICE_F_GIFT", PPM_SPLICE_F_GIFT},
+	{ },
+};


### PR DESCRIPTION
Known issue: filtering works like "fd" is "fd_in", however, it looks like splice is the first syscall here using two fds.
