### PR TITLE
Forward k8s url as is instead of recreating it

### DIFF
--- a/userspace/libsinsp/k8s_net.cpp
+++ b/userspace/libsinsp/k8s_net.cpp
@@ -142,35 +142,26 @@ k8s_net::handler_ptr_t k8s_net::make_handler(k8s_state_t& state, const k8s_compo
 											handler_ptr_t dep, collector_ptr_t collector, const std::string& urlstr,
 											ssl_ptr_t ssl, bt_ptr_t bt, bool blocking, filter_ptr_t event_filter)
 {
-	std::ostringstream os;
-	if(!urlstr.empty())
-	{
-		uri url(urlstr);
-		os << url.get_scheme() << "://" << url.get_host();
-		int port = url.get_port();
-		if(port) { os << ':' << port; }
-	}
-
 	switch(component)
 	{
 		case k8s_component::K8S_NODES:
-			return std::make_shared<k8s_node_handler>(state, dep, collector, os.str(), "1.1", ssl, bt, connect, blocking);
+			return std::make_shared<k8s_node_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking);
 		case k8s_component::K8S_NAMESPACES:
-			return std::make_shared<k8s_namespace_handler>(state, dep, collector, os.str(), "1.1", ssl, bt, connect, blocking);
+			return std::make_shared<k8s_namespace_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking);
 		case k8s_component::K8S_PODS:
-			return std::make_shared<k8s_pod_handler>(state, dep, collector, os.str(), "1.1", ssl, bt, connect, blocking);
+			return std::make_shared<k8s_pod_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking);
 		case k8s_component::K8S_REPLICATIONCONTROLLERS:
-			return std::make_shared<k8s_replicationcontroller_handler>(state, dep, collector, os.str(), "1.1", ssl, bt, connect, blocking);
+			return std::make_shared<k8s_replicationcontroller_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking);
 		case k8s_component::K8S_REPLICASETS:
-			return std::make_shared<k8s_replicaset_handler>(state, dep, collector, os.str(), "1.1", ssl, bt, connect, blocking);
+			return std::make_shared<k8s_replicaset_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking);
 		case k8s_component::K8S_SERVICES:
-			return  std::make_shared<k8s_service_handler>(state, dep, collector, os.str(), "1.1", ssl, bt, connect, blocking);
+			return  std::make_shared<k8s_service_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking);
 		case k8s_component::K8S_DAEMONSETS:
-			return  std::make_shared<k8s_daemonset_handler>(state, dep, collector, os.str(), "1.1", ssl, bt, connect, blocking);
+			return  std::make_shared<k8s_daemonset_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking);
 		case k8s_component::K8S_DEPLOYMENTS:
-			return  std::make_shared<k8s_deployment_handler>(state, dep, collector, os.str(), "1.1", ssl, bt, connect, blocking);
+			return  std::make_shared<k8s_deployment_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking);
 		case k8s_component::K8S_EVENTS:
-			return std::make_shared<k8s_event_handler>(state, dep, collector, os.str(), "1.1", ssl, bt, connect, blocking, event_filter);
+			return std::make_shared<k8s_event_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking, event_filter);
 		case k8s_component::K8S_COMPONENT_COUNT:
 		default:
 			return nullptr;


### PR DESCRIPTION
It was missing credentials in the copy, thus k8s with basic auth wasn't working