### PR TITLE
Detect aname loops

### DIFF
--- a/test/sysdig_batch_parser.sh
+++ b/test/sysdig_batch_parser.sh
@@ -47,7 +47,7 @@ do
 	echo "Corresponding reference file $ref does not exist--skipping"
     else
 	echo "Processing $f"
-	TZ=UTC eval $SYSDIG -N -r $f $ARGS > $DIRNAME/$(basename $f).output
+	TZ=UTC eval timeout 60 $SYSDIG -N -r $f $ARGS > $DIRNAME/$(basename $f).output
     fi
 done
 

--- a/test/sysdig_trace_regression.sh
+++ b/test/sysdig_trace_regression.sh
@@ -107,5 +107,10 @@ $BASEDIR/sysdig_batch_parser.sh $SYSDIG $CHISELS "-p '*%evt.num %evt.outputtime 
 # Cwd
 $BASEDIR/sysdig_batch_parser.sh $SYSDIG $CHISELS "-pc -p\"*%evt.num %evt.outputtime %evt.cpu %container.name (%container.id) %proc.name (%thread.tid:%thread.vtid) %evt.dir %evt.type %evt.info %proc.cwd\"" $TRACEDIR $RESULTDIR/cwd $BASELINEDIR/cwd || ret=1
 
+# Testing filters/outputs that can traverse parent thread state
+$BASEDIR/sysdig_batch_parser.sh $SYSDIG $CHISELS "-p\"*%evt.num %evt.outputtime %evt.cpu %proc.name (%thread.tid) %evt.dir %evt.type %evt.info LS=%proc.loginshellid\"" $TRACEDIR $RESULTDIR/loginshell-parent-loop $BASELINEDIR/loginshell-parent-loop || ret=1
+$BASEDIR/sysdig_batch_parser.sh $SYSDIG $CHISELS "proc.apid=10 or proc.apid=26890" $TRACEDIR $RESULTDIR/apid-parent-loop $BASELINEDIR/apid-parent-loop || ret=1
+$BASEDIR/sysdig_batch_parser.sh $SYSDIG $CHISELS "proc.aname=foo or proc.aname=sh" $TRACEDIR $RESULTDIR/aname-parent-loop $BASELINEDIR/aname-parent-loop || ret=1
+
 rm -rf "${TMPBASE}"
 exit $ret

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -368,7 +368,7 @@ void sinsp_threadinfo::init(scap_threadinfo* pi)
 	m_vtid = pi->vtid;
 	m_vpid = pi->vpid;
 	m_clone_ts = pi->clone_ts;
-	
+
 	set_cgroups(pi->cgroups, pi->cgroups_len);
 	m_root = pi->root;
 	ASSERT(m_inspector);
@@ -640,7 +640,7 @@ string sinsp_threadinfo::get_cwd()
 {
 	// Ideally we should use get_cwd_root()
 	// but scap does not read CLONE_FS from /proc
-	// Also glibc and muslc use always 
+	// Also glibc and muslc use always
 	// CLONE_THREAD|CLONE_FS so let's use
 	// get_main_thread() for now
 	sinsp_threadinfo* tinfo = get_main_thread();

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -199,6 +199,14 @@ public:
 	uint64_t get_fd_limit();
 
 	//
+	// Walk up the parent process heirarchy, calling the provided
+	// function for each node. If the function returns false, the
+	// traversal stops.
+	//
+	typedef std::function<bool (sinsp_threadinfo *)> visitor_func_t;
+	void traverse_parent_state(visitor_func_t &visitor);
+
+	//
 	// Core state
 	//
 	int64_t m_tid;  ///< The id of this thread
@@ -325,6 +333,7 @@ VISIBILITY_PRIVATE
 	uint16_t m_lastevent_type;
 	uint16_t m_lastevent_cpuid;
 	sinsp_evt::category m_lastevent_category;
+	bool m_parent_loop_detected;
 
 	friend class sinsp;
 	friend class sinsp_parser;


### PR DESCRIPTION
Detect loops when traversing parent threads and exit the loop.

Actually fixing whatever is causing the loop to form is a separate issue, https://github.com/draios/sysdig/issues/752.

This will fix the problems observed in https://github.com/draios/falco/issues/208.