### PR TITLE
Fix sign mismatch for env_len.

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1303,7 +1303,7 @@ cgroups_error:
 		/*
 		 * execve-only parameters
 		 */
-		unsigned long env_len = 0;
+		long env_len = 0;
 
 		if (likely(retval >= 0)) {
 			/*


### PR DESCRIPTION
env_len is used as the return value from (compat_)accumulate_argv_or_env
which returns < 0 on failure, so make env_len signed.

This fixes #595.

@ldegio @gianlucaborello 