### PR TITLE
spy_users memory leak #751

### DIFF
--- a/userspace/sysdig/chisels/spy_users.lua
+++ b/userspace/sysdig/chisels/spy_users.lua
@@ -112,11 +112,6 @@ function on_event()
 		table.insert(fanames, 0, 0)
 		table.insert(fapids, 0, 0)
 		icorr = 0
-	else
-		for j = 0, MAX_ANCESTOR_NAVIGATION do
-			fanames[j] = chisel.request_field("proc.aname[" .. j .. "]")
-			fapids[j] = chisel.request_field("proc.apid[" .. j .. "]")
-		end
 	end
 
 	if user == nil then


### PR DESCRIPTION
chisel was unnecessary calling `request_field`, which was piling up filterchecks that were never cleaned