### PR TITLE
Fix for lxc on Ubuntu 16.10

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -326,8 +326,10 @@ bool sinsp_container_manager::resolve_container(sinsp_threadinfo* tinfo, bool qu
 		pos = cgroup.find("/lxc/");
 		if(pos != string::npos)
 		{
+			auto id_start = pos + sizeof("/lxc/") - 1;
+			auto id_end = cgroup.find('/', id_start);
 			container_info.m_type = CT_LXC;
-			container_info.m_id = cgroup.substr(pos + sizeof("/lxc/") - 1);
+			container_info.m_id = cgroup.substr(id_start, id_end - id_start);
 			valid_id = true;
 			break;
 		}


### PR DESCRIPTION
It looks that on Ubuntu 16.10 lxc containers cgroups may contain
systemd slices:

```
11:devices:/lxc/x1/system.slice/snapd.service
10:memory:/lxc/x1/system.slice/snapd.service
9:hugetlb:/lxc/x1
8:perf_event:/lxc/x1
7:cpuset:/lxc/x1
6:pids:/lxc/x1/system.slice/snapd.service
5:freezer:/lxc/x1
4:cpu,cpuacct:/lxc/x1/system.slice/snapd.service
3:net_cls,net_prio:/lxc/x1
2:blkio:/lxc/x1/system.slice/snapd.service
1:name=systemd:/lxc/x1/system.slice/snapd.service
```

this fix uses as container id only the first path after `/lxc/` instead of
everything. It looks safe since `/` is forbidden as containerid