### PR TITLE
userspace/libsinsp: add sinsp dependencies when using bundled projects

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -92,6 +92,12 @@ if(NOT WIN32)
 	if(USE_BUNDLED_LUAJIT)
 		add_dependencies(sinsp luajit)
 	endif()
+	if(USE_BUNDLED_OPENSSL)
+		add_dependencies(sinsp openssl)
+	endif()
+	if(USE_BUNDLED_CURL)
+		add_dependencies(sinsp curl)
+	endif()
 
 	if(NOT APPLE)
 		target_link_libraries(sinsp


### PR DESCRIPTION
This should allow `make -jX` when compiling sysdig, without errors