### PR TITLE
Bug 306: normalize all directory names to exclude trailing /

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -197,7 +197,7 @@ uint8_t* sinsp_filter_check_fd::extract_from_null_fd(sinsp_evt *evt, OUT uint32_
 			{
 				if(pos < m_tstr.size() - 1)
 				{
-					m_tstr.resize(pos + 1);
+					m_tstr.resize(pos);
 				}
 			}
 			else
@@ -362,7 +362,7 @@ uint8_t* sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT uint32_t* len)
 				{
 					if(pos < m_tstr.size() - 1)
 					{
-						m_tstr.resize(pos + 1);
+						m_tstr.resize(pos);
 					}
 				}
 				else


### PR DESCRIPTION
Consider this a very naive attempt.  From what I can tell, this is enough, and my test build produces a working copy (output below), but I didn't run any more comprehensive tests.

Thoughts and feedback would be very appreciated.


------
$ sysdig -zr bug306.20150211.1125.scap.z  fd.directory contains /tmp -p "%fd.directory %fd.name" | uniq
/tmp /tmp
/tmp /tmp/sh-thd-1062265610
/tmp /tmp/foo
/tmp /tmp/baz
/tmp /tmp/qux
/tmp /tmp/foo
/tmp /tmp
$ sysdig -zr bug306.20150211.1125.scap.z  fd.directory=/tmp -p "%fd.directory %fd.name" | uniq
/tmp /tmp
/tmp /tmp/sh-thd-1062265610
/tmp /tmp/foo
/tmp /tmp/baz
/tmp /tmp/qux
/tmp /tmp/foo
/tmp /tmp
$ sysdig -zr bug306.20150211.1125.scap.z  fd.directory=/tmp/ -p "%fd.directory %fd.name" | uniq
$