### PR TITLE
Use https for all downloads.

### DIFF
--- a/scripts/install-sysdig.in
+++ b/scripts/install-sysdig.in
@@ -27,18 +27,18 @@ function install_rpm {
 	if ! yum -q list dkms > /dev/null 2>&1; then
 		echo "* Installing EPEL repository (for DKMS)"
 		if [ $VERSION -eq 7 ] && [ $DISTRO = "centos" ]; then
-			rpm --quiet -i http://mirrors.kernel.org/centos/7/extras/x86_64/Packages/epel-release-7-5.noarch.rpm
+			rpm --quiet -i https://mirrors.kernel.org/centos/7/extras/x86_64/Packages/epel-release-7-5.noarch.rpm
 		elif [ $VERSION -eq 7 ]; then
-			rpm --quiet -i http://mirrors.kernel.org/fedora-epel/7/x86_64/e/epel-release-7-8.noarch.rpm
+			rpm --quiet -i https://mirrors.kernel.org/fedora-epel/7/x86_64/e/epel-release-7-8.noarch.rpm
 		else
-			rpm --quiet -i http://mirrors.kernel.org/fedora-epel/6/i386/epel-release-6-8.noarch.rpm
+			rpm --quiet -i https://mirrors.kernel.org/fedora-epel/6/i386/epel-release-6-8.noarch.rpm
 		fi
 	fi
 
 	echo "* Installing _COMPONENT_ public key"
 	rpm --quiet --import https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public
 	echo "* Installing _COMPONENT_ repository"
-	curl -s -o /etc/yum.repos.d/draios.repo http://download.draios.com/_REPOSITORY_NAME_/rpm/draios.repo
+	curl -s -o /etc/yum.repos.d/draios.repo https://s3.amazonaws.com/download.draios.com/_REPOSITORY_NAME_/rpm/draios.repo
 	echo "* Installing kernel headers"
 	KERNEL_VERSION=$(uname -r)
 	if [[ $KERNEL_VERSION == *PAE* ]]; then
@@ -66,7 +66,7 @@ function install_deb {
 	echo "* Installing Sysdig public key"
 	curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public | apt-key add -
 	echo "* Installing _COMPONENT_ repository"
-	curl -s -o /etc/apt/sources.list.d/draios.list http://download.draios.com/_REPOSITORY_NAME_/deb/draios.list
+	curl -s -o /etc/apt/sources.list.d/draios.list https://s3.amazonaws.com/download.draios.com/_REPOSITORY_NAME_/deb/draios.list
 	apt-get -qq update < /dev/null
 	echo "* Installing kernel headers"
 	apt-get -qq -y install linux-headers-$(uname -r) < /dev/null || kernel_warning


### PR DESCRIPTION
Use https instead of http for all downloads within the install
script. In cases where the links refer to artifacts in our s3 bucket,
switch to https + s3.amazon.aws.com, which is already used by other urls
in the script.

This fixes https://github.com/draios/falco/issues/152.