### PR TITLE
Addl docker container info

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -407,6 +407,8 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 	container["type"] = container_info.m_type;
 	container["name"] = container_info.m_name;
 	container["image"] = container_info.m_image;
+	container["privileged"] = container_info.m_privileged;
+
 
 	char addrbuff[100];
 	uint32_t iph = ntohl(container_info.m_container_ip);
@@ -608,6 +610,11 @@ bool sinsp_container_manager::parse_docker(sinsp_container_info* container)
 	if(cpu_period > 0)
 	{
 		container->m_cpu_period = cpu_period;
+	}
+	const Json::Value &privileged = host_config_obj["Privileged"];
+	if(!privileged.isNull() && privileged.isBool())
+	{
+		container->m_privileged = privileged.asBool();
 	}
 	return true;
 }

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -25,6 +25,59 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include "sinsp.h"
 #include "sinsp_int.h"
 #include "container.h"
+#include "utils.h"
+
+void sinsp_container_info::parse_json_mounts(const Json::Value &mnt_obj, vector<sinsp_container_info::container_mount_info> &mounts)
+{
+	if(!mnt_obj.isNull() && mnt_obj.isArray())
+	{
+		for(uint32_t i=0; i<mnt_obj.size(); i++)
+		{
+			const Json::Value &mount = mnt_obj[i];
+			mounts.emplace_back(mount["Source"], mount["Destination"],
+					    mount["Mode"], mount["RW"],
+					    mount["Propagation"]);
+		}
+	}
+}
+
+sinsp_container_info::container_mount_info *sinsp_container_info::mount_by_idx(uint32_t idx)
+{
+	if (idx >= m_mounts.size())
+	{
+		return NULL;
+	}
+
+	return &(m_mounts[idx]);
+}
+
+sinsp_container_info::container_mount_info *sinsp_container_info::mount_by_source(std::string &source)
+{
+	// note: linear search
+	for (auto &mntinfo :m_mounts)
+	{
+		if(sinsp_utils::glob_match(source.c_str(), mntinfo.m_source.c_str()))
+		{
+			return &mntinfo;
+		}
+	}
+
+	return NULL;
+}
+
+sinsp_container_info::container_mount_info *sinsp_container_info::mount_by_dest(std::string &dest)
+{
+	// note: linear search
+	for (auto &mntinfo :m_mounts)
+	{
+		if(sinsp_utils::glob_match(dest.c_str(), mntinfo.m_dest.c_str()))
+		{
+			return &mntinfo;
+		}
+	}
+
+	return NULL;
+}
 
 sinsp_container_manager::sinsp_container_manager(sinsp* inspector) :
 	m_inspector(inspector),
@@ -409,6 +462,22 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 	container["image"] = container_info.m_image;
 	container["privileged"] = container_info.m_privileged;
 
+	Json::Value mounts = Json::arrayValue;
+
+	for (auto &mntinfo : container_info.m_mounts)
+	{
+		Json::Value mount;
+
+		mount["Source"] = mntinfo.m_source;
+		mount["Destination"] = mntinfo.m_dest;
+		mount["Mode"] = mntinfo.m_mode;
+		mount["RW"] = mntinfo.m_rdwr;
+		mount["Propagation"] = mntinfo.m_propagation;
+
+		mounts.append(mount);
+	}
+
+	container["Mounts"] = mounts;
 
 	char addrbuff[100];
 	uint32_t iph = ntohl(container_info.m_container_ip);
@@ -616,6 +685,9 @@ bool sinsp_container_manager::parse_docker(sinsp_container_info* container)
 	{
 		container->m_privileged = privileged.asBool();
 	}
+
+	sinsp_container_info::parse_json_mounts(root["Mounts"], container->m_mounts);
+
 	return true;
 }
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -41,7 +41,7 @@ bool sinsp_container_manager::remove_inactive_containers()
 		m_last_flush_time_ns = m_inspector->m_lastevent_ts - m_inspector->m_inactive_container_scan_time_ns + 30 * ONE_SECOND_IN_NS;
 	}
 
