### PR TITLE
Support glob matching on strings.

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -34,6 +34,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "sinsp.h"
 #include "sinsp_int.h"
+#include "utils.h"
 
 #ifdef HAS_FILTERING
 #include "filter.h"
@@ -188,6 +189,9 @@ bool flt_compare_uint64(cmpop op, uint64_t operand1, uint64_t operand2)
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for numeric filters");
 		return false;
+	case CO_GLOB:
+		throw sinsp_exception("'glob' not supported for numeric filters");
+		return false;
 	default:
 		throw sinsp_exception("'unknown' not supported for numeric filters");
 		return false;
@@ -219,6 +223,9 @@ bool flt_compare_int64(cmpop op, int64_t operand1, int64_t operand2)
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for numeric filters");
 		return false;
+	case CO_GLOB:
+		throw sinsp_exception("'glob' not supported for numeric filters");
+		return false;
 	default:
 		throw sinsp_exception("'unknown' not supported for numeric filters");
 		return false;
@@ -243,6 +250,8 @@ bool flt_compare_string(cmpop op, char* operand1, char* operand2)
 #endif
 	case CO_STARTSWITH:
 		return (strncmp(operand1, operand2, strlen(operand2)) == 0);
+	case CO_GLOB:
+		return sinsp_utils::glob_match(operand2, operand1);
 	case CO_LT:
 		return (strcmp(operand1, operand2) < 0);
 	case CO_LE:
