### PR TITLE
Support for updated cpu hotplug API in 4.10 kernel

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -2064,7 +2064,9 @@ int sysdig_init(void)
 	unsigned int num_cpus;
 	int ret;
 	int acrret = 0;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0))
 	int hp_ret;
+#endif
 	int j;
 	int n_created_devices = 0;
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)

--- a/driver/main.c
+++ b/driver/main.c
@@ -179,7 +179,7 @@ static struct tracepoint *tp_signal_deliver;
 #ifdef _DEBUG
 static bool verbose = 1;
 #else
-static bool verbose = 1;
+static bool verbose = 0;
 #endif
 
 static unsigned int max_consumers = 5;
@@ -2007,13 +2007,13 @@ static int do_cpu_callback(unsigned long cpu, long sd_action)
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0))
 static int sysdig_cpu_online(unsigned int cpu)
 {
-	pr_info("sysdig_cpu_online on cpu %d\n", cpu);
+	vpr_info("sysdig_cpu_online on cpu %d\n", cpu);
 	return do_cpu_callback(cpu, 1);
 }
 
 static int sysdig_cpu_offline(unsigned int cpu)
 {
-	pr_info("sysdig_cpu_offline on cpu %d\n", cpu);
+	vpr_info("sysdig_cpu_offline on cpu %d\n", cpu);
 	return do_cpu_callback(cpu, 2);
 }
 #else /* LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)) */

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -69,6 +69,7 @@ struct syscall_evt_pair {
  * We have one of these for each CPU.
  */
 struct ppm_ring_buffer_context {
+	bool cpu_online;
 	bool open;
 	bool capture_enabled;
 	struct ppm_ring_buffer_info *info;

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -69,7 +69,6 @@ struct syscall_evt_pair {
  * We have one of these for each CPU.
  */
 struct ppm_ring_buffer_context {
-	bool cpu_online;
 	bool open;
 	bool capture_enabled;
 	struct ppm_ring_buffer_info *info;


### PR DESCRIPTION
Fixes #722 - Update the probe module to use the new cpu hotplug API coming in the 4.10 kernel. 

- [x] Add support for 4.10 kernel
- [x] Test pre-4.10 kernel (confirm bugfix works)
- [x] Cleanup code
- [x] Debug+perf tests on 4.10-rc
- [x] Sanity check once 4.10 is (near) finalized

While working on this, I found a bug in the existing code. If you start the module without all CPUs online and bring one of the offline CPUs up, it kernel panics because it expects the ring buffer to already be initialized. I've fixed that bug in 4.10, and the fix should work in earlier versions but needs to be tested.