### PR TITLE
Clean up utils header file to be self-contained

### DIFF
--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -46,7 +46,6 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include "filterchecks.h"
 #include "chisel.h"
 #include "protodecoder.h"
-#include "json/json.h"
 #include "uri.h"
 #ifndef _WIN32
 #include "curl/curl.h"

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -18,9 +18,16 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include <string>
+#include <vector>
+#include <list>
+#include <cctype>
 #include <algorithm>
 #include <locale>
 #include <sstream>
+
+#include <scap.h>
+#include "json/json.h"
 
 class sinsp_evttables;
 typedef union _sinsp_sockinfo sinsp_sockinfo;
@@ -80,12 +87,12 @@ public:
 	//
 	// Given a string, scan the event list and find the longest argument that the input string contains
 	//
-	static const struct ppm_param_info* find_longest_matching_evt_param(string name);
+	static const struct ppm_param_info* find_longest_matching_evt_param(std::string name);
 
 	//
 	// Get the list of filtercheck fields
 	//
-	static void get_filtercheck_fields_info(vector<const filter_check_info*>* list);
+	static void get_filtercheck_fields_info(std::vector<const filter_check_info*>* list);
 
 	static uint64_t get_current_time_ns();
 
@@ -116,7 +123,7 @@ struct g_invalidchar
     }
 };
 
-inline void sanitize_string(string &str)
+inline void sanitize_string(std::string &str)
 {
 	// It turns out with -O3 (release flags) using erase and
 	// remove_if is slighly faster than the inline version that
@@ -149,7 +156,7 @@ SINSP_PUBLIC int gettimeofday(struct timeval *tv, struct timezone2 *tz);
 ///////////////////////////////////////////////////////////////////////////////
 // gethostname wrapper
 ///////////////////////////////////////////////////////////////////////////////
-string sinsp_gethostname();
+std::string sinsp_gethostname();
 
 ///////////////////////////////////////////////////////////////////////////////
 // tuples to string
@@ -157,25 +164,25 @@ string sinsp_gethostname();
 
 // each of these functions uses values in network byte order
 
-string ipv4tuple_to_string(ipv4tuple* tuple, bool resolve);
-string ipv6tuple_to_string(_ipv6tuple* tuple, bool resolve);
-string ipv4serveraddr_to_string(ipv4serverinfo* addr, bool resolve);
-string ipv6serveraddr_to_string(ipv6serverinfo* addr, bool resolve);
+std::string ipv4tuple_to_string(ipv4tuple* tuple, bool resolve);
+std::string ipv6tuple_to_string(_ipv6tuple* tuple, bool resolve);
+std::string ipv4serveraddr_to_string(ipv4serverinfo* addr, bool resolve);
+std::string ipv6serveraddr_to_string(ipv6serverinfo* addr, bool resolve);
 
 // `l4proto` should be of type scap_l4_proto, but since it's an enum sometimes
 // is used as int and we would have to cast
 // `port` must be saved with network byte order
 // `l4proto` could be neither TCP nor UDP, in this case any protocol will be
 //           matched
-string port_to_string(uint16_t port, uint8_t l4proto, bool resolve);
+std::string port_to_string(uint16_t port, uint8_t l4proto, bool resolve);
 
 ///////////////////////////////////////////////////////////////////////////////
 // String helpers
 ///////////////////////////////////////////////////////////////////////////////
-vector<string> sinsp_split(const string& s, char delim);
+std::vector<std::string> sinsp_split(const std::string& s, char delim);
 
 template<typename It>
-string sinsp_join(It begin, It end, char delim)
+std::string sinsp_join(It begin, It end, char delim)
 {
 	if(begin == end)
 	{
@@ -191,11 +198,11 @@ string sinsp_join(It begin, It end, char delim)
 	return ss.str();
 }
 
-string& ltrim(string& s);
-string& rtrim(string& s);
-string& trim(string& s);
-string& replace_in_place(string& s, const string& search, const string& replacement);
-string replace(const string& str, const string& search, const string& replacement);
+std::string& ltrim(std::string& s);
+std::string& rtrim(std::string& s);
+std::string& trim(std::string& s);
+std::string& replace_in_place(std::string& s, const std::string& search, const std::string& replacement);
+std::string replace(const std::string& str, const std::string& search, const std::string& replacement);
 
 ///////////////////////////////////////////////////////////////////////////////
 // number parser
@@ -203,19 +210,19 @@ string replace(const string& str, const string& search, const string& replacemen
 class sinsp_numparser
 {
 public:
-	static uint8_t parseu8(const string& str);
-	static int8_t parsed8(const string& str);
-	static uint16_t parseu16(const string& str);
-	static int16_t parsed16(const string& str);
-	static uint32_t parseu32(const string& str);
-	static int32_t parsed32(const string& str);
-	static uint64_t parseu64(const string& str);
-	static int64_t parsed64(const string& str);
+	static uint8_t parseu8(const std::string& str);
+	static int8_t parsed8(const std::string& str);
+	static uint16_t parseu16(const std::string& str);
+	static int16_t parsed16(const std::string& str);
+	static uint32_t parseu32(const std::string& str);
+	static int32_t parsed32(const std::string& str);
+	static uint64_t parseu64(const std::string& str);
+	static int64_t parsed64(const std::string& str);
 
-	static bool tryparseu32(const string& str, uint32_t* res);
-	static bool tryparsed32(const string& str, int32_t* res);
-	static bool tryparseu64(const string& str, uint64_t* res);
-	static bool tryparsed64(const string& str, int64_t* res);
+	static bool tryparseu32(const std::string& str, uint32_t* res);
+	static bool tryparsed32(const std::string& str, int32_t* res);
+	static bool tryparseu64(const std::string& str, uint64_t* res);
+	static bool tryparsed64(const std::string& str, int64_t* res);
 
 	static bool tryparseu32_fast(const char* str, uint32_t strlen, uint32_t* res);
 	static bool tryparsed32_fast(const char* str, uint32_t strlen, int32_t* res);
@@ -285,8 +292,8 @@ public:
 	}
 
 private:
-	list<OBJ*> m_avail_list;
-	list<OBJ*> m_full_list;
+	std::list<OBJ*> m_avail_list;
+	std::list<OBJ*> m_full_list;
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Currently, utils.h has a lot of implicit dependencies on other stl
header files as well as assuming the std namespace is available.

Clean it up so it can be included on its own (say, in
https://github.com/draios/falco/pull/162).