### PR TITLE
Add support for tagging falco rules.

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1439,7 +1439,8 @@ const string sinsp::get_filter()
 }
 
 void sinsp::add_evttype_filter(string &name,
-			       list<uint32_t> &evttypes,
+			       set<uint32_t> &evttypes,
+			       set<string> &tags,
 			       sinsp_filter *filter)
 {
 	// Create the evttype filter if it doesn't exist.
@@ -1448,7 +1449,7 @@ void sinsp::add_evttype_filter(string &name,
 		m_evttype_filter = new sinsp_evttype_filter();
 	}
 
-	m_evttype_filter->add(name, evttypes, filter);
+	m_evttype_filter->add(name, evttypes, tags, filter);
 }
 
 bool sinsp::run_filters_on_evt(sinsp_evt *evt)
@@ -1827,7 +1828,7 @@ void sinsp::init_k8s_client(string* api_server, string* ssl_cert, bool verbose)
 	m_k8s_api_server = api_server;
 	m_k8s_api_cert = ssl_cert;
 
-	
+
 #ifdef HAS_CAPTURE
 	if(m_k8s_api_detected && m_k8s_ext_detect_done)
 #endif // HAS_CAPTURE

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -366,7 +366,8 @@ public:
 	const string get_filter();
 
 	void add_evttype_filter(std::string &name,
-				list<uint32_t> &evttypes,
+				std::set<uint32_t> &evttypes,
+				std::set<std::string> &tags,
 				sinsp_filter* filter);
 
 	bool run_filters_on_evt(sinsp_evt *evt);


### PR DESCRIPTION
Add support for tagging falco rules with tags, enabling/disabling sets
of rules based on the tags they have, and having the ability to run a
subset of loaded rules against a given event:

 - Typedef sinsp_evttype_filter::tag_t, which represents a tag tagset_t
   which represents a set<tag_t>. These tags are numeric to allow for
   quick comparisons. Users of sinsp_evttype_filter (like falco)
   maintain a string tag to numeric tag dictionary.
 - in sinsp_evttype_filter::add(), you now provide a set of tags for
   each filter (can be empty).
 - internal to sinsp_evttype_filter, m_filter_by_tag maintains a mapping
   from numeric tag to list of filters having that tag. This is used for
   sinsp_evttype_filter::enable_tags, which allows enabling/disabling
   all filters having a given tag.
 - also internal to sinsp_evttype_filter, each filter struct has a
   vector tags where entry[tag] is true/false if the tag is present for
   the filter.
 - sinsp_evttype_filter::run() now takes an optional set of tags. If
   provided, only those filters that have a tag in the tagset will
   run. run now has an additional test implemented in run_given_tags. It
   loops over the tags provided to see if the filter has tags[tag] true
   for any tag.
 - In sinsp_evttype_filter, clean up use of auto loops to use references
   whenever possible and use std:: for stl objects in the header file.

This has corresponding changes on the falco side in https://github.com/draios/falco/pull/206.