### PR TITLE
Lua filter support

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -35,6 +35,8 @@ add_library(sinsp STATIC
 	k8s_event_data.cpp
 	k8s_http.cpp
 	k8s_net.cpp
+	lua_parser.cpp
+	lua_parser_api.cpp
 	marathon_component.cpp
 	marathon_http.cpp
 	memmem.cpp

--- a/userspace/libsinsp/lua_parser.cpp
+++ b/userspace/libsinsp/lua_parser.cpp
@@ -18,6 +18,8 @@ const static struct luaL_reg ll_filter [] =
 {
 	{"rel_expr", &lua_parser_cbacks::rel_expr},
 	{"bool_op", &lua_parser_cbacks::bool_op},
+	{"nest", &lua_parser_cbacks::nest},
+	{"unnest", &lua_parser_cbacks::unnest},
 	{NULL,NULL}
 };
 
@@ -28,10 +30,17 @@ lua_parser::lua_parser(sinsp* inspector, string filename)
 	m_ls = NULL;
 	m_lua_has_load_rules = false;
 	m_last_boolop = BO_NONE;
+	m_have_rel_expr = false;
+	m_nest_level = 0;
 
 	m_filter = new sinsp_filter(m_inspector);
 
 	load(filename);
+
+	if (m_nest_level != 0)
+	{
+		throw sinsp_exception("Error in configured filter: unbalanced nesting");
+	}
 }
 
 lua_parser::~lua_parser()

--- a/userspace/libsinsp/lua_parser.cpp
+++ b/userspace/libsinsp/lua_parser.cpp
@@ -22,20 +22,16 @@ const static struct luaL_reg ll_filter [] =
 	{NULL,NULL}
 };
 
-lua_parser::lua_parser(sinsp* inspector)
+lua_parser::lua_parser(sinsp* inspector, lua_State *ls)
 {
 	m_inspector = inspector;
 
-	m_ls = NULL;
+	m_ls = ls;
 	m_have_rel_expr = false;
 	m_last_boolop = BO_NONE;
 	m_nest_level = 0;
 
 	m_filter = new sinsp_filter(m_inspector);
-
-	// Initialize Lua interpreter
-	m_ls = lua_open();
-	luaL_openlibs(m_ls);
 
 	// Register our c++ defined functions
 	luaL_openlib(m_ls, "filter", ll_filter, 0);

--- a/userspace/libsinsp/lua_parser.cpp
+++ b/userspace/libsinsp/lua_parser.cpp
@@ -7,7 +7,6 @@
 #include "lua_parser_api.h"
 
 
-
 extern "C" {
 #include "lua.h"
 #include "lualib.h"
@@ -23,41 +22,16 @@ const static struct luaL_reg ll_filter [] =
 	{NULL,NULL}
 };
 
-lua_parser::lua_parser(sinsp* inspector, string filename)
+lua_parser::lua_parser(sinsp* inspector)
 {
 	m_inspector = inspector;
 
 	m_ls = NULL;
-	m_lua_has_load_rules = false;
-	m_last_boolop = BO_NONE;
 	m_have_rel_expr = false;
+	m_last_boolop = BO_NONE;
 	m_nest_level = 0;
 
 	m_filter = new sinsp_filter(m_inspector);
-
-	load(filename);
-
-	if (m_nest_level != 0)
-	{
-		throw sinsp_exception("Error in configured filter: unbalanced nesting");
-	}
-}
-
-lua_parser::~lua_parser()
-{
-	if(m_ls)
-	{
-		lua_close(m_ls);
-		m_ls = NULL;
-	}
-	delete m_filter;
-
-}
-
-void lua_parser::load(string filename)
-{
-	m_filename = filename;
-	trim(filename);
 
 	// Initialize Lua interpreter
 	m_ls = lua_open();
@@ -69,33 +43,25 @@ void lua_parser::load(string filename)
 	lua_pushlightuserdata(m_ls, this);
 	lua_setglobal(m_ls, "siparser");
 
-	ifstream is;
-	is.open(filename);
-	if(!is.is_open())
-	{
-		throw sinsp_exception("can't open file " + filename);
-	}
+}
 
-	string scriptstr((istreambuf_iterator<char>(is)),
-			 istreambuf_iterator<char>());
-
-	//
-	// Load the script
-	//
-	if(luaL_loadstring(m_ls, scriptstr.c_str()) || lua_pcall(m_ls, 0, 0, 0))
+sinsp_filter* lua_parser::get_filter()
+{
+	if (m_nest_level != 0)
 	{
-		throw sinsp_exception("Failed to load script " +
-			m_filename + ": " + lua_tostring(m_ls, -1));
+		throw sinsp_exception("Error in configured filter: unbalanced nesting");
 	}
-	//
-	// Check if the script has a "load_rules" function
-	//
-	lua_getglobal(m_ls, "load_rules");
-	if(lua_isfunction(m_ls, -1))
+	return m_filter;
+}
+lua_parser::~lua_parser()
+{
+	if(m_ls)
 	{
-		m_lua_has_load_rules = true;
-		lua_pop(m_ls, 1);
+		lua_close(m_ls);
+		m_ls = NULL;
 	}
+	delete m_filter;
 
 }
+
 

--- a/userspace/libsinsp/lua_parser.cpp
+++ b/userspace/libsinsp/lua_parser.cpp
@@ -27,7 +27,7 @@ lua_parser::lua_parser(sinsp* inspector, string filename)
 	m_ls = NULL;
 	m_lua_has_load_rules = false;
 
-	m_filter = new sinsp_filter_expression();
+	m_filter = new sinsp_filter(m_inspector);
 
 	load(filename);
 }
