### PR TITLE
libscap: fix compilation errors on OS X

### DIFF
--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -1003,7 +1003,7 @@ bool scap_is_thread_alive(scap_t* handle, int64_t pid, int64_t tid, const char* 
 #endif // HAS_CAPTURE
 }
 
-#ifndef _WIN32
+#if defined(HAS_CAPTURE)
 int scap_proc_scan_proc_table(scap_t *handle)
 {
 	char filename[SCAP_MAX_PATH_SIZE];
@@ -1029,7 +1029,7 @@ void scap_refresh_proc_table(scap_t* handle)
 void scap_refresh_proc_table(scap_t* handle)
 {
 }
-#endif // _WIN32
+#endif // HAS_CAPTURE
 
 void scap_proc_free(scap_t* handle, struct scap_threadinfo* proc)
 {


### PR DESCRIPTION
OS X complained that `scap_proc_scan_proc_dir` was not defined. Indeed it is in a #ifdef block.