### PR TITLE
Log-rotation options (-C, -G and -W) had some issues so I'm disabling them

### DIFF
--- a/scripts/completions/bash/sysdig
+++ b/scripts/completions/bash/sysdig
@@ -48,16 +48,19 @@ complete -W                                     \
   --snaplen                                     \
   -t                                            \
   --timetype                                    \
-  -C                                            \
-  --file-size                                   \
-  -G                                            \
-  --seconds                                     \
-  -W                                            \
-  --limit                                       \
   -c                                            \
   --chisel                                      \
   -i                                            \
   --chisel-info' sysdig
+
+  # Sysdig 0.1.85 had these options too, but they were problematic, so I'm
+  # removing them until they can be fixed
+  # -C
+  # --file-size
+  # -G
+  # --seconds
+  # -W
+  # --limit
 
 # Local Variables:
 # mode:sh

--- a/scripts/completions/zsh/_sysdig
+++ b/scripts/completions/zsh/_sysdig
@@ -217,12 +217,15 @@ _arguments                                                                      
        a\:"absolute timestamp from epoch"                                                                       \
        r\:"relative time from capture start"                                                                    \
        d\:"delta between enter/exit"))'                                                                         \
-    '(-C --file-size)'{-C,--file-size=-}'[Chunk captures to files of given size]:Maximum chunk file size:'      \
-    '(-G --seconds)'{-G,--seconds=-}'[Rotate the capture file every <num> seconds]:Rotation period (seconds):'  \
-    '(-W --limit)'{-W,--limit}'[Limit split captures (-C or -G) to a given number of files]:Maximum number of files' \
     '(-c --chisel)'{-c,--chisel}'[Run a given chisel]:Chisel:->chisel'                                          \
     '(-i --chisel-info)'{-i,--chisel-info}'[Get a detailed chisel description]:Chisel:->chisel' \
     '*:Filter or chisel argument:->filter_or_chiselarg' && return 0
+
+    # Sysdig 0.1.85 had these options too, but they were problematic, so I'm
+    # removing them until they can be fixed
+    # '(-C --file-size)'{-C,--file-size=-}'[Chunk captures to files of given size]:Maximum chunk file size:'
+    # '(-G --seconds)'{-G,--seconds=-}'[Rotate the capture file every <num> seconds]:Rotation period (seconds):'
+    # '(-W --limit)'{-W,--limit}'[Limit split captures (-C or -G) to a given number of files]:Maximum number of files'
 
 
 case $state in

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -43,6 +43,13 @@ static bool g_terminate = false;
 vector<sinsp_chisel*> g_chisels;
 #endif
 
+
+
+// Sysdig 0.1.85 had log-rotation options (-C,-G,-W), but they were problematic,
+// so I'm disabling them until they can be fixed
+#define DISABLE_CGW
+
+
 static void usage();
 
 //
@@ -90,6 +97,7 @@ static void usage()
 "                    lists the available chisels. Looks for chisels in .,\n"
 "                    ./chisels, ~/.chisels and /usr/share/sysdig/chisels.\n"
 #endif
+#ifndef DISABLE_CGW
 " -C <file_size>, --file-size=<file_size>\n"
 "                    Before writing an event, check whether the file is\n"
 "                    currently larger than file_size and, if so, close the\n"
@@ -98,12 +106,14 @@ static void usage()
 "                    starting at 0 and continuing upward. The units of file_size\n"
 "                    are millions of bytes (10^6, not 2^20). Use the -W flag to\n"
 "                    determine how many files will be saved to disk.\n"
+#endif
 " -d, --displayflt   Make the given filter a display one.\n"
 "                    Setting this option causes the events to be filtered\n"
 "                    after being parsed by the state system. Events are\n"
 "                    normally filtered before being analyzed, which is more\n"
 "                    efficient, but can cause state (e.g. FD names) to be lost.\n"
 " -D, --debug        Capture events about sysdig itself\n"
+#ifndef DISABLE_CGW
 " -G <num_seconds>, --seconds=<num_seconds>\n"
 "                    Rotates the dump file specified with the -w option every\n"
 "                    num_seconds seconds. Savefiles will have the name specified\n"
@@ -113,6 +123,7 @@ static void usage()
 "\n"
 "                    If used in conjunction with the -C option, filenames will take\n"
 "                    the form of `file<count>'.\n"
+#endif
 " -h, --help         Print this page\n"
 #ifdef HAS_CHISELS
 " -i <chiselname>, --chisel-info <chiselname>\n"