@@ -39,6 +39,7 @@ lua_parser::~lua_parser()
 		lua_close(m_ls);
 		m_ls = NULL;
 	}
+	delete m_filter;
 
 }
 

--- a/userspace/libsinsp/lua_parser.cpp
+++ b/userspace/libsinsp/lua_parser.cpp
@@ -16,7 +16,8 @@ extern "C" {
 
 const static struct luaL_reg ll_filter [] =
 {
-	{"make_filter_check", &lua_parser_cbacks::make_filter_check},
+	{"rel_expr", &lua_parser_cbacks::rel_expr},
+	{"bool_op", &lua_parser_cbacks::bool_op},
 	{NULL,NULL}
 };
 
@@ -26,6 +27,7 @@ lua_parser::lua_parser(sinsp* inspector, string filename)
 
 	m_ls = NULL;
 	m_lua_has_load_rules = false;
+	m_last_boolop = BO_NONE;
 
 	m_filter = new sinsp_filter(m_inspector);
 

--- a/userspace/libsinsp/lua_parser.cpp
+++ b/userspace/libsinsp/lua_parser.cpp
@@ -1,0 +1,89 @@
+#include <iostream>
+#include <fstream>
+#include "sinsp.h"
+#include "sinsp_int.h"
+
+#include "lua_parser.h"
+#include "lua_parser_api.h"
+
+
+
+extern "C" {
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
+}
+
+const static struct luaL_reg ll_filter [] =
+{
+	{"make_filter_check", &lua_parser_cbacks::make_filter_check},
+	{NULL,NULL}
+};
+
+lua_parser::lua_parser(sinsp* inspector, string filename)
+{
+	m_inspector = inspector;
+
+	m_ls = NULL;
+	m_lua_has_load_rules = false;
+
+	m_filter = new sinsp_filter_expression();
+
+	load(filename);
+}
+
+lua_parser::~lua_parser()
+{
+	if(m_ls)
+	{
+		lua_close(m_ls);
+		m_ls = NULL;
+	}
+
+}
+
+void lua_parser::load(string filename)
+{
+	m_filename = filename;
+	trim(filename);
+
+	// Initialize Lua interpreter
+	m_ls = lua_open();
+	luaL_openlibs(m_ls);
+
+	// Register our c++ defined functions
+	luaL_openlib(m_ls, "filter", ll_filter, 0);
+
+	lua_pushlightuserdata(m_ls, this);
+	lua_setglobal(m_ls, "siparser");
+
+	ifstream is;
+	is.open(filename);
+	if(!is.is_open())
+	{
+		throw sinsp_exception("can't open file " + filename);
+	}
+
+	string scriptstr((istreambuf_iterator<char>(is)),
+			 istreambuf_iterator<char>());
+
+	//
+	// Load the script
+	//
+	if(luaL_loadstring(m_ls, scriptstr.c_str()) || lua_pcall(m_ls, 0, 0, 0))
+	{
+		throw sinsp_exception("Failed to load script " +
+			m_filename + ": " + lua_tostring(m_ls, -1));
+	}
+	//
+	// Check if the script has a "load_rules" function
+	//
+	lua_getglobal(m_ls, "load_rules");
+	if(lua_isfunction(m_ls, -1))
+	{
+		m_lua_has_load_rules = true;
+		lua_pop(m_ls, 1);
+	}
+
+}
+

--- a/userspace/libsinsp/lua_parser.h
+++ b/userspace/libsinsp/lua_parser.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string.h>
+
+#include "sinsp.h"
+#include "filterchecks.h"
+
+typedef struct lua_State lua_State;
+
+class lua_parser
+{
+public:
+	lua_parser(sinsp* inspector, string filename);
+	~lua_parser();
+	void load(string cmdstr);
+	sinsp_filter_expression* m_filter;
+
+ private:
+	sinsp* m_inspector;
+	bool m_lua_has_load_rules;
+	lua_State* m_ls;
+	string m_filename;
+
+	friend class lua_parser_cbacks;
+};
+

--- a/userspace/libsinsp/lua_parser.h
+++ b/userspace/libsinsp/lua_parser.h
@@ -17,10 +17,14 @@ public:
 
  private:
 	sinsp* m_inspector;
-	bool m_lua_has_load_rules;
 	lua_State* m_ls;
+
+	bool m_lua_has_load_rules;
 	string m_filename;
+
 	boolop m_last_boolop;
+	bool m_have_rel_expr;
+	int32_t m_nest_level;
 
 	friend class lua_parser_cbacks;
 };

