### PR TITLE
Fixing error: could not convert '0' from 'int'

### DIFF
--- a/userspace/libsinsp/ctext.h
+++ b/userspace/libsinsp/ctext.h
@@ -373,7 +373,7 @@ class ctext
 		// application to this library seamlessly.
 		//
 		int8_t printf(const char*format, ...);
-		int8_t vprintf(const char*format, va_list ap = 0);
+		int8_t vprintf(const char*format, va_list ap);
 
 		//
 		// nprintf is identical to the printf above EXCEPT for


### PR DESCRIPTION
This patch fixes the error:

build/sysdig-0.1.101/userspace/libsinsp/ctext.h:376:50: error: could not convert '0' from 'int' to 'va_list {aka __va_list}'
   int8_t vprintf(const char*format, va_list ap = 0);

Which I obtain with gcc 4.8.3, binutils 2.24.51, glibc 2.18 and cmake options -DUSE_BUNDLED_LUAJIT=OFF -DUSE_BUNDLED_ZLIB=OFF -DUSE_BUNDLED_JSONCPP=OFF -DENABLE_DKMS=OFF -DUSE_BUNDLED_NCURSES=OFF