### PR TITLE
Install bash completions in /usr

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -2,7 +2,7 @@ configure_file(debian/postinst.in debian/postinst)
 configure_file(debian/prerm.in debian/prerm)
 
 install(FILES completions/bash/sysdig
-	DESTINATION "${DIR_ETC}/bash_completion.d")
+	DESTINATION share/bash-completion/completions)
 
 install(FILES completions/zsh/_sysdig
 	DESTINATION share/zsh/vendor-completions)


### PR DESCRIPTION
System-owned completions file should be installed in /usr instead of /etc.
zsh was already configured to do so but not bash.