### PR TITLE
fix scap_fds.c compile and link

### DIFF
--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -165,7 +165,7 @@ int32_t scap_fd_info_to_string(scap_fdinfo* fdi, OUT char* str, uint32_t strlen)
 // Calculate the length on disk of an fd entry's info
 uint32_t scap_fd_info_len(scap_fdinfo* fdi);
 // Write the given fd info to disk
-int32_t scap_fd_write_to_disk(scap_t* handle, scap_fdinfo* fdi, gzFile f);
+int32_t scap_fd_write_to_disk(scap_t* handle, scap_fdinfo* fdi, scap_dumper_t* dumper);
 // Populate the given fd by reading the info from disk
 uint32_t scap_fd_read_from_disk(scap_t* handle, OUT scap_fdinfo* fdi, OUT size_t* nbytes, gzFile f);
 // Parse the headers of a trace file and load the tables

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -216,6 +216,8 @@ uint32_t scap_fd_info_len(scap_fdinfo *fdi)
 	return res;
 }
 
+int scap_dump_write(scap_dumper_t *d, void* buf, unsigned len);
+
 //
 // Write the given fd info to disk
 //

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -36,7 +36,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Write data into a dump file
 //
-inline int scap_dump_write(scap_dumper_t *d, void* buf, unsigned len)
+int scap_dump_write(scap_dumper_t *d, void* buf, unsigned len)
 {
 	if(d->m_type == DT_FILE)
 	{


### PR DESCRIPTION
There were some issues preventing scap_fds.c from compiling, and preventing the resulting libscap.a from linking properly. See individual commit descriptions for details.

Only change I'm not quite happy with is the forward declaration for scap_dump_write in scap_fds.c. Wasn't sure what header would be best for it, so might want to move that wherever you think is appropriate.