### PR TITLE
add the possibility to stop collecting after X seconds (-M)

### DIFF
--- a/userspace/sysdig/man/sysdig.md
+++ b/userspace/sysdig/man/sysdig.md
@@ -153,6 +153,9 @@ OPTIONS
 **-N**
   Don't convert port numbers to names.
 
+**-M** _num_seconds_
+  Stop collecting after reaching <num_seconds>
+
 **-n** _num_, **--numevents**=_num_  
   Stop capturing after _num_ events
 

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -504,15 +504,15 @@ captureinfo do_inspect(sinsp* inspector,
 	duration_start = ((double)clock()) / CLOCKS_PER_SEC;
 	while(1)
 	{
-                if(duration_to_tot > 0)
-                {
-		 	int duration_tot = ((double)clock()) / CLOCKS_PER_SEC - duration_start;
+		if(duration_to_tot > 0)
+		{
+			int duration_tot = ((double)clock()) / CLOCKS_PER_SEC - duration_start;
 			if(duration_tot >= duration_to_tot)
-                   	{
+			{
 				handle_end_of_file(print_progress, formatter);
 				break;
-		   	}
-                }
+			}
+		}
 		if(retval.m_nevts == cnt || g_terminate)
 		{
 			//

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -505,9 +505,9 @@ captureinfo do_inspect(sinsp* inspector,
 	duration_start = ((double)clock()) / CLOCKS_PER_SEC;
 	while(1)
 	{
-                duration_tot = ((double)clock()) / CLOCKS_PER_SEC - duration_start;
                 if(duration_to_tot > 0)
                 {
+		   duration_tot = ((double)clock()) / CLOCKS_PER_SEC - duration_start;
 		   if (duration_tot >= duration_to_tot)
                    {
 			handle_end_of_file(print_progress, formatter);

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -477,7 +477,7 @@ void handle_end_of_file(bool print_progress, sinsp_evt_formatter* formatter = NU
 //
 captureinfo do_inspect(sinsp* inspector,
 	uint64_t cnt,
-        double duration_to_tot,
+	int duration_to_tot,
 	bool quiet,
 	bool json,
 	bool do_flush,
@@ -491,8 +491,7 @@ captureinfo do_inspect(sinsp* inspector,
 	sinsp_evt* ev;
 	string line;
 	double last_printed_progress_pct = 0;
-        double duration_start = 0;
-        double duration_tot = 0;
+        int duration_start = 0;
 
 	if(json)
 	{
@@ -507,12 +506,12 @@ captureinfo do_inspect(sinsp* inspector,
 	{
                 if(duration_to_tot > 0)
                 {
-		   duration_tot = ((double)clock()) / CLOCKS_PER_SEC - duration_start;
-		   if (duration_tot >= duration_to_tot)
-                   {
-			handle_end_of_file(print_progress, formatter);
-			break;
-		   }
+		 	int duration_tot = ((double)clock()) / CLOCKS_PER_SEC - duration_start;
+			if(duration_tot >= duration_to_tot)
+                   	{
+				handle_end_of_file(print_progress, formatter);
+				break;
+		   	}
                 }
 		if(retval.m_nevts == cnt || g_terminate)
 		{
@@ -679,7 +678,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 	sinsp_evt::param_fmt event_buffer_format = sinsp_evt::PF_NORMAL;
 	sinsp_filter* display_filter = NULL;
 	double duration = 1;
-	double duration_to_tot = 0;
+	int duration_to_tot = 0;
 	captureinfo cinfo;
 	string output_format;
 	uint32_t snaplen = 0;
@@ -918,15 +917,14 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				delete inspector;
 				return sysdig_init_res(EXIT_SUCCESS);
 			case 'M':
-                                duration_to_tot = atoi(optarg);
-                                if(duration_to_tot <= 0)
-                                {
-                                        throw sinsp_exception(string("invalid duration") + optarg);
-                                        res.m_res = EXIT_FAILURE;
-                                        goto exit;
-                                }
-                                break;
-
+				duration_to_tot = atoi(optarg);
+				if(duration_to_tot <= 0)
+				{
+					throw sinsp_exception(string("invalid duration") + optarg);
+					res.m_res = EXIT_FAILURE;
+					goto exit;
+				}
+				break;
 			case 'N':
 				inspector->set_hostname_and_port_resolution_mode(false);
 				break;

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -146,6 +146,7 @@ static void usage()
 " -l, --list         List the fields that can be used for filtering and output\n"
 "                    formatting. Use -lv to get additional information for each\n"
 "                    field.\n"
+" -M <num_seconds>   Stop collecting after <num_seconds> reached.\n"
 " -N                 Don't convert port numbers to names.\n"
 " -n <num>, --numevents=<num>\n"
 "                    Stop capturing after <num> events\n"
@@ -476,6 +477,7 @@ void handle_end_of_file(bool print_progress, sinsp_evt_formatter* formatter = NU
 //
 captureinfo do_inspect(sinsp* inspector,
 	uint64_t cnt,
+        double duration_to_tot,
 	bool quiet,
 	bool json,
 	bool do_flush,
@@ -489,6 +491,8 @@ captureinfo do_inspect(sinsp* inspector,
 	sinsp_evt* ev;
 	string line;
 	double last_printed_progress_pct = 0;
+        double duration_start = 0;
+        double duration_tot = 0;
 
 	if(json)
 	{
@@ -498,8 +502,18 @@ captureinfo do_inspect(sinsp* inspector,
 	//
 	// Loop through the events
 	//
+	duration_start = ((double)clock()) / CLOCKS_PER_SEC;
 	while(1)
 	{
+                duration_tot = ((double)clock()) / CLOCKS_PER_SEC - duration_start;
+                if(duration_to_tot > 0)
+                {
+		   if (duration_tot >= duration_to_tot)
+                   {
+			handle_end_of_file(print_progress, formatter);
+			break;
+		   }
+                }
 		if(retval.m_nevts == cnt || g_terminate)
 		{
 			//
@@ -665,6 +679,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 	sinsp_evt::param_fmt event_buffer_format = sinsp_evt::PF_NORMAL;
 	sinsp_filter* display_filter = NULL;
 	double duration = 1;
+	double duration_to_tot = 0;
 	captureinfo cinfo;
 	string output_format;
 	uint32_t snaplen = 0;
@@ -746,7 +761,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
                                         "C:"
                                         "dDEe:F"
                                         "G:"
-                                        "hi:jk:lLNn:Pp:qr:Ss:t:v"
+                                        "hi:jk:lLM:Nn:Pp:qr:Ss:t:v"
                                         "W:"
                                         "w:xXz", long_options, &long_index)) != -1)
 		{
@@ -902,6 +917,16 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				list_events(inspector);
 				delete inspector;
 				return sysdig_init_res(EXIT_SUCCESS);
+			case 'M':
+                                duration_to_tot = atoi(optarg);
+                                if(duration_to_tot <= 0)
+                                {
+                                        throw sinsp_exception(string("invalid duration") + optarg);
+                                        res.m_res = EXIT_FAILURE;
+                                        goto exit;
+                                }
+                                break;
+
 			case 'N':
 				inspector->set_hostname_and_port_resolution_mode(false);
 				break;
@@ -1328,6 +1353,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 
 			cinfo = do_inspect(inspector,
 				cnt,
+                                duration_to_tot,
 				quiet,
 				jflag,
 				unbuf_flag,


### PR DESCRIPTION
This feature allows the possibility to run sysdig and stop the collection after X seconds. This is useful if we need to collect some samples at a specific time (with a cron for example) and not let it run for ever or specify a number of events.