### PR TITLE
Filter evaluation: fully short-circuit.

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1119,10 +1119,18 @@ bool sinsp_filter_expression::compare(sinsp_evt *evt)
 			switch(chk->m_boolop)
 			{
 			case BO_OR:
-				res = res || chk->compare(evt);
+				if(res)
+				{
+					goto done;
+				}
+				res = chk->compare(evt);
 				break;
 			case BO_AND:
-				res = res && chk->compare(evt);
+				if(!res)
+				{
+					goto done;
+				}
+				res = chk->compare(evt);
 				break;
 			case BO_ORNOT:
 				res = res || !chk->compare(evt);
@@ -1136,7 +1144,7 @@ bool sinsp_filter_expression::compare(sinsp_evt *evt)
 			}
 		}
 	}
-
+ done:
 	return res;
 }
 


### PR DESCRIPTION
Before this commit, we shortcircuited unnecessary compare()'s in a chain
of checks, but we still iterated through the chain.

With this commit, we interrupt the iteration itself as well. This should
shave off a bunch of cycles on long chains of filters.