### PR TITLE
K8s pods fix

### DIFF
--- a/userspace/libsinsp/k8s_handler.h
+++ b/userspace/libsinsp/k8s_handler.h
@@ -16,8 +16,6 @@ class sinsp;
 class k8s_handler
 {
 public:
-	static const std::string POD_STATE_FILTER;
-
 	typedef k8s_component::msg_reason msg_reason;
 	typedef k8s_component::msg_data msg_data;
 

--- a/userspace/libsinsp/k8s_pod_handler.cpp
+++ b/userspace/libsinsp/k8s_pod_handler.cpp
@@ -201,71 +201,49 @@ size_t k8s_pod_handler::extract_pod_restart_count(const Json::Value& item)
 	return restart_count;
 }
 
-bool k8s_pod_handler::is_pod_active(const Json::Value& item)
-{
-	const Json::Value& phase = item["phase"];
-	if(!phase.isNull() && phase.isString())
-	{
-		if(phase.asString() == "Running")
-		{
-			return true;
-		}
-	}
-	return false;
-}
-
 bool k8s_pod_handler::handle_component(const Json::Value& json, const msg_data* data)
 {
-	if(is_pod_active(json))
+	if(data)
 	{
-		if(data)
+		if(m_state)
 		{
-			if(m_state)
+			if((data->m_reason == k8s_component::COMPONENT_ADDED) ||
+			   (data->m_reason == k8s_component::COMPONENT_MODIFIED))
 			{
-				if((data->m_reason == k8s_component::COMPONENT_ADDED) ||
-				   (data->m_reason == k8s_component::COMPONENT_MODIFIED))
+				k8s_pod_t& pod =
+					m_state->get_component<k8s_pods, k8s_pod_t>(m_state->get_pods(),
+																  data->m_name, data->m_uid, data->m_namespace);
+				k8s_pair_list entries = k8s_component::extract_object(json, "labels");
+				if(entries.size() > 0)
 				{
-					k8s_pod_t& pod =
-						m_state->get_component<k8s_pods, k8s_pod_t>(m_state->get_pods(),
-																	  data->m_name, data->m_uid, data->m_namespace);
-					k8s_pair_list entries = k8s_component::extract_object(json, "labels");
-					if(entries.size() > 0)
-					{
-						pod.set_labels(std::move(entries));
-					}
-					k8s_pod_t::container_id_list container_ids = extract_pod_container_ids(json);
-					k8s_container::list containers = extract_pod_containers(json);
-					extract_pod_data(json, pod);
-					pod.set_restart_count(extract_pod_restart_count(json));
-					pod.set_container_ids(std::move(container_ids));
-					pod.set_containers(std::move(containers));
+					pod.set_labels(std::move(entries));
 				}
-				else if(data->m_reason == k8s_component::COMPONENT_DELETED)
-				{
-					if(!m_state->delete_component(m_state->get_pods(), data->m_uid))
-					{
-						log_not_found(*data);
-						return false;
-					}
-				}
+				k8s_pod_t::container_id_list container_ids = extract_pod_container_ids(json);
+				k8s_container::list containers = extract_pod_containers(json);
+				extract_pod_data(json, pod);
+				pod.set_restart_count(extract_pod_restart_count(json));
+				pod.set_container_ids(std::move(container_ids));
+				pod.set_containers(std::move(containers));
 			}
-			else if(data->m_reason != k8s_component::COMPONENT_ERROR)
+			else if(data->m_reason == k8s_component::COMPONENT_DELETED)
 			{
-				g_logger.log(std::string("Unsupported K8S " + name() + " event reason: ") +
-							 std::to_string(data->m_reason), sinsp_logger::SEV_ERROR);
-				return false;
+				if(!m_state->delete_component(m_state->get_pods(), data->m_uid))
+				{
+					log_not_found(*data);
+					return false;
+				}
 			}
 		}
-		else
+		else if(data->m_reason != k8s_component::COMPONENT_ERROR)
 		{
-			throw sinsp_exception("K8s node handler: data is null.");
+			g_logger.log(std::string("Unsupported K8S " + name() + " event reason: ") +
+						 std::to_string(data->m_reason), sinsp_logger::SEV_ERROR);
+			return false;
 		}
 	}
 	else
 	{
-		g_logger.log("Received handling request for non-running pod: " + (data ? data->m_name : std::string()),
-				 sinsp_logger::SEV_WARNING);
-		return false;
+		throw sinsp_exception("K8s node handler: data is null.");
 	}
 	return true;
 }

--- a/userspace/libsinsp/k8s_pod_handler.cpp
+++ b/userspace/libsinsp/k8s_pod_handler.cpp
@@ -71,7 +71,7 @@ k8s_pod_handler::k8s_pod_handler(k8s_state_t& state
 	):
 		k8s_handler("k8s_pod_handler", true,
 #ifdef HAS_CAPTURE
-					url, "/api/v1/pods?" + POD_STATE_FILTER,
+					url, "/api/v1/pods?fieldSelector=status.phase%3DRunning",
 					STATE_FILTER, EVENT_FILTER, "", collector,
 					http_version, 1000L, ssl, bt, true,
 					connect, dependency_handler, blocking_socket,

--- a/userspace/libsinsp/k8s_pod_handler.h
+++ b/userspace/libsinsp/k8s_pod_handler.h
@@ -29,7 +29,6 @@ public:
 
 	~k8s_pod_handler();
 
-	static bool is_pod_active(const Json::Value& item);
 	static std::vector<std::string> extract_pod_container_ids(const Json::Value& item);
 	static k8s_container::list extract_pod_containers(const Json::Value& item);
 	static void extract_pod_data(const Json::Value& item, k8s_pod_t& pod);


### PR DESCRIPTION
This pull rolls back #779 and provides this fix: don't require phase==Running for Pod Event. We are listening only to running Pods but watch event can come for Pod in a different state and it's normal. This is an example for a successful batch Job:

```json
{"type":"ADDED","kind":"Pod","uid":"5a7ea8e9-03e8-11e7-948b-06f419bf9c8b","phase":"Running","name":"echo2-8u17n"}
{"type":"DELETED","kind":"Pod","uid":"5a7ea8e9-03e8-11e7-948b-06f419bf9c8b","phase":"Succeeded","name":"echo2-8u17n"}
```

And this is for a failing Pod:

```json
{"type":"ADDED","kind":"Pod","uid":"bde88eb8-03e8-11e7-948b-06f419bf9c8b","phase":"Running","name":"echo"}
{"type":"DELETED","kind":"Pod","uid":"bde88eb8-03e8-11e7-948b-06f419bf9c8b","phase":"Failed","name":"echo"}
```