-	if(m_inspector->m_lastevent_ts > 
+	if(m_inspector->m_lastevent_ts >
 		m_last_flush_time_ns + m_inspector->m_inactive_thread_scan_time_ns)
 	{
 		res = true;
@@ -187,7 +187,7 @@ bool sinsp_container_manager::resolve_container(sinsp_threadinfo* tinfo, bool qu
 		if(pos != string::npos)
 		{
 			if(cgroup.length() - pos - 1 == 64 &&
-				cgroup.find_first_not_of("0123456789abcdefABCDEF", pos + 1) == string::npos) 
+				cgroup.find_first_not_of("0123456789abcdefABCDEF", pos + 1) == string::npos)
 			{
 				container_info.m_type = CT_DOCKER;
 				container_info.m_id = cgroup.substr(pos + 1, 12);
@@ -552,7 +552,7 @@ bool sinsp_container_manager::parse_docker(sinsp_container_info* container)
 		if(v.isArray())
 		{
 			for(uint32_t j = 0; j < v.size(); ++j)
-			{	
+			{
 				sinsp_container_info::container_port_mapping port_mapping;
 
 				ip = v[j]["HostIp"].asString();

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -60,6 +60,7 @@ public:
 	string m_name;
 	string m_image;
 	uint32_t m_container_ip;
+	bool m_privileged;
 	vector<container_port_mapping> m_port_mappings;
 	map<string, string> m_labels;
 	string m_mesos_task_id;

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -45,6 +45,57 @@ public:
 		uint16_t m_container_port;
 	};
 
+	class container_mount_info
+	{
+	public:
+         	container_mount_info():
+         		m_source(""),
+			m_dest(""),
+			m_mode(""),
+			m_rdwr(false),
+			m_propagation("")
+		{
+		}
+
+		container_mount_info(const Json::Value &source, const Json::Value &dest,
+				     const Json::Value &mode, const Json::Value &rw,
+				     const Json::Value &propagation)
+		{
+			get_string_value(source, m_source);
+			get_string_value(dest, m_dest);
+			get_string_value(mode, m_mode);
+			get_string_value(propagation, m_propagation);
+
+			if(!rw.isNull() && rw.isBool())
+			{
+				m_rdwr = rw.asBool();
+			}
+		}
+
+		std::string to_string()
+		{
+			return m_source + ":" +
+				m_dest + ":" +
+				m_mode + ":" +
+				(m_rdwr ? "true" : "false") + ":" +
+				m_propagation;
+		}
+
+		inline void get_string_value(const Json::Value &val, std::string &result)
+		{
+			if(!val.isNull() && val.isString())
+			{
+				result = val.asString();
+			}
+		}
+
+		std::string m_source;
+		std::string m_dest;
+		std::string m_mode;
+		bool m_rdwr;
+		std::string m_propagation;
+	};
+
 	sinsp_container_info():
 		m_container_ip(0),
 		m_memory_limit(0),
@@ -55,12 +106,19 @@ public:
 	{
 	}
 
+	static void parse_json_mounts(const Json::Value &mnt_obj, vector<container_mount_info> &mounts);
+
+	container_mount_info *mount_by_idx(uint32_t idx);
+	container_mount_info *mount_by_source(std::string &source);
+	container_mount_info *mount_by_dest(std::string &dest);
+
 	string m_id;
 	sinsp_container_type m_type;
 	string m_name;
 	string m_image;
 	uint32_t m_container_ip;
 	bool m_privileged;
+	vector<container_mount_info> m_mounts;
 	vector<container_port_mapping> m_port_mappings;
 	map<string, string> m_labels;
 	string m_mesos_task_id;

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -5324,7 +5324,14 @@ const filtercheck_field_info sinsp_filter_check_container_fields[] =
 	{PT_CHARBUF, EPF_NONE, PF_NA, "container.name", "the container name."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "container.image", "the container image."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "container.type", "the container type, eg: docker or rkt"},
-	{PT_BOOL, EPF_NONE, PF_NA, "container.privileged", "true for containers running as privileged, false otherwise"}
+	{PT_BOOL, EPF_NONE, PF_NA, "container.privileged", "true for containers running as privileged, false otherwise"},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "container.mounts", "A space-separated list of mount information. Each item in the list has the format <source>:<dest>:<mode>:<rdrw>:<propagation>"},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "container.mount", "Information about a single mount, specified by number (e.g. container.mount[0]) or mount source (container.mount[/usr/local]). The pathname can be a glob (container.mount[/usr/local/*]), in which case the first matching mount will be returned. The information has the format <source>:<dest>:<mode>:<rdrw>:<propagation>. If there is no mount with the specified index or matching the provided source, returns the string \"none\" instead of a NULL value."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "container.mount.source", "the mount source, specified by number (e.g. container.mount.dest[0]) or mount destination (container.mount.source[/usr/local]). The pathname can be a glob."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "container.mount.dest", "the mount destination, specified by number (e.g. container.mount.dest[0]) or mount source (container.mount.dest[/usr/local]). The pathname can be a glob."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "container.mount.mode", "the mount mode, specified by number (e.g. container.mount.mode[0]) or mount source (container.mount.mode[/usr/local]). The pathname can be a glob."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "container.mount.rdwr", "the mount rdwr value, specified by number (e.g. container.mount.rdwr[0]) or mount source (container.mount.rdwr[/usr/local]). The pathname can be a glob."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "container.mount.propagation", "the mount propagation value, specified by number (e.g. container.mount.propagation[0]) or mount source (container.mount.propagation[/usr/local]). The pathname can be a glob."}
 };
 
 sinsp_filter_check_container::sinsp_filter_check_container()
@@ -5339,6 +5346,95 @@ sinsp_filter_check* sinsp_filter_check_container::allocate_new()
 {
 	return (sinsp_filter_check*) new sinsp_filter_check_container();
 }
+
+int32_t sinsp_filter_check_container::extract_arg(const string &val, size_t basepos)
+{
+	size_t start = val.find_first_of('[', basepos);
+	if(start == string::npos)
+	{
+		throw sinsp_exception("filter syntax error: " + val);
+	}
+
+	size_t end = val.find_first_of(']', start);
+	if(end == string::npos)
+	{
+		throw sinsp_exception("filter syntax error: " + val);
+	}
+
+	string numstr = val.substr(start + 1, end-start-1);
+	try
+	{
+		m_argid = sinsp_numparser::parsed32(numstr);
+	} catch (sinsp_exception e)
+	{
+		if(strstr(e.what(), "is not a valid number") == NULL)
+		{
+			throw;
+		}
+
+		m_argid = -1;
+		m_argstr = numstr;
+	}
+
+	return end+1;
+}
+
+int32_t sinsp_filter_check_container::parse_field_name(const char* str, bool alloc_state)
+{
+	string val(str);
+	int32_t res = 0;
+
+	size_t basepos = sizeof("container.mount");
+
+	// container.mount. fields allow for indexing by number or source/dest mount path.
+	if(val.find("container.mount.") == 0)
+	{
+		// Note--basepos includes the trailing null, which is
+		// equivalent to the trailing '.' here.
+		if(val.find("source", basepos) == basepos)
+		{
+			m_field_id = TYPE_CONTAINER_MOUNT_SOURCE;
+		}
+		else if(val.find("dest", basepos) == basepos)
+		{
+			m_field_id = TYPE_CONTAINER_MOUNT_DEST;
+		}
+		else if(val.find("mode", basepos) == basepos)
+		{
+			m_field_id = TYPE_CONTAINER_MOUNT_MODE;
+		}
+		else if(val.find("rdwr", basepos) == basepos)
+		{
+			m_field_id = TYPE_CONTAINER_MOUNT_RDWR;
+		}
+		else if(val.find("propagation", basepos) == basepos)
+		{
+			m_field_id = TYPE_CONTAINER_MOUNT_PROPAGATION;
+		}
+		else
+		{
+			throw sinsp_exception("filter syntax error: " + val);
+		}
+		m_field = &m_info.m_fields[m_field_id];
+
+		res = extract_arg(val, basepos);
+	}
+	else if (val.find("container.mount") == 0 &&
+		 val[basepos-1] != 's')
+	{
+		m_field_id = TYPE_CONTAINER_MOUNT;
+		m_field = &m_info.m_fields[m_field_id];
+
+		res = extract_arg(val, basepos-1);
+	}
+	else
+	{
+		res = sinsp_filter_check::parse_field_name(str, alloc_state);
+	}
+
+	return res;
+}
+
 
 uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
@@ -5474,6 +5570,147 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 
 		return (uint8_t*)&m_u32val;
 		break;
+	case TYPE_CONTAINER_MOUNTS:
+		if(tinfo->m_container_id.empty())
+		{
+			return NULL;
+		}
+		else
+		{
+			sinsp_container_info container_info;
+			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
+			if(!found)
+			{
+				return NULL;
+			}
+
+			m_tstr = "";
+			bool first = true;
+			for(auto &mntinfo : container_info.m_mounts)
+			{
+				if(first)
+				{
+					first = false;
+				}
+				else
+				{
+					m_tstr += ",";
+				}
+
+				m_tstr += mntinfo.to_string();
+			}
+
+			*len = m_tstr.size();
+			return (uint8_t*)m_tstr.c_str();
+		}
+
+		break;
+	case TYPE_CONTAINER_MOUNT:
+		if(tinfo->m_container_id.empty())
+		{
+			return NULL;
+		}
+		else
+		{
+
+			sinsp_container_info container_info;
+			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
+			if(!found)
+			{
+				return NULL;
+			}
+
+			sinsp_container_info::container_mount_info *mntinfo;
+
+			if(m_argid != -1)
+			{
+				mntinfo = container_info.mount_by_idx(m_argid);
+			}
+			else
+			{
+				mntinfo = container_info.mount_by_source(m_argstr);
+			}
+
+			if(!mntinfo)
+			{
+				return NULL;
+			}
+			else
+			{
+				m_tstr = mntinfo->to_string();
+			}
+
+			*len = m_tstr.size();
+			return (uint8_t*)m_tstr.c_str();
+		}
+
+		break;
+	case TYPE_CONTAINER_MOUNT_SOURCE:
+	case TYPE_CONTAINER_MOUNT_DEST:
+	case TYPE_CONTAINER_MOUNT_MODE:
+	case TYPE_CONTAINER_MOUNT_RDWR:
+	case TYPE_CONTAINER_MOUNT_PROPAGATION:
+		if(tinfo->m_container_id.empty())
+		{
+			return NULL;
+		}
+		else
+		{
+
+			sinsp_container_info container_info;
+			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
+			if(!found)
+			{
+				return NULL;
+			}
+
+			sinsp_container_info::container_mount_info *mntinfo;
+
+			if(m_argid != -1)
+			{
+				mntinfo = container_info.mount_by_idx(m_argid);
+			}
+			else
+			{
+				if (m_field_id == TYPE_CONTAINER_MOUNT_SOURCE)
+				{
+					mntinfo = container_info.mount_by_dest(m_argstr);
+				}
+				else
+				{
+					mntinfo = container_info.mount_by_source(m_argstr);
+				}
+			}
+
+			if(!mntinfo)
+			{
+				return NULL;
+			}
+
+			switch (m_field_id)
+			{
+			case TYPE_CONTAINER_MOUNT_SOURCE:
+				m_tstr = mntinfo->m_source;
+				break;
+			case TYPE_CONTAINER_MOUNT_DEST:
+				m_tstr = mntinfo->m_dest;
+				break;
+			case TYPE_CONTAINER_MOUNT_MODE:
+				m_tstr = mntinfo->m_mode;
+				break;
+			case TYPE_CONTAINER_MOUNT_RDWR:
+				m_tstr = (mntinfo->m_rdwr ? "true" : "false");
+				break;
+			case TYPE_CONTAINER_MOUNT_PROPAGATION:
+				m_tstr = mntinfo->m_propagation;
+				break;
+			}
+
+			*len = m_tstr.size();
+			return (uint8_t*)m_tstr.c_str();
+		}
+		break;
+
 	default:
 		ASSERT(false);
 		break;

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -767,7 +767,8 @@ public:
 		TYPE_CONTAINER_ID = 0,
 		TYPE_CONTAINER_NAME,
 		TYPE_CONTAINER_IMAGE,
-		TYPE_CONTAINER_TYPE
+		TYPE_CONTAINER_TYPE,
+		TYPE_CONTAINER_PRIVILEGED
 	};
 
 	sinsp_filter_check_container();
@@ -776,6 +777,7 @@ public:
 
 private:
 	string m_tstr;
+	uint32_t m_u32val;
 };
 
 //

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -768,7 +768,14 @@ public:
 		TYPE_CONTAINER_NAME,
 		TYPE_CONTAINER_IMAGE,
 		TYPE_CONTAINER_TYPE,
-		TYPE_CONTAINER_PRIVILEGED
+		TYPE_CONTAINER_PRIVILEGED,
+		TYPE_CONTAINER_MOUNTS,
+		TYPE_CONTAINER_MOUNT,
+		TYPE_CONTAINER_MOUNT_SOURCE,
+		TYPE_CONTAINER_MOUNT_DEST,
+		TYPE_CONTAINER_MOUNT_MODE,
+		TYPE_CONTAINER_MOUNT_RDWR,
+		TYPE_CONTAINER_MOUNT_PROPAGATION
 	};
 
 	sinsp_filter_check_container();
