### PR TITLE
Fixes 533 - adds libssh2 as a dependency for building

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -76,6 +76,7 @@ if(NOT WIN32)
 	target_link_libraries(sinsp
 		"${LUAJIT_LIB}"
 		dl
+		ssh2
 		pthread)
 else()
 	target_link_libraries(sinsp


### PR DESCRIPTION
See issue #533 for more information.