### PR TITLE
Allow scopes to be initially empty.

### DIFF
--- a/userspace/libsinsp/user_event.cpp
+++ b/userspace/libsinsp/user_event.cpp
@@ -44,7 +44,10 @@ const std::string event_scope::KEY_FORMAT = "^[a-zA-Z0-9_/\\.-]*$";
 
 event_scope::event_scope(const std::string& key, const std::string& value)
 {
-	add(key, value, "");
+	if(!key.empty() && !value.empty())
+	{
+		add(key, value, "");
+	}
 }
 
 bool event_scope::add(const std::string& key, const std::string& value, const std::string& op)

--- a/userspace/libsinsp/user_event.h
+++ b/userspace/libsinsp/user_event.h
@@ -70,11 +70,22 @@ private:
 
 inline const std::string& event_scope::get() const
 {
+	if(m_scope.empty())
+	{
+		g_logger.log("Scope is empty--at least one key/value pair should be present",
+			     sinsp_logger::SEV_WARNING);
+	}
 	return m_scope;
 }
 
 inline std::string& event_scope::get_ref()
 {
+	if(m_scope.empty())
+	{
+		g_logger.log("Scope is empty--at least one key/value pair should be present",
+			     sinsp_logger::SEV_WARNING);
+	}
+
 	return m_scope;
 }
 


### PR DESCRIPTION
Allow an initially empty scope by skipping the add() call in the
constructor unless both key and value are non-empty.

Also, in get()/get_ref() log a warning if the scope-as-string is empty.

@aleks-f wanna take a look?