### PR TITLE
Multiple consumers (proof of concept)

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -179,10 +179,12 @@ static struct ppm_consumer_t *ppm_find_consumer(struct task_struct *consumer_id)
 
 	rcu_read_lock();
 	list_for_each_entry_rcu(el, &g_consumer_list, node) {
-		if (el->consumer_id == consumer_id)
+		if (el->consumer_id == consumer_id) {
+			rcu_read_unlock();
 			return el;
+		}
 	}
-	rcu_read_lock();
+	rcu_read_unlock();
 
 	return NULL;
 }

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -174,7 +174,7 @@ int32_t dpi_lookahead_init(void)
 
 inline u32 compute_snaplen(struct event_filler_arguments *args, char *buf, u32 lookahead_size)
 {
-	u32 res = g_snaplen;
+	u32 res = args->consumer->snaplen;
 	int err;
 	struct socket *sock;
 	sa_family_t family;
@@ -213,7 +213,7 @@ inline u32 compute_snaplen(struct event_filler_arguments *args, char *buf, u32 l
 	}
 */
 
-	if (!g_do_dynamic_snaplen)
+	if (!args->consumer->do_dynamic_snaplen)
 		return res;
 
 	sock = sockfd_lookup(args->fd, &err);
@@ -418,7 +418,7 @@ int val_to_ring(struct event_filler_arguments *args, uint64_t val, u16 val_len, 
 					 * Calculate the snaplen
 					 */
 					if (likely(args->enforce_snaplen)) {
-						u32 sl = g_snaplen;
+						u32 sl = args->consumer->snaplen;
 
 						sl = compute_snaplen(args, args->buffer + args->arg_data_offset, dpi_lookahead_size);
 

--- a/driver/ppm_events.h
+++ b/driver/ppm_events.h
@@ -26,6 +26,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
  * Various crap that a callback might need
  */
 struct event_filler_arguments {
+	struct ppm_consumer_t *consumer;
 	char *buffer; /* the buffer that will be filled with the data */
 	u32 buffer_size; /* the space in the ring buffer available for this event */
 	u32 syscall_id; /* the system call ID */

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1835,7 +1835,7 @@ static int f_sys_sendmsg_e(struct event_filler_arguments *args)
 	iov = (const struct iovec __user *)mh.msg_iov;
 	iovcnt = mh.msg_iovlen;
 
-	res = parse_readv_writev_bufs(args, iov, iovcnt, g_snaplen, PRB_FLAG_PUSH_SIZE);
+	res = parse_readv_writev_bufs(args, iov, iovcnt, args->consumer->snaplen, PRB_FLAG_PUSH_SIZE);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 
@@ -1915,7 +1915,7 @@ static int f_sys_sendmsg_x(struct event_filler_arguments *args)
 	iov = (const struct iovec __user *)mh.msg_iov;
 	iovcnt = mh.msg_iovlen;
 
-	res = parse_readv_writev_bufs(args, iov, iovcnt, g_snaplen, PRB_FLAG_PUSH_DATA);
+	res = parse_readv_writev_bufs(args, iov, iovcnt, args->consumer->snaplen, PRB_FLAG_PUSH_DATA);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 
@@ -2673,7 +2673,7 @@ static int f_sys_writev_e(struct event_filler_arguments *args)
 	/*
 	 * Copy the buffer
 	 */
-	res = parse_readv_writev_bufs(args, iov, iovcnt, g_snaplen, PRB_FLAG_PUSH_SIZE);
+	res = parse_readv_writev_bufs(args, iov, iovcnt, args->consumer->snaplen, PRB_FLAG_PUSH_SIZE);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 
@@ -2706,7 +2706,7 @@ static int f_sys_writev_pwritev_x(struct event_filler_arguments *args)
 	/*
 	 * Copy the buffer
 	 */
-	res = parse_readv_writev_bufs(args, iov, iovcnt, g_snaplen, PRB_FLAG_PUSH_DATA);
+	res = parse_readv_writev_bufs(args, iov, iovcnt, args->consumer->snaplen, PRB_FLAG_PUSH_DATA);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 
@@ -2813,7 +2813,7 @@ static int f_sys_pwritev_e(struct event_filler_arguments *args)
 	/*
 	 * Copy the buffer
 	 */
-	res = parse_readv_writev_bufs(args, iov, iovcnt, g_snaplen, PRB_FLAG_PUSH_SIZE);
+	res = parse_readv_writev_bufs(args, iov, iovcnt, args->consumer->snaplen, PRB_FLAG_PUSH_SIZE);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 
@@ -3179,7 +3179,7 @@ static int f_sched_drop(struct event_filler_arguments *args)
 	/*
 	 * next
 	 */
-	res = val_to_ring(args, g_sampling_ratio, 0, false, 0);
+	res = val_to_ring(args, args->consumer->sampling_ratio, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 


### PR DESCRIPTION
This patch implements multiple consumers support in the driver (e.g. sysdig instances or sysdig cloud agent), issue #51.

Essentially, I keep a dynamic list of consumers (each consumer contains the ring buffers and ioctl settings such as sampling and snaplen), and during record_event I iterate over this RCU-protected list, writing the events in each consumer's buffer. A consumer is uniquely identified by his thread's task_struct pointer, so the only requirement is that each consumer must open the various /dev/sysdig* devices from the exact same thread. The devices can then be used from any thread, if necessary. I'm not sure this is the best approach but I really didn't have a lot of spare time to experiment and the idea behind this sounded fun enough to implement and it didn't require a lot of time to write the code, so if it's not the best way it can be easily thrown away.

I tested it with 30 sysdig instances going up and down in a while loop for almost one hour and couldn't find any apparent race condition. Of course I am not confident this can get merged without disastrous results, so this is more a proof of concept, but it seems to work well and it's incredibly useful since now I can run more than one chisel at a time.

I haven't patched g_events_mask yet because it's just boring work, but I can do it easily.

I also ran some performance tests by running multiple copies of this stress program: 

```
#include <stdio.h>
#include <time.h>

int main()
{
	struct timespec start;

	while(1)
	{
		close(-1);
		clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &start);
	}

	return 0;
}
```

I measured the number of events seen by the driver, which is a direct measure of the throughput of the test application itself:

1 CPU

Before patch: 6.5M evt/sec
After patch (1 consumer): 6.5M evt/sec
After patch (2 consumers): 4.9M evt/sec
After patch (4 consumers): 3.5M evt/sec

4 CPU

Before patch: 18.9M evt/sec
After patch (1 consumer): 18.9M evt/sec
After patch (2 consumers): 13.6M evt/sec
After patch (4 consumers): 9.3M evt/sec

So the RCU overhead is essentially zero.
