### PR TITLE
probe kmod parameter publishing

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -1710,7 +1710,7 @@ void sysdig_exit(void)
 
 module_init(sysdig_init);
 module_exit(sysdig_exit);
-module_param(max_consumers, uint, 0);
+module_param(max_consumers, uint, 0444);
 MODULE_PARM_DESC(max_consumers, "Maximum number of consumers that can simultaneously open the devices");
-module_param(verbose, bool, 0);
+module_param(verbose, bool, 0444);
 MODULE_PARM_DESC(verbose, "Enable verbose logging");

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -37,11 +37,11 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 //#define NDEBUG
 #include <assert.h>
 
-uint32_t get_max_consumers()
+static uint32_t get_max_consumers()
 {
 	uint32_t max;
-	FILE * pfile = fopen("/sys/module/sysdig_probe/parameters/max_consumers", "r");
-	if(pfile!=NULL)
+	FILE *pfile = fopen("/sys/module/sysdig_probe/parameters/max_consumers", "r");
+	if(pfile != NULL)
 	{
 		fscanf(pfile, "%"PRIu32, &max);
 		fclose(pfile);


### PR DESCRIPTION
The sysdig_probe module now publishes it's parameter values in the /sys filesystem.  As a result, the max_connections value can be used in the error message from too many readers (a feature Gianluca added with pr#336).

I believe the coding style matches convention, but would appreciate a double-check.  Likewise, I'm no ninja with c/c++ so any pointers on the function would be appreciated as well; I'm happy to refactor.

Thanks.