### PR TITLE
install a rebuilt version of the manpage if pandoc is available

### DIFF
--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -23,11 +23,10 @@ target_link_libraries(sysdig
 
 if(NOT WIN32)
 
+	add_subdirectory(man)
+
 	install(TARGETS sysdig 
 		DESTINATION bin)
-
-	install(FILES man/sysdig.8
-		DESTINATION share/man/man8)
 
 	install(DIRECTORY chisels
 		DESTINATION share/sysdig)

--- a/userspace/sysdig/man/CMakeLists.txt
+++ b/userspace/sysdig/man/CMakeLists.txt
@@ -1,0 +1,13 @@
+find_program(PANDOC pandoc)
+
+if (PANDOC)
+	add_custom_target(man ALL
+		COMMAND ${PANDOC} -s -f markdown_github -t man sysdig.md -o ${CMAKE_CURRENT_BINARY_DIR}/sysdig.8
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+		VERBATIM)
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sysdig.8
+		DESTINATION share/man/man8)
+else()
+	install(FILES sysdig.8
+		DESTINATION share/man/man8)
+endif()


### PR DESCRIPTION
sysdig.8 is generated from sysdig.md. When a packager wants to modify
the manpage, he has to modify the manpage and not the source, which is
wrong. Let's rebuild the manpage if pandoc is available.

In a perfect world, we would get rid of the prebuilt version at all,
but pandoc may not be available on some tagets.
