### PR TITLE
Allow batch snapshots of containers

### DIFF
--- a/userspace/libsinsp/cursesui.cpp
+++ b/userspace/libsinsp/cursesui.cpp
@@ -66,6 +66,7 @@ sinsp_cursesui::sinsp_cursesui(sinsp* inspector,
 							   uint64_t refresh_interval_ns,
 							   bool print_containers,
 							   bool raw_output,
+							   uint32_t batch_count,
 							   bool is_mousedrag_available)
 {
 	m_inspector = inspector;
@@ -97,6 +98,7 @@ sinsp_cursesui::sinsp_cursesui(sinsp* inspector,
 	m_raw_output = raw_output;
 	m_truncated_input = false;
 	m_view_depth = 0;
+	m_batch_count = batch_count;
 
 #ifndef NOCURSESUI
 	m_viz = NULL;
@@ -386,12 +388,12 @@ void sinsp_cursesui::start(bool is_drilldown, bool is_spy_switch)
 		if(wi->m_type == sinsp_view_info::T_TABLE)
 		{
 			ty = sinsp_table::TT_TABLE;
-			m_datatable = new sinsp_table(m_inspector, ty, m_refresh_interval_ns, m_raw_output);
+			m_datatable = new sinsp_table(m_inspector, ty, m_refresh_interval_ns, m_raw_output, m_batch_count);
 		}
 		else if(wi->m_type == sinsp_view_info::T_LIST)
 		{
 			ty = sinsp_table::TT_LIST;
-			m_datatable = new sinsp_table(m_inspector, ty, m_refresh_interval_ns, m_raw_output);
+			m_datatable = new sinsp_table(m_inspector, ty, m_refresh_interval_ns, m_raw_output, m_batch_count);
 		}
 		else if(wi->m_type == sinsp_view_info::T_SPECTRO)
 		{
@@ -402,11 +404,11 @@ void sinsp_cursesui::start(bool is_drilldown, bool is_spy_switch)
 			//
 			if(m_refresh_interval_ns == 2000000000)
 			{
-				m_datatable = new sinsp_table(m_inspector, ty, m_refresh_interval_ns / 4, m_raw_output);
+				m_datatable = new sinsp_table(m_inspector, ty, m_refresh_interval_ns / 4, m_raw_output, m_batch_count);
 			}
 			else
 			{
-				m_datatable = new sinsp_table(m_inspector, ty, m_refresh_interval_ns, m_raw_output);
+				m_datatable = new sinsp_table(m_inspector, ty, m_refresh_interval_ns, m_raw_output, m_batch_count);
 			}
 		}
 		else

--- a/userspace/libsinsp/cursesui.h
+++ b/userspace/libsinsp/cursesui.h
@@ -400,7 +400,8 @@ public:
 
 	sinsp_cursesui(sinsp* inspector, string event_source_name, 
 		string cmdline_capture_filter, uint64_t refresh_interval_ns, 
-		bool print_containers, bool raw_output, bool is_mousedrag_available);
+		bool print_containers, bool raw_output, uint32_t batch_count,
+		bool is_mousedrag_available);
 	~sinsp_cursesui();
 	void configure(sinsp_view_manager* views);
 	void start(bool is_drilldown, bool is_spy_switch);
@@ -720,6 +721,7 @@ public:
 	bool m_search_nomatch;
 	bool m_print_containers;
 	int32_t m_sidemenu_sorting_col;
+	uint32_t m_batch_count;
 #ifndef NOCURSESUI
 	curses_table* m_viz;
 	curses_spectro* m_spectro;

--- a/userspace/libsinsp/table.cpp
+++ b/userspace/libsinsp/table.cpp
@@ -75,7 +75,7 @@ typedef struct table_row_cmp
 	bool m_ascending;
 }table_row_cmp;
 
-sinsp_table::sinsp_table(sinsp* inspector, tabletype type, uint64_t refresh_interval_ns, bool print_to_stdout)
+sinsp_table::sinsp_table(sinsp* inspector, tabletype type, uint64_t refresh_interval_ns, bool print_to_stdout, uint32_t batch_count)
 {
 	m_inspector = inspector;
 	m_type = type;
@@ -106,6 +106,7 @@ sinsp_table::sinsp_table(sinsp* inspector, tabletype type, uint64_t refresh_inte
 	m_zero_double = 0;
 	m_paused = false;
 	m_sample_data = NULL;
+	m_batch_count = batch_count;
 }
 
 sinsp_table::~sinsp_table()
@@ -631,6 +632,15 @@ void sinsp_table::stdout_print(vector<sinsp_sample_row>* sample_data, uint64_t t
 	}
 
 	printf("----------------------\n");
+
+	if(!m_batch_count)
+	{
+		exit(0);
+	}
+	else if(m_batch_count > 0)
+	{
+		m_batch_count -= 1;
+	}
 }
 
 void sinsp_table::filter_sample()

--- a/userspace/libsinsp/table.h
+++ b/userspace/libsinsp/table.h
@@ -227,7 +227,7 @@ public:
 		TT_LIST,
 	};
 
-	sinsp_table(sinsp* inspector, tabletype type, uint64_t refresh_interval_ns, bool print_to_stdout);
+	sinsp_table(sinsp* inspector, tabletype type, uint64_t refresh_interval_ns, bool print_to_stdout, uint32_t batch_count);
 	~sinsp_table();
 	void configure(vector<sinsp_view_column_info>* entries, const string& filter, bool use_defaults, uint32_t view_depth);
 	void process_event(sinsp_evt* evt);
@@ -285,6 +285,7 @@ public:
 	uint64_t m_next_flush_time_ns;
 	uint64_t m_prev_flush_time_ns;
 	uint64_t m_refresh_interval_ns;
+	uint32_t m_batch_count;
 
 private:
 	inline void add_row(bool merging);


### PR DESCRIPTION
Allow sysdig to be run in batch mode so users can pipe the output to another application. 

```
/usr/local/bin/csysdig -vcontainers --raw -c 3
----------------------
      0.00          0          0        62M         8M       0.00       0.00 docker nginx 6569940fb61a adoring_heisenberg 
      0.00          0          0        62M         8M       0.00       0.00 docker nginx afd3bac36889 nostalgic_goldwasser 
      0.00          1          1        62M         7M       0.00       0.00 docker nginx 3ce1820eb9c7 serene_bardeen 
----------------------
      0.00          0          0        62M         8M       0.00       0.00 docker nginx 6569940fb61a adoring_heisenberg 
      0.00          0          0        62M         8M       0.00       0.00 docker nginx afd3bac36889 nostalgic_goldwasser 
      0.00          1          1        62M         7M       0.00       0.00 docker nginx 3ce1820eb9c7 serene_bardeen 
----------------------
      0.00          0          0        62M         8M       0.00       0.00 docker nginx 6569940fb61a adoring_heisenberg 
      0.00          0          0        62M         8M       0.00       0.00 docker nginx afd3bac36889 nostalgic_goldwasser 
      0.00          1          1        62M         7M       0.00       0.00 docker nginx 3ce1820eb9c7 serene_bardeen 
```