### PR TITLE
fix build in register_event_callback after d5b334cebb96840885f6a5cd7557dd4672bfd931

### DIFF
--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -193,7 +193,7 @@ template<> scap_l4_proto sinsp_fdinfo_t::get_l4proto()
 	}
 }
 
-void sinsp_fdinfo_t::register_event_callback(sinsp_fdinfo_t::callback_type etype, sinsp_protodecoder* dec)
+template<> void sinsp_fdinfo_t::register_event_callback(sinsp_fdinfo_t::callback_type etype, sinsp_protodecoder* dec)
 {
 	switch(etype)
 	{

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -157,7 +157,7 @@ public:
 	/*!
 	  \brief Used by protocol decoders to register callbacks related to this FD.
 	*/
-	void register_event_callback(sinsp_fdinfo_t::callback_type etype, sinsp_protodecoder* dec);
+	void register_event_callback(callback_type etype, sinsp_protodecoder* dec);
 
 	scap_fd_type m_type; ///< The fd type, e.g. file, directory, IPv4 socket...
 	uint32_t m_openflags; ///< If this FD is a file, the flags that were used when opening it. See the PPM_O_* definitions in driver/ppm_events_public.h.


### PR DESCRIPTION
without this, the build will first fail with

  In file included from /home/evgeni/Devel/sysdig/userspace/libsinsp/sinsp.h:84:0,
                   from /home/evgeni/Devel/sysdig/userspace/libsinsp/chisel.cpp:31:
  /home/evgeni/Devel/sysdig/userspace/libsinsp/fdinfo.h:160:47: error: ‘sinsp_fdinfo_t<int>::callback_type’ has not been declared
    void register_event_callback(sinsp_fdinfo_t::callback_type etype, sinsp_protodecoder\* dec);
                                               ^
  userspace/libsinsp/CMakeFiles/sinsp.dir/build.make:54: recipe for target   'userspace/libsinsp/CMakeFiles/sinsp.dir/chisel.cpp.o' failed
   make[2]: **\* [userspace/libsinsp/CMakeFiles/sinsp.dir/chisel.cpp.o] Error 1

and later with

/home/evgeni/Devel/sysdig/userspace/libsinsp/fdinfo.cpp:196:6: error: specializing member ‘sinsp_fdinfo<int>::register_event_callback’ requires ‘template<>’ syntax
 void sinsp_fdinfo_t::register_event_callback(sinsp_fdinfo_t::callback_type etype, sinsp_protodecoder\* dec)
      ^
userspace/libsinsp/CMakeFiles/sinsp.dir/build.make:169: recipe for target 'userspace/libsinsp/CMakeFiles/sinsp.dir/fdinfo.cpp.o' failed
make[2]: **\* [userspace/libsinsp/CMakeFiles/sinsp.dir/fdinfo.cpp.o] Error 1
