### PR TITLE
Use tsk_seruntime() to collect runtime info instead of scheduler-specific struct access.

### DIFF
--- a/driver/ppm_cputime.c
+++ b/driver/ppm_cputime.c
@@ -239,7 +239,7 @@ out:
 void ppm_task_cputime_adjusted(struct task_struct *p, cputime_t *ut, cputime_t *st)
 {
 	struct task_cputime cputime = {
-		.sum_exec_runtime = p->se.sum_exec_runtime,
+		.sum_exec_runtime = tsk_seruntime(p),
 	};
 
 	task_cputime(p, &cputime.utime, &cputime.stime);


### PR DESCRIPTION
Building sysdig against a kernel configured with the BFS CPU scheduler has always worked fine, but fails since 0.1.101 with:
```
/home/holger/Projects/sysdig/driver/ppm_cputime.c: In function 'ppm_task_cputime_adjusted':
/home/holger/Projects/sysdig/driver/ppm_cputime.c:242:24: error: 'struct task_struct' has no member named 'se'
   .sum_exec_runtime = p->se.sum_exec_runtime,
                        ^
scripts/Makefile.build:258: recipe for target '/home/holger/Projects/sysdig/driver/ppm_cputime.o' failed
```
BFS does task runtime accounting slightly differently, so direct access to the CFS-specific 'scheduled entity' field fails. Instead we can (and should) use the generic macro ```tsk_seruntime(p)```, which BFS also provides. This lets the compilation suceed with both schedulers.