### PR TITLE
Fix check_id setting on events

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -85,7 +85,9 @@ sinsp_evt::~sinsp_evt()
 
 void sinsp_evt::set_check_id(int32_t id)
 {
-	m_check_id = id;
+	if (id) {
+		m_check_id = id;
+	}
 }
 
 int32_t sinsp_evt::get_check_id()

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -379,7 +379,7 @@ VISIBILITY_PRIVATE
 	uint16_t m_cpuid;
 	uint64_t m_evtnum;
 	uint32_t m_flags;
-	int32_t m_check_id = -1;
+	int32_t m_check_id = 0;
 	bool m_params_loaded;
 	const struct ppm_event_info* m_info;
 	vector<sinsp_evt_param> m_params;

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1059,7 +1059,7 @@ sinsp_filter_expression::~sinsp_filter_expression()
 // Only filter checks get IDs
 int32_t sinsp_filter_expression::get_check_id()
 {
-	return -1;
+	return 0;
 }
 
 sinsp_filter_check* sinsp_filter_expression::allocate_new()
@@ -1095,6 +1095,9 @@ bool sinsp_filter_expression::compare(sinsp_evt *evt)
 			{
 			case BO_NONE:
 				res = chk->compare(evt);
+				if (res) {
+					evt->set_check_id(chk->get_check_id());
+				}
 				break;
 			case BO_NOT:
 				res = !chk->compare(evt);
@@ -1114,6 +1117,9 @@ bool sinsp_filter_expression::compare(sinsp_evt *evt)
 					goto done;
 				}
 				res = chk->compare(evt);
+				if (res) {
+					evt->set_check_id(chk->get_check_id());
+				}
 				break;
 			case BO_AND:
 				if(!res)
@@ -1121,6 +1127,9 @@ bool sinsp_filter_expression::compare(sinsp_evt *evt)
 					goto done;
 				}
 				res = chk->compare(evt);
+				if (res) {
+					evt->set_check_id(chk->get_check_id());
+				}
 				break;
 			case BO_ORNOT:
 				if(res)
@@ -1128,6 +1137,9 @@ bool sinsp_filter_expression::compare(sinsp_evt *evt)
 					goto done;
 				}
 				res = !chk->compare(evt);
+				if (res) {
+					evt->set_check_id(chk->get_check_id());
+				}
 				break;
 			case BO_ANDNOT:
 				if(!res)
@@ -1135,6 +1147,9 @@ bool sinsp_filter_expression::compare(sinsp_evt *evt)
 					goto done;
 				}
 				res = !chk->compare(evt);
+				if (res) {
+					evt->set_check_id(chk->get_check_id());
+				}
 				break;
 			default:
 				ASSERT(false);
@@ -1143,14 +1158,6 @@ bool sinsp_filter_expression::compare(sinsp_evt *evt)
 		}
 	}
  done:
-	if(res)
-	{
-		int32_t id = chk->get_check_id();
-		if(id >= 0)
-		{
-			evt->set_check_id(id);
-		}
-	}
 
 	return res;
 }

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -153,7 +153,7 @@ protected:
 
 private:
 	void set_inspector(sinsp* inspector);
-	int32_t m_check_id = -1;
+	int32_t m_check_id = 0;
 
 friend class sinsp_filter_check_list;
 };


### PR DESCRIPTION
Before this fix, the wrong check_id could be set on an event which
passed a filter.

For example in `A OR B` where A evaluates to true and B evaluates to
false, the check_id from B would incorrectly be set on the event.

This fix addresses that (in a cleaner way than the earlier fix on the
`demo-hack` branch).