@@ -272,6 +281,8 @@ bool flt_compare_buffer(cmpop op, char* operand1, char* operand2, uint32_t op1_l
 		throw sinsp_exception("'icontains' not supported for buffer filters");
 	case CO_STARTSWITH:
 		return (memcmp(operand1, operand2, op2_len) == 0);
+	case CO_GLOB:
+		throw sinsp_exception("'glob' not supported for buffer filters");
 	case CO_LT:
 		throw sinsp_exception("'<' not supported for buffer filters");
 	case CO_LE:
@@ -312,6 +323,9 @@ bool flt_compare_double(cmpop op, double operand1, double operand2)
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for numeric filters");
 		return false;
+	case CO_GLOB:
+		throw sinsp_exception("'glob' not supported for numeric filters");
+		return false;
 	default:
 		throw sinsp_exception("'unknown' not supported for numeric filters");
 		return false;
@@ -336,6 +350,9 @@ bool flt_compare_ipv4net(cmpop op, uint64_t operand1, ipv4net* operand2)
 		return false;
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for numeric filters");
+		return false;
+	case CO_GLOB:
+		throw sinsp_exception("'glob' not supported for numeric filters");
 		return false;
 	default:
 		throw sinsp_exception("comparison operator not supported for ipv4 networks");
@@ -1576,6 +1593,11 @@ cmpop sinsp_filter_compiler::next_comparison_operator()
 	{
 		m_scanpos += 10;
 		return CO_STARTSWITH;
+	}
+	else if(compare_no_consume("glob"))
+	{
+		m_scanpos += 4;
+		return CO_GLOB;
 	}
 	else if(compare_no_consume("in"))
 	{

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -26,6 +26,10 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 // code at every new release, and I will have a cleaner and easier to understand code base.
 //
 
+#ifdef _WIN32
+#define NOMINMAX
+#endif
+
 #include <regex>
 
 #include "sinsp.h"

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -38,7 +38,8 @@ enum cmpop {
 	CO_IN = 8,
 	CO_EXISTS = 9,
 	CO_ICONTAINS = 10,
-	CO_STARTSWITH = 11
+	CO_STARTSWITH = 11,
+	CO_GLOB = 12
 };
 
 enum boolop

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -31,8 +31,8 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #pragma comment(lib, "Ws2_32.lib")
 #include <WinSock2.h>
 #endif
-#include <algorithm> 
-#include <functional> 
+#include <algorithm>
+#include <functional>
 #include <errno.h>
 
 #include "sinsp.h"
@@ -457,7 +457,7 @@ bool sinsp_utils::sockinfo_to_str(sinsp_sockinfo* sinfo, scap_fd_type stype, cha
 			{
 				char srcstr[INET6_ADDRSTRLEN];
 				char dststr[INET6_ADDRSTRLEN];
-				if(inet_ntop(AF_INET6, sip6, srcstr, sizeof(srcstr)) && 
+				if(inet_ntop(AF_INET6, sip6, srcstr, sizeof(srcstr)) &&
 					inet_ntop(AF_INET6, sip6, dststr, sizeof(dststr)))
 				{
 					snprintf(targetbuf,
@@ -493,7 +493,7 @@ bool sinsp_utils::sockinfo_to_str(sinsp_sockinfo* sinfo, scap_fd_type stype, cha
 			{
 				char srcstr[INET6_ADDRSTRLEN];
 				char dststr[INET6_ADDRSTRLEN];
-				if(inet_ntop(AF_INET6, sip6, srcstr, sizeof(srcstr)) && 
+				if(inet_ntop(AF_INET6, sip6, srcstr, sizeof(srcstr)) &&
 					inet_ntop(AF_INET6, sip6, dststr, sizeof(dststr)))
 				{
 					snprintf(targetbuf,
@@ -540,10 +540,10 @@ void rewind_to_parent_path(char* targetbase, char** tc, const char** pc, uint32_
 
 //
 // Args:
-//  - target: the string where we are supposed to start copying 
-//  - targetbase: the base of the path, i.e. the furthest we can go back when 
-//                following parent directories 
-//  - path: the path to copy 
+//  - target: the string where we are supposed to start copying
+//  - targetbase: the base of the path, i.e. the furthest we can go back when
+//                following parent directories
+//  - path: the path to copy
 //
 void copy_and_sanitize_path(char* target, char* targetbase, const char* path)
 {
@@ -663,11 +663,11 @@ void copy_and_sanitize_path(char* target, char* targetbase, const char* path)
 //
 // Return false if path2 is an absolute path
 //
-bool sinsp_utils::concatenate_paths(char* target, 
-									uint32_t targetlen, 
-									const char* path1, 
-									uint32_t len1, 
-									const char* path2, 
+bool sinsp_utils::concatenate_paths(char* target,
+									uint32_t targetlen,
+									const char* path1,
+									uint32_t len1,
+									const char* path2,
 									uint32_t len2)
 {
 	if(targetlen < (len1 + len2 + 1))
@@ -693,8 +693,8 @@ bool sinsp_utils::concatenate_paths(char* target,
 
 bool sinsp_utils::is_ipv4_mapped_ipv6(uint8_t* paddr)
 {
-	if(paddr[0] == 0 && paddr[1] == 0 && paddr[2] == 0 && paddr[3] == 0 && paddr[4] == 0 && 
-		paddr[5] == 0 && paddr[6] == 0 && paddr[7] == 0 && paddr[8] == 0 && paddr[9] == 0 && 
+	if(paddr[0] == 0 && paddr[1] == 0 && paddr[2] == 0 && paddr[3] == 0 && paddr[4] == 0 &&
+		paddr[5] == 0 && paddr[6] == 0 && paddr[7] == 0 && paddr[8] == 0 && paddr[9] == 0 &&
 		paddr[10] == 0xff && paddr[11] == 0xff)
 	{
 		return true;
@@ -720,7 +720,7 @@ const struct ppm_param_info* sinsp_utils::find_longest_matching_evt_param(string
 			const char* an = pi->name;
 			uint32_t alen = (uint32_t)strlen(an);
 			string subs = string(name, 0, alen);
-			
+
 			if(subs == an)
 			{
 				if(alen > maxlen)
@@ -764,7 +764,7 @@ void sinsp_utils::bt(void)
 	bt_size = backtrace(bt, 1024);
 	bt_syms = backtrace_symbols(bt, bt_size);
 	g_logger.format("%s", start);
-	for (i = 1; i < bt_size; i++) 
+	for (i = 1; i < bt_size; i++)
 	{
 		g_logger.format("%s", bt_syms[i]);
 	}
@@ -809,7 +809,7 @@ time_t get_epoch_utc_seconds_now()
 #ifdef _WIN32
 
 #include <time.h>
-#include <windows.h> 
+#include <windows.h>
 
 const __int64 DELTA_EPOCH_IN_MICROSECS = 11644473600000000;
 
@@ -833,7 +833,7 @@ int gettimeofday(struct timeval *tv, struct timezone2 *tz)
 	// converting file time to unix epoch
 	//
 	tmpres /= 10;  // convert into microseconds
-	tmpres -= DELTA_EPOCH_IN_MICROSECS; 
+	tmpres -= DELTA_EPOCH_IN_MICROSECS;
 	tv->tv_sec = (__int32)(tmpres*0.000001);
 	tv->tv_usec =(tmpres%1000000);
 
@@ -915,13 +915,13 @@ string ipv4serveraddr_to_string(ipv4serverinfo* addr, bool resolve)
 	// IP address is saved with host byte order, that's why we do shifts
 	snprintf(buf,
 		sizeof(buf),
-		"%d.%d.%d.%d:%s", 
+		"%d.%d.%d.%d:%s",
 		(addr->m_ip & 0xFF),
 		((addr->m_ip & 0xFF00) >> 8),
 		((addr->m_ip & 0xFF0000) >> 16),
 		((addr->m_ip & 0xFF000000) >> 24),
 		port_to_string(addr->m_port, addr->m_l4proto, resolve).c_str());
-	
+
 	return string(buf);
 }
 
@@ -942,7 +942,7 @@ string ipv4tuple_to_string(ipv4tuple* tuple, bool resolve)
 	string dest = ipv4serveraddr_to_string(&info, resolve);
 
 	snprintf(buf, sizeof(buf), "%s->%s", source.c_str(), dest.c_str());
-	
+
 	return string(buf);
 }
 
@@ -959,7 +959,7 @@ string ipv6serveraddr_to_string(ipv6serverinfo* addr, bool resolve)
 	snprintf(buf,200,"%s:%s",
 		address,
 		port_to_string(addr->m_port, addr->m_l4proto, resolve).c_str());
-	
+
 	return string(buf);
 }
 
@@ -978,13 +978,13 @@ string ipv6tuple_to_string(_ipv6tuple* tuple, bool resolve)
 	{
 		return string();
 	}
-	
+
 	snprintf(buf,200,"%s:%s->%s:%s",
 		source_address,
 		port_to_string(tuple->m_fields.m_sport, tuple->m_fields.m_l4proto, resolve).c_str(),
 		destination_address,
 		port_to_string(tuple->m_fields.m_dport, tuple->m_fields.m_l4proto, resolve).c_str());
-	
+
 	return string(buf);
 }
 
@@ -1011,7 +1011,7 @@ vector<string> sinsp_split(const string &s, char delim)
 //
 // trim from start
 //
-string& ltrim(string &s) 
+string& ltrim(string &s)
 {
 	s.erase(s.begin(), find_if(s.begin(), s.end(), not1(ptr_fun<int, int>(isspace))));
 	return s;
@@ -1020,7 +1020,7 @@ string& ltrim(string &s)
 //
 // trim from end
 //
-string& rtrim(string &s) 
+string& rtrim(string &s)
 {
 	s.erase(find_if(s.rbegin(), s.rend(), not1(ptr_fun<int, int>(isspace))).base(), s.end());
 	return s;
@@ -1029,7 +1029,7 @@ string& rtrim(string &s)
 //
 // trim from both ends
 //
-string& trim(string &s) 
+string& trim(string &s)
 {
 	return ltrim(rtrim(s));
 }

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -27,9 +27,12 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include <netdb.h>
 #include <strings.h>
 #include <sys/ioctl.h>
+#include <fnmatch.h>
 #else
 #pragma comment(lib, "Ws2_32.lib")
 #include <WinSock2.h>
+#include "Shlwapi.h"
+#pragma comment(lib,"shlwapi.lib")
 #endif
 #include <algorithm>
 #include <functional>
@@ -748,6 +751,15 @@ uint64_t sinsp_utils::get_current_time_ns()
     gettimeofday(&tv, NULL);
 
     return tv.tv_sec * (uint64_t) 1000000000 + tv.tv_usec * 1000;
+}
+
+bool sinsp_utils::glob_match(const char *pattern, const char *string)
+{
+#ifdef _WIN32
+	return PathMatchSpec(string, pattern) == TRUE;
+#else
+	return fnmatch(pattern, string, FNM_PATHNAME) == 0;
+#endif
 }
 
 #ifndef _WIN32

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -89,6 +89,8 @@ public:
 
 	static uint64_t get_current_time_ns();
 
+	static bool glob_match(const char *pattern, const char *string);
+
 #ifndef _WIN32
 	//
 	// Print the call stack


### PR DESCRIPTION
Add new comparison "glob" that allows for glob matching on pathnames, as
implemented by fnmatch(). This handles simple stuff like *, ?, etc. but
not shell specific extensions.

Sound like a good idea @luca, @ldegio @gianlucaborello?