### PR TITLE
Add regression tests for proc.sid/proc.sname.

### DIFF
--- a/test/sysdig_batch_parser.sh
+++ b/test/sysdig_batch_parser.sh
@@ -35,10 +35,20 @@ export SYSDIG_CHISEL_DIR
 rm -rf $DIRNAME || true
 mkdir -p $DIRNAME
 
+if [ ! -e $REFERENCEDIR ]; then
+    echo "Reference directory $REFERENCEDIR does not exist--skipping directory entirely"
+    exit 0
+fi
+
 for f in $TRACESDIR/*
 do
+    ref=$REFERENCEDIR/$(basename $f).output;
+    if [ ! -e $ref ]; then
+	echo "Corresponding reference file $ref does not exist--skipping"
+    else
 	echo "Processing $f"
 	TZ=UTC eval $SYSDIG -N -r $f $ARGS > $DIRNAME/$(basename $f).output
+    fi
 done
 
 echo Data saved in $DIRNAME

--- a/test/sysdig_trace_regression.sh
+++ b/test/sysdig_trace_regression.sh
@@ -15,7 +15,7 @@ BRANCH=$3
 if [ ! -d "$TRACEDIR" ]; then
 	mkdir -p $TRACEDIR
 	cd $TRACEDIR
-	wget https://s3.amazonaws.com/download.draios.com/sysdig-tests/traces.zip
+	wget -O traces.zip https://s3.amazonaws.com/download.draios.com/sysdig-tests/traces-$BRANCH.zip || wget -O traces.zip https://s3.amazonaws.com/download.draios.com/sysdig-tests/traces.zip
 	unzip traces.zip
 	rm -rf traces.zip
 	cd -
@@ -102,6 +102,8 @@ $BASEDIR/sysdig_batch_parser.sh $SYSDIG $CHISELS "-clsof" $TRACEDIR $RESULTDIR/l
 $BASEDIR/sysdig_batch_parser.sh $SYSDIG $CHISELS "-cps" $TRACEDIR $RESULTDIR/ps $BASELINEDIR/ps || ret=1
 # JSON
 $BASEDIR/sysdig_batch_parser.sh $SYSDIG $CHISELS "-j -n 10000" $TRACEDIR $RESULTDIR/fd_fields_json $BASELINEDIR/fd_fields_json || ret=1
+# Sessions
+$BASEDIR/sysdig_batch_parser.sh $SYSDIG $CHISELS "-p '*%evt.num %evt.outputtime %evt.cpu %proc.name (%thread.tid) %evt.dir %evt.type %evt.info sid=%proc.sid sname=%proc.sname'" $TRACEDIR $RESULTDIR/sessions $BASELINEDIR/sessions || ret=1
 
 rm -rf "${TMPBASE}"
 exit $ret


### PR DESCRIPTION
The actual new change is to add a second trace file sessions.scap which
shows the results of calling "setsid -w ls", with results scoped to the
shell where setsid is run. This handles all the cases of tracking a
session id/name for an existing process (the base shell), execing
"setsid -w ls", which changes the sid and sname, and waiting for the ls
to exit.

In order to add this new trace file, I needed to change how the
regression tests were run. The current regression tests assumed that for
a given input trace file that there would be a corresponding baseline
directory with the results of running that trace file with all the sets
of arguments in sysdig_trace_regression.sh. That didn't really handle
forward-looking cases like this, where I don't want to run old files
with new combinations of arguments and didn't want to use old arguments
on the new trace file.

Fix this by changing sysdig_batch_parser to skip running sysdig with a
given set of arguments when the corresponding baseline directory doesn't
exist.

This change has zip files baseline-add-session-tests.zip and
traces-add-session-tests.zip, which should work based on my
understanding of TRAVIS_BRANCH. After merging this branch to dev I'll
update the actual baseline.zip/traces.zip files, and give anyone working
on an active branch to rebase.

This won't handle the case of the master branch, though. I need to check
to see if sysdig_trace_regression is run outside of travis.

@ltagliamonte are you familiar with these tests at all? If so does the approach look good to you?