### PR TITLE
Don't crash on short capture lengths.

### DIFF
--- a/userspace/libsinsp/protodecoder.cpp
+++ b/userspace/libsinsp/protodecoder.cpp
@@ -299,6 +299,12 @@ const char* sinsp_decoder_syslog::get_facility_str()
 
 void sinsp_decoder_syslog::decode_message(char *data, uint32_t len, char* pristr, uint32_t pristrlen)
 {
+	if(len < pristrlen + 2 || pristrlen == 0)
+	{
+		m_priority = -1;
+		return;
+	}
+
 	bool res = sinsp_numparser::tryparsed32_fast(pristr, pristrlen, &m_priority);
 
 	if(!res)


### PR DESCRIPTION
Handle trivially short capture lengths (<4).

If the priority string length is 0, or if the message buffer is not long
enough to hold the priority string plus surrounding <> characters,
simply set the priority to -1 and return.

This fixes https://github.com/draios/sysdig/issues/725.