### PR TITLE
Fix parsing of cgroups with empty subsys

### DIFF
--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -329,6 +329,16 @@ int32_t scap_proc_fill_cgroups(struct scap_threadinfo* tinfo, const char* procdi
 			return SCAP_FAILURE;
 		}
 
+		// Hack to detect empty fields, because strtok does not support it
+		// strsep() should be used to fix this but it's not available
+		// on CentOS 6 (has been added from Glibc 2.19)
+		if(subsys_list-token-strlen(token) > 1)
+		{
+			// skip cgroups like this:
+			// 0::/init.scope
+			continue;
+		}
+
 		// transient cgroup
 		if(strncmp(subsys_list, "name=", sizeof("name=") - 1) == 0)
 		{


### PR DESCRIPTION
It started to appear new cgroups with empty subsys that break our parser:

```
11:blkio:/docker/3be35aad864d0b6ec02c1cfb076e386345c755074bd6d2239c94fac8a8a98e6e
10:pids:/docker/3be35aad864d0b6ec02c1cfb076e386345c755074bd6d2239c94fac8a8a98e6e
9:freezer:/docker/3be35aad864d0b6ec02c1cfb076e386345c755074bd6d2239c94fac8a8a98e6e
8:perf_event:/docker/3be35aad864d0b6ec02c1cfb076e386345c755074bd6d2239c94fac8a8a98e6e
7:memory:/docker/3be35aad864d0b6ec02c1cfb076e386345c755074bd6d2239c94fac8a8a98e6e
6:devices:/docker/3be35aad864d0b6ec02c1cfb076e386345c755074bd6d2239c94fac8a8a98e6e
5:hugetlb:/docker/3be35aad864d0b6ec02c1cfb076e386345c755074bd6d2239c94fac8a8a98e6e
4:cpuset:/docker/3be35aad864d0b6ec02c1cfb076e386345c755074bd6d2239c94fac8a8a98e6e
3:net_cls,net_prio:/docker/3be35aad864d0b6ec02c1cfb076e386345c755074bd6d2239c94fac8a8a98e6e
2:cpu,cpuacct:/docker/3be35aad864d0b6ec02c1cfb076e386345c755074bd6d2239c94fac8a8a98e6e
1:name=systemd:/docker/3be35aad864d0b6ec02c1cfb076e386345c755074bd6d2239c94fac8a8a98e6e
0::/system.slice/docker.service
```

```
11:blkio:/init.scope
10:pids:/init.scope
9:freezer:/
8:perf_event:/
7:memory:/init.scope
6:devices:/init.scope
5:hugetlb:/
4:cpuset:/
3:net_cls,net_prio:/
2:cpu,cpuacct:/init.scope
1:name=systemd:/init.scope
0::/init.scope
```

The function we use `strtok` does not report empty tokens, so I did an hack to detect them and for now I think we can just skip them