@@ -776,8 +783,13 @@ public:
 	uint8_t* extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings = true);
 
 private:
+	int32_t parse_field_name(const char* str, bool alloc_state);
+	int32_t extract_arg(const string& val, size_t basename);
+
 	string m_tstr;
 	uint32_t m_u32val;
+	int32_t m_argid;
+	string m_argstr;
 };
 
 //

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3948,6 +3948,11 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		{
 			container_info.m_image = image.asString();
 		}
+		const Json::Value& privileged = container["privileged"];
+		if(!privileged.isNull() && privileged.isConvertibleTo(Json::booleanValue))
+		{
+			container_info.m_privileged = privileged.asBool();
+		}
 		const Json::Value& contip = container["ip"];
 		if(!contip.isNull() && contip.isConvertibleTo(Json::stringValue))
 		{

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3953,6 +3953,8 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		{
 			container_info.m_privileged = privileged.asBool();
 		}
+
+		sinsp_container_info::parse_json_mounts(container["Mounts"], container_info.m_mounts);
 		const Json::Value& contip = container["ip"];
 		if(!contip.isNull() && contip.isConvertibleTo(Json::stringValue))
 		{

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -758,7 +758,8 @@ bool sinsp_utils::glob_match(const char *pattern, const char *string)
 #ifdef _WIN32
 	return PathMatchSpec(string, pattern) == TRUE;
 #else
-	return fnmatch(pattern, string, FNM_PATHNAME) == 0;
+	int flags = 0;
+	return fnmatch(pattern, string, flags) == 0;
 #endif
 }
 


### PR DESCRIPTION
Add new visibility into containers (specifically docker) with filterchecks that return whether or not a container is privileged and information on mounts made by a container.

Only implemented for docker containers right now.

I plan on using these to implement new falco rules that detect privileged containers and containers that mount sensitive host directories like '/proc', etc.

@luca3m @gianlucaborello I'd love feedback on the mount stuff. I tried to come up with something flexible and not too complex but I'd like to get your impressions on it.