### PR TITLE
Fix a (very remotely) possible deadlock: reading and writing from/to …

### DIFF
--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -92,7 +92,6 @@ struct ppm_consumer_t {
 	volatile int need_to_insert_drop_e;
 	volatile int need_to_insert_drop_x;
 	struct list_head node;
-	struct ppm_proclist_info *proclist_info;
 };
 
 #define STR_STORAGE_SIZE PAGE_SIZE


### PR DESCRIPTION
…userspace during ioctl() must be done outside g_consumer_lock, because this read/write might cause a page fault which causes locking a semaphore which might be already locked if there's another consumer entering the mmap phase (where the acquisition order is reversed).

This change moves the ioctl for getting procinfo to a stateless one that is independent from consumers.