### PR TITLE
Added some NULL checks before using strlen(), fixing issue #740

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -3103,7 +3103,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 		}
 	case TYPE_TYPE:
 		{
-			uint8_t* evname;
+			uint8_t* evname = NULL;
 			uint16_t etype = evt->m_pevt->type;
 
 			if(etype == PPME_GENERIC_E || etype == PPME_GENERIC_X)
@@ -3119,7 +3119,10 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 				evname = (uint8_t*)evt->get_name();
 			}
 
-			*len = strlen((char *) evname);
+			if(evname)
+			{
+				*len = strlen((char *) evname);
+			}
 			return evname;
 		}
 		break;
@@ -3141,7 +3144,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 		break;
 	case TYPE_SYSCALL_TYPE:
 		{
-			uint8_t* evname;
+			uint8_t* evname = NULL;
 			uint16_t etype = evt->m_pevt->type;
 			enum ppm_event_flags flags = g_infotables.m_event_info[etype].flags;
 
@@ -3164,7 +3167,10 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 				evname = (uint8_t*)evt->get_name();
 			}
 
-			*len = strlen((char *) evname);
+			if(evname)
+			{
+				*len = strlen((char *) evname);
+			}
 			return evname;
 		}
 		break;
@@ -4427,7 +4433,10 @@ uint8_t* sinsp_filter_check_tracer::extract_arg(sinsp_partial_tracer* pae, OUT u
 		}
 	}
 
-	*len = strlen(res);
+	if (res)
+	{
+		*len = strlen(res);
+	}
 	return (uint8_t*)res;
 }
 
@@ -4541,7 +4550,10 @@ uint8_t* sinsp_filter_check_tracer::extract(sinsp_evt *evt, OUT uint32_t* len, b
 				}
 			}
 
-			*len = strlen(res);
+			if(res)
+			{
+				*len = strlen(res);
+			}
 			return (uint8_t*)res;
 		}
 	case TYPE_IDTAG:
@@ -5030,7 +5042,10 @@ inline uint8_t* sinsp_filter_check_evtin::extract_tracer(sinsp_evt *evt, sinsp_p
 			}
 		}
 
-		*len = strlen(val);
+		if(val)
+		{
+			*len = strlen(val);
+		}
 		return (uint8_t*) val;
 	}
 	case TYPE_ARGS:
@@ -5123,7 +5138,10 @@ inline uint8_t* sinsp_filter_check_evtin::extract_tracer(sinsp_evt *evt, sinsp_p
 			}
 		}
 
-		*len = strlen(val);
+		if(val)
+		{
+			*len = strlen(val);
+		}
 		return (uint8_t*) val;
 	}
 	default:

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -3103,7 +3103,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 		}
 	case TYPE_TYPE:
 		{
-			uint8_t* evname = NULL;
+			uint8_t* evname;
 			uint16_t etype = evt->m_pevt->type;
 
 			if(etype == PPME_GENERIC_E || etype == PPME_GENERIC_X)
@@ -3119,10 +3119,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 				evname = (uint8_t*)evt->get_name();
 			}
 
-			if(evname)
-			{
-				*len = strlen((char *) evname);
-			}
+			*len = strlen((char *) evname);
 			return evname;
 		}
 		break;
@@ -3144,7 +3141,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 		break;
 	case TYPE_SYSCALL_TYPE:
 		{
-			uint8_t* evname = NULL;
+			uint8_t* evname;
 			uint16_t etype = evt->m_pevt->type;
 			enum ppm_event_flags flags = g_infotables.m_event_info[etype].flags;
 
@@ -3167,10 +3164,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 				evname = (uint8_t*)evt->get_name();
 			}
 
-			if(evname)
-			{
-				*len = strlen((char *) evname);
-			}
+			*len = strlen((char *) evname);
 			return evname;
 		}
 		break;


### PR DESCRIPTION
Was thinking of doing
*len = val ? strlen(val) : 0;

But I noticed *len is usually not set by the extract() methods when they return NULL, so I went with
if (val) { *len = strlen(val); }

(I also noticed *len often doesn't get set when an extract() method returns non-NULL either. I haven't studied the libsinsp enough yet to know if that's something we should care about).