### PR TITLE
Catch a potential double free()

### DIFF
--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1402,6 +1402,7 @@ static int32_t scap_read_iflist(scap_t *handle, gzFile f, uint32_t block_length)
 
 scap_read_iflist_error:
 	scap_free_iflist(handle->m_addrlist);
+	handle->m_addrlist = NULL;
 
 	if(readbuf)
 	{


### PR DESCRIPTION
Set handle->m_addrlist as NULL after freeing it to prevent a potential
double free()

Fixes #190