### PR TITLE
133 additional options flags mimic tcpdump file size

### DIFF
--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -551,6 +551,19 @@ int64_t scap_dump_get_offset(scap_dumper_t *d);
 void scap_dump_flush(scap_dumper_t *d);
 
 /*!
+  \brief Tell how many bytes would be written (a dry run of scap_dump)
+
+  \param e pointer to an event returned by \ref scap_next.
+  \param cpuid The cpu from which the event was captured. Returned by \ref scap_next.
+  \param bytes The number of bytes to write
+
+  \return SCAP_SUCCESS if the call is succesful.
+   On Failure, SCAP_FAILURE is returned and scap_getlasterr() can be used to obtain 
+   the cause of the error. 
+*/
+int32_t scap_number_of_bytes_to_write(scap_evt *e, uint16_t cpuid, int32_t* bytes);
+
+/*!
   \brief Write an event to a trace file 
 
   \param handle Handle to the capture instance.

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -674,6 +674,14 @@ void scap_dump_flush(scap_dumper_t *d)
 	gzflush((gzFile)d, Z_FULL_FLUSH);
 }
 
+// Tell me how many bytes we will have written if we did.
+int32_t scap_number_of_bytes_to_write(scap_evt *e, uint16_t cpuid, int32_t *bytes)
+{
+	*bytes = scap_normalize_block_len(sizeof(block_header) + sizeof(cpuid) + e->len + 4);
+
+	return SCAP_SUCCESS;
+}
+
 //
 // Write an event to a dump file
 //
@@ -701,7 +709,7 @@ int32_t scap_dump(scap_t *handle, scap_dumper_t *d, scap_evt *e, uint16_t cpuid)
 	}
 
 	//
-	// Enalbe this to make sure that everything is saved to disk during the tests
+	// Enable this to make sure that everything is saved to disk during the tests
 	//
 #if 0
 	fflush(f);

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories("${LUAJIT_INCLUDE}")
 
 add_library(sinsp STATIC
 	chisel.cpp
+	cyclewriter.cpp
 	event.cpp
 	eventformatter.cpp
 	dumper.cpp

--- a/userspace/libsinsp/cyclewriter.cpp
+++ b/userspace/libsinsp/cyclewriter.cpp
@@ -34,6 +34,11 @@ bool cycle_writer::setup(string base_file_name, int rollover_mb, int duration_se
 	m_file_limit = file_limit;
 	m_do_cycle = do_cycle;
 
+	//
+	// Seed the filename with an initial
+	// value.
+	//
+	consider(0);
 	return true;
 }
 

--- a/userspace/libsinsp/cyclewriter.h
+++ b/userspace/libsinsp/cyclewriter.h
@@ -1,8 +1,8 @@
-#include<string>
-#include<stdlib.h>
-#include<stddef.h>
-#include<time.h>
-#include<stdio.h>
+#include <string>
+#include <stdlib.h>
+#include <stddef.h>
+#include <time.h>
+#include <stdio.h>
 
 using namespace std;
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -31,6 +31,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include "sinsp_int.h"
 #include "filter.h"
 #include "filterchecks.h"
+#include "cyclewriter.h"
 #ifdef HAS_ANALYZER
 #include "analyzer_int.h"
 #include "analyzer.h"
@@ -57,6 +58,7 @@ sinsp::sinsp() :
 	m_max_thread_table_size = MAX_THREAD_TABLE_SIZE;
 	m_thread_timeout_ns = DEFAULT_THREAD_TIMEOUT_S * ONE_SECOND_IN_NS;
 	m_inactive_thread_scan_time_ns = DEFAULT_INACTIVE_THREAD_SCAN_TIME_S * ONE_SECOND_IN_NS;
+	m_cycle_writer = new cycle_writer();
 
 #ifdef HAS_ANALYZER
 	m_analyzer = NULL;
@@ -265,6 +267,12 @@ void sinsp::autodump_start(const string& dump_filename, bool compress)
 	}
 }
 
+void sinsp::autodump_next_file()
+{
+	autodump_stop();
+	autodump_start(m_cycle_writer->get_current_file_name(), m_compress);
+}
+
 void sinsp::autodump_stop()
 {
 	if(NULL == m_h)
@@ -354,6 +362,10 @@ int32_t sinsp::next(OUT sinsp_evt **evt)
 	// Get the event from libscap
 	//
 	int32_t res = scap_next(m_h, &(m_evt.m_pevt), &(m_evt.m_cpuid));
+
+	// The number of bytes to consider in the dumper
+	int32_t bytes_to_write;
+
 	if(res != SCAP_SUCCESS)
 	{
 		if(res == SCAP_TIMEOUT)
@@ -476,6 +488,31 @@ int32_t sinsp::next(OUT sinsp_evt **evt)
 	//
 	if(NULL != m_dumper)
 	{
+		
+		res = scap_number_of_bytes_to_write(m_evt.m_pevt, m_evt.m_cpuid, &bytes_to_write);
+		if(SCAP_SUCCESS != res)
+		{
+			throw sinsp_exception(scap_getlasterr(m_h));
+		}
+		else 
+		{
+			switch(m_cycle_writer->consider(bytes_to_write))
+			{
+				case cycle_writer::NEWFILE:
+					autodump_next_file();
+					break;
+
+				case cycle_writer::DOQUIT:
+					stop_capture();
+					return SCAP_EOF;
+					break;
+
+				case cycle_writer::SAMEFILE:
+					// do nothing.
+					break;
+			}
+		} 
+
 		res = scap_dump(m_h, m_dumper, m_evt.m_pevt, m_evt.m_cpuid);
 		if(SCAP_SUCCESS != res)
 		{
@@ -830,6 +867,13 @@ bool sinsp::is_debug_enabled()
 sinsp_parser* sinsp::get_parser()
 {
 	return m_parser;
+}
+
+bool sinsp::setup_cycle_writer(string base_file_name, int rollover_mb, int duration_seconds, int file_limit, bool do_cycle, bool compress) 
+{
+	m_compress = compress;
+
+	return m_cycle_writer->setup(base_file_name, rollover_mb, duration_seconds, file_limit, do_cycle);
 }
 
 double sinsp::get_read_progress()

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -90,6 +90,7 @@ class sinsp_partial_transaction;
 class sinsp_parser;
 class sinsp_analyzer;
 class sinsp_filter;
+class cycle_writer;
 
 vector<string> sinsp_split(const string &s, char delim);
 
@@ -279,6 +280,11 @@ public:
 	   of failure.
 	*/
 	void autodump_start(const string& dump_filename, bool compress);
+ 
+ 	/*!
+	  \brief Cycles the file pointer to a new capture file
+	*/
+	void autodump_next_file();
 
 	/*!
 	  \brief Stops an event dump that was started with \ref autodump_start().
@@ -467,6 +473,8 @@ public:
 
 	sinsp_parser* get_parser();
 
+	bool setup_cycle_writer(string base_file_name, int rollover_mb, int duration_seconds, int file_limit, bool do_cycle, bool compress);
+
 VISIBILITY_PRIVATE
 
 // Doxygen doesn't understand VISIBILITY_PRIVATE
@@ -486,6 +494,7 @@ private:
 	int64_t m_filesize;
 	bool m_islive;
 	bool m_isdebug_enabled;
+	bool m_compress;
 	sinsp_evt m_evt;
 	string m_lasterr;
 	int64_t m_tid_to_remove;
@@ -541,6 +550,11 @@ private:
 	//
 	unordered_map<uint32_t, scap_userinfo*> m_userlist;
 	unordered_map<uint32_t, scap_groupinfo*> m_grouplist;
+
+	//
+	// The cycle-writer for files
+	//
+	cycle_writer* m_cycle_writer;
 
 	//
 	// Some dropping infrastructure


### PR DESCRIPTION
This commit introduces an engine called the "cycle writer" that is intended to mimic tcpdump's style of captures spanning multiple files.

It supports the same arguments as tcpdump and has the same functionality.  It was implemented independently, without viewing any of the tcpdump code and so should be free to fall under any license.
