### PR TITLE
improve json output

### DIFF
--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -576,6 +576,10 @@ captureinfo do_inspect(sinsp* inspector,
 				{
 					cout << endl;
 				}
+				else
+				{
+					cout << flush;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This solves two problems with json:
1) when you read a trace from a file, the terminator ']' is not inserted
2) on live capture the last event is not printed until you quit sysdig or another event is printed
