### PR TITLE
Fix regression tests

### DIFF
--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -881,6 +881,7 @@ static int32_t scap_read_proclist(scap_t *handle, gzFile f, uint32_t block_lengt
 	tinfo.filtered_out = 0;
 	tinfo.root[0] = 0;
 	tinfo.sid = -1;
+	tinfo.clone_ts = 0;
 
 	while(((int32_t)block_length - (int32_t)totreadsize) >= 4)
 	{

--- a/userspace/libsinsp/chisel_api.cpp
+++ b/userspace/libsinsp/chisel_api.cpp
@@ -165,7 +165,7 @@ uint32_t lua_cbacks::rawval_to_lua_stack(lua_State *ls, uint8_t* rawval, const f
 	}
 }
 
-int lua_cbacks::get_num(lua_State *ls) 
+int lua_cbacks::get_num(lua_State *ls)
 {
 	lua_getglobal(ls, "sievt");
 	sinsp_evt* evt = (sinsp_evt*)lua_touserdata(ls, -1);
@@ -182,7 +182,7 @@ int lua_cbacks::get_num(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::get_ts(lua_State *ls) 
+int lua_cbacks::get_ts(lua_State *ls)
 {
 	lua_getglobal(ls, "sievt");
 	sinsp_evt* evt = (sinsp_evt*)lua_touserdata(ls, -1);
@@ -202,7 +202,7 @@ int lua_cbacks::get_ts(lua_State *ls)
 	return 2;
 }
 
-int lua_cbacks::get_type(lua_State *ls) 
+int lua_cbacks::get_type(lua_State *ls)
 {
 	lua_getglobal(ls, "sievt");
 	sinsp_evt* evt = (sinsp_evt*)lua_touserdata(ls, -1);
@@ -236,7 +236,7 @@ int lua_cbacks::get_type(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::get_cpuid(lua_State *ls) 
+int lua_cbacks::get_cpuid(lua_State *ls)
 {
 	lua_getglobal(ls, "sievt");
 	sinsp_evt* evt = (sinsp_evt*)lua_touserdata(ls, -1);
@@ -255,7 +255,7 @@ int lua_cbacks::get_cpuid(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::request_field(lua_State *ls) 
+int lua_cbacks::request_field(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -264,7 +264,7 @@ int lua_cbacks::request_field(lua_State *ls)
 
 	sinsp* inspector = ch->m_inspector;
 
-	const char* fld = lua_tostring(ls, 1); 
+	const char* fld = lua_tostring(ls, 1);
 
 	if(fld == NULL)
 	{
@@ -274,7 +274,7 @@ int lua_cbacks::request_field(lua_State *ls)
 	}
 
 	sinsp_filter_check* chk = g_filterlist.new_filter_check_from_fldname(fld,
-		inspector, 
+		inspector,
 		false);
 
 	if(chk == NULL)
@@ -293,7 +293,7 @@ int lua_cbacks::request_field(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::field(lua_State *ls) 
+int lua_cbacks::field(lua_State *ls)
 {
 	lua_getglobal(ls, "sievt");
 	sinsp_evt* evt = (sinsp_evt*)lua_touserdata(ls, -1);
@@ -310,8 +310,8 @@ int lua_cbacks::field(lua_State *ls)
 	if(chk == NULL)
 	{
 		//
-		// This happens if the lua code is calling field() without invoking 
-		// sysdig.request_field() before. 
+		// This happens if the lua code is calling field() without invoking
+		// sysdig.request_field() before.
 		//
 		lua_pushnil(ls);
 		return 1;
@@ -331,14 +331,14 @@ int lua_cbacks::field(lua_State *ls)
 	}
 }
 
-int lua_cbacks::set_global_filter(lua_State *ls) 
+int lua_cbacks::set_global_filter(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
 	sinsp_chisel* ch = (sinsp_chisel*)lua_touserdata(ls, -1);
 	lua_pop(ls, 1);
 
-	const char* filter = lua_tostring(ls, 1); 
+	const char* filter = lua_tostring(ls, 1);
 
 	ASSERT(ch);
 	ASSERT(ch->m_lua_cinfo);
@@ -357,14 +357,14 @@ int lua_cbacks::set_global_filter(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::set_filter(lua_State *ls) 
+int lua_cbacks::set_filter(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
 	sinsp_chisel* ch = (sinsp_chisel*)lua_touserdata(ls, -1);
 	lua_pop(ls, 1);
 
-	const char* filter = lua_tostring(ls, 1); 
+	const char* filter = lua_tostring(ls, 1);
 
 	ASSERT(ch);
 	ASSERT(ch->m_lua_cinfo);
@@ -383,14 +383,14 @@ int lua_cbacks::set_filter(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::set_snaplen(lua_State *ls) 
+int lua_cbacks::set_snaplen(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
 	sinsp_chisel* ch = (sinsp_chisel*)lua_touserdata(ls, -1);
 	lua_pop(ls, 1);
 
-	const uint32_t snaplen = (uint32_t)lua_tointeger(ls, 1); 
+	const uint32_t snaplen = (uint32_t)lua_tointeger(ls, 1);
 
 	ASSERT(ch);
 	ASSERT(ch->m_lua_cinfo);
@@ -400,7 +400,7 @@ int lua_cbacks::set_snaplen(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::set_output_format(lua_State *ls) 
+int lua_cbacks::set_output_format(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -419,7 +419,7 @@ int lua_cbacks::set_output_format(lua_State *ls)
 		return 0;
 	}
 
-	const char* fmt = lua_tostring(ls, 1); 
+	const char* fmt = lua_tostring(ls, 1);
 
 	if(string(fmt) == "normal")
 	{
@@ -463,14 +463,14 @@ int lua_cbacks::set_output_format(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::set_fatfile_dump_mode(lua_State *ls) 
+int lua_cbacks::set_fatfile_dump_mode(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
 	sinsp_chisel* ch = (sinsp_chisel*)lua_touserdata(ls, -1);
 	lua_pop(ls, 1);
 
-	int mode = lua_toboolean(ls, 1); 
+	int mode = lua_toboolean(ls, 1);
 
 	ASSERT(ch);
 	ASSERT(ch->m_lua_cinfo);
@@ -480,7 +480,7 @@ int lua_cbacks::set_fatfile_dump_mode(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::make_ts(lua_State *ls) 
+int lua_cbacks::make_ts(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -495,14 +495,14 @@ int lua_cbacks::make_ts(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::run_sysdig(lua_State *ls) 
+int lua_cbacks::run_sysdig(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
 	sinsp_chisel* ch = (sinsp_chisel*)lua_touserdata(ls, -1);
 	lua_pop(ls, 1);
 
-	const char* args = lua_tostring(ls, 1); 
+	const char* args = lua_tostring(ls, 1);
 
 	ASSERT(ch);
 	ASSERT(ch->m_lua_cinfo);
@@ -513,7 +513,7 @@ int lua_cbacks::run_sysdig(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::end_capture(lua_State *ls) 
+int lua_cbacks::end_capture(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -528,7 +528,7 @@ int lua_cbacks::end_capture(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::is_live(lua_State *ls) 
+int lua_cbacks::is_live(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -542,7 +542,7 @@ int lua_cbacks::is_live(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::is_tty(lua_State *ls) 
+int lua_cbacks::is_tty(lua_State *ls)
 {
 #ifdef _WIN32
 	int use_color = false;
@@ -554,7 +554,7 @@ int lua_cbacks::is_tty(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::get_terminal_info(lua_State *ls) 
+int lua_cbacks::get_terminal_info(lua_State *ls)
 {
 	int32_t width = -1;
 	int32_t height = -1;
@@ -579,7 +579,7 @@ int lua_cbacks::get_terminal_info(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::get_filter(lua_State *ls) 
+int lua_cbacks::get_filter(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -596,7 +596,7 @@ int lua_cbacks::get_filter(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::get_machine_info(lua_State *ls) 
+int lua_cbacks::get_machine_info(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -632,7 +632,7 @@ int lua_cbacks::get_machine_info(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::get_thread_table(lua_State *ls) 
+int lua_cbacks::get_thread_table(lua_State *ls)
 {
 	threadinfo_map_iterator_t it;
 	unordered_map<int64_t, sinsp_fdinfo_t>::iterator fdit;
@@ -658,7 +658,7 @@ int lua_cbacks::get_thread_table(lua_State *ls)
 	//
 	// If the caller specified a filter, compile it
 	//
-	if(lua_isstring(ls, 1)) 
+	if(lua_isstring(ls, 1))
 	{
 		string filterstr = lua_tostring(ls, 1);
 		lua_pop(ls, 1);
@@ -1000,7 +1000,7 @@ int lua_cbacks::get_thread_table(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::get_container_table(lua_State *ls) 
+int lua_cbacks::get_container_table(lua_State *ls)
 {
 	unordered_map<int64_t, sinsp_fdinfo_t>::iterator fdit;
 	uint32_t j;
@@ -1081,7 +1081,7 @@ int lua_cbacks::get_container_table(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::is_print_container_data(lua_State *ls) 
+int lua_cbacks::is_print_container_data(lua_State *ls)
 {
         lua_getglobal(ls, "sichisel");
 
@@ -1096,7 +1096,7 @@ int lua_cbacks::is_print_container_data(lua_State *ls)
 }
 
 
-int lua_cbacks::get_output_format(lua_State *ls) 
+int lua_cbacks::get_output_format(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -1120,7 +1120,7 @@ int lua_cbacks::get_output_format(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::get_evtsource_name(lua_State *ls) 
+int lua_cbacks::get_evtsource_name(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -1142,14 +1142,14 @@ int lua_cbacks::get_evtsource_name(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::set_event_formatter(lua_State *ls) 
+int lua_cbacks::set_event_formatter(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
 	sinsp_chisel* ch = (sinsp_chisel*)lua_touserdata(ls, -1);
 	lua_pop(ls, 1);
 
-	const char* formatter = lua_tostring(ls, 1); 
+	const char* formatter = lua_tostring(ls, 1);
 
 	ASSERT(ch);
 	ASSERT(ch->m_lua_cinfo);
@@ -1159,7 +1159,7 @@ int lua_cbacks::set_event_formatter(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::set_interval_ns(lua_State *ls) 
+int lua_cbacks::set_interval_ns(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -1176,7 +1176,7 @@ int lua_cbacks::set_interval_ns(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::set_interval_s(lua_State *ls) 
+int lua_cbacks::set_interval_s(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -1193,7 +1193,7 @@ int lua_cbacks::set_interval_s(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::exec(lua_State *ls) 
+int lua_cbacks::exec(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -1230,7 +1230,7 @@ int lua_cbacks::exec(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::log(lua_State *ls) 
+int lua_cbacks::log(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 
@@ -1265,7 +1265,7 @@ int lua_cbacks::log(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::udp_setpeername(lua_State *ls) 
+int lua_cbacks::udp_setpeername(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 	sinsp_chisel* ch = (sinsp_chisel*)lua_touserdata(ls, -1);
@@ -1295,14 +1295,14 @@ int lua_cbacks::udp_setpeername(lua_State *ls)
 	return 0;
 }
 
-int lua_cbacks::udp_send(lua_State *ls) 
+int lua_cbacks::udp_send(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 	sinsp_chisel* ch = (sinsp_chisel*)lua_touserdata(ls, -1);
 
 	string message(lua_tostring(ls, 1));
 
-	if(sendto(ch->m_udp_socket, message.c_str(), message.size(), 0, 
+	if(sendto(ch->m_udp_socket, message.c_str(), message.size(), 0,
 		(struct sockaddr *)&ch->m_serveraddr, sizeof(ch->m_serveraddr)) < 0)
 	{
 		string err = "udp_send error: cannot send the buffer: ";
@@ -1314,7 +1314,7 @@ int lua_cbacks::udp_send(lua_State *ls)
 }
 
 #ifdef HAS_ANALYZER
-int lua_cbacks::push_metric(lua_State *ls) 
+int lua_cbacks::push_metric(lua_State *ls)
 {
 	statsd_metric metric;
 	metric.m_type = statsd_metric::type_t::GAUGE;
@@ -1336,7 +1336,7 @@ int lua_cbacks::push_metric(lua_State *ls)
 	{
 		lua_pushnil(ls);
 
-		while(lua_next(ls, 3) != 0) 
+		while(lua_next(ls, 3) != 0)
 		{
 			string tag = lua_tostring(ls, -1);
 			metric.m_tags[tag] = "";

--- a/userspace/libsinsp/chisel_api.cpp
+++ b/userspace/libsinsp/chisel_api.cpp
@@ -109,7 +109,7 @@ uint32_t lua_cbacks::rawval_to_lua_stack(lua_State *ls, uint8_t* rawval, const f
 			lua_pushnumber(ls, *(double*)rawval);
 			return 1;
 		case PT_CHARBUF:
-			lua_pushstring(ls, (char*)rawval);
+			lua_pushlstring(ls, (char*)rawval, len);
 			return 1;
 		case PT_BYTEBUF:
 			if(rawval[len] == 0)

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -388,6 +388,7 @@ uint8_t* sinsp_filter_check_fd::extract_from_null_fd(sinsp_evt *evt, OUT uint32_
 		}
 	}
 	case TYPE_FDTYPECHAR:
+		*len = 1;
 		switch(PPME_MAKE_ENTER(evt->get_type()))
 		{
 		case PPME_SYSCALL_OPEN_E:
@@ -501,8 +502,16 @@ uint8_t* sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT uint32_t* len, bool 
 		{
 			return NULL;
 		}
+		else
+		{
+			uint8_t *typestr = (uint8_t*)m_fdinfo->get_typestring();
+			if(typestr)
+			{
+				*len = strlen((char *) typestr);
+			}
+			return typestr;
+		}
 
-		return (uint8_t*)m_fdinfo->get_typestring();
 	case TYPE_DIRECTORY:
 	case TYPE_CONTAINERDIRECTORY:
 		{
@@ -3110,6 +3119,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 				evname = (uint8_t*)evt->get_name();
 			}
 
+			*len = strlen((char *) evname);
 			return evname;
 		}
 		break;
@@ -3154,6 +3164,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 				evname = (uint8_t*)evt->get_name();
 			}
 
+			*len = strlen((char *) evname);
 			return evname;
 		}
 		break;
@@ -3272,10 +3283,14 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 
 			if(resolved_argstr != NULL && resolved_argstr[0] != 0)
 			{
+				*len = strlen(resolved_argstr);
 				return (uint8_t*)resolved_argstr;
 			}
 			else
-			{
+			{	if(argstr != NULL)
+				{
+					*len = strlen(argstr);
+				}
 				return (uint8_t*)argstr;
 			}
 		}
@@ -3293,6 +3308,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 				{
 					if((*it)->get_info_line(&il))
 					{
+						*len = strlen(il);
 						return (uint8_t*)il;
 					}
 				}
@@ -3309,6 +3325,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 				//
 				// Don't print the arguments for generic events: they have only internal use
 				//
+				*len = 1;
 				return (uint8_t*)"";
 			}
 
@@ -3412,10 +3429,12 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 
 					if(resolved_argstr != NULL && resolved_argstr[0] != 0)
 					{
+						*len = strlen(resolved_argstr);
 						return (uint8_t*)resolved_argstr;
 					}
 					else if(argstr != NULL)
 					{
+						*len = strlen(argstr);
 						return (uint8_t*)argstr;
 					}
 				}
@@ -3440,10 +3459,12 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 
 						if(resolved_argstr != NULL && resolved_argstr[0] != 0)
 						{
+							*len = strlen(resolved_argstr);
 							return (uint8_t*)resolved_argstr;
 						}
 						else if(argstr != NULL)
 						{
+							*len = strlen(argstr);
 							return (uint8_t*)argstr;
 						}
 					}
@@ -3990,10 +4011,22 @@ uint8_t* sinsp_filter_check_user::extract(sinsp_evt *evt, OUT uint32_t* len, boo
 	case TYPE_UID:
 		return (uint8_t*)&tinfo->m_uid;
 	case TYPE_NAME:
+		if(uinfo->name != NULL)
+		{
+			*len = strlen(uinfo->name);
+		}
 		return (uint8_t*)uinfo->name;
 	case TYPE_HOMEDIR:
+		if(uinfo->homedir != NULL)
+		{
+			*len = strlen(uinfo->homedir);
+		}
 		return (uint8_t*)uinfo->homedir;
 	case TYPE_SHELL:
+		if(uinfo->shell != NULL)
+		{
+			*len = strlen(uinfo->shell);
+		}
 		return (uint8_t*) uinfo->shell;
 	default:
 		ASSERT(false);
@@ -4062,6 +4095,10 @@ uint8_t* sinsp_filter_check_group::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 			scap_groupinfo* ginfo = it->second;
 			ASSERT(ginfo != NULL);
 
+			if(ginfo->name)
+			{
+				*len = strlen(ginfo->name);
+			}
 			return (uint8_t*)ginfo->name;
 		}
 	default:
@@ -4289,7 +4326,7 @@ int64_t* sinsp_filter_check_tracer::extract_duration(uint16_t etype, sinsp_trace
 	}
 }
 
-uint8_t* sinsp_filter_check_tracer::extract_args(sinsp_partial_tracer* pae)
+uint8_t* sinsp_filter_check_tracer::extract_args(sinsp_partial_tracer* pae, OUT uint32_t* len)
 {
 	if(pae == NULL)
 	{
@@ -4336,10 +4373,11 @@ uint8_t* sinsp_filter_check_tracer::extract_args(sinsp_partial_tracer* pae)
 		*p = 0;
 	}
 
+	*len = strlen(m_storage);
 	return (uint8_t*)m_storage;
 }
 
-uint8_t* sinsp_filter_check_tracer::extract_arg(sinsp_partial_tracer* pae)
+uint8_t* sinsp_filter_check_tracer::extract_arg(sinsp_partial_tracer* pae, OUT uint32_t* len)
 {
 	char* res = NULL;
 
@@ -4389,6 +4427,7 @@ uint8_t* sinsp_filter_check_tracer::extract_arg(sinsp_partial_tracer* pae)
 		}
 	}
 
+	*len = strlen(res);
 	return (uint8_t*)res;
 }
 
@@ -4478,6 +4517,7 @@ uint8_t* sinsp_filter_check_tracer::extract(sinsp_evt *evt, OUT uint32_t* len, b
 				*p = 0;
 			}
 
+			*len = strlen(m_storage);
 			return (uint8_t*)m_storage;
 		}
 	case TYPE_TAG:
@@ -4501,6 +4541,7 @@ uint8_t* sinsp_filter_check_tracer::extract(sinsp_evt *evt, OUT uint32_t* len, b
 				}
 			}
 
+			*len = strlen(res);
 			return (uint8_t*)res;
 		}
 	case TYPE_IDTAG:
@@ -4530,25 +4571,25 @@ uint8_t* sinsp_filter_check_tracer::extract(sinsp_evt *evt, OUT uint32_t* len, b
 	case TYPE_ARGS:
 		if(PPME_IS_ENTER(etype))
 		{
-			return extract_args(eparser->m_enter_pae);
+			return extract_args(eparser->m_enter_pae, len);
 		}
 		else
 		{
-			return extract_args(&eparser->m_exit_pae);
+			return extract_args(&eparser->m_exit_pae, len);
 		}
 	case TYPE_ARG:
 		if(PPME_IS_ENTER(etype))
 		{
-			return extract_arg(eparser->m_enter_pae);
+			return extract_arg(eparser->m_enter_pae, len);
 		}
 		else
 		{
-			return extract_arg(&eparser->m_exit_pae);
+			return extract_arg(&eparser->m_exit_pae, len);
 		}
 	case TYPE_ENTERARGS:
-		return extract_args(eparser->m_enter_pae);
+		return extract_args(eparser->m_enter_pae, len);
 	case TYPE_ENTERARG:
-		return extract_arg(eparser->m_enter_pae);
+		return extract_arg(eparser->m_enter_pae, len);
 	case TYPE_DURATION:
 		return (uint8_t*)extract_duration(etype, eparser);
 	case TYPE_DURATION_HUMAN:
@@ -4861,7 +4902,7 @@ sinsp_filter_check* sinsp_filter_check_evtin::allocate_new()
 	return (sinsp_filter_check*) new sinsp_filter_check_evtin();
 }
 
-inline uint8_t* sinsp_filter_check_evtin::extract_tracer(sinsp_evt *evt, sinsp_partial_tracer* pae)
+inline uint8_t* sinsp_filter_check_evtin::extract_tracer(sinsp_evt *evt, sinsp_partial_tracer* pae, OUT uint32_t* len)
 {
 	ASSERT(pae);
 	uint32_t field_id = m_field_id;
@@ -4965,6 +5006,7 @@ inline uint8_t* sinsp_filter_check_evtin::extract_tracer(sinsp_evt *evt, sinsp_p
 			*p = 0;
 		}
 
+		*len = strlen(m_storage);
 		return (uint8_t*)m_storage;
 	}
 	case TYPE_TAG:
@@ -4988,6 +5030,7 @@ inline uint8_t* sinsp_filter_check_evtin::extract_tracer(sinsp_evt *evt, sinsp_p
 			}
 		}
 
+		*len = strlen(val);
 		return (uint8_t*) val;
 	}
 	case TYPE_ARGS:
@@ -5032,6 +5075,7 @@ inline uint8_t* sinsp_filter_check_evtin::extract_tracer(sinsp_evt *evt, sinsp_p
 			*p = 0;
 		}
 
+		*len = strlen(m_storage);
 		return (uint8_t*)m_storage;
 	}
 	case TYPE_ARG:
@@ -5079,6 +5123,7 @@ inline uint8_t* sinsp_filter_check_evtin::extract_tracer(sinsp_evt *evt, sinsp_p
 			}
 		}
 
+		*len = strlen(val);
 		return (uint8_t*) val;
 	}
 	default:
@@ -5117,7 +5162,7 @@ uint8_t* sinsp_filter_check_evtin::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 	//
 	for(it = partial_tracers_list->begin(); it != partial_tracers_list->end(); ++it)
 	{
-		uint8_t* res = extract_tracer(evt, *it);
+		uint8_t* res = extract_tracer(evt, *it, len);
 		if(res != NULL)
 		{
 			return res;
@@ -5129,7 +5174,8 @@ uint8_t* sinsp_filter_check_evtin::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 
 inline bool sinsp_filter_check_evtin::compare_tracer(sinsp_evt *evt, sinsp_partial_tracer* pae)
 {
-	uint8_t* res = extract_tracer(evt, pae);
+	uint32_t len;
+	uint8_t* res = extract_tracer(evt, pae, &len);
 
 	if(res == NULL)
 	{
@@ -5295,6 +5341,7 @@ int32_t sinsp_filter_check_syslog::parse_field_name(const char* str, bool alloc_
 
 uint8_t* sinsp_filter_check_syslog::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
+	const char *str;
 	ASSERT(m_decoder != NULL);
 	if(!m_decoder->is_data_valid())
 	{
@@ -5306,11 +5353,21 @@ uint8_t* sinsp_filter_check_syslog::extract(sinsp_evt *evt, OUT uint32_t* len, b
 	case TYPE_FACILITY:
 		return (uint8_t*)&m_decoder->m_facility;
 	case TYPE_FACILITY_STR:
-		return (uint8_t*)m_decoder->get_facility_str();
+		str = m_decoder->get_facility_str();
+		if(str)
+		{
+			*len = strlen(str);
+		}
+		return (uint8_t*)str;
 	case TYPE_SEVERITY:
 		return (uint8_t*)&m_decoder->m_severity;
 	case TYPE_SEVERITY_STR:
-		return (uint8_t*)m_decoder->get_severity_str();
+		str = m_decoder->get_severity_str();
+		if(str)
+		{
+			*len = strlen(str);
+		}
+		return (uint8_t*)str;
 	case TYPE_MESSAGE:
 		*len = m_decoder->m_msg.size();
 		return (uint8_t*)m_decoder->m_msg.c_str();

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -593,8 +593,8 @@ public:
 private:
 	int32_t extract_arg(string fldname, string val, OUT const struct ppm_param_info** parinfo);
 	inline int64_t* extract_duration(uint16_t etype, sinsp_tracerparser* eparser);
-	uint8_t* extract_args(sinsp_partial_tracer* pae);
-	uint8_t* extract_arg(sinsp_partial_tracer* pae);
+	uint8_t* extract_args(sinsp_partial_tracer* pae, OUT uint32_t *len);
+	uint8_t* extract_arg(sinsp_partial_tracer* pae, OUT uint32_t *len);
 
 	int32_t m_argid;
 	string m_argname;
@@ -670,7 +670,7 @@ public:
 
 private:
 	int32_t extract_arg(string fldname, string val);
-	inline uint8_t* extract_tracer(sinsp_evt *evt, sinsp_partial_tracer* pae);
+	inline uint8_t* extract_tracer(sinsp_evt *evt, sinsp_partial_tracer* pae, OUT uint32_t* len);
 	inline bool compare_tracer(sinsp_evt *evt, sinsp_partial_tracer* pae);
 
 	bool m_is_compare;


### PR DESCRIPTION
Two sets of changes to fix the sysdig regression tests. One ensures that PT_CHARBUF strings passed to lua chisels don't run past the end of the string, and the other ensures that the initial clone time for thread info is initialized.

This fixes https://github.com/draios/sysdig/issues/736