### PR TITLE
fix building of libscap on archs w/o live capture support (*BSD, Hurd)

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -973,11 +973,8 @@ static int32_t scap_handle_eventmask(scap_t* handle, uint32_t op, uint32_t event
 		return SCAP_FAILURE;
 	}
 
-#ifdef _WIN32
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on windows");
-	return SCAP_FAILURE;
-#elif defined(__APPLE__)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on OSX");
+#if !defined(HAS_CAPTURE)
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
 	//
@@ -1028,11 +1025,8 @@ static int32_t scap_handle_eventmask(scap_t* handle, uint32_t op, uint32_t event
 
 
 int32_t scap_clear_eventmask(scap_t* handle) {
-#ifdef _WIN32
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on windows");
-	return SCAP_FAILURE;
-#elif defined(__APPLE__)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on OSX");
+#if !defined(HAS_CAPTURE)
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
 	return(scap_handle_eventmask(handle, PPM_IOCTL_MASK_ZERO_EVENTS, 0));
@@ -1040,11 +1034,8 @@ int32_t scap_clear_eventmask(scap_t* handle) {
 }
 
 int32_t scap_set_eventmask(scap_t* handle, uint32_t event_id) {
-#ifdef _WIN32
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on windows");
-	return SCAP_FAILURE;
-#elif defined(__APPLE__)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on OSX");
+#if !defined(HAS_CAPTURE)
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
 	return(scap_handle_eventmask(handle, PPM_IOCTL_MASK_SET_EVENT, event_id));
@@ -1052,11 +1043,8 @@ int32_t scap_set_eventmask(scap_t* handle, uint32_t event_id) {
 }
 
 int32_t scap_unset_eventmask(scap_t* handle, uint32_t event_id) {
-#ifdef _WIN32
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on windows");
-	return SCAP_FAILURE;
-#elif defined(__APPLE__)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on OSX");
+#if !defined(HAS_CAPTURE)
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
 	return(scap_handle_eventmask(handle, PPM_IOCTL_MASK_UNSET_EVENT, event_id));


### PR DESCRIPTION
setting eventmask is only supported when we do a live capture, so use the old `HAS_CAPTURE` define to surround them.

Without that patch, the build fails on FreeBSD and Hurd:
- https://buildd.debian.org/status/fetch.php?pkg=sysdig&arch=kfreebsd-amd64&ver=0.1.85-2&stamp=1405266480
- https://buildd.debian.org/status/fetch.php?pkg=sysdig&arch=kfreebsd-i386&ver=0.1.85-2&stamp=1405258294
- https://buildd.debian.org/status/fetch.php?pkg=sysdig&arch=hurd-i386&ver=0.1.85-2&stamp=1405284815

also, Travis really needs a BSD or Hurd build machine :)
