### PR TITLE
Path prefix search

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(sinsp STATIC
 	"${JSONCPP_LIB_SRC}"
 	logger.cpp
 	parsers.cpp
+	prefix_search.cpp
 	protodecoder.cpp
 	threadinfo.cpp
 	sinsp.cpp

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -39,7 +39,8 @@ enum cmpop {
 	CO_EXISTS = 9,
 	CO_ICONTAINS = 10,
 	CO_STARTSWITH = 11,
-	CO_GLOB = 12
+	CO_GLOB = 12,
+	CO_PMATCH = 13
 };
 
 enum boolop

--- a/userspace/libsinsp/filter_value.h
+++ b/userspace/libsinsp/filter_value.h
@@ -1,0 +1,60 @@
+/*
+Copyright (C) 2013-2016 Draios inc.
+
+This file is part of sysdig.
+
+sysdig is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+sysdig is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <string.h>
+#include <utility>
+
+// Used for CO_IN/CO_PMATCH filterchecks using PT_CHARBUFs to allow
+// for quick multi-value comparisons. Should also work for any
+// filtercheck with a buffer and length. When compiling with gnu
+// compilers, use the built in but not standard _hash_impl::hash
+// function, which uses murmurhash2 and is quite fast. Otherwise, uses
+// http://www.cse.yorku.ca/~oz/hash.html.
+
+typedef std::pair<uint8_t *, uint32_t> filter_value_t;
+
+struct g_hash_membuf
+{
+	size_t operator()(filter_value_t val) const
+	{
+#ifdef __GNUC__
+		return std::_Hash_impl::hash(val.first, val.second);
+#else
+		size_t hash = 5381;
+		for(uint8_t *p = val.first; p-val.first < val.second; p++)
+		{
+			int c = *p;
+
+			hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+		}
+		return hash;
+#endif
+	}
+};
+
+struct g_equal_to_membuf
+{
+	bool operator()(filter_value_t a, filter_value_t b) const
+	{
+		return (a.second == b.second &&
+			memcmp(a.first, b.first, a.second) == 0);
+	}
+};
+

--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -54,6 +54,10 @@ cmpop string_to_cmpop(const char* str)
 	{
 		return CO_IN;
 	}
+	else if(strcmp(str, "pmatch") == 0)
+	{
+		return CO_PMATCH;
+	}
 	else if(strcmp(str, "exists") == 0)
 	{
 		return CO_EXISTS;
@@ -216,7 +220,7 @@ int lua_parser_cbacks::rel_expr(lua_State *ls)
 		// "exists" is the only unary comparison op
 		if(strcmp(cmpop, "exists"))
 		{
-			if (strcmp(cmpop, "in") == 0)
+			if (strcmp(cmpop, "in") == 0 || strcmp(cmpop, "pmatch") == 0)
 			{
 				if (!lua_istable(ls, 3))
 				{

--- a/userspace/libsinsp/prefix_search.cpp
+++ b/userspace/libsinsp/prefix_search.cpp
@@ -1,0 +1,197 @@
+/*
+Copyright (C) 2013-2016 Draios inc.
+
+This file is part of sysdig.
+
+sysdig is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+sysdig is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <sstream>
+#include <string.h>
+
+#include "prefix_search.h"
+
+using namespace std;
+
+path_prefix_search::path_prefix_search()
+{
+}
+
+path_prefix_search::~path_prefix_search()
+{
+	for (auto &ent : m_dirs)
+	{
+		delete(ent.second);
+	}
+}
+
+// Split path /var/log/messages into dirent (var) and remainder (/log/messages)
+void path_prefix_search::split_path(const filter_value_t &path, filter_value_t &dirent, filter_value_t &remainder)
+{
+	uint32_t length = path.second;
+
+	if(path.second == 0)
+	{
+		// The result of splitting an empty string is 2 empty strings
+		return;
+	}
+
+	// Skip any trailing /, not needed
+	if (path.first[path.second-1] == '/')
+	{
+		length--;
+	}
+
+	uint32_t start = 0;
+
+	// Also skip any leading '/', not needed.
+	if(path.first[0] == '/')
+	{
+		start++;
+	}
+
+	void *pos = memmem(path.first+start, path.second, "/", 1);
+	if(pos == NULL || pos >= (path.first + length))
+	{
+		dirent.first = path.first + start;
+		dirent.second = length-start;
+	}
+	else
+	{
+		dirent.first = path.first + start;
+		dirent.second = (uint8_t *) pos-dirent.first;
+
+		remainder.first = (uint8_t *) pos;
+		remainder.second = length-dirent.second-start;
+	}
+}
+
+// NOTE: this does not copy, so it is only valid as long as path is valid.
+void path_prefix_search::add_search_path(const char *path)
+{
+	filter_value_t mem((uint8_t *) path, (uint32_t) strlen(path));
+	return add_search_path(mem);
+}
+
+void path_prefix_search::add_search_path(const filter_value_t &path)
+{
+	filter_value_t dirent, remainder;
+	path_prefix_search *subtree = NULL;
+	path_prefix_search::split_path(path, dirent, remainder);
+	auto it = m_dirs.find(dirent);
+
+	if(it == m_dirs.end())
+	{
+		// This path component doesn't match any existing
+		// dirent. We need to add one and its subtree.
+		if(remainder.second > 0)
+		{
+			subtree = new path_prefix_search();
+			subtree->add_search_path(remainder);
+		}
+
+		m_dirs[dirent] = subtree;
+	}
+	else
+	{
+		// An entry for this dirent already exists. We will
+		// either add a new entry to the subtree, do nothing,
+		// or get rid of the existing subtree.
+		if(remainder.second == 0)
+		{
+			// This path is a prefix of the current path and we
+			// can drop the existing subtree. For example, we can
+			// drop /usr/lib when adding /usr.
+			delete(it->second);
+			m_dirs.erase(dirent);
+			m_dirs[dirent] = NULL;
+		}
+		else if(it->second == NULL)
+		{
+			// The existing path is shorter than the
+			// current path, in which case we don't have
+			// to do anything. For example, no need to add
+			// /usr/lib when /usr exists.
+		}
+		else
+		{
+			// We need to add the remainder to the
+			// sub-tree's search path.
+			it->second->add_search_path(remainder);
+		}
+	}
+}
+
+// NOTE: this does not copy, so it is only valid as long as path is valid.
+bool path_prefix_search::match(const char *path)
+{
+	filter_value_t mem((uint8_t *) path, (uint32_t) strlen(path));
+	return match(mem);
+}
+
+bool path_prefix_search::match(const filter_value_t &path)
+{
+	filter_value_t dirent, remainder;
+	path_prefix_search::split_path(path, dirent, remainder);
+	auto it = m_dirs.find(dirent);
+
+	if(it == m_dirs.end())
+	{
+		return false;
+	}
+	else
+	{
+		// If there is nothing left in the match path, the
+		// subtree must be null. This ensures that /var
+		// matches only /var and not /var/lib
+		if(remainder.second == 0)
+		{
+			return (it->second == NULL);
+		}
+		else if(it->second == NULL)
+		{
+			// /foo/bar matched a prefix /foo, so we're
+			// done.
+			return true;
+		}
+		else
+		{
+			return it->second->match(remainder);
+		}
+	}
+}
+
+std::string path_prefix_search::as_string()
+{
+	return as_string(string(""));
+}
+
+// Unlike all the other methods, this does perform copies.
+std::string path_prefix_search::as_string(const std::string &prefix)
+{
+	std::ostringstream os;
+
+	for (auto &it : m_dirs)
+	{
+		string dirent((const char *) it.first.first, it.first.second);
+		os << prefix << dirent << " -> " << endl;
+		if(it.second)
+		{
+			std::string indent = prefix;
+			indent += "    ";
+			os << it.second->as_string(indent);
+		}
+	}
+
+	return os.str();
+}

--- a/userspace/libsinsp/prefix_search.h
+++ b/userspace/libsinsp/prefix_search.h
@@ -1,0 +1,81 @@
+/*
+Copyright (C) 2013-2016 Draios inc.
+
+This file is part of sysdig.
+
+sysdig is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+sysdig is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "filter_value.h"
+
+//
+// A data structure that allows testing a path P against a set of
+// search paths S. The search succeeds if any of the search paths Si
+// is a prefix of the path P.
+//
+// Here are some examples:
+// - search(/var/run/docker, [/var/run, /etc, /lib, /usr/lib])
+//         succeeds because /var/run is a prefix of /var/run/docker.
+// - search(/boot, [/var/run, /etc, /lib, /usr/lib])
+//         does not succeed because no path is a prefix of /boot.
+// - search(/var/lib/messages, [/var/run, /etc, /lib, /usr/lib])
+//         does not succeed because no path is a prefix of /var/lib/messages.
+//         /var is a partial match but not /var/run.
+// - search(/var, [/var/run, /etc, /lib, /usr/lib])
+//         does not succeed because no path is a prefix of /var
+//         /var is a partial match but the search path is /var/run, not /var.
+
+class path_prefix_search
+{
+public:
+	path_prefix_search();
+	~path_prefix_search();
+
+	void add_search_path(const char *path);
+	void add_search_path(const filter_value_t &path);
+
+	bool match(const char *path);
+	bool match(const filter_value_t &path);
+
+	std::string as_string();
+
+private:
+
+	std::string as_string(const std::string &prefix);
+
+	static void split_path(const filter_value_t &path, filter_value_t &dirent, filter_value_t &remainder);
+
+	// Maps from the path component at the current level to a
+	// prefix search for the sub-path below the current level.
+	// For example, if the set of search paths is (/var/run, /etc,
+	// /lib, /usr, /usr/lib, /var/lib, /var/run), m_dirs contains:
+	//   - (var, path_prefix_search(/run)
+	//   - (etc, NULL)
+	//   - (lib, NULL)
+	//   - (usr, NULL)
+	//   - (var, path_prefix_search(/lib, /run)
+	// Note that because usr is a prefix of /usr/lib, the /usr/lib
+	// path is dropped and only /usr is kept.  Also note that
+	// terminator paths have a NULL path_prefix_search object.
+	std::unordered_map<filter_value_t,
+		path_prefix_search *,
+		g_hash_membuf,
+		g_equal_to_membuf> m_dirs;
+};
+
+


### PR DESCRIPTION
Add a 'pmatch' operator that allows for parallel testing of a pathname against a set of patch prefixes.

As a result, you can run sysdig using a command line like:

sudo sysdig "evt.type=open and fd.directory pmatch (/var, /usr)"

and see all the file opens for files below either /var or /usr.

This PR also adds unit test support using [Google Test](https://github.com/google/googletest).

I still need to modify travis to install gtest locally but I'll do that next.