### PR TITLE
Handle netlink sockets

### DIFF
--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -122,7 +122,8 @@ typedef enum scap_fd_type
 	SCAP_FD_SIGNALFD = 11,
 	SCAP_FD_EVENTPOLL = 12,
 	SCAP_FD_INOTIFY = 13,
-	SCAP_FD_TIMERFD = 14
+	SCAP_FD_TIMERFD = 14,
+	SCAP_FD_NETLINK = 15
 }scap_fd_type;
 
 /*!

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -311,7 +311,12 @@ int32_t scap_fd_write_to_disk(scap_t *handle, scap_fdinfo *fdi, scap_dumper_t *d
 			return SCAP_FAILURE;
 		}
 		break;
+	case SCAP_FD_UNKNOWN:
+		// Ignore UNKNOWN fds without failing
+		ASSERT(false);
+		break;
 	default:
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Unknown fdi type %d", fdi->type);
 		ASSERT(false);
 		return SCAP_FAILURE;
 	}
@@ -448,6 +453,9 @@ uint32_t scap_fd_read_from_disk(scap_t *handle, OUT scap_fdinfo *fdi, OUT size_t
 	case SCAP_FD_TIMERFD:
 	case SCAP_FD_NETLINK:
 		res = scap_fd_read_fname_from_disk(handle, fdi->info.fname,nbytes,f);
+		break;
+	case SCAP_FD_UNKNOWN:
+		ASSERT(false);
 		break;
 	default:
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error reading the fd info from file, wrong fd type %u", (uint32_t)fdi->type);

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -150,6 +150,9 @@ int32_t scap_fd_info_to_string(scap_fdinfo *fdi, OUT char *str, uint32_t stlen)
  	case SCAP_FD_UNSUPPORTED:
  		snprintf(str, stlen, "<UNSUPPORTED>");
  		break;
+ 	case SCAP_FD_NETLINK:
+ 		snprintf(str, stlen, "<NETLINK>");
+ 		break;
 	default:
 		ASSERT(false);
 		return SCAP_FAILURE;
@@ -206,6 +209,7 @@ uint32_t scap_fd_info_len(scap_fdinfo *fdi)
 	case SCAP_FD_EVENTPOLL:
 	case SCAP_FD_INOTIFY:
 	case SCAP_FD_TIMERFD:
+	case SCAP_FD_NETLINK:
 		res += (uint32_t)strnlen(fdi->info.fname, SCAP_MAX_PATH_SIZE) + 2;    // 2 is the length field before the string
 		break;
 	default:
@@ -298,6 +302,7 @@ int32_t scap_fd_write_to_disk(scap_t *handle, scap_fdinfo *fdi, scap_dumper_t *d
 	case SCAP_FD_EVENTPOLL:
 	case SCAP_FD_INOTIFY:
 	case SCAP_FD_TIMERFD:
+	case SCAP_FD_NETLINK:
 		stlen = (uint16_t)strnlen(fdi->info.fname, SCAP_MAX_PATH_SIZE);
 		if(scap_dump_write(d, &stlen,  sizeof(uint16_t)) != sizeof(uint16_t) ||
 		        (stlen > 0 && scap_dump_write(d, fdi->info.fname, stlen) != stlen))
@@ -441,6 +446,7 @@ uint32_t scap_fd_read_from_disk(scap_t *handle, OUT scap_fdinfo *fdi, OUT size_t
 	case SCAP_FD_EVENTPOLL:
 	case SCAP_FD_INOTIFY:
 	case SCAP_FD_TIMERFD:
+	case SCAP_FD_NETLINK:
 		res = scap_fd_read_fname_from_disk(handle, fdi->info.fname,nbytes,f);
 		break;
 	default:
@@ -832,6 +838,143 @@ int32_t scap_fd_read_unix_sockets_from_proc_fs(scap_t *handle, const char* filen
 		if(uth_status != SCAP_SUCCESS)
 		{
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unix socket allocatiallocation error");
+			return SCAP_FAILURE;
+		}
+	}
+	fclose(f);
+	return uth_status;
+}
+
+//sk       Eth Pid    Groups   Rmem     Wmem     Dump     Locks     Drops     Inode
+//ffff88011abfb000 0   0      00000000 0        0        0 2        0        13
+
+int32_t scap_fd_read_netlink_sockets_from_proc_fs(scap_t *handle, const char* filename, scap_fdinfo **sockets)
+{
+	FILE *f;
+	char line[1024];
+	int first_line = false;
+	char *delimiters = " \t";
+	char *token;
+	int32_t uth_status = SCAP_SUCCESS;
+
+	f = fopen(filename, "r");
+	if(NULL == f)
+	{
+		ASSERT(false);
+		return SCAP_FAILURE;
+	}
+	while(NULL != fgets(line, sizeof(line), f))
+	{
+		// skip the first line ... contains field names
+		if(!first_line)
+		{
+			first_line = true;
+			continue;
+		}
+		scap_fdinfo *fdinfo = malloc(sizeof(scap_fdinfo));
+		memset(fdinfo, 0, sizeof(scap_fdinfo));
+		fdinfo->type = SCAP_FD_UNIX_SOCK;
+
+
+		//
+		// parse the fields
+		//
+		// 1. Num
+		token = strtok(line, delimiters);
+		if(token == NULL)
+		{
+			ASSERT(false);
+			free(fdinfo);
+			continue;
+		}
+
+		// 2. Eth
+		token = strtok(NULL, delimiters);
+		if(token == NULL)
+		{
+			ASSERT(false);
+			free(fdinfo);
+			continue;
+		}
+
+		// 3. Pid
+		token = strtok(NULL, delimiters);
+		if(token == NULL)
+		{
+			ASSERT(false);
+			free(fdinfo);
+			continue;
+		}
+
+		// 4. Groups
+		token = strtok(NULL, delimiters);
+		if(token == NULL)
+		{
+			ASSERT(false);
+			free(fdinfo);
+			continue;
+		}
+
+		// 5. Rmem
+		token = strtok(NULL, delimiters);
+		if(token == NULL)
+		{
+			ASSERT(false);
+			free(fdinfo);
+			continue;
+		}
+
+		// 6. Wmem
+		token = strtok(NULL, delimiters);
+		if(token == NULL)
+		{
+			ASSERT(false);
+			free(fdinfo);
+			continue;
+		}
+
+		// 7. Dump
+		token = strtok(NULL, delimiters);
+		if(token == NULL)
+		{
+			ASSERT(false);
+			free(fdinfo);
+			continue;
+		}
+
+		// 8. Locks
+		token = strtok(NULL, delimiters);
+		if(token == NULL)
+		{
+			ASSERT(false);
+			free(fdinfo);
+			continue;
+		}
+
+		// 9. Drops
+		token = strtok(NULL, delimiters);
+		if(token == NULL)
+		{
+			ASSERT(false);
+			free(fdinfo);
+			continue;
+		}
+
+		// 10. Inode
+		token = strtok(NULL, delimiters);
+		if(token == NULL)
+		{
+			ASSERT(false);
+			free(fdinfo);
+			continue;
+		}
+
+		sscanf(token, "%"PRIu64, &(fdinfo->ino));
+
+		HASH_ADD_INT64((*sockets), ino, fdinfo);
+		if(uth_status != SCAP_SUCCESS)
+		{
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "netlink socket allocation error");
 			return SCAP_FAILURE;
 		}
 	}
@@ -1274,6 +1417,13 @@ int32_t scap_fd_read_sockets(scap_t *handle, char* procdir, struct scap_ns_socke
 
 	snprintf(filename, sizeof(filename), "%sunix", netroot);
 	if(scap_fd_read_unix_sockets_from_proc_fs(handle, filename, &sockets->sockets) == SCAP_FAILURE)
+	{
+		scap_fd_free_table(handle, &sockets->sockets);
+		return SCAP_FAILURE;
+	}
+
+	snprintf(filename, sizeof(filename), "%snetlink", netroot);
+	if(scap_fd_read_netlink_sockets_from_proc_fs(handle, filename, &sockets->sockets) == SCAP_FAILURE)
 	{
 		scap_fd_free_table(handle, &sockets->sockets);
 		return SCAP_FAILURE;

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -121,7 +121,8 @@ static int32_t scap_write_proc_fds(scap_t *handle, struct scap_threadinfo *tinfo
 	//
 	HASH_ITER(hh, tinfo->fdlist, fdi, tfdi)
 	{
-		if(fdi->type != SCAP_FD_UNINITIALIZED)
+		if(fdi->type != SCAP_FD_UNINITIALIZED &&
+		   fdi->type != SCAP_FD_UNKNOWN)
 		{
 			totlen += scap_fd_info_len(fdi);
 		}

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2376,6 +2376,7 @@ void sinsp_evt::get_category(OUT sinsp_evt::category* cat)
 					case SCAP_FD_UNSUPPORTED:
 					case SCAP_FD_EVENTPOLL:
 					case SCAP_FD_TIMERFD:
+					case SCAP_FD_NETLINK:
 						cat->m_subcategory = SC_OTHER;
 						break;
 					case SCAP_FD_UNKNOWN:

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -83,6 +83,8 @@ template<> char sinsp_fdinfo_t::get_typechar()
 		return CHAR_FD_INOTIFY;
 	case SCAP_FD_TIMERFD:
 		return CHAR_FD_TIMERFD;
+	case SCAP_FD_NETLINK:
+		return CHAR_FD_NETLINK;
 	default:
 //		ASSERT(false);
 		return '?';
@@ -117,6 +119,8 @@ template<> char* sinsp_fdinfo_t::get_typestring()
 		return (char*)"inotify";
 	case SCAP_FD_TIMERFD:
 		return (char*)"timerfd";
+	case SCAP_FD_NETLINK:
+		return (char*)"netlink";
 	default:
 		return (char*)"<NA>";
 	}

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -42,6 +42,7 @@ class sinsp_protodecoder;
 #define CHAR_FD_EVENTPOLL		'l'
 #define CHAR_FD_INOTIFY			'i'
 #define CHAR_FD_TIMERFD			't'
+#define CHAR_FD_NETLINK			'n'
 
 /** @defgroup state State management 
  * A collection of classes to query process and FD state.

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2024,6 +2024,17 @@ inline void sinsp_parser::add_socket(sinsp_evt *evt, int64_t fd, uint32_t domain
 		}
 	}
 
+	if(fdi.m_type == SCAP_FD_UNKNOWN)
+	{
+		g_logger.log("Unknown fd fd=" + to_string(fd) +
+			     " domain=" + to_string(domain) +
+			     " type=" + to_string(type) +
+			     " protocol=" + to_string(protocol) +
+			     " pid=" + to_string(evt->m_tinfo->m_pid) +
+			     " comm=" + evt->m_tinfo->m_comm,
+			     sinsp_logger::SEV_DEBUG);
+	}
+
 #ifndef INCLUDE_UNKNOWN_SOCKET_FDS
 	if(fdi.m_type == SCAP_FD_UNKNOWN)
 	{

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2008,10 +2008,13 @@ inline void sinsp_parser::add_socket(sinsp_evt *evt, int64_t fd, uint32_t domain
 			fdi.m_sockinfo.m_ipv4info.m_fields.m_l4proto = SCAP_L4_ICMP;
 		}
 	}
+	else if (domain == PPM_AF_NETLINK)
+	{
+		fdi.m_type = SCAP_FD_NETLINK;
+	}
 	else
 	{
-		if(domain != 16 &&  // AF_NETLINK, used by processes to talk to the kernel
-		        domain != 10 && // IPv6
+		if(     domain != 10 && // IPv6
 		        domain != 17)   // AF_PACKET, used for packet capture
 		{
 			//

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -305,6 +305,7 @@ void sinsp_threadinfo::add_fd_from_scap(scap_fdinfo *fdi, OUT sinsp_fdinfo_t *re
 	case SCAP_FD_EVENT:
 	case SCAP_FD_INOTIFY:
 	case SCAP_FD_TIMERFD:
+	case SCAP_FD_NETLINK:
 		newfdi->m_name = fdi->info.fname;
 
 		if(newfdi->m_name == USER_EVT_DEVICE_NAME)
@@ -968,6 +969,7 @@ void sinsp_threadinfo::fd_to_scap(scap_fdinfo *dst, sinsp_fdinfo_t* src)
 	case SCAP_FD_EVENT:
 	case SCAP_FD_INOTIFY:
 	case SCAP_FD_TIMERFD:
+	case SCAP_FD_NETLINK:
 		strncpy(dst->info.fname, src->m_name.c_str(), SCAP_MAX_PATH_SIZE);
 		break;
 	default:


### PR DESCRIPTION
Minimal support for sockets with family AF_NETLINK, just enough to ensure they are not confused with unknown sockets.

Also make the scap read/write process a bit more robust in the face of unknown sockets.

@luca3m @gianlucaborello @ldegio wanna take a look?