### PR TITLE
Update descriptions for memory-related columns

### DIFF
--- a/userspace/sysdig/chisels/v_containers.lua
+++ b/userspace/sysdig/chisels/v_containers.lua
@@ -61,7 +61,7 @@ view_info =
 		{
 			name = "VIRT",
 			field = "thread.vmsize.b",
-			description = "total virtual memory for the process (as kb).",
+			description = "Total virtual memory for the process.",
 			aggregation = "MAX",
 			groupby_aggregation = "SUM",
 			colsize = 9
@@ -69,7 +69,7 @@ view_info =
 		{
 			name = "RES",
 			field = "thread.vmrss.b",
-			description = "resident non-swapped memory for the process (as kb).",
+			description = "Resident non-swapped memory for the process.",
 			aggregation = "MAX",
 			groupby_aggregation = "SUM",
 			colsize = 9

--- a/userspace/sysdig/chisels/v_kubernetes_controllers.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_controllers.lua
@@ -45,7 +45,7 @@ view_info =
 		{
 			name = "VIRT",
 			field = "thread.vmsize.b",
-			description = "total virtual memory for the controller (as kb).",
+			description = "Total virtual memory for the controller.",
 			aggregation = "MAX",
 			groupby_aggregation = "SUM",
 			colsize = 9
@@ -53,7 +53,7 @@ view_info =
 		{
 			name = "RES",
 			field = "thread.vmrss.b",
-			description = "resident non-swapped memory for the controller (as kb).",
+			description = "Resident non-swapped memory for the controller.",
 			aggregation = "MAX",
 			groupby_aggregation = "SUM",
 			colsize = 9

--- a/userspace/sysdig/chisels/v_kubernetes_namespaces.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_namespaces.lua
@@ -45,7 +45,7 @@ view_info =
 		{
 			name = "VIRT",
 			field = "thread.vmsize.b",
-			description = "total virtual memory for the namespace (as kb).",
+			description = "Total virtual memory for the namespace.",
 			aggregation = "MAX",
 			groupby_aggregation = "SUM",
 			colsize = 9
@@ -53,7 +53,7 @@ view_info =
 		{
 			name = "RES",
 			field = "thread.vmrss.b",
-			description = "resident non-swapped memory for the namespace (as kb).",
+			description = "Resident non-swapped memory for the namespace.",
 			aggregation = "MAX",
 			groupby_aggregation = "SUM",
 			colsize = 9

--- a/userspace/sysdig/chisels/v_kubernetes_pods.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_pods.lua
@@ -45,7 +45,7 @@ view_info =
 		{
 			name = "VIRT",
 			field = "thread.vmsize.b",
-			description = "total virtual memory for the pod (as kb).",
+			description = "Total virtual memory for the pod.",
 			aggregation = "MAX",
 			groupby_aggregation = "SUM",
 			colsize = 9
@@ -53,7 +53,7 @@ view_info =
 		{
 			name = "RES",
 			field = "thread.vmrss.b",
-			description = "resident non-swapped memory for the pod (as kb).",
+			description = "Resident non-swapped memory for the pod.",
 			aggregation = "MAX",
 			groupby_aggregation = "SUM",
 			colsize = 9

--- a/userspace/sysdig/chisels/v_kubernetes_services.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_services.lua
@@ -45,7 +45,7 @@ view_info =
 		{
 			name = "VIRT",
 			field = "thread.vmsize.b",
-			description = "total virtual memory for the service (as kb).",
+			description = "Total virtual memory for the service.",
 			aggregation = "MAX",
 			groupby_aggregation = "SUM",
 			colsize = 9
@@ -53,7 +53,7 @@ view_info =
 		{
 			name = "RES",
 			field = "thread.vmrss.b",
-			description = "resident non-swapped memory for the service (as kb).",
+			description = "Resident non-swapped memory for the service.",
 			aggregation = "MAX",
 			groupby_aggregation = "SUM",
 			colsize = 9

--- a/userspace/sysdig/chisels/v_procs.lua
+++ b/userspace/sysdig/chisels/v_procs.lua
@@ -78,7 +78,7 @@ view_info =
 		{
 			name = "VIRT",
 			field = "thread.vmsize.b",
-			description = "total virtual memory for the process (as kb).",
+			description = "Total virtual memory for the process.",
 			aggregation = "MAX",
 			groupby_aggregation = "MAX",
 			colsize = 9
@@ -86,7 +86,7 @@ view_info =
 		{
 			name = "RES",
 			field = "thread.vmrss.b",
-			description = "resident non-swapped memory for the process (as kb).",
+			description = "Resident non-swapped memory for the process.",
 			aggregation = "MAX",
 			groupby_aggregation = "MAX",
 			colsize = 9


### PR DESCRIPTION
This PR changes the column descriptions for memory-related values after commits 5377b63, 7559c7c and 75e36a7 closed 492 and changed the display values to bytes instead of kilobytes.

I've also capitalised the first letters in these descriptions so that their style matches the other descriptions.