--- a/userspace/libsinsp/lua_parser.h
+++ b/userspace/libsinsp/lua_parser.h
@@ -13,7 +13,7 @@ public:
 	lua_parser(sinsp* inspector, string filename);
 	~lua_parser();
 	void load(string cmdstr);
-	sinsp_filter_expression* m_filter;
+	sinsp_filter* m_filter;
 
  private:
 	sinsp* m_inspector;

--- a/userspace/libsinsp/lua_parser.h
+++ b/userspace/libsinsp/lua_parser.h
@@ -10,11 +10,9 @@ typedef struct lua_State lua_State;
 class lua_parser
 {
 public:
-	lua_parser(sinsp* inspector);
+	lua_parser(sinsp* inspector, lua_State *ls);
 	~lua_parser();
 	sinsp_filter* get_filter();
-
-	lua_State* m_ls;
 
  private:
 	sinsp* m_inspector;
@@ -24,6 +22,8 @@ public:
 	boolop m_last_boolop;
 	bool m_have_rel_expr;
 	int32_t m_nest_level;
+
+	lua_State* m_ls;
 
 	friend class lua_parser_cbacks;
 };

--- a/userspace/libsinsp/lua_parser.h
+++ b/userspace/libsinsp/lua_parser.h
@@ -10,17 +10,16 @@ typedef struct lua_State lua_State;
 class lua_parser
 {
 public:
-	lua_parser(sinsp* inspector, string filename);
+	lua_parser(sinsp* inspector);
 	~lua_parser();
-	void load(string cmdstr);
-	sinsp_filter* m_filter;
+	sinsp_filter* get_filter();
+
+	lua_State* m_ls;
 
  private:
 	sinsp* m_inspector;
-	lua_State* m_ls;
 
-	bool m_lua_has_load_rules;
-	string m_filename;
+	sinsp_filter* m_filter;
 
 	boolop m_last_boolop;
 	bool m_have_rel_expr;

--- a/userspace/libsinsp/lua_parser.h
+++ b/userspace/libsinsp/lua_parser.h
@@ -20,6 +20,7 @@ public:
 	bool m_lua_has_load_rules;
 	lua_State* m_ls;
 	string m_filename;
+	boolop m_last_boolop;
 
 	friend class lua_parser_cbacks;
 };

