### PR TITLE
Make sure there is enough buffer space in binary_buffer_to_base64_string()

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -425,7 +425,7 @@ uint32_t binary_buffer_to_string_dots(char *dst, char *src, uint32_t dstlen, uin
 uint32_t binary_buffer_to_base64_string(char *dst, char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	//
-	// base64 encoder, source:
+	// base64 encoder, malloc-free version of:
 	// http://stackoverflow.com/questions/342409/how-do-i-base64-encode-decode-in-c
 	//
 	static char encoding_table[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
@@ -438,9 +438,16 @@ uint32_t binary_buffer_to_base64_string(char *dst, char *src, uint32_t dstlen, u
 		'4', '5', '6', '7', '8', '9', '+', '/'};
 	static uint32_t mod_table[] = {0, 2, 1};
 
-	uint32_t j,k;
+	uint32_t j,k, enc_dstlen;
 
-	dstlen = 4 * ((srclen + 2) / 3);
+	enc_dstlen = 4 * ((srclen + 2) / 3);
+	//
+	// Make sure there's enough space in the target buffer.
+	//
+	if(enc_dstlen >= dstlen - 1)
+	{
+		return dstlen;
+	}
 
 	for (j = 0, k = 0; j < srclen;) {
 
@@ -457,9 +464,9 @@ uint32_t binary_buffer_to_base64_string(char *dst, char *src, uint32_t dstlen, u
 	}
 
 	for (j = 0; j < mod_table[srclen % 3]; j++)
-		dst[dstlen - 1 - j] = '=';
+		dst[enc_dstlen - 1 - j] = '=';
 
-	return dstlen;
+	return enc_dstlen;
 }
 
 uint32_t binary_buffer_to_json_string(char *dst, char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)


### PR DESCRIPTION
Hi everyone,

just noticed the -b/--print-base64 format was buggy with large event buffer, causing sysdig to crash printing a backtrace. I isolated a capture able to reproduce the bug consistently.

A quick valgrind run isolated the issue as belonging to my new function binary_buffer_to_base64_string():
==2306== ERROR SUMMARY: 64 errors from 4 contexts (suppressed: 2 from 2)
==2306== 
==2306== 16 errors in context 1 of 4:
==2306== Invalid write of size 1
==2306==    at 0x4370A8: binary_buffer_to_base64_string(char_, char_, unsigned int, unsigned int, sinsp_evt::param_fmt) (event.cpp:456)

This simple fix  will make sure I account for the buffer size similarly to other print format functions: the test is now passing and valgrind doesn't complain anymore.
