### PR TITLE
topprocs_net missing evt.type=sendfile

### DIFF
--- a/userspace/sysdig/chisels/topprocs_net.lua
+++ b/userspace/sysdig/chisels/topprocs_net.lua
@@ -36,7 +36,7 @@ function on_init()
 					"Process,Host_pid,Container_pid,container.name",
 					"evt.rawarg.res",
 					"Bytes",
-					"(fd.type=ipv4 or fd.type=ipv6) and evt.is_io=true",
+					"(fd.type=ipv4 or fd.type=ipv6) and (evt.is_io=true or evt.type=sendfile)",
 					"100",
 					"bytes")
 	else
@@ -45,7 +45,7 @@ function on_init()
 					"Process,PID",
 					"evt.rawarg.res",
 					"Bytes",
-					"(fd.type=ipv4 or fd.type=ipv6) and evt.is_io=true",
+					"(fd.type=ipv4 or fd.type=ipv6) and (evt.is_io=true or evt.type=sendfile)",
 					"100",
 					"bytes")
 	end


### PR DESCRIPTION
chisel topprocs_net do not catch nginx io action, when nginx use sendfile api. This may also affect other web servers.
