### PR TITLE
Subnet filters

### DIFF
--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1165,7 +1165,8 @@ enum ppm_param_type {
 	PT_SIGSET = 34, /* sigset_t. I only store the lower UINT32 of it */
 	PT_CHARBUFARRAY = 35,	/* Pointer to an array of strings, exported by the user events decoder. 64bit. For internal use only. */
 	PT_CHARBUF_PAIR_ARRAY = 36,	/* Pointer to an array of string pairs, exported by the user events decoder. 64bit. For internal use only. */
-	PT_MAX = 37 /* array size */
+	PT_IPV4NET = 37, /* An IPv4 network. */
+	PT_MAX = 38 /* array size */
 };
 
 enum ppm_print_format {

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -31,6 +31,7 @@ class sinsp_filter_check_reference;
 
 bool flt_compare(cmpop op, ppm_param_type type, void* operand1, void* operand2, uint32_t op1_len = 0, uint32_t op2_len = 0);
 bool flt_compare_avg(cmpop op, ppm_param_type type, void* operand1, void* operand2, uint32_t op1_len, uint32_t op2_len, uint32_t cnt1, uint32_t cnt2);
+bool flt_compare_ipv4net(cmpop op, uint64_t operand1, ipv4net* operand2);
 
 char* flt_to_string(uint8_t* rawval, filtercheck_field_info* finfo);
 
@@ -256,7 +257,12 @@ public:
 		TYPE_CLIENTPROTO = 23,
 		TYPE_SERVERPROTO = 24,
 		TYPE_LPROTO = 25,
-		TYPE_RPROTO = 26
+		TYPE_RPROTO = 26,
+		TYPE_NET = 27,
+		TYPE_CNET = 28,
+		TYPE_SNET = 29,
+		TYPE_LNET = 30,
+		TYPE_RNET = 31
 	};
 
 	enum fd_type
@@ -279,6 +285,7 @@ public:
 	sinsp_filter_check* allocate_new();
 	uint8_t* extract(sinsp_evt *evt, OUT uint32_t* len);
 	bool compare_ip(sinsp_evt *evt);
+	bool compare_net(sinsp_evt *evt);
 	bool compare_port(sinsp_evt *evt);
 	bool compare(sinsp_evt *evt);
 

--- a/userspace/libsinsp/tuples.h
+++ b/userspace/libsinsp/tuples.h
@@ -39,6 +39,15 @@ typedef union _ipv4tuple
 }ipv4tuple;
 
 /*!
+	\brief An IPv4 network.
+*/
+typedef struct ipv4net
+{
+	uint32_t m_ip; ///< IP addr
+	uint32_t m_netmask; ///< Subnet mask
+}ipv4net;
+
+/*!
 	\brief An IPv6 tuple. 
 */
 typedef union _ipv6tuple


### PR DESCRIPTION
Adds subnet filters, allowing one to check if a file descriptor's associated IP address is part of a subnet.
Uses CIDR notation, e.g:

`fd.cip = 10.0.2.4/24`