### PR TITLE
Fix misspelling of "length".

### DIFF
--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -205,7 +205,7 @@ uint32_t scap_fd_info_len(scap_fdinfo *fdi)
 	case SCAP_FD_EVENTPOLL:
 	case SCAP_FD_INOTIFY:
 	case SCAP_FD_TIMERFD:
-		res += (uint32_t)strnlen(fdi->info.fname, SCAP_MAX_PATH_SIZE) + 2;    // 2 is the lenght field before the string
+		res += (uint32_t)strnlen(fdi->info.fname, SCAP_MAX_PATH_SIZE) + 2;    // 2 is the length field before the string
 		break;
 	default:
 		ASSERT(false);

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1584,7 +1584,7 @@ const filtercheck_field_info sinsp_filter_check_event_fields[] =
 	{PT_DYN, EPF_REQUIRES_ARGUMENT, PF_NA, "evt.rawarg", "one of the event arguments specified by name. E.g. 'arg.fd'."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "evt.info", "for most events, this field returns the same value as evt.args. However, for some events (like writes to /dev/log) it provides higher level information coming from decoding the arguments."},
 	{PT_BYTEBUF, EPF_NONE, PF_NA, "evt.buffer", "the binary data buffer for events that have one, like read(), recvfrom(), etc. Use this field in filters with 'contains' to search into I/O data buffers."},
-	{PT_UINT64, EPF_NONE, PF_DEC, "evt.buflen", "the lenght of the binary data buffer for events that have one, like read(), recvfrom(), etc."},
+	{PT_UINT64, EPF_NONE, PF_DEC, "evt.buflen", "the length of the binary data buffer for events that have one, like read(), recvfrom(), etc."},
 	{PT_CHARBUF, EPF_NONE, PF_DEC, "evt.res", "event return value, as an error code string (e.g. 'ENOENT')."},
 	{PT_INT64, EPF_NONE, PF_DEC, "evt.rawres", "event return value, as a number (e.g. -2). Useful for range comparisons."},
 	{PT_BOOL, EPF_NONE, PF_NA, "evt.failed", "'true' for events that returned an error status."},

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -47,7 +47,7 @@ class sinsp_filter_check
 {
 public:
 	sinsp_filter_check();
-	
+
 	virtual ~sinsp_filter_check()
 	{
 	}
@@ -68,19 +68,19 @@ public:
 
 	//
 	// Parse the name of the field.
-	// Returns the lenght of the parsed field if successful, an exception in 
+	// Returns the length of the parsed field if successful, an exception in
 	// case of error.
 	//
 	virtual int32_t parse_field_name(const char* str);
-	
+
 	//
 	// If this check is used by a filter, extract the constant to compare it to
-	// Doesn't return the field lenght because the filtering engine can calculate it.
+	// Doesn't return the field length because the filtering engine can calculate it.
 	//
 	virtual void parse_filter_value(const char* str, uint32_t len);
 
 	//
-	// Return the info about the field that this instance contains 
+	// Return the info about the field that this instance contains
 	//
 	virtual const filtercheck_field_info* get_field_info();
 
@@ -398,7 +398,7 @@ public:
 	int32_t m_argid;
 	const ppm_param_info* m_arginfo;
 	//
-	// Note: this copy of the field is used by some fields, like TYPE_ARGS and 
+	// Note: this copy of the field is used by some fields, like TYPE_ARGS and
 	// TYPE_RESARG, that need to do on the fly type customization
 	//
 	filtercheck_field_info m_customfield;
@@ -469,7 +469,7 @@ public:
 
 	// XXX this is overkill and wasted for most of the fields.
 	// It could be optimized by dynamically allocating the right amount
-	// of memory, but we don't care for the moment since we expect filters 
+	// of memory, but we don't care for the moment since we expect filters
 	// to be pretty small.
 	string m_text;
 	uint32_t m_text_len;


### PR DESCRIPTION
Fix a minor misspelling of "length" in comments and strings.