### PR TITLE
Expose mesos token

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(sinsp STATIC
 	marathon_http.cpp
 	memmem.cpp
 	tracers.cpp
+	mesos_auth.cpp
 	mesos.cpp
 	mesos_collector.cpp
 	mesos_component.cpp

--- a/userspace/libsinsp/mesos.cpp
+++ b/userspace/libsinsp/mesos.cpp
@@ -141,6 +141,7 @@ mesos::mesos(const std::string& state_uri,
 	int timeout_ms,
 	bool is_captured,
 	bool verbose):
+	mesos_auth(dcos_enterprise_credentials),
 #ifdef HAS_CAPTURE
 		m_collector(false),
 		m_mesos_uri(state_uri),
@@ -151,8 +152,7 @@ mesos::mesos(const std::string& state_uri,
 		m_discover_marathon_uris(discover_marathon_leader || marathon_uris.empty()),
 		m_timeout_ms(timeout_ms),
 		m_verbose(verbose),
-		m_testing(false),
-		m_dcos_enterprise_credentials(dcos_enterprise_credentials)
+		m_testing(false)
 {
 #ifdef HAS_CAPTURE
 	g_logger.log(std::string("Creating Mesos object for [" +
@@ -235,7 +235,7 @@ void mesos::init_marathon()
 void mesos::refresh_token()
 {
 #ifdef HAS_CAPTURE
-	authenticate();
+	mesos_auth::refresh_token();
 	m_state_http->set_token(m_token);
 	if(has_marathon())
 	{
@@ -261,41 +261,6 @@ void mesos::refresh_token()
 				throw sinsp_exception("Marathon apps HTTP client is null.");
 			}
 		}
-	}
-#endif // HAS_CAPTURE
-}
-
-void mesos::authenticate()
-{
-#ifdef HAS_CAPTURE
-	sinsp_curl auth_request(uri("https://localhost/acs/api/v1/auth/login"), "", "");
-	Json::FastWriter json_writer;
-	Json::Value auth_obj;
-	auth_obj["uid"] = m_dcos_enterprise_credentials.first;
-	auth_obj["password"] = m_dcos_enterprise_credentials.second;
-	auth_request.add_header("Content-Type: application/json");
-	auth_request.setopt(CURLOPT_POST, 1);
-	auth_request.set_body(json_writer.write(auth_obj));
-	//auth_request.enable_debug();
-	auto response = auth_request.get_data();
-
-	if(auth_request.get_response_code() == 200)
-	{
-		Json::Reader json_reader;
-		Json::Value response_obj;
-		auto parse_ok = json_reader.parse(response, response_obj, false);
-		if(parse_ok && response_obj.isMember("token"))
-		{
-			m_token = response_obj["token"].asString();
-			g_logger.format(sinsp_logger::SEV_DEBUG, "Mesos authenticated with token=%s", m_token.c_str());
-		}
-		else
-		{
-			throw sinsp_exception(string("Cannot authenticate on Mesos master, response=") + response);
-		}
-	} else
-	{
-		throw sinsp_exception(string("Cannot authenticate on Mesos master, response_code=") + to_string(auth_request.get_response_code()));
 	}
 #endif // HAS_CAPTURE
 }

--- a/userspace/libsinsp/mesos.cpp
+++ b/userspace/libsinsp/mesos.cpp
@@ -169,7 +169,7 @@ mesos::mesos(const std::string& state_uri,
 		g_logger.log("Multiple root marathon URIs configured; only the first one (" + marathon_uri + ") will have effect;"
 					" others will be treated as generic frameworks (user Marathon frameworks will be discovered).", sinsp_logger::SEV_WARNING);
 	}
-	
+
 	authenticate();
 #endif
 	init();
@@ -765,7 +765,7 @@ void mesos::handle_frameworks(const Json::Value& root)
 								g_logger.log("New or activated Mesos framework detected: " + name + " [" + uid.asString() + ']', sinsp_logger::SEV_INFO);
 								m_activated_frameworks.insert(uid.asString());
 #ifdef HAS_CAPTURE
-								if(mesos_framework::is_root_marathon(name) && 
+								if(mesos_framework::is_root_marathon(name) &&
 									find_if(m_marathon_groups_http.begin(), m_marathon_groups_http.end(), [uid](const decltype(m_marathon_groups_http)::value_type& item)
 									{
 										return item.second->get_framework_id() == uid.asString();

--- a/userspace/libsinsp/mesos.cpp
+++ b/userspace/libsinsp/mesos.cpp
@@ -170,7 +170,6 @@ mesos::mesos(const std::string& state_uri,
 					" others will be treated as generic frameworks (user Marathon frameworks will be discovered).", sinsp_logger::SEV_WARNING);
 	}
 
-	authenticate();
 #endif
 	init();
 }

--- a/userspace/libsinsp/mesos.cpp
+++ b/userspace/libsinsp/mesos.cpp
@@ -264,6 +264,11 @@ void mesos::refresh_token()
 #endif // HAS_CAPTURE
 }
 
+const mesos::uri_list_t &mesos::marathon_uris()
+{
+	return (m_discover_marathon_uris ? m_state_http->get_marathon_uris() : m_marathon_uris);
+}
+
 void mesos::refresh()
 {
 	rebuild_mesos_state();

--- a/userspace/libsinsp/mesos.h
+++ b/userspace/libsinsp/mesos.h
@@ -172,7 +172,7 @@ private:
 	uri::credentials_t m_dcos_enterprise_credentials;
 	string             m_token;
 	bool               m_token_authentication;
-	
+
 	typedef std::unordered_set<std::string> framework_list_t;
 	framework_list_t m_inactive_frameworks;
 	framework_list_t m_activated_frameworks;

--- a/userspace/libsinsp/mesos.h
+++ b/userspace/libsinsp/mesos.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "json/json.h"
+#include "mesos_auth.h"
 #include "mesos_common.h"
 #include "mesos_component.h"
 #include "mesos_http.h"
@@ -16,7 +17,7 @@
 #include <utility>
 #include <unordered_map>
 
-class mesos
+class mesos : public mesos_auth
 {
 public:
 
@@ -62,7 +63,7 @@ public:
 		bool is_captured = false,
 		bool verbose = false);
 
-	~mesos();
+	virtual ~mesos();
 
 	const mesos_state_t& get_state() const;
 	bool is_alive() const;
@@ -74,8 +75,8 @@ public:
 
 	void simulate_event(const std::string& json);
 	bool collect_data();
-	void refresh_token();
-	
+	virtual void refresh_token();
+
 #ifdef HAS_CAPTURE
 	void send_data_request(bool collect = true);
 
@@ -129,7 +130,6 @@ private:
 private:
 	void init();
 	void init_marathon();
-	void authenticate();
 	void rebuild_mesos_state(bool full = false);
 	void rebuild_marathon_state(bool full = false);
 
@@ -169,9 +169,6 @@ private:
 	bool               m_testing = false;
 	uri::credentials_t m_mesos_credentials;
 	uri::credentials_t m_marathon_credentials;
-	uri::credentials_t m_dcos_enterprise_credentials;
-	string             m_token;
-	bool               m_token_authentication;
 
 	typedef std::unordered_set<std::string> framework_list_t;
 	framework_list_t m_inactive_frameworks;

--- a/userspace/libsinsp/mesos.h
+++ b/userspace/libsinsp/mesos.h
@@ -77,6 +77,8 @@ public:
 	bool collect_data();
 	virtual void refresh_token();
 
+	const uri_list_t &marathon_uris();
+
 #ifdef HAS_CAPTURE
 	void send_data_request(bool collect = true);
 

--- a/userspace/libsinsp/mesos_auth.cpp
+++ b/userspace/libsinsp/mesos_auth.cpp
@@ -1,0 +1,80 @@
+/*
+Copyright (C) 2013-2016 Draios inc.
+
+This file is part of sysdig.
+
+sysdig is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+sysdig is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//
+// mesos_auth.cpp
+//
+
+#include "mesos_auth.h"
+
+mesos_auth::mesos_auth(const uri::credentials_t& dcos_enterprise_credentials)
+	: m_dcos_enterprise_credentials(dcos_enterprise_credentials)
+{
+}
+
+mesos_auth::~mesos_auth()
+{
+}
+
+string mesos_auth::get_token()
+{
+	return m_token;
+}
+
+void mesos_auth::authenticate()
+{
+#ifdef HAS_CAPTURE
+	sinsp_curl auth_request(uri("https://localhost/acs/api/v1/auth/login"), "", "");
+	Json::FastWriter json_writer;
+	Json::Value auth_obj;
+	auth_obj["uid"] = m_dcos_enterprise_credentials.first;
+	auth_obj["password"] = m_dcos_enterprise_credentials.second;
+	auth_request.add_header("Content-Type: application/json");
+	auth_request.setopt(CURLOPT_POST, 1);
+	auth_request.set_body(json_writer.write(auth_obj));
+	//auth_request.enable_debug();
+	auto response = auth_request.get_data();
+
+	if(auth_request.get_response_code() == 200)
+	{
+		Json::Reader json_reader;
+		Json::Value response_obj;
+		auto parse_ok = json_reader.parse(response, response_obj, false);
+		if(parse_ok && response_obj.isMember("token"))
+		{
+			m_token = response_obj["token"].asString();
+			g_logger.format(sinsp_logger::SEV_DEBUG, "Mesos authenticated with token=%s", m_token.c_str());
+		}
+		else
+		{
+			throw sinsp_exception(string("Cannot authenticate on Mesos master, response=") + response);
+		}
+	} else
+	{
+		throw sinsp_exception(string("Cannot authenticate on Mesos master, response_code=") + to_string(auth_request.get_response_code()));
+	}
+#endif // HAS_CAPTURE
+}
+
+void mesos_auth::refresh_token()
+{
+#ifdef HAS_CAPTURE
+	authenticate();
+#endif // HAS_CAPTURE
+}
+

--- a/userspace/libsinsp/mesos_auth.cpp
+++ b/userspace/libsinsp/mesos_auth.cpp
@@ -25,8 +25,10 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include "mesos_auth.h"
 
 mesos_auth::mesos_auth(const uri::credentials_t& dcos_enterprise_credentials,
+		       string auth_hostname,
 		       int token_refresh_interval)
 	: m_dcos_enterprise_credentials(dcos_enterprise_credentials),
+	  m_auth_uri(string("https://") + auth_hostname + string("/acs/api/v1/auth/login")),
 	  m_token_refresh_interval(token_refresh_interval),
 	  m_last_token_refresh_s(0)
 
@@ -50,7 +52,7 @@ string mesos_auth::get_token()
 void mesos_auth::authenticate()
 {
 #ifdef HAS_CAPTURE
-	sinsp_curl auth_request(uri("https://localhost/acs/api/v1/auth/login"), "", "");
+	sinsp_curl auth_request(m_auth_uri, "", "");
 	Json::FastWriter json_writer;
 	Json::Value auth_obj;
 	auth_obj["uid"] = m_dcos_enterprise_credentials.first;

--- a/userspace/libsinsp/mesos_auth.h
+++ b/userspace/libsinsp/mesos_auth.h
@@ -1,0 +1,49 @@
+/*
+Copyright (C) 2013-2016 Draios inc.
+
+This file is part of sysdig.
+
+sysdig is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+sysdig is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//
+// mesos_auth.h
+//
+
+#pragma once
+
+#include "json/json.h"
+#include "mesos_http.h"
+#include "uri.h"
+
+class mesos_auth
+{
+public:
+	mesos_auth(const uri::credentials_t& dcos_enterprise_credentials = uri::credentials_t());
+	virtual ~mesos_auth();
+
+	void authenticate();
+	virtual void refresh_token();
+
+	// Return the current token. It's up to the caller to know
+	// when the token has been refreshed, making the returned
+	// token obsolete.
+	string get_token();
+
+protected:
+	string             m_token;
+
+private:
+	const uri::credentials_t m_dcos_enterprise_credentials;
+};
+

--- a/userspace/libsinsp/mesos_auth.h
+++ b/userspace/libsinsp/mesos_auth.h
@@ -32,6 +32,7 @@ class mesos_auth
 {
 public:
 	mesos_auth(const uri::credentials_t& dcos_enterprise_credentials = uri::credentials_t(),
+		   string auth_hostname = "localhost",
 		   int token_refresh_interval = DCOS_ENTERPRISE_TOKEN_REFRESH_S);
 	virtual ~mesos_auth();
 
@@ -50,6 +51,7 @@ private:
 	void authenticate();
 
 	const uri::credentials_t m_dcos_enterprise_credentials;
+	uri m_auth_uri;
 	int m_token_refresh_interval;
 	time_t m_last_token_refresh_s;
 };

--- a/userspace/libsinsp/mesos_auth.h
+++ b/userspace/libsinsp/mesos_auth.h
@@ -26,24 +26,31 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include "mesos_http.h"
 #include "uri.h"
 
+static const uint64_t DCOS_ENTERPRISE_TOKEN_REFRESH_S = 60*60*24; // 1 day
+
 class mesos_auth
 {
 public:
-	mesos_auth(const uri::credentials_t& dcos_enterprise_credentials = uri::credentials_t());
+	mesos_auth(const uri::credentials_t& dcos_enterprise_credentials = uri::credentials_t(),
+		   int token_refresh_interval = DCOS_ENTERPRISE_TOKEN_REFRESH_S);
 	virtual ~mesos_auth();
 
-	void authenticate();
 	virtual void refresh_token();
 
-	// Return the current token. It's up to the caller to know
-	// when the token has been refreshed, making the returned
-	// token obsolete.
+	// Return the current token. The token may expire at any time
+	// after the token has been returned, so it's best to call
+	// get_token periodically, which will internally refresh the
+	// token if necessary.
 	string get_token();
 
 protected:
 	string             m_token;
 
 private:
+	void authenticate();
+
 	const uri::credentials_t m_dcos_enterprise_credentials;
+	int m_token_refresh_interval;
+	time_t m_last_token_refresh_s;
 };
 


### PR DESCRIPTION
Changes to split mesos authentication into its own class so it can be used without doing any of the other mesos fetching.

@luca3m I think this is ready for review now. @bertocci if you'd like to take a look any feedback would be welcome too.