### PR TITLE
Add driver support for PPC64

### DIFF
--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -120,6 +120,8 @@ long ppm_strncpy_from_user(char *to, const char __user *from, unsigned long n);
   #define SYSCALL_TABLE_ID0 __NR_SYSCALL_BASE
 #elif defined CONFIG_X86 || defined CONFIG_SUPERH
   #define SYSCALL_TABLE_ID0 0
+#elif defined CONFIG_PPC64
+  #define SYSCALL_TABLE_ID0 0
 #endif
 
 #define SYSCALL_TABLE_SIZE 512

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -3874,10 +3874,14 @@ static inline u16 ptrace_requests_to_scap(unsigned long req)
 	case PTRACE_SET_THREAD_AREA:
 		return PPM_PTRACE_SET_THREAD_AREA;
 #endif
+#ifdef PTRACE_GET_THREAD_AREA
 	case PTRACE_GET_THREAD_AREA:
 		return PPM_PTRACE_GET_THREAD_AREA;
+#endif
+#ifdef PTRACE_OLDSETOPTIONS
 	case PTRACE_OLDSETOPTIONS:
 		return PPM_PTRACE_OLDSETOPTIONS;
+#endif
 #ifdef PTRACE_SETFPXREGS
 	case PTRACE_SETFPXREGS:
 		return PPM_PTRACE_SETFPXREGS;


### PR DESCRIPTION
This patchset, enables support for kernel driver on PPC64.