### PR TITLE
issue #317 added evt.num back for default output

### DIFF
--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -167,8 +167,7 @@ struct sinsp_capture_interrupt_exception : sinsp_exception
 /*!
   \brief The deafult way an event is converted to string by the library
 */
-//#define DEFAULT_OUTPUT_STR "*%evt.num %evt.time %evt.cpu %proc.name (%thread.tid) %evt.dir %evt.type %evt.args"
-#define DEFAULT_OUTPUT_STR "*%evt.time %evt.cpu %proc.name (%thread.tid) %evt.dir %evt.type %evt.args"
+#define DEFAULT_OUTPUT_STR "*%evt.num %evt.time %evt.cpu %proc.name (%thread.tid) %evt.dir %evt.type %evt.args"
 
 /** @defgroup inspector Main library
  @{


### PR DESCRIPTION
Request
-----------
Please do a code review and merge these changes

Reason
----------
The evt.num field was missing while using the "default" option in this chisel call: chisel.set_event_formatter("default") as mentioned in issue #317. 
**Note:** this was tested and worked.

Change Overview
-----------------------
Uncommented out the #define DEFAULT_OUTPUT_STR which contained the "*evt.num ..." and removed the one which didn't have this field.
