### PR TITLE
userspace/libscap: handle trace file with no events

### DIFF
--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1659,6 +1659,18 @@ int32_t scap_read_init(scap_t *handle, gzFile f)
 	while(true)
 	{
 		readsize = gzread(f, &bh, sizeof(bh));
+
+		//
+		// If we don't find the event block header,
+		// it means there is no event in the file.
+		//
+		if (readsize == 0 && !found_ev && found_mi && found_pl &&
+			found_il && found_fdl && found_ul)
+		{
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "no events in file");
+			return SCAP_FAILURE;
+		}
+
 		CHECK_READ_SIZE(readsize, sizeof(bh));
 
 		switch(bh.block_type)


### PR DESCRIPTION
Currently when you save a file with 0 events, you receive a "expecting 8 bytes, read 0 at /sysdig/userspace/libscap/scap_savefile.c, line 1662. Is the file truncated?"

This patch tries to give the user a more meaningful message, by checking if the header is the only one to be not there when you read 0 bytes.
