### PR TITLE
Add Actions to renice processes and for one-shot lsof

### DIFF
--- a/userspace/sysdig/chisels/v_procs.lua
+++ b/userspace/sysdig/chisels/v_procs.lua
@@ -161,7 +161,7 @@ view_info =
 		{
 			hotkey = "f",
 			command = "lsof -p %proc.pid",
-			description = "one-time lsof for given process",
+			description = "one-time lsof",
 		},
 		{
 			hotkey = "[",

--- a/userspace/sysdig/chisels/v_procs.lua
+++ b/userspace/sysdig/chisels/v_procs.lua
@@ -158,5 +158,22 @@ view_info =
 			command = "gdb -p %proc.pid --batch --quiet -ex \"thread apply all bt full\" -ex \"quit\"",
 			description = "print stack",
 		},
+		{
+			hotkey = "f",
+			command = "lsof -p %proc.pid",
+			description = "one-time lsof for given process",
+		},
+		{
+			hotkey = "[",
+			command = "renice $(expr $(ps -h -p %proc.pid -o nice) + 1) -p %proc.pid",
+			description = "increment nice by 1",
+			wait_finish = false,
+		},
+		{
+			hotkey = "]",
+			command = "renice $(expr $(ps -h -p %proc.pid -o nice) - 1) -p %proc.pid",
+			description = "decrement nice by 1",
+			wait_finish = false,
+		},
 	},
 }


### PR DESCRIPTION
This adds a few actions to the common "Processes" view in Csysdig.

- Press "[" and "]" to do the equivalent re-nicing as these keys do in htop. I noticed that Csysdig doesn't actually give "nice" visibility at the moment, so opening htop is the best way to see it's having the desired effect.

- Press "f" to see a one-shot lsof. When doing a comparison with htop, I noticed the usefulness of their "l" (lowercase "ell") for a one-shot lsof, which did something different from the "File Opens List" or "Files" VIews in Csysdig, where I'd need to actually wait to see the opens as they occur or ball up a full SCAP in advance to get an all-in-one report.

sysdig-CLA-1.0-signed-off-by: Phillip A. Rzewski <philrz@yahoo.com>