### PR TITLE
Fix ipv4 mapped ipv6 when used on sendto and receiver endpoint is 0

### DIFF
--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -698,7 +698,11 @@ bool sinsp_utils::is_ipv4_mapped_ipv6(uint8_t* paddr)
 {
 	if(paddr[0] == 0 && paddr[1] == 0 && paddr[2] == 0 && paddr[3] == 0 && paddr[4] == 0 &&
 		paddr[5] == 0 && paddr[6] == 0 && paddr[7] == 0 && paddr[8] == 0 && paddr[9] == 0 &&
-		paddr[10] == 0xff && paddr[11] == 0xff)
+			(
+					( paddr[10] == 0xff && paddr[11] == 0xff) || // A real IPv4 address
+					(paddr[10] == 0 && paddr[11] == 0 && paddr[12] == 0 && paddr[13] == 0 && paddr[14] == 0 && paddr[15] == 0) // all zero address, assume IPv4 as well
+			)
+		)
 	{
 		return true;
 	}


### PR DESCRIPTION
IPv4 mapped IPv6 addresses are not mapped correctly if used with `sendto`. My proposal fix is to return `true` from `is_ipv4_mapped_ipv6` if the address has all zeroes.

Before:

```
10213 15:26:17.965447725 0 statsd (94769) > sendto fd=3(<6>family 10) size=26 tuple=:::46468->::ffff:12.17.5.1:8125
10224 15:26:17.965584744 0 statsd (94769) < sendto res=26 data=test-client.costa.test:1|c
```

After:

```
5363 15:27:09.602128968 0 statsd (94780) > sendto fd=3(<4u>172.16.199.134:40361->12.17.5.1:8125) size=26 tuple=0.0.0.0:40361->12.17.5.1:8125
5381 15:27:09.602260023 0 statsd (94780) < sendto res=26 data=test-client.costa.test:1|c
```