### PR TITLE
libsinsp: fix compilation when the library is compiled outside sysdig

### DIFF
--- a/userspace/libsinsp/user_event.h
+++ b/userspace/libsinsp/user_event.h
@@ -31,6 +31,9 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #else
 #include <regex>
 #endif
+
+#include "sinsp_int.h"
+
 //
 // scope utilities
 //


### PR DESCRIPTION
g_logger was not found in user_event.h. By including sinsp_int.h we
get the logger declaration.