### PR TITLE
Checking Sysdig with PVS-Studio static analyzer

### DIFF
--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -225,6 +225,17 @@ int32_t scap_proc_fill_cgroups(struct scap_threadinfo* tinfo, const char* procdi
 		return SCAP_FAILURE;\
 	}
 
+#define CHECK_READ_SIZE_WITH_FREE(alloc_buffer, read_size, expected_size) if(read_size != expected_size) \
+    	{\
+		snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "expecting %d bytes, read %d at %s, line %d. Is the file truncated?",\
+			(int)expected_size,\
+			(int)read_size,\
+			__FILE__,\
+			__LINE__);\
+		free(alloc_buffer);\
+		return SCAP_FAILURE;\
+	}
+
 //
 // Useful stuff
 //

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -523,24 +523,24 @@ void scap_close(scap_t* handle)
 
 		ASSERT(handle->m_file == NULL);
 
-		//
-		// Destroy all the device descriptors
-		//
-		for(j = 0; j < handle->m_ndevs; j++)
-		{
-			if(handle->m_devs[j].m_buffer != MAP_FAILED)
-			{
-				munmap(handle->m_devs[j].m_bufinfo, sizeof(struct ppm_ring_buffer_info));
-				munmap(handle->m_devs[j].m_buffer, RING_BUF_SIZE * 2);
-				close(handle->m_devs[j].m_fd);
-			}
-		}
-
-		//
-		// Free the memory
-		//
 		if(handle->m_devs != NULL)
 		{
+			//
+			// Destroy all the device descriptors
+			//
+			for(j = 0; j < handle->m_ndevs; j++)
+			{
+				if(handle->m_devs[j].m_buffer != MAP_FAILED)
+				{
+				    munmap(handle->m_devs[j].m_bufinfo, sizeof(struct ppm_ring_buffer_info));
+				    munmap(handle->m_devs[j].m_buffer, RING_BUF_SIZE * 2);
+				    close(handle->m_devs[j].m_fd);
+				}
+			}
+
+			//
+			// Free the memory
+			//
 			free(handle->m_devs);
 		}
 #endif // HAS_CAPTURE

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1362,7 +1362,7 @@ static int32_t scap_read_iflist(scap_t *handle, gzFile f, uint32_t block_length)
 	}
 
 	readsize = gzread(f, readbuf, block_length);
-	CHECK_READ_SIZE(readsize, block_length);
+	CHECK_READ_SIZE_WITH_FREE(readbuf, readsize, block_length);
 
 	//
 	// First pass, count the number of addresses

--- a/userspace/libscap/scap_userlist.c
+++ b/userspace/libscap/scap_userlist.c
@@ -82,8 +82,8 @@ int32_t scap_create_userlist(scap_t* handle)
 	if(handle->m_userlist->groups == NULL)
 	{
 		snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "grouplist allocation failed(2)");
-		free(handle->m_userlist);
 		free(handle->m_userlist->users);
+		free(handle->m_userlist);
 		return SCAP_FAILURE;		
 	}
 

--- a/userspace/libsinsp/ctext.cpp
+++ b/userspace/libsinsp/ctext.cpp
@@ -240,12 +240,13 @@ int8_t ctext::str_search_single(ctext_search *to_search_in, ctext_search *new_po
 	size_t found;
 	string haystack;
 	ctext_search res, *out;
-	string query = to_search_in->_query; 
 
 	if(!to_search_in)
 	{
 		return -1;
 	}
+
+	string query = to_search_in->_query;
 
 	if(!new_pos_out) 
 	{

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -5452,7 +5452,7 @@ int32_t sinsp_filter_check_container::extract_arg(const string &val, size_t base
 	try
 	{
 		m_argid = sinsp_numparser::parsed32(numstr);
-	} catch (sinsp_exception e)
+	} catch (sinsp_exception &e)
 	{
 		if(strstr(e.what(), "is not a valid number") == NULL)
 		{

--- a/userspace/libsinsp/socket_collector.h
+++ b/userspace/libsinsp/socket_collector.h
@@ -60,7 +60,8 @@ public:
 			handler->enable();
 			return;
 		}
-		g_logger.log("Socket collector: attempt to enable non-existing handler: " + handler->get_id());
+		g_logger.log("Socket collector: attempt to enable non-existing handler.",
+			     sinsp_logger::SEV_ERROR);
 	}
 
 	int get_socket(std::shared_ptr<T> handler) const


### PR DESCRIPTION
Hello,
I have found and fixed several weakness and bugs using the PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

Analyzer warnings: 

* [V773](https://www.viva64.com/en/w/V773/) ([CWE-401](https://cwe.mitre.org/data/definitions/401.html)) The function was exited without releasing the 'readbuf' pointer. A memory leak is possible. userspace/libscap/scap_savefile.c 1365
* [V774](https://www.viva64.com/en/w/V774/) ([CWE-416](https://cwe.mitre.org/data/definitions/416.html)) The 'handle->m_userlist' pointer was used after the memory was released. userspace/libscap/scap_userlist.c 86
* [V522](https://www.viva64.com/en/w/V522/) ([CWE-476](https://cwe.mitre.org/data/definitions/476.html)) Dereferencing of the null pointer 'handler' might take place. userspace/libsinsp/socket_collector.h 63
* [V595](https://www.viva64.com/en/w/V595/) ([CWE-476](https://cwe.mitre.org/data/definitions/476.html)) The 'handle->m_devs' pointer was utilized before it was verified against nullptr. Check lines: 535, 542. userspace/libscap/scap.c 535
* [V595](https://www.viva64.com/en/w/V595/) ([CWE-476](https://cwe.mitre.org/data/definitions/476.html)) The 'to_search_in' pointer was utilized before it was verified against nullptr. Check lines: 243, 245. userspace/libsinsp/ctext.cpp 243
* [V746](https://www.viva64.com/en/w/V746/) Type slicing. An exception should be caught by reference rather than by value. userspace/libsinsp/filterchecks.cpp 5455

In addition, I suggest having a look at the emails, sent from @pvs-studio.com.

Best regards,
Phillip Khandeliants