### PR TITLE
(sinsp_threadinfo): Do not needlessly use C++11 for loop.

### DIFF
--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -137,9 +137,9 @@ void sinsp_threadinfo::compute_program_hash()
 {
 	string phs = m_exe;
 
-	for(string arg : m_args)
+	for(auto arg = m_args.begin(); arg != m_args.end(); ++arg)
 	{
-		phs += arg;
+		phs += *arg;
 	}
 
 	phs += m_container_id;


### PR DESCRIPTION
These lines is the only thing preventing all of sysdig from being compiled with gcc version 4.4.7.