### PR TITLE
updated zsh completion to use the new indent size

### DIFF
--- a/scripts/completions/zsh/_sysdig
+++ b/scripts/completions/zsh/_sysdig
@@ -4,7 +4,7 @@
 # 0.1.84
 
 # this must match fields_info.cpp
-local DESCRIPTION_TEXT_START=19
+local DESCRIPTION_TEXT_START=20
 
 # handles completion of filter fields
 function _filter () {


### PR DESCRIPTION
The zsh completion parses the output of some sysdig commands. Recently (in bf0e7badf2240dd4e88e9618967f7d0410db2ac4) the indent length changed and the zsh completion must be updated accordingly.
