### PR TITLE
Event check id

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -83,6 +83,16 @@ sinsp_evt::~sinsp_evt()
 {
 }
 
+void sinsp_evt::set_check_id(int32_t id)
+{
+	m_check_id = id;
+}
+
+int32_t sinsp_evt::get_check_id()
+{
+	return m_check_id;
+}
+
 uint64_t sinsp_evt::get_ts()
 {
 	return m_pevt->ts;

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -290,6 +290,16 @@ public:
 	*/
 	void get_category(OUT sinsp_evt::category* cat);
 
+	/*!
+	  \brief Set an opaque "check id", corresponding to the id of the last filtercheck that matched this event.
+	*/
+	void set_check_id(int32_t id);
+
+	/*!
+	  \brief Get the opaque "check id" (-1 if not set).
+	*/
+	int32_t get_check_id();
+
 #ifdef HAS_FILTERING
 	/*!
 	  \brief Return true if the event has been rejected by the filtering system.
@@ -359,6 +369,7 @@ VISIBILITY_PRIVATE
 	scap_evt* m_pevt;
 	uint16_t m_cpuid;
 	uint64_t m_evtnum;
+	int32_t m_check_id = -1;
 	bool m_params_loaded;
 	const struct ppm_event_info* m_info;
 	vector<sinsp_evt_param> m_params;

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1181,7 +1181,7 @@ void sinsp_filter::push_expression(boolop op)
 	newexpr->m_boolop = op;
 	newexpr->m_parent = m_curexpr;
 
-	m_curexpr->m_checks.push_back((sinsp_filter_check*)newexpr);
+	add_check((sinsp_filter_check*)newexpr);
 	m_curexpr = newexpr;
 }
 

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1027,6 +1027,16 @@ int32_t sinsp_filter_check::parse_field_name(const char* str, bool alloc_state)
 	return max_fldlen;
 }
 
+void sinsp_filter_check::set_check_id(int32_t id)
+{
+	m_check_id = id;
+}
+
+int32_t sinsp_filter_check::get_check_id()
+{
+	return m_check_id;
+}
+
 void sinsp_filter_check::parse_filter_value(const char* str, uint32_t len)
 {
 	string_to_rawval(str, len, m_field->m_type);
@@ -1073,6 +1083,12 @@ sinsp_filter_expression::~sinsp_filter_expression()
 	}
 }
 
+// Only filter checks get IDs
+int32_t sinsp_filter_expression::get_check_id()
+{
+	return -1;
+}
+
 sinsp_filter_check* sinsp_filter_expression::allocate_new()
 {
 	ASSERT(false);
@@ -1093,10 +1109,11 @@ bool sinsp_filter_expression::compare(sinsp_evt *evt)
 	uint32_t j;
 	uint32_t size = (uint32_t)m_checks.size();
 	bool res = true;
+	sinsp_filter_check* chk;
 
 	for(j = 0; j < size; j++)
 	{
-		sinsp_filter_check* chk = m_checks[j];
+		chk = m_checks[j];
 		ASSERT(chk != NULL);
 
 		if(j == 0)
@@ -1153,6 +1170,15 @@ bool sinsp_filter_expression::compare(sinsp_evt *evt)
 		}
 	}
  done:
+	if(res)
+	{
+		int32_t id = chk->get_check_id();
+		if(id >= 0)
+		{
+			evt->set_check_id(id);
+		}
+	}
+
 	return res;
 }
 

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -119,6 +119,12 @@ public:
 	//
 	virtual Json::Value tojson(sinsp_evt* evt);
 
+	//
+	// Configure numeric id to be set on events that match this filter
+	//
+	void set_check_id(int32_t id);
+	virtual int32_t get_check_id();
+
 	sinsp* m_inspector;
 	boolop m_boolop;
 	cmpop m_cmpop;
@@ -140,6 +146,7 @@ protected:
 
 private:
 	void set_inspector(sinsp* inspector);
+	int32_t m_check_id = -1;
 
 friend class sinsp_filter_check_list;
 };
@@ -204,6 +211,8 @@ public:
 		ASSERT(false);
 		return NULL;
 	}
+
+	int32_t get_check_id();
 
 	sinsp_filter_expression* m_parent;
 	vector<sinsp_filter_check*> m_checks;

--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -198,6 +198,7 @@ int lua_parser_cbacks::rel_expr(lua_State *ls)
 
 	try
 	{
+		int next_index = 3;
 		chk->m_boolop = parser->m_last_boolop;
 		parser->m_last_boolop = BO_NONE;
 
@@ -206,11 +207,16 @@ int lua_parser_cbacks::rel_expr(lua_State *ls)
 		const char* cmpop = luaL_checkstring(ls, 2);
 		chk->m_cmpop = string_to_cmpop(cmpop);
 
+		next_index++;
 		// "exists" is the only unary comparison op
 		if(strcmp(cmpop, "exists"))
 		{
 			const char* value = luaL_checkstring(ls, 3);
 			chk->parse_filter_value(value, strlen(value));
+			next_index = 4;
+		}
+		if (lua_isnumber(ls, next_index)) {
+			chk->set_check_id((int) luaL_checkinteger(ls, next_index));
 		}
 	}
 	catch(sinsp_exception& e)

--- a/userspace/libsinsp/lua_parser_api.h
+++ b/userspace/libsinsp/lua_parser_api.h
@@ -27,7 +27,11 @@ extern "C" {
 class lua_parser_cbacks
 {
 public:
-	// filter.rel_expr(field_name, cmpop, value)
+	// filter.rel_expr(field_name, cmpop, value, index)
+	// field_name and cmpop are mandatory
+	// value is mandatory unless cmpop=="exists"
+	// index is an optional index (integer) that will be written
+	// into events matching this expression (internal use).
 	static int rel_expr(lua_State *ls);
 
 	// filter.bool_op(op)


### PR DESCRIPTION
This PR adds the ability to tag filter checks with IDs, which are then written into events during filtering. This allows a client to associate events with filters and is made available in the Lua filter API.