### PR TITLE
Always initialize privileged to false.

### DIFF
--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -102,7 +102,8 @@ public:
 		m_swap_limit(0),
 		m_cpu_shares(1024),
 		m_cpu_quota(0),
-		m_cpu_period(100000)
+		m_cpu_period(100000),
+		m_privileged(false)
 	{
 	}
 


### PR DESCRIPTION
This way, we don't fully rely on the container type being docker or the
response from GET /container/XXX/json having a Privileged field.