### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ sysdig
 
 [![Join the chat at https://gitter.im/draios/sysdig](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/draios/sysdig?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-#Welcome to **sysdig**!
+# Welcome to **sysdig**!
 
 **Sysdig** is a universal system visibility tool with native support for containers:  
 `~$ sysdig`

--- a/userspace/sysdig/man/csysdig.md
+++ b/userspace/sysdig/man/csysdig.md
@@ -60,7 +60,7 @@ Starting csysdig with the -pc command line switch will cause many of the views t
 INTERACTIVE COMMANDS  
 --------------------  
 
-##Views Window##
+## Views Window ##
 
 **Arrows, PgUP, PgDn, Home, End**  
   Change the selection and scroll view content, both vertically and horizontally.  
@@ -110,7 +110,7 @@ INTERACTIVE COMMANDS
 **F1, h, ?**  
   Show the help screen.  
 
-##Echo and sysdig Windows##
+## Echo and sysdig Windows ##
 
 **Arrows, PgUP, PgDn, Home, End**  
   Scroll the page content.  
@@ -136,7 +136,7 @@ INTERACTIVE COMMANDS
 **CTRL+G**  
   Go to line.  
 
-##Spectrogram Window##
+## Spectrogram Window ##
 
 **F2**  
   Show the view picker. This will let you switch to another view.  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
