### PR TITLE
icontains operator

### DIFF
--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1136,6 +1136,7 @@ enum ppm_cmp_operator {
 	CO_CONTAINS = 7,
 	CO_IN = 8,
 	CO_EXISTS = 9,
+	CO_ICONTAINS = 10,
 };
 
 /*

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -191,6 +191,9 @@ bool flt_compare_int64(ppm_cmp_operator op, int64_t operand1, int64_t operand2)
 	case CO_CONTAINS:
 		throw sinsp_exception("'contains' not supported for numeric filters");
 		return false;
+	case CO_ICONTAINS:
+		throw sinsp_exception("'icontains' not supported for numeric filters");
+		return false;
 	default:
 		throw sinsp_exception("'unknown' not supported for numeric filters");
 		return false;
@@ -207,6 +210,8 @@ bool flt_compare_string(ppm_cmp_operator op, char* operand1, char* operand2)
 		return (strcmp(operand1, operand2) != 0);
 	case CO_CONTAINS:
 		return (strstr(operand1, operand2) != NULL);
+        case CO_ICONTAINS:
+		return (strcasestr(operand1, operand2) != NULL);
 	case CO_LT:
 		return (strcmp(operand1, operand2) < 0);
 	case CO_LE:
@@ -1448,6 +1453,11 @@ ppm_cmp_operator sinsp_filter::next_comparison_operator()
 	{
 		m_scanpos += 8;
 		return CO_CONTAINS;
+	}
+	else if(compare_no_consume("icontains"))
+	{
+		m_scanpos += 9;
+		return CO_ICONTAINS;
 	}
 	else if(compare_no_consume("in"))
 	{

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -191,9 +191,6 @@ bool flt_compare_int64(ppm_cmp_operator op, int64_t operand1, int64_t operand2)
 	case CO_CONTAINS:
 		throw sinsp_exception("'contains' not supported for numeric filters");
 		return false;
-	case CO_IN:
-		throw sinsp_exception("'in' not supported for numeric filters");
-		return false;
 	default:
 		throw sinsp_exception("'unknown' not supported for numeric filters");
 		return false;
@@ -209,8 +206,6 @@ bool flt_compare_string(ppm_cmp_operator op, char* operand1, char* operand2)
 	case CO_NE:
 		return (strcmp(operand1, operand2) != 0);
 	case CO_CONTAINS:
-		return (strstr(operand1, operand2) != NULL);
-	case CO_IN:
 		return (strstr(operand1, operand2) != NULL);
 	case CO_LT:
 		return (strcmp(operand1, operand2) < 0);


### PR DESCRIPTION
The icontains operator is a case-insensitive version of 'contains'.