### PR TITLE
Properly set length for extracted filenames.

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -493,9 +493,8 @@ uint8_t* sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT uint32_t* len, bool 
 		if(sanitize_strings)
 		{
 			sanitize_string(m_tstr);
-			*len = m_tstr.size();
 		}
-
+		*len = m_tstr.size();
 		return (uint8_t*)m_tstr.c_str();
 	case TYPE_FDTYPE:
 		if(m_fdinfo == NULL)
@@ -1270,7 +1269,7 @@ bool sinsp_filter_check_fd::compare(sinsp_evt *evt)
 	//
 	// Standard extract-based fields
 	//
-	uint32_t len;
+	uint32_t len = 0;
 	bool sanitize_strings = false;
 	uint8_t* extracted_val = extract(evt, &len, sanitize_strings);
 


### PR DESCRIPTION
While merging together #624 (multi string search) and #625 (don't
sanitize strings), the length was only being set when string
sanitization was enabled.

Additionally, the length was not being initialized to 0, meaning that it
was not defined.

This led to some FPs for some of the falco tests.

I'll go ahead and merge this once tests pass so I can do more comprehensive testing in falco.