### PR TITLE
Thread info command parsed from the `proc` directory keeps whitespaces.

### DIFF
--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -572,8 +572,10 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, int parentt
 		}
 
 		line[SCAP_MAX_PATH_SIZE - 1] = 0;
-		sscanf(line, "Name:%[^\n]", tinfo->comm);
-		const char* non_space = tinfo->comm;
+		// auxiliary string to protect against undefined behaviour of `strncpy`
+		char comm_copy[SCAP_MAX_PATH_SIZE - 1];
+		sscanf(line, "Name:%[^\n]", comm_copy);
+		const char* non_space = comm_copy;
 		while (isspace(*non_space))
 			non_space++;
 		strncpy(tinfo->comm, non_space, SCAP_MAX_PATH_SIZE - 1);

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -18,6 +18,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <ctype.h>
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/param.h>
@@ -572,6 +573,10 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, int parentt
 
 		line[SCAP_MAX_PATH_SIZE - 1] = 0;
 		sscanf(line, "Name:%[^\n]", tinfo->comm);
+		const char* non_space = tinfo->comm;
+		while (isspace(*non_space))
+			non_space++;
+		strncpy(tinfo->comm, non_space, SCAP_MAX_PATH_SIZE - 1);
 		fclose(f);
 	}
 

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -571,7 +571,7 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, int parentt
 		}
 
 		line[SCAP_MAX_PATH_SIZE - 1] = 0;
-		sscanf(line, "Name:%s", tinfo->comm);
+		sscanf(line, "Name:%[^\n]", tinfo->comm);
 		fclose(f);
 	}
 


### PR DESCRIPTION
The commit fixes the issue with truncated comm. However, the output looks like
 ``` 
gnome-shell─┬─  firefox─┬─{     BgHangManager}
             │           ├─{       Cache I/O}
             │           ├─{       Cache2 I/O}
             │           ├─{       Cert Verify}
             │           ├─{       Closing Service}
```
Not sure if the leading tabs are made by `pstree` chisel. Is there a chance to fetch similar info from the sysdig command line tool?