--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -1,0 +1,71 @@
+#include "filterchecks.h"
+#include "lua_parser_api.h"
+#include "lua_parser.h"
+
+extern "C" {
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
+}
+
+extern sinsp_filter_check_list g_filterlist;
+
+int lua_parser_cbacks::make_filter_check(lua_State *ls)
+{
+	lua_getglobal(ls, "siparser");
+
+	lua_parser* parser = (lua_parser*)lua_touserdata(ls, -1);
+	lua_pop(ls, 1);
+
+	sinsp* inspector = parser->m_inspector;
+
+	const char* fld = lua_tostring(ls, 1);
+	const char* value = lua_tostring(ls, 2);
+
+	if(fld == NULL)
+	{
+		string err = " make_filter_check called with nil field";
+		fprintf(stderr, "%s\n", err.c_str());
+		throw sinsp_exception("parser API error");
+	}
+
+	if(value == NULL)
+	{
+		string err = " make_filter_check called with nil value";
+		fprintf(stderr, "%s\n", err.c_str());
+		throw sinsp_exception("parser API error");
+	}
+
+	sinsp_filter_check* chk = g_filterlist.new_filter_check_from_fldname(fld,
+									     inspector,
+									     true);
+
+	if(chk == NULL)
+	{
+		string err = "make_filter_check called with nonexistent field " + string(fld);
+		fprintf(stderr, "%s\n", err.c_str());
+		throw sinsp_exception("parser API error");
+	}
+
+	try
+	{
+		chk->parse_field_name(fld, true);
+		chk->parse_filter_value(value, strlen(value));
+	}
+	catch(sinsp_exception& e)
+	{
+		fprintf(stderr, "%s\n\n", e.what());
+		throw e;
+	}
+	catch(...)
+	{
+		throw sinsp_exception("error parsing the filter operands");
+	}
+
+
+
+	//	parser->m_allocated_fltchecks.push_back(chk);
+
+	return 0;
+}
+

