### PR TITLE
Fix format memory leak

### DIFF
--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -151,7 +151,9 @@ void sinsp_evt_formatter::set_format(const string& fmt)
 
 	if(last_nontoken_str_start != j)
 	{
-		m_tokens.push_back(new rawstring_check(lfmt.substr(last_nontoken_str_start, j - last_nontoken_str_start)));
+		sinsp_filter_check * chk = new rawstring_check(lfmt.substr(last_nontoken_str_start, j - last_nontoken_str_start));
+		m_tokens.push_back(chk);
+		m_chks_to_free.push_back(chk);
 		m_tokenlens.push_back(0);
 	}
 }

--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -128,8 +128,8 @@ void sinsp_evt_formatter::set_format(const string& fmt)
 				}
 			}
 
-			sinsp_filter_check* chk = g_filterlist.new_filter_check_from_fldname(string(cfmt + j + 1), 
-				m_inspector, 
+			sinsp_filter_check* chk = g_filterlist.new_filter_check_from_fldname(string(cfmt + j + 1),
+				m_inspector,
 				false);
 
 			if(chk == NULL)
@@ -206,12 +206,12 @@ bool sinsp_evt_formatter::tostring(sinsp_evt* evt, OUT string* res)
 
 			fi = m_tokens[j]->get_field_info();
 
-			if(fi) 
+			if(fi)
 			{
 				m_root[fi->m_name] = m_tokens[j]->tojson(evt);
-			} 
-		} 
-		else 
+			}
+		}
+		else
 		{
 			char* str = m_tokens[j]->tostring(evt);
 
@@ -220,14 +220,14 @@ bool sinsp_evt_formatter::tostring(sinsp_evt* evt, OUT string* res)
 				continue;
 			}
 
-			if(str == NULL) 
+			if(str == NULL)
 			{
 				if(m_require_all_values)
 				{
 					retval = false;
 					continue;
 				}
-				else 
+				else
 				{
 					str = (char*)"<NA>";
 				}
@@ -254,13 +254,13 @@ bool sinsp_evt_formatter::tostring(sinsp_evt* evt, OUT string* res)
 	   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONHEXASCII
 	   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONBASE64)
 	{
-		if(m_first) 
+		if(m_first)
 		{
 			// Give it the opening stanza of a JSON array
 			(*res) = '[';
 			m_first = false;
-		} 
-		else 
+		}
+		else
 		{
 			// Otherwise say this is another object in an
 			// existing JSON array


### PR DESCRIPTION
Fix a memory leak that occurs when a filter string ends in something other than a %XXX field.

This fixes https://github.com/draios/sysdig/issues/693 and is related to https://github.com/draios/falco/issues/156.

@luca @gianlucaborello and/or @ldegio does this seem reasonable?