### PR TITLE
typo: get_filelds commented such that get_fields sounded more appropriate

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1256,7 +1256,7 @@ void sinsp_filter::parse_check(sinsp_filter_expression* parent_expr, boolop op)
 
 	if(m_ttable_only)
 	{
-		if(!(chk->get_filelds()->m_flags & filter_check_info::FL_WORKS_ON_THREAD_TABLE))
+		if(!(chk->get_fields()->m_flags & filter_check_info::FL_WORKS_ON_THREAD_TABLE))
 		{
 			throw sinsp_exception("the given filter is not supported for thread table filtering");
 		}

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -61,7 +61,7 @@ public:
 	//
 	// Get the list of fields that this check exports
 	//
-	virtual filter_check_info* get_filelds()
+	virtual filter_check_info* get_fields()
 	{
 		return &m_info;
 	}


### PR DESCRIPTION
very minor, just cleaning up because I was there.