### PR TITLE
add tgid and comm from kernel to event header

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -1445,6 +1445,9 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 		hdr->tid = current->pid;
 		hdr->type = event_type;
 
+
+		hdr->tgid = current->tgid;
+		memcpy(hdr->comm, current->comm, 16);
 		/*
 		 * Populate the parameters for the filler callback
 		 */

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1235,6 +1235,9 @@ struct ppm_evt_hdr {
 	uint64_t tid; /* the tid of the thread that generated this event */
 	uint32_t len; /* the event len, including the header */
 	uint16_t type; /* the event type */
+
+	uint64_t tgid; /* the tgid of the thread that generated this event */
+	char comm[16]; /* the process name that generated this event */
 };
 #if defined __sun
 #pragma pack()


### PR DESCRIPTION
Adding the tgid and comm (process name) to the event header to get this fields in the scap layer if the sinsp layer state is not required.