@@ -148,6 +159,7 @@ static void usage()
 " -v, --verbose      Verbose output.\n"
 " -w <writefile>, --write=<writefile>\n"
 "                    Write the captured events to <writefile>.\n"
+#ifndef DISABLE_CGW
 " -W <num>, --limit <num>\n"
 "                    Used in conjunction with the -C option, this will limit the number\n"
 "                    of files created to the specified number, and begin overwriting files\n"
@@ -159,6 +171,7 @@ static void usage()
 "                    of rotated dump files that get created, exiting with status 0 when\n"
 "                    reaching the limit. If used with -C as well, the behavior will result\n"
 "                    in cyclical files per timeslice.\n"
+#endif
 " -x, --print-hex    Print data buffers in hex.\n"
 " -X, --print-hex-ascii\n"
 "                    Print data buffers in hex and ASCII.\n"
@@ -636,12 +649,16 @@ int main(int argc, char **argv)
 		{"compress", no_argument, 0, 'z' },
 		{"displayflt", no_argument, 0, 'd' },
 		{"debug", no_argument, 0, 'D'},
+#ifndef DISABLE_CGW
 		{"seconds", required_argument, 0, 'G' },
+#endif
 		{"help", no_argument, 0, 'h' },
 #ifdef HAS_CHISELS
 		{"chisel-info", required_argument, 0, 'i' },
 #endif
+#ifndef DISABLE_CGW
 		{"file-size", required_argument, 0, 'C' },
+#endif
 		{"json", no_argument, 0, 'j' },
 		{"list", no_argument, 0, 'l' },
 		{"list-events", no_argument, 0, 'L' },
@@ -655,7 +672,9 @@ int main(int argc, char **argv)
 		{"timetype", required_argument, 0, 't' },
 		{"verbose", no_argument, 0, 'v' },
 		{"writefile", required_argument, 0, 'w' },
+#ifndef DISABLE_CGW
 		{"limit", required_argument, 0, 'W' },
+#endif
 		{"print-hex", no_argument, 0, 'x'},
 		{"print-hex-ascii", no_argument, 0, 'X'},
 		{0, 0, 0, 0}
@@ -675,7 +694,20 @@ int main(int argc, char **argv)
 		//
 		// Parse the args
 		//
-		while((op = getopt_long(argc, argv, "Aac:C:dDG:hi:jlLn:Pp:qr:Ss:t:vW:w:xXz", long_options, &long_index)) != -1)
+		while((op = getopt_long(argc, argv,
+                                        "Aac:"
+#ifndef DISABLE_CGW
+                                        "C:"
+#endif
+                                        "dD"
+#ifndef DISABLE_CGW
+                                        "G:"
+#endif
+                                        "hi:jlLn:Pp:qr:Ss:t:v"
+#ifndef DISABLE_CGW
+                                        "W:"
+#endif
+                                        "w:xXz", long_options, &long_index)) != -1)
 		{
 			switch(op)
 			{
@@ -734,6 +766,7 @@ int main(int argc, char **argv)
 #endif
 				break;
 
+#ifndef DISABLE_CGW
 			// File-size
 			case 'C':
 				rollover_mb = atoi(optarg);
@@ -747,11 +780,13 @@ int main(int argc, char **argv)
 				// -C always implicates a cycle
 				do_cycle = true;
 				break;
+#endif
 
 			case 'D':
 				inspector->set_debug_mode(true);
 				break;
 
+#ifndef DISABLE_CGW
 			// Number of seconds between roll-over
 			case 'G':
 				duration_seconds = atoi(optarg);
@@ -762,6 +797,7 @@ int main(int argc, char **argv)
 					goto exit;
 				}
 				break;
+#endif
 
 #ifdef HAS_CHISELS
 			// --chisel-info and -i
@@ -896,6 +932,7 @@ int main(int argc, char **argv)
 				quiet = true;
 				break;
 
+#ifndef DISABLE_CGW
 			// Number of capture files to cycle through
 			case 'W':
 				file_limit = atoi(optarg);
@@ -906,6 +943,7 @@ int main(int argc, char **argv)
 					goto exit;
 				}
 				break;
+#endif
 
 			case 'x':
 				if(event_buffer_format != sinsp_evt::PF_NORMAL)


### PR DESCRIPTION
This patch disables them in the tab completion, in the option parsing and in the
--help string. The actual core functionality is left in-place, but users can no
longer access it
