### PR TITLE
Initialize per-evttype filter array.

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -143,6 +143,8 @@ sinsp::sinsp() :
 	m_mesos_last_watch_time_ns = 0;
 
 	m_filter_proc_table_when_saving = false;
+
+	memset(m_filter_by_evttype, 0, PPM_EVENT_MAX * sizeof(list<sinsp_filter *> *));
 }
 
 sinsp::~sinsp()


### PR DESCRIPTION
Set the contents of the per-evttype filter array to NULL pointers so
only those lists that are created while running are deleted.

@aleks-f this should fix the crash you saw on shutdown.

I'll merge this later today.