--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -10,6 +10,55 @@ extern "C" {
 
 extern sinsp_filter_check_list g_filterlist;
 
+cmpop string_to_cmpop(const char* str)
+{
+	if(strcmp(str, "=") == 0)
+	{
+		return CO_EQ;
+	}
+	else if(strcmp(str, "!=") == 0)
+	{
+		return CO_NE;
+	}
+	else if(strcmp(str, "<=") == 0)
+	{
+		return CO_LE;
+	}
+	else if(strcmp(str, "<") == 0)
+	{
+		return CO_LT;
+	}
+	else if(strcmp(str, ">=") == 0)
+	{
+		return CO_GE;
+	}
+	else if(strcmp(str, ">") == 0)
+	{
+		return CO_GT;
+	}
+	else if(strcmp(str, "contains") == 0)
+	{
+		return CO_CONTAINS;
+	}
+	else if(strcmp(str, "icontains") == 0)
+	{
+		return CO_ICONTAINS;
+	}
+	else if(strcmp(str, "in") == 0)
+	{
+		return CO_IN;
+	}
+	else if(strcmp(str, "exists") == 0)
+	{
+		return CO_EXISTS;
+	}
+	else
+	{
+		throw sinsp_exception("filter error: invalid comparison operator: " + string(str));
+	}
+}
+
+
 int lua_parser_cbacks::make_filter_check(lua_State *ls)
 {
 	lua_getglobal(ls, "siparser");
@@ -18,24 +67,9 @@ int lua_parser_cbacks::make_filter_check(lua_State *ls)
 	lua_pop(ls, 1);
 
 	sinsp* inspector = parser->m_inspector;
+	sinsp_filter* filter = parser->m_filter;
 
-	const char* fld = lua_tostring(ls, 1);
-	const char* value = lua_tostring(ls, 2);
-
-	if(fld == NULL)
-	{
-		string err = " make_filter_check called with nil field";
-		fprintf(stderr, "%s\n", err.c_str());
-		throw sinsp_exception("parser API error");
-	}
-
-	if(value == NULL)
-	{
-		string err = " make_filter_check called with nil value";
-		fprintf(stderr, "%s\n", err.c_str());
-		throw sinsp_exception("parser API error");
-	}
-
+	const char* fld = luaL_checkstring(ls, 1);
 	sinsp_filter_check* chk = g_filterlist.new_filter_check_from_fldname(fld,
 									     inspector,
 									     true);
@@ -50,21 +84,26 @@ int lua_parser_cbacks::make_filter_check(lua_State *ls)
 	try
 	{
 		chk->parse_field_name(fld, true);
-		chk->parse_filter_value(value, strlen(value));
+
+		const char* cmpop = luaL_checkstring(ls, 2);
+		chk->m_cmpop = string_to_cmpop(cmpop);
+
+		// "exists" is the only unary comparison op
+		if(strcmp(cmpop, "exists"))
+		{
+			const char* value = luaL_checkstring(ls, 3);
+			chk->parse_filter_value(value, strlen(value));
+		}
 	}
 	catch(sinsp_exception& e)
 	{
-		fprintf(stderr, "%s\n\n", e.what());
+		fprintf(stderr, "filter parsing error: %s\n\n", e.what());
 		throw e;
 	}
-	catch(...)
-	{
-		throw sinsp_exception("error parsing the filter operands");
-	}
 
-
-
-	//	parser->m_allocated_fltchecks.push_back(chk);
+	filter->push_expression(BO_NONE);
+	filter->add_check(chk);
+	filter->pop_expression();
 
 	return 0;
 }

--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -10,6 +10,8 @@ extern "C" {
 
 extern sinsp_filter_check_list g_filterlist;
 
+// It would be nice to expose this up to Lua so that comparison operator
+// parsing/encoding can be done there.
 cmpop string_to_cmpop(const char* str)
 {
 	if(strcmp(str, "=") == 0)
@@ -58,8 +60,42 @@ cmpop string_to_cmpop(const char* str)
 	}
 }
 
+boolop string_to_boolop(const char* str)
+{
+	if(strcmp(str, "or") == 0)
+	{
+		return BO_OR;
+	}
+	else if(strcmp(str, "and") == 0)
+	{
+		return BO_AND;
+	}
+	else if(strcmp(str, "not") == 0)
+	{
+		return BO_NOT;
+	}
+	else
+	{
+		throw sinsp_exception("filter error: invalid boolean operator: " + string(str));
+	}
+}
 
-int lua_parser_cbacks::make_filter_check(lua_State *ls)
+int lua_parser_cbacks::bool_op(lua_State *ls)
+{
+	lua_getglobal(ls, "siparser");
+
+	lua_parser* parser = (lua_parser*)lua_touserdata(ls, -1);
+	lua_pop(ls, 1);
+
+	const char* opstr = luaL_checkstring(ls, 1);
+	boolop op = string_to_boolop(opstr);
+
+	parser->m_last_boolop = op;
+	return 0;
+
+}
+
+int lua_parser_cbacks::rel_expr(lua_State *ls)
 {
 	lua_getglobal(ls, "siparser");
 
@@ -73,16 +109,17 @@ int lua_parser_cbacks::make_filter_check(lua_State *ls)
 	sinsp_filter_check* chk = g_filterlist.new_filter_check_from_fldname(fld,
 									     inspector,
 									     true);
-
 	if(chk == NULL)
 	{
-		string err = "make_filter_check called with nonexistent field " + string(fld);
+		string err = "filter_check called with nonexistent field " + string(fld);
 		fprintf(stderr, "%s\n", err.c_str());
 		throw sinsp_exception("parser API error");
 	}
 
 	try
 	{
+		chk->m_boolop = parser->m_last_boolop;
+
 		chk->parse_field_name(fld, true);
 
 		const char* cmpop = luaL_checkstring(ls, 2);
@@ -101,9 +138,9 @@ int lua_parser_cbacks::make_filter_check(lua_State *ls)
 		throw e;
 	}
 
-	filter->push_expression(BO_NONE);
+	//	filter->push_expression(BO_NONE);
 	filter->add_check(chk);
-	filter->pop_expression();
+	//	filter->pop_expression();
 
 	return 0;
 }

--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -112,6 +112,13 @@ int lua_parser_cbacks::unnest(lua_State *ls)
 	lua_parser* parser = (lua_parser*)lua_touserdata(ls, -1);
 	lua_pop(ls, 1);
 
+	if (parser->m_nest_level < 1)
+	{
+		string err = "filter.unnest() called without being nested";
+		fprintf(stderr, "%s\n", err.c_str());
+		throw sinsp_exception(err);
+	}
+
 	sinsp_filter* filter = parser->m_filter;
 
 	filter->pop_expression();

--- a/userspace/libsinsp/lua_parser_api.h
+++ b/userspace/libsinsp/lua_parser_api.h
@@ -27,7 +27,7 @@ extern "C" {
 class lua_parser_cbacks
 {
 public:
-	// filter.make_filter_check(field_name, value)
+	// filter.make_filter_check(field_name, cmpop, value)
 	static int make_filter_check(lua_State *ls);
 };
 

--- a/userspace/libsinsp/lua_parser_api.h
+++ b/userspace/libsinsp/lua_parser_api.h
@@ -32,5 +32,11 @@ public:
 
 	// filter.bool_op(op)
 	static int bool_op(lua_State *ls);
+
+	// filter.nest()
+	static int nest(lua_State *ls);
+
+	// filter.unnest()
+	static int unnest(lua_State *ls);
 };
 

--- a/userspace/libsinsp/lua_parser_api.h
+++ b/userspace/libsinsp/lua_parser_api.h
@@ -27,7 +27,10 @@ extern "C" {
 class lua_parser_cbacks
 {
 public:
-	// filter.make_filter_check(field_name, cmpop, value)
-	static int make_filter_check(lua_State *ls);
+	// filter.rel_expr(field_name, cmpop, value)
+	static int rel_expr(lua_State *ls);
+
+	// filter.bool_op(op)
+	static int bool_op(lua_State *ls);
 };
 

--- a/userspace/libsinsp/lua_parser_api.h
+++ b/userspace/libsinsp/lua_parser_api.h
@@ -1,0 +1,33 @@
+/*
+Copyright (C) 2013-2014 Draios inc.
+
+This file is part of sysdig.
+
+sysdig is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+sysdig is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+extern "C" {
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
+}
+
+class lua_parser_cbacks
+{
+public:
+	// filter.make_filter_check(field_name, value)
+	static int make_filter_check(lua_State *ls);
+};
+


### PR DESCRIPTION
Add support for creating filters from Lua. The `lua_parser` and `lua_parser_api` class can be used to expose a simple API allowing a Lua script to create and configure arbitrary filters.