### PR TITLE
zsh tab completion can parse multi-line descriptions again

### DIFF
--- a/scripts/completions/zsh/_sysdig
+++ b/scripts/completions/zsh/_sysdig
@@ -1,7 +1,7 @@
 #compdef sysdig
 
 # This completion code is based on the cmdline interface as it exists in sysdig
-# 0.1.90
+# 0.1.101
 
 # this must match fields_info.cpp
 local DESCRIPTION_TEXT_START=16

--- a/scripts/completions/zsh/_sysdig
+++ b/scripts/completions/zsh/_sysdig
@@ -4,7 +4,7 @@
 # 0.1.90
 
 # this must match fields_info.cpp
-local DESCRIPTION_TEXT_START=20
+local DESCRIPTION_TEXT_START=16
 
 # handles completion of filter fields
 function _filter () {

--- a/userspace/sysdig/fields_info.cpp
+++ b/userspace/sysdig/fields_info.cpp
@@ -29,7 +29,10 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include "chisel.h"
 #include "sysdig.h"
 
+// Must match the value in the zsh tab completion
 #define DESCRIPTION_TEXT_START 16
+
+
 #define CONSOLE_LINE_LEN 79
 #define PRINTF_WRAP_CPROC(x)  #x
 #define PRINTF_WRAP(x) PRINTF_WRAP_CPROC(x)


### PR DESCRIPTION
DESCRIPTION_TEXT_START must match in the sources and in the completion script, and it got out of sync. Updated to the new value, and added comment to request that these be synced