### PR TITLE
Syscall access.

### DIFF
--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -286,4 +286,6 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_K8S_X */{"NA3", EC_SYSTEM, EF_UNUSED, 0},
 	/* PPME_SYSCALL_SEMGET_E */{"semget", EC_PROCESS, EF_NONE, 3, {{"key", PT_INT32, PF_HEX}, {"nsems", PT_INT32, PF_DEC}, {"semflg", PT_FLAGS32, PF_HEX, semget_flags} } },
 	/* PPME_SYSCALL_SEMGET_X */{"semget", EC_PROCESS, EF_NONE, 1, {{"res", PT_ERRNO, PF_DEC} } },
+	/* PPME_SYSCALL_ACCESS_E */{"access", EC_FILE, EF_NONE, 1, {{"mode", PT_FLAGS32, PF_HEX, access_flags} } },
+	/* PPME_SYSCALL_ACCESS_X */{"access", EC_FILE, EF_NONE, 2, {{"res", PT_ERRNO, PF_DEC}, {"name", PT_FSPATH, PF_NA} } }
 };

--- a/driver/flags_table.c
+++ b/driver/flags_table.c
@@ -405,3 +405,11 @@ const struct ppm_name_value semctl_commands[] = {
 	{"SETVAL", PPM_SETVAL},
 	{ },
 };
+
+const struct ppm_name_value access_flags[] = {
+	{"F_OK", PPM_F_OK},
+	{"R_OK", PPM_R_OK},
+	{"W_OK", PPM_W_OK},
+	{"X_OK", PPM_X_OK},
+	{ },
+};

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -439,6 +439,14 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #define PPM_SETVAL		(1 << 12)
 
 /*
+ * Access flags
+ */
+#define PPM_F_OK            (0)
+#define PPM_X_OK            (1 << 0)
+#define PPM_W_OK            (1 << 1)
+#define PPM_R_OK            (1 << 2)
+
+/*
  * SuS says limits have to be unsigned.
  * Which makes a ton more sense anyway.
  *
@@ -745,7 +753,9 @@ enum ppm_event_type {
 	PPME_K8S_X = 261,
 	PPME_SYSCALL_SEMGET_E = 262,
 	PPME_SYSCALL_SEMGET_X = 263,
-	PPM_EVENT_MAX = 264
+	PPME_SYSCALL_ACCESS_E = 264,
+	PPME_SYSCALL_ACCESS_X = 265,
+	PPM_EVENT_MAX = 266
 };
 /*@}*/
 
@@ -1287,6 +1297,7 @@ extern const struct ppm_name_value quotactl_quota_fmts[];
 extern const struct ppm_name_value semop_flags[];
 extern const struct ppm_name_value semget_flags[];
 extern const struct ppm_name_value semctl_commands[];
+extern const struct ppm_name_value access_flags[];
 
 
 extern const struct ppm_param_info ptrace_dynamic_param[];

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -264,6 +264,9 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_semctl - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_SEMCTL_E, PPME_SYSCALL_SEMCTL_X},
 #endif
 	[__NR_ppoll - SYSCALL_TABLE_ID0] =                      {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_PPOLL_E, PPME_SYSCALL_PPOLL_X},
+#ifdef __NR_access
+	[__NR_access - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_ACCESS_E, PPME_SYSCALL_ACCESS_X},
+#endif
 };
 
 /*
@@ -799,6 +802,9 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 #ifdef __NR_setns
 	[__NR_setns - SYSCALL_TABLE_ID0] = PPM_SC_SETNS,
 #endif
+#ifdef __NR_access
+	[__NR_access - SYSCALL_TABLE_ID0] = PPM_SC_ACCESS,
+#endif
 };
 
 #ifdef CONFIG_IA32_EMULATION
@@ -1014,6 +1020,9 @@ const struct syscall_evt_pair g_syscall_ia32_table[SYSCALL_TABLE_SIZE] = {
 #endif
 #ifdef __NR_ia32_semctl
 	[__NR_ia32_semctl - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_SEMCTL_E, PPME_SYSCALL_SEMCTL_X},
+#endif
+#ifdef __NR_ia32_access
+	[__NR_ia32_access - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_ACCESS_E, PPME_SYSCALL_ACCESS_X},
 #endif
 };
 

--- a/userspace/libscap/event_table.c
+++ b/userspace/libscap/event_table.c
@@ -286,4 +286,6 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_K8S_X */{"NA3", EC_SYSTEM, EF_UNUSED, 0},
 	/* PPME_SYSCALL_SEMGET_E */{"semget", EC_PROCESS, EF_NONE, 3, {{"key", PT_INT32, PF_HEX}, {"nsems", PT_INT32, PF_DEC}, {"semflg", PT_FLAGS32, PF_HEX, semget_flags} } },
 	/* PPME_SYSCALL_SEMGET_X */{"semget", EC_PROCESS, EF_NONE, 1, {{"res", PT_ERRNO, PF_DEC} } },
+	/* PPME_SYSCALL_ACCESS_E */{"access", EC_FILE, EF_NONE, 1, {{"mode", PT_FLAGS32, PF_HEX, access_flags} } },
+	/* PPME_SYSCALL_ACCESS_X */{"access", EC_FILE, EF_NONE, 2, {{"res", PT_ERRNO, PF_DEC}, {"name", PT_FSPATH, PF_NA} } }
 };

--- a/userspace/libscap/flags_table.c
+++ b/userspace/libscap/flags_table.c
@@ -406,3 +406,11 @@ const struct ppm_name_value semget_flags[] = {
 	{"IPC_EXCL", PPM_IPC_EXCL},
 	{0, 0},
 };
+
+const struct ppm_name_value access_flags[] = {
+	{"F_OK", PPM_F_OK},
+	{"R_OK", PPM_R_OK},
+	{"W_OK", PPM_W_OK},
+	{"X_OK", PPM_X_OK},
+	{0, 0},
+};

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1140,7 +1140,9 @@ Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_
 
 			while(flags != NULL && flags->name != NULL && flags->value != initial_val)
 			{
-				if((val & flags->value) == flags->value && val != 0)
+				// If flag is 0, then initial_val needs to be 0 for the flag to be resolved
+				if((flags->value == 0 && initial_val == 0) ||
+				   (flags->value != 0 && (val & flags->value) == flags->value && val != 0))
 				{
 					ret["flags"].append(flags->name);
 
@@ -1781,7 +1783,9 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 
 			while(flags != NULL && flags->name != NULL && flags->value != initial_val)
 			{
-				if((val & flags->value) == flags->value && val != 0)
+				// If flag is 0, then initial_val needs to be 0 for the flag to be resolved
+				if((flags->value == 0 && initial_val == 0) ||
+				   (flags->value != 0 && (val & flags->value) == flags->value && val != 0))
 				{
 					if(m_resolved_paramstr_storage.size() < j + strlen(separator) + strlen(flags->name))
 					{


### PR DESCRIPTION
Also modify the method to print flags in the case where a flag is equal to zero (like F_OK for the syscall access).
The modification is necessary because sysdig prints the value of the "sysdig flags" (sum of `PPM_*_OK`, not sum of `*_OK`), and we want to print the value used with the syscall, not a wrong value if (`PPM_?_OK` != `?_OK`).