### PR TITLE
fix arm64 build by not forcing va_list to be 0

### DIFF
--- a/userspace/libsinsp/ctext.h
+++ b/userspace/libsinsp/ctext.h
@@ -373,7 +373,7 @@ class ctext
 		// application to this library seamlessly.
 		//
 		int8_t printf(const char*format, ...);
-		int8_t vprintf(const char*format, va_list ap = 0);
+		int8_t vprintf(const char*format, va_list ap);
 
 		//
 		// nprintf is identical to the printf above EXCEPT for


### PR DESCRIPTION
otherwise the build will fail with the following error:

    /«PKGBUILDDIR»/userspace/libsinsp/ctext.h:376:50: error: could not convert '0' from 'int' to 'va_list {aka __va_list}'
       int8_t vprintf(const char*format, va_list ap = 0);
                                                      ^
    make[3]: *** [userspace/libsinsp/CMakeFiles/sinsp.dir/cursescomponents.cpp.o] Error 1
    userspace/libsinsp/CMakeFiles/sinsp.dir/build.make:172: recipe for target 'userspace/libsinsp/CMakeFiles/sinsp.dir/cursescomponents.cpp.o' failed
    make[2]: *** [userspace/libsinsp/CMakeFiles/sinsp.dir/all] Error 2
    make[3]: Leaving directory '/«PKGBUILDDIR»/obj-aarch64-linux-gnu'
    CMakeFiles/Makefile2:504: recipe for target 'userspace/libsinsp/CMakeFiles/sinsp.dir/all' failed
    make[2]: Leaving directory '/«PKGBUILDDIR»/obj-aarch64-linux-gnu'

closes #375