### PR TITLE
Fix probe module deadlocks

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -698,7 +698,8 @@ cleanup_ioctl_procinfo:
 
 		if (!ring) {
 			ASSERT(false);
-			return -ENODEV;
+			ret = -ENODEV;
+			goto cleanup_ioctl;
 		}
 
 		ring->capture_enabled = false;
@@ -719,7 +720,8 @@ cleanup_ioctl_procinfo:
 
 		if (!ring) {
 			ASSERT(false);
-			return -ENODEV;
+			ret = -ENODEV;
+			goto cleanup_ioctl;
 		}
 
 		ring->capture_enabled = true;
@@ -772,7 +774,8 @@ cleanup_ioctl_procinfo:
 			new_sampling_ratio != 64 &&
 			new_sampling_ratio != 128) {
 			pr_err("invalid sampling ratio %u\n", new_sampling_ratio);
-			return -EINVAL;
+			ret = -EINVAL;
+			goto cleanup_ioctl;
 		}
 
 		consumer->sampling_interval = 1000000000 / new_sampling_ratio;
@@ -792,7 +795,8 @@ cleanup_ioctl_procinfo:
 
 		if (new_snaplen > RW_MAX_SNAPLEN) {
 			pr_err("invalid snaplen %u\n", new_snaplen);
-			return -EINVAL;
+			ret = -EINVAL;
+			goto cleanup_ioctl;
 		}
 
 		consumer->snaplen = new_snaplen;
@@ -823,7 +827,8 @@ cleanup_ioctl_procinfo:
 
 		if (syscall_to_set > PPM_EVENT_MAX) {
 			pr_err("invalid syscall %u\n", syscall_to_set);
-			return -EINVAL;
+			ret = -EINVAL;
+			goto cleanup_ioctl;
 		}
 
 		set_bit(syscall_to_set, g_events_mask);
@@ -839,7 +844,8 @@ cleanup_ioctl_procinfo:
 
 		if (syscall_to_unset > NR_syscalls) {
 			pr_err("invalid syscall %u\n", syscall_to_unset);
-			return -EINVAL;
+			ret = -EINVAL;
+			goto cleanup_ioctl;
 		}
 
 		clear_bit(syscall_to_unset, g_events_mask);
@@ -1004,7 +1010,8 @@ static int ppm_mmap(struct file *filp, struct vm_area_struct *vma)
 		ring = per_cpu_ptr(consumer->ring_buffers, ring_no);
 		if (!ring) {
 			ASSERT(false);
-			return -ENODEV;
+			ret = -ENODEV;
+			goto cleanup_mmap;
 		}
 
 		if (length <= PAGE_SIZE) {


### PR DESCRIPTION
During certain error conditions, e.g. an invalid sampling ratio, the driver will return without unlocking a mutex. The next call to require that mutex will cause the driver to try to acquire the lock again and hang.