### PR TITLE
Force a probe module build for old, whitelisted kernel versions

### DIFF
--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -526,6 +526,11 @@ if [ -z "$KERNEL_TYPE" ]; then
 	do
 		debian_build $URL
 	done
+	# XXX agent/434 - We need to force a build for certain kernel versions
+	# because they are still in use by some GCE customers but the headers
+	# are no longer available from the mirror. We pass the URL but nothing
+	# needs to be downloaded because we already have it cached on the builder.
+	debian_build https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-3.16.0-4-amd64_3.16.36-1+deb8u2_amd64.deb
 
 	#
 	# Oracle RHCK build


### PR DESCRIPTION
I grabbed the URL by manually running `kernel-crawler.py` for the current debian URLs and modifying the version string for the old one. This assumes we have the debs cached on the builder and will break the build if they go away.