### PR TITLE
Add startswith as a string comparison operator.

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -173,8 +173,17 @@ bool flt_compare_uint64(cmpop op, uint64_t operand1, uint64_t operand2)
 		return (operand1 > operand2);
 	case CO_GE:
 		return (operand1 >= operand2);
-	default:
+	case CO_CONTAINS:
 		throw sinsp_exception("'contains' not supported for numeric filters");
+		return false;
+	case CO_ICONTAINS:
+		throw sinsp_exception("'icontains' not supported for numeric filters");
+		return false;
+	case CO_STARTSWITH:
+		throw sinsp_exception("'startswith' not supported for numeric filters");
+		return false;
+	default:
+		throw sinsp_exception("'unknown' not supported for numeric filters");
 		return false;
 	}
 }
@@ -201,6 +210,9 @@ bool flt_compare_int64(cmpop op, int64_t operand1, int64_t operand2)
 	case CO_ICONTAINS:
 		throw sinsp_exception("'icontains' not supported for numeric filters");
 		return false;
+	case CO_STARTSWITH:
+		throw sinsp_exception("'startswith' not supported for numeric filters");
+		return false;
 	default:
 		throw sinsp_exception("'unknown' not supported for numeric filters");
 		return false;
@@ -223,6 +235,8 @@ bool flt_compare_string(cmpop op, char* operand1, char* operand2)
 #else
 		return (strcasestr(operand1, operand2) != NULL);
 #endif
+	case CO_STARTSWITH:
+		return (strncmp(operand1, operand2, strlen(operand2)) == 0);
 	case CO_LT:
 		return (strcmp(operand1, operand2) < 0);
 	case CO_LE:
@@ -250,6 +264,8 @@ bool flt_compare_buffer(cmpop op, char* operand1, char* operand2, uint32_t op1_l
 		return (memmem(operand1, op1_len, operand2, op2_len) != NULL);
 	case CO_ICONTAINS:
 		throw sinsp_exception("'icontains' not supported for buffer filters");
+	case CO_STARTSWITH:
+		return (memcmp(operand1, operand2, op2_len) == 0);
 	case CO_LT:
 		throw sinsp_exception("'<' not supported for buffer filters");
 	case CO_LE:
@@ -281,8 +297,17 @@ bool flt_compare_double(cmpop op, double operand1, double operand2)
 		return (operand1 > operand2);
 	case CO_GE:
 		return (operand1 >= operand2);
-	default:
+	case CO_CONTAINS:
 		throw sinsp_exception("'contains' not supported for numeric filters");
+		return false;
+	case CO_ICONTAINS:
+		throw sinsp_exception("'icontains' not supported for numeric filters");
+		return false;
+	case CO_STARTSWITH:
+		throw sinsp_exception("'startswith' not supported for numeric filters");
+		return false;
+	default:
+		throw sinsp_exception("'unknown' not supported for numeric filters");
 		return false;
 	}
 }
@@ -297,6 +322,15 @@ bool flt_compare_ipv4net(cmpop op, uint64_t operand1, ipv4net* operand2)
 	}
 	case CO_NE:
 		return ((operand1 & operand2->m_netmask) != (operand2->m_ip && operand2->m_netmask));
+	case CO_CONTAINS:
+		throw sinsp_exception("'contains' not supported for numeric filters");
+		return false;
+	case CO_ICONTAINS:
+		throw sinsp_exception("'icontains' not supported for numeric filters");
+		return false;
+	case CO_STARTSWITH:
+		throw sinsp_exception("'startswith' not supported for numeric filters");
+		return false;
 	default:
 		throw sinsp_exception("comparison operator not supported for ipv4 networks");
 	}
@@ -1514,6 +1548,11 @@ cmpop sinsp_filter_compiler::next_comparison_operator()
 	{
 		m_scanpos += 9;
 		return CO_ICONTAINS;
+	}
+	else if(compare_no_consume("startswith"))
+	{
+		m_scanpos += 10;
+		return CO_STARTSWITH;
 	}
 	else if(compare_no_consume("in"))
 	{

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -38,6 +38,7 @@ enum cmpop {
 	CO_IN = 8,
 	CO_EXISTS = 9,
 	CO_ICONTAINS = 10,
+	CO_STARTSWITH = 11
 };
 
 enum boolop

--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -46,6 +46,10 @@ cmpop string_to_cmpop(const char* str)
 	{
 		return CO_ICONTAINS;
 	}
+	else if(strcmp(str, "startswith") == 0)
+	{
+		return CO_STARTSWITH;
+	}
 	else if(strcmp(str, "in") == 0)
 	{
 		return CO_IN;


### PR DESCRIPTION
Add startswith as a string comparison operator.

Currently, the only way to do a substring match is the 'contains'
operator. This is less than ideal when you specifically want to test the
beginning of a string for the substring, as contains will traverse the
entire string and may return a match in the middle of the string.

Add a startswith operator that specifically tests for a substring match
at the beginning of the string.

There were a few places in non-string comparison operators where any
operator not in the set of supported operators was assumed to be
'contains'. Replace this with checks for all operators including
'icontains', 'startswith' with appropriate error messages.

@luca3m @ldegio @gianlucaborello 