### PR TITLE
zsh completion: FILTER-ONLY fields excluded from -p strings

### DIFF
--- a/scripts/completions/zsh/_sysdig
+++ b/scripts/completions/zsh/_sysdig
@@ -48,7 +48,7 @@ function _filter () {
     elif [[ $1 == "format" ]]; then
         # expanding format specifiers
         local allfields_withpercent;
-        allfields_withpercent=("%"${^fields})
+        allfields_withpercent=("%"${^fields:#*FILTER ONLY*})
 
         # skip all leading characters that can't be in a field name. This lets
         # me specify multiple fields in the string or do things like


### PR DESCRIPTION
Yet another small patch. Sorry for the noise, and feel free to refrain from merging until release-time so that any possible new changes can be consolidated.
