### PR TITLE
don't include sys/epoll.h

### DIFF
--- a/userspace/libsinsp/k8s_http.cpp
+++ b/userspace/libsinsp/k8s_http.cpp
@@ -13,7 +13,6 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
-#include <sys/epoll.h>
 #include <unistd.h>
 
 k8s_http::k8s_http(k8s& k8s,


### PR DESCRIPTION
this file is not existant on non-Linux systems and the include seemed not to be used anyways

and yes, the Debian gang finds more stuff ;-)