### PR TITLE
added ( and ) to the zsh completions

### DIFF
--- a/scripts/completions/zsh/_sysdig
+++ b/scripts/completions/zsh/_sysdig
@@ -42,7 +42,7 @@ function _filter () {
     if [[ -z $1 ]]; then
         # full filter expansion
         local ops
-        ops=("=" "!=" "<" "<=" ">" ">=" "contains" "and" "or" "not")
+        ops=("=" "!=" "<" "<=" ">" ">=" "contains" "and" "or" "not" "(" ")")
 
         # Remove the FILTER-ONLY string, since we don't need to indicate that to
         # the user here


### PR DESCRIPTION
Hi. Here's a trivial change to the zsh completion. Adding () as options is less for the tab COMPLETION, than for letting the user know that these are allowed.