### PR TITLE
Ubuntu Snappy.

### DIFF
--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -6,13 +6,21 @@
 #
 set -euo pipefail
 
+#
+# For continuous integration log purposes, wget prints its own output to stderr
+# so it can be convenient to redirect it to a file. This can be done directly
+# at runtime.
+#
+
 SYSDIG_VERSION=$1
 REPOSITORY_NAME=$2
 BASEDIR=$(pwd)
 ARCH=$(uname -m)
 
 #rm -rf $BASEDIR/output || true
-#mkdir $BASEDIR/output
+if [ ! -d $BADEDIR/output ]; then
+	mkdir $BASEDIR/output
+fi
 
 function build_sysdig {
 
@@ -229,6 +237,7 @@ function rhel_build {
 # Ubuntu build
 #
 
+echo Crawling Ubuntu repos
 DIR=$(dirname $(readlink -f $0))
 URLS="$($DIR/kernel-crawler.py Ubuntu 2> /dev/null)"
 
@@ -242,6 +251,8 @@ exit
 #
 # RHEL build
 #
+
+echo Crawling CentOS repos
 DIR=$(dirname $(readlink -f $0))
 URLS="$($DIR/kernel-crawler.py CentOS 2> /dev/null)"
 

--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -103,6 +103,7 @@ function boot2docker_build {
 	cd $CONFIGURATION_NAME
 
 	if [ ! -f $TGZ_NAME ]; then
+		echo Downloading $TGZ_NAME [Boot2Docker]
 		wget $KERNEL_URL
 	fi
 
@@ -235,6 +236,8 @@ for URL in $URLS
 do
 	ubuntu_build $URL
 done
+
+exit
 
 #
 # RHEL build

--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -137,7 +137,7 @@ function ubuntu_build {
 		echo -e "\e[92mBuilding Ubuntu $KERNEL_RELEASE_FULL\e[39m"
 
 		HASH=$(md5sum boot/config-$KERNEL_RELEASE-generic | cut -d' ' -f1)
-		HASH_ORIG=HASH
+		HASH_ORIG=$HASH
 
 		export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/$KERNEL_UPDATE/usr/src/linux-headers-$KERNEL_RELEASE-generic
 		build_sysdig

--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -209,8 +209,6 @@ do
 	ubuntu_build $URL
 done
 
-exit
-
 #
 # RHEL build
 #

--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -18,7 +18,7 @@ BASEDIR=$(pwd)
 ARCH=$(uname -m)
 
 #rm -rf $BASEDIR/output || true
-if [ ! -d $BADEDIR/output ]; then
+if [ ! -d $BASEDIR/output ]; then
 	mkdir $BASEDIR/output
 fi
 
@@ -246,8 +246,6 @@ do
 	ubuntu_build $URL
 done
 
-exit
-
 #
 # RHEL build
 #
@@ -300,3 +298,5 @@ boot2docker_build boot2docker-1.8.1 4.0.9-boot2docker https://www.kernel.org/pub
 # Upload modules
 #
 aws s3 cp ./output/ s3://download.draios.com/$REPOSITORY_NAME/sysdig-probe-binaries/ --recursive --acl public-read
+
+echo "All done. Bye bye!"

--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -112,12 +112,6 @@ function ubuntu_build {
 	KERNEL_RELEASE=$(echo $KERNEL_RELEASE_FULL | grep -E -o "[0-9]{1}\.[0-9]+\.[0-9]+-[0-9]+")	# ex. 3.13.0-24
 	KERNEL_UPDATE=$(echo $KERNEL_RELEASE_FULL | grep -E -o "[0-9]+$")							# ex. 47
 
-	if [ ! -d Ubuntu ]; then
-		mkdir Ubuntu
-	fi
-
-	cd Ubuntu
-
 	if [ ! -d $KERNEL_RELEASE ]; then
 		mkdir $KERNEL_RELEASE
 	fi
@@ -131,8 +125,22 @@ function ubuntu_build {
 	cd $KERNEL_UPDATE
 
 	if [ ! -f $DEB ]; then
-		echo -e "\e[92mDownloading $DEB ($INDEX of $TOT)...\e[39m"
+		echo -e "\e[34mDownloading $DEB ($INDEX of $TOT)...\e[39m"
 		wget $URL
+		dpkg -x $DEB ./
+	fi
+
+	$NUM_DEB=$(ls linux-*.deb -1 | wc -l)
+
+	if [ $NUM_DEB -eq 3 ]; then
+
+		echo -e "\e[92mBuilding Ubuntu $KERNEL_RELEASE_FULL\e[39m"
+
+		HASH=$(md5sum $KERNEL_RELEASE/boot/config-$KERNEL_RELEASE-generic | cut -d' ' -f1)
+		HASH_ORIG=HASH
+
+		export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/usr/src/linux-headers-$KERNEL_RELEASE-generic
+		build_sysdig
 	fi
 
 	cd $BASEDIR
@@ -156,7 +164,7 @@ function rhel_build {
 	cd $KERNEL_RELEASE
 
 	if [ ! -f $RPM ]; then
-		echo Downloading $RPM
+		echo -e "\e[34mDownloading $RPM ($INDEX of $TOT)...\e[39m"
 		wget $URL
 		rpm2cpio $RPM | cpio -idm
 	fi
@@ -167,7 +175,7 @@ function rhel_build {
 
 		#echo Building $KERNEL_RELEASE
 
-		echo -e "\e[92mBuilding $KERNEL_RELEASE\e[39m"
+		echo -e "\e[92mBuilding CentOS $KERNEL_RELEASE\e[39m"
 
 		HASH=$(md5sum boot/config-$KERNEL_RELEASE | cut -d' ' -f1)
 		HASH_ORIG=$HASH
@@ -208,6 +216,13 @@ exit
 #
 DIR=$(dirname $(readlink -f $0))
 URLS="$($DIR/kernel-crawler.py CentOS 2> /dev/null)"
+INDEX=0
+TOT=0
+
+for URL in $URLS
+do
+	TOT=$(( $TOT + 1 ))
+done
 
 for URL in $URLS
 do

--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -4,31 +4,42 @@
 # The precompiled binary is then obtained at runtime by sysdig-probe-loader
 # Ideally, the community should expand this stuff with better support
 #
-set -exuo pipefail
+set -euo pipefail
 
 SYSDIG_VERSION=$1
 REPOSITORY_NAME=$2
 BASEDIR=$(pwd)
 ARCH=$(uname -m)
 
-rm -rf $BASEDIR/output || true
-mkdir $BASEDIR/output
+#rm -rf $BASEDIR/output || true
+#mkdir $BASEDIR/output
 
 function build_sysdig {
-	if [ ! -f $SYSDIG_VERSION.tar.gz ]; then
-		wget https://github.com/draios/sysdig/archive/$SYSDIG_VERSION.tar.gz
+
+	if [ ! -f $BASEDIR/output/sysdig-probe-$SYSDIG_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko ] || [ ! -f $BASEDIR/output/sysdig-probe-$SYSDIG_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko ]; then
+
+		# In ${FUNCNAME[1]} there's the name of the caller function so we can understand which OS we are building the kernel for
+		echo Building sysdig-probe-$SYSDIG_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko [${FUNCNAME[1]}]
+
+		if [ ! -f $SYSDIG_VERSION.tar.gz ]; then
+			wget https://github.com/draios/sysdig/archive/$SYSDIG_VERSION.tar.gz
+		fi
+
+		rm -rf sysdig-$SYSDIG_VERSION
+		tar zxf $SYSDIG_VERSION.tar.gz
+		cd sysdig-$SYSDIG_VERSION
+		mkdir build
+		cd build
+		cmake -DCMAKE_BUILD_TYPE=Release -DSYSDIG_VERSION=$SYSDIG_VERSION ..
+		make driver
+		strip -g driver/sysdig-probe.ko
+		cp driver/sysdig-probe.ko $BASEDIR/output/sysdig-probe-$SYSDIG_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
+		cp driver/sysdig-probe.ko $BASEDIR/output/sysdig-probe-$SYSDIG_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko
+
+	else
+		echo Skypping sysdig-probe-$SYSDIG_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko \(already built\)
 	fi
 
-	rm -rf sysdig-$SYSDIG_VERSION
-	tar zxf $SYSDIG_VERSION.tar.gz
-	cd sysdig-$SYSDIG_VERSION
-	mkdir build
-	cd build
-	cmake -DCMAKE_BUILD_TYPE=Release -DSYSDIG_VERSION=$SYSDIG_VERSION ..
-	make driver
-	strip -g driver/sysdig-probe.ko
-	cp driver/sysdig-probe.ko $BASEDIR/output/sysdig-probe-$SYSDIG_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
-	cp driver/sysdig-probe.ko $BASEDIR/output/sysdig-probe-$SYSDIG_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko
 	cd $BASEDIR
 }
 
@@ -49,6 +60,7 @@ function coreos_build {
 	cd $CONFIGURATION_NAME
 
 	if [ ! -f $TGZ_NAME ]; then
+		echo Downloading $TGZ_NAME [CoreOS]
 		wget $KERNEL_URL
 	fi
 
@@ -74,37 +86,6 @@ function coreos_build {
 }
 
 function ubuntu_build {
-	#KERNEL_RELEASE=$1
-	#IMAGE_URL=$2
-	#HEADERS_GENERIC_URL=$3
-	#HEADERS_URL=$4
-	#
-	#IMAGE_NAME=$(echo $IMAGE_URL | awk -F"/" '{print $NF }')
-	#HEADERS_GENERIC_NAME=$(echo $HEADERS_GENERIC_URL | awk -F"/" '{print $NF }')
-	#HEADERS_NAME=$(echo $HEADERS_URL | awk -F"/" '{print $NF }')
-	#
-	#if [ ! -f $IMAGE_NAME ]; then
-	#	wget $IMAGE_URL
-	#fi
-	#
-	#if [ ! -f $HEADERS_GENERIC_NAME ]; then
-	#	wget $HEADERS_GENERIC_URL
-	#fi
-	#
-	#if [ ! -f $HEADERS_NAME ]; then
-	#	wget $HEADERS_URL
-	#fi
-	#
-	#if [ ! -d $KERNEL_RELEASE ]; then
-	#	dpkg -x $IMAGE_NAME $KERNEL_RELEASE
-	#	dpkg -x $HEADERS_GENERIC_NAME $KERNEL_RELEASE
-	#	dpkg -x $HEADERS_NAME $KERNEL_RELEASE
-	#fi
-	#
-	#HASH=$(md5sum $KERNEL_RELEASE/boot/config-$KERNEL_RELEASE | cut -d' ' -f1)
-	#
-	#export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/usr/src/linux-headers-$KERNEL_RELEASE
-	#build_sysdig
 
 	URL=$1
 	DEB=$(echo $URL | grep -o '[^/]*$')
@@ -125,7 +106,7 @@ function ubuntu_build {
 	cd $KERNEL_UPDATE
 
 	if [ ! -f $DEB ]; then
-		echo -e "\e[93mDownloading $DEB ($INDEX of $TOT)...\e[39m"
+		echo Downloading $DEB [Ubuntu]
 		wget $URL
 		dpkg -x $DEB ./
 	fi
@@ -133,8 +114,6 @@ function ubuntu_build {
 	NUM_DEB=$(ls linux-*.deb -1 | wc -l)
 
 	if [ $NUM_DEB -eq 3 ]; then
-
-		echo -e "\e[92mBuilding Ubuntu $KERNEL_RELEASE_FULL\e[39m"
 
 		HASH=$(md5sum boot/config-$KERNEL_RELEASE-generic | cut -d' ' -f1)
 		HASH_ORIG=$HASH
@@ -164,7 +143,7 @@ function rhel_build {
 	cd $KERNEL_RELEASE
 
 	if [ ! -f $RPM ]; then
-		echo -e "\e[93mDownloading $RPM ($INDEX of $TOT)...\e[39m"
+		echo Downloading $RPM [RHEL and CentOS]
 		wget $URL
 		rpm2cpio $RPM | cpio -idm
 	fi
@@ -174,8 +153,6 @@ function rhel_build {
 	if [ $NUM_RPM -eq 2 ]; then
 
 		#echo Building $KERNEL_RELEASE
-
-		echo -e "\e[92mBuilding CentOS $KERNEL_RELEASE\e[39m"
 
 		HASH=$(md5sum boot/config-$KERNEL_RELEASE | cut -d' ' -f1)
 		HASH_ORIG=$HASH
@@ -195,17 +172,9 @@ function rhel_build {
 
 DIR=$(dirname $(readlink -f $0))
 URLS="$($DIR/kernel-crawler.py Ubuntu 2> /dev/null)"
-INDEX=0
-TOT=0
 
 for URL in $URLS
 do
-	TOT=$(( $TOT + 1 ))
-done
-
-for URL in $URLS
-do
-	INDEX=$(( $INDEX + 1 ))
 	ubuntu_build $URL
 done
 
@@ -214,13 +183,6 @@ done
 #
 DIR=$(dirname $(readlink -f $0))
 URLS="$($DIR/kernel-crawler.py CentOS 2> /dev/null)"
-INDEX=0
-TOT=0
-
-for URL in $URLS
-do
-	TOT=$(( $TOT + 1 ))
-done
 
 for URL in $URLS
 do

--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -136,7 +136,7 @@ function ubuntu_build {
 
 		echo -e "\e[92mBuilding Ubuntu $KERNEL_RELEASE_FULL\e[39m"
 
-		HASH=$(md5sum $KERNEL_RELEASE/$KERNEL_UPDATE/boot/config-$KERNEL_RELEASE-generic | cut -d' ' -f1)
+		HASH=$(md5sum boot/config-$KERNEL_RELEASE-generic | cut -d' ' -f1)
 		HASH_ORIG=HASH
 
 		export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/$KERNEL_UPDATE/usr/src/linux-headers-$KERNEL_RELEASE-generic

--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -130,16 +130,16 @@ function ubuntu_build {
 		dpkg -x $DEB ./
 	fi
 
-	$NUM_DEB=$(ls linux-*.deb -1 | wc -l)
+	NUM_DEB=$(ls linux-*.deb -1 | wc -l)
 
 	if [ $NUM_DEB -eq 3 ]; then
 
 		echo -e "\e[92mBuilding Ubuntu $KERNEL_RELEASE_FULL\e[39m"
 
-		HASH=$(md5sum $KERNEL_RELEASE/boot/config-$KERNEL_RELEASE-generic | cut -d' ' -f1)
+		HASH=$(md5sum $KERNEL_RELEASE/$KERNEL_UPDATE/boot/config-$KERNEL_RELEASE-generic | cut -d' ' -f1)
 		HASH_ORIG=HASH
 
-		export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/usr/src/linux-headers-$KERNEL_RELEASE-generic
+		export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/$KERNEL_UPDATE/usr/src/linux-headers-$KERNEL_RELEASE-generic
 		build_sysdig
 	fi
 

--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -17,7 +17,6 @@ REPOSITORY_NAME=$2
 BASEDIR=$(pwd)
 ARCH=$(uname -m)
 
-#rm -rf $BASEDIR/output || true
 if [ ! -d $BASEDIR/output ]; then
 	mkdir $BASEDIR/output
 fi
@@ -239,7 +238,7 @@ function rhel_build {
 
 echo Crawling Ubuntu repos
 DIR=$(dirname $(readlink -f $0))
-URLS="$($DIR/kernel-crawler.py Ubuntu 2> /dev/null)"
+URLS="$($DIR/kernel-crawler.py Ubuntu)"
 
 for URL in $URLS
 do
@@ -252,7 +251,7 @@ done
 
 echo Crawling CentOS repos
 DIR=$(dirname $(readlink -f $0))
-URLS="$($DIR/kernel-crawler.py CentOS 2> /dev/null)"
+URLS="$($DIR/kernel-crawler.py CentOS)"
 
 for URL in $URLS
 do
@@ -299,4 +298,4 @@ boot2docker_build boot2docker-1.8.1 4.0.9-boot2docker https://www.kernel.org/pub
 #
 aws s3 cp ./output/ s3://download.draios.com/$REPOSITORY_NAME/sysdig-probe-binaries/ --recursive --acl public-read
 
-echo "All done. Bye bye!"
+echo "Success."

--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -125,7 +125,7 @@ function ubuntu_build {
 	cd $KERNEL_UPDATE
 
 	if [ ! -f $DEB ]; then
-		echo -e "\e[34mDownloading $DEB ($INDEX of $TOT)...\e[39m"
+		echo -e "\e[93mDownloading $DEB ($INDEX of $TOT)...\e[39m"
 		wget $URL
 		dpkg -x $DEB ./
 	fi
@@ -164,7 +164,7 @@ function rhel_build {
 	cd $KERNEL_RELEASE
 
 	if [ ! -f $RPM ]; then
-		echo -e "\e[34mDownloading $RPM ($INDEX of $TOT)...\e[39m"
+		echo -e "\e[93mDownloading $RPM ($INDEX of $TOT)...\e[39m"
 		wget $URL
 		rpm2cpio $RPM | cpio -idm
 	fi

--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -154,7 +154,7 @@ function rhel_build {
 # RHEL build
 #
 DIR=$(dirname $(readlink -f $0))
-URLS="$($DIR/kernel-crawler.py)"
+URLS="$($DIR/kernel-crawler.py CentOS 2> /dev/null)"
 
 for URL in $URLS
 do

--- a/scripts/build-sysdig-probe-binaries
+++ b/scripts/build-sysdig-probe-binaries
@@ -74,37 +74,68 @@ function coreos_build {
 }
 
 function ubuntu_build {
-	KERNEL_RELEASE=$1
-	IMAGE_URL=$2
-	HEADERS_GENERIC_URL=$3
-	HEADERS_URL=$4
+	#KERNEL_RELEASE=$1
+	#IMAGE_URL=$2
+	#HEADERS_GENERIC_URL=$3
+	#HEADERS_URL=$4
+	#
+	#IMAGE_NAME=$(echo $IMAGE_URL | awk -F"/" '{print $NF }')
+	#HEADERS_GENERIC_NAME=$(echo $HEADERS_GENERIC_URL | awk -F"/" '{print $NF }')
+	#HEADERS_NAME=$(echo $HEADERS_URL | awk -F"/" '{print $NF }')
+	#
+	#if [ ! -f $IMAGE_NAME ]; then
+	#	wget $IMAGE_URL
+	#fi
+	#
+	#if [ ! -f $HEADERS_GENERIC_NAME ]; then
+	#	wget $HEADERS_GENERIC_URL
+	#fi
+	#
+	#if [ ! -f $HEADERS_NAME ]; then
+	#	wget $HEADERS_URL
+	#fi
+	#
+	#if [ ! -d $KERNEL_RELEASE ]; then
+	#	dpkg -x $IMAGE_NAME $KERNEL_RELEASE
+	#	dpkg -x $HEADERS_GENERIC_NAME $KERNEL_RELEASE
+	#	dpkg -x $HEADERS_NAME $KERNEL_RELEASE
+	#fi
+	#
+	#HASH=$(md5sum $KERNEL_RELEASE/boot/config-$KERNEL_RELEASE | cut -d' ' -f1)
+	#
+	#export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/usr/src/linux-headers-$KERNEL_RELEASE
+	#build_sysdig
 
-	IMAGE_NAME=$(echo $IMAGE_URL | awk -F"/" '{print $NF }')
-	HEADERS_GENERIC_NAME=$(echo $HEADERS_GENERIC_URL | awk -F"/" '{print $NF }')
-	HEADERS_NAME=$(echo $HEADERS_URL | awk -F"/" '{print $NF }')
+	URL=$1
+	DEB=$(echo $URL | grep -o '[^/]*$')
+	KERNEL_RELEASE_FULL=$(echo $DEB | grep -E -o "[0-9]{1}\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+")		# ex. 3.13.0-24.47
+	KERNEL_RELEASE=$(echo $KERNEL_RELEASE_FULL | grep -E -o "[0-9]{1}\.[0-9]+\.[0-9]+-[0-9]+")	# ex. 3.13.0-24
+	KERNEL_UPDATE=$(echo $KERNEL_RELEASE_FULL | grep -E -o "[0-9]+$")							# ex. 47
 
-	if [ ! -f $IMAGE_NAME ]; then
-		wget $IMAGE_URL
+	if [ ! -d Ubuntu ]; then
+		mkdir Ubuntu
 	fi
 
-	if [ ! -f $HEADERS_GENERIC_NAME ]; then
-		wget $HEADERS_GENERIC_URL
-	fi
-
-	if [ ! -f $HEADERS_NAME ]; then
-		wget $HEADERS_URL
-	fi
+	cd Ubuntu
 
 	if [ ! -d $KERNEL_RELEASE ]; then
-		dpkg -x $IMAGE_NAME $KERNEL_RELEASE
-		dpkg -x $HEADERS_GENERIC_NAME $KERNEL_RELEASE
-		dpkg -x $HEADERS_NAME $KERNEL_RELEASE
+		mkdir $KERNEL_RELEASE
 	fi
 
-	HASH=$(md5sum $KERNEL_RELEASE/boot/config-$KERNEL_RELEASE | cut -d' ' -f1)
+	cd $KERNEL_RELEASE
 
-	export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/usr/src/linux-headers-$KERNEL_RELEASE
-	build_sysdig
+	if [ ! -d $KERNEL_UPDATE ]; then
+		mkdir $KERNEL_UPDATE
+	fi
+
+	cd $KERNEL_UPDATE
+
+	if [ ! -f $DEB ]; then
+		echo -e "\e[92mDownloading $DEB ($INDEX of $TOT)...\e[39m"
+		wget $URL
+	fi
+
+	cd $BASEDIR
 }
 
 function rhel_build {
@@ -149,6 +180,28 @@ function rhel_build {
 
 	cd $BASEDIR
 }
+
+#
+# Ubuntu build
+#
+
+DIR=$(dirname $(readlink -f $0))
+URLS="$($DIR/kernel-crawler.py Ubuntu 2> /dev/null)"
+INDEX=0
+TOT=0
+
+for URL in $URLS
+do
+	TOT=$(( $TOT + 1 ))
+done
+
+for URL in $URLS
+do
+	INDEX=$(( $INDEX + 1 ))
+	ubuntu_build $URL
+done
+
+exit
 
 #
 # RHEL build

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -56,14 +56,34 @@ repos = {
 			],
 			"page_pattern" : "//body//table/tr/td/a[regex:test(@href, '^kernel-(devel-)?[0-9].*\.rpm$')]/@href"
 		}
+	],
+
+	"Ubuntu" : [
+		{
+			# Had to split the URL because, unlikely other repos for which the
+			# script was first created, Ubuntu puts everything into a single
+			# folder. The real URL is be:
+			# http://mirrors.us.kernel.org/ubuntu/pool/main/l/linux/
+			"root" : "https://mirrors.kernel.org/ubuntu/pool/main/l/",
+			"discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
+			"subdirs" : [""],
+			"page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-3.*-generic.*amd64.deb$')]/@href"
+		},
+
+		{
+			"root" : "https://mirrors.kernel.org/ubuntu/pool/main/l/",
+			"discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
+			"subdirs" : [""],
+			"page_pattern" : "/html/body//a[regex:test(@href, '^linux-headers-3.*_all.deb$')]/@href"
+		}
 	]
 }
 
 #
 # In our design you are not supposed to modify the code. The whole script is
 # created so that you just have to add entry to the `repos` array and new
-# links will be found automagically without needing to write any single line
-# of code.
+# links will be found automagically without needing to write any single line of
+# code.
 #
 packages = {}
 

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -8,7 +8,7 @@ import urllib2
 from lxml import html
 
 #
-# This is the main configuration tree for easily analying Linux repositories
+# This is the main configuration tree for easily analyze Linux repositories
 # hunting packages. When adding repos or so be sure to respect the same data
 # structure
 #

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -67,14 +67,14 @@ repos = {
 			"root" : "https://mirrors.kernel.org/ubuntu/pool/main/l/",
 			"discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
 			"subdirs" : [""],
-			"page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-3.*-generic.*amd64.deb$')]/@href"
+			"page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-[3-9].*-generic.*amd64.deb$')]/@href"
 		},
 
 		{
 			"root" : "https://mirrors.kernel.org/ubuntu/pool/main/l/",
 			"discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
 			"subdirs" : [""],
-			"page_pattern" : "/html/body//a[regex:test(@href, '^linux-headers-3.*_all.deb$')]/@href"
+			"page_pattern" : "/html/body//a[regex:test(@href, '^linux-headers-[3-9].*_all.deb$')]/@href"
 		}
 	]
 }


### PR DESCRIPTION
Now we have the automatic probe builder for Ubuntu's distro based on the same kernel. We're still unable to run sysdig in a container inside Snappy (however it runs fine outside) due to some specific problems with this distro.