### PR TITLE
Consider SERV sockets to also be ip sockets.

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -992,7 +992,8 @@ uint8_t* sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT uint32_t* len, bool 
 				return NULL;
 			}
 
-			if(m_fdinfo->m_type == SCAP_FD_IPV4_SOCK || m_fdinfo->m_type == SCAP_FD_IPV6_SOCK)
+			if(m_fdinfo->m_type == SCAP_FD_IPV4_SOCK || m_fdinfo->m_type == SCAP_FD_IPV6_SOCK ||
+			   m_fdinfo->m_type == SCAP_FD_IPV4_SERVSOCK || m_fdinfo->m_type == SCAP_FD_IPV6_SERVSOCK)
 			{
 				m_tstr = "ip";
 				*len = m_tstr.size();


### PR DESCRIPTION
Add SCAP_FD_IPV{4,6}_SERVSOCK to the socket types considered ip
sockets. The type can be set to SERVSOCK based on the port number after
other system calls.

This is related to #635. The fix for #634 will mean that this is required.

@luca3m @ldegio @gianlucaborello 