### PR TITLE
Implement probe_kernel_read() function for kernels versions below 2.6.26

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1016,6 +1016,23 @@ static int compat_accumulate_argv_or_env(compat_uptr_t argv,
 
 #endif
 
+// probe_kernel_read() only added in kernel 2.6.26
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 26)
+long probe_kernel_read(void *dst, const void *src, size_t size)
+{
+	long ret;
+	mm_segment_t old_fs = get_fs();
+
+	set_fs(KERNEL_DS);
+	pagefault_disable();
+	ret = __copy_from_user_inatomic(dst, (__force const void __user *)src, size);
+	pagefault_enable();
+	set_fs(old_fs);
+
+	return ret ? -EFAULT : 0;
+}
+#endif
+
 static int ppm_get_tty(void)
 {
 	/* Locking of the signal structures seems too complicated across


### PR DESCRIPTION
sysdig-CLA-1.0-contributing-entity: Amir Rossert
sysdig-CLA-1.0-signed-off-by: John Tsai johntsai@paypal.com