### PR TITLE
Adding ability to open trace files from fds

### DIFF
--- a/userspace/libscap/scap.def
+++ b/userspace/libscap/scap.def
@@ -17,6 +17,7 @@ EXPORTS
 		scap_dump_close
 		scap_dump_get_offset
 		scap_dump_flush
+		scap_dump_ftell
 		scap_dump
 		scap_event_reset_count
 		scap_event_get_num

--- a/userspace/libscap/scap.def
+++ b/userspace/libscap/scap.def
@@ -3,6 +3,7 @@ LIBRARY scap
 EXPORTS
 		scap_open_live
 		scap_open_offline
+		scap_open_offline_fd
 		scap_open
 		scap_close
 		scap_get_os_platform
@@ -12,10 +13,12 @@ EXPORTS
 		scap_event_getlen
 		scap_event_get_ts
 		scap_dump_open
+		scap_dump_open_fd
 		scap_dump_close
 		scap_dump_get_offset
 		scap_dump_flush
 		scap_dump
+		scap_event_reset_count
 		scap_event_get_num
 		scap_get_proc_table
 		scap_event_getinfo

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -657,6 +657,15 @@ void scap_dump_close(scap_dumper_t *d);
 int64_t scap_dump_get_offset(scap_dumper_t *d);
 
 /*!
+  \brief Return the position for the next write to a tracefile.
+         This uses gztell, while scap_dump_get_offset uses gzoffset.
+
+  \param d The dump handle, returned by \ref scap_dump_open
+  \return The next write position.
+*/
+int64_t scap_dump_ftell(scap_dumper_t *d);
+
+/*!
   \brief Flush all pending output into the file.
 
   \param d The dump handle, returned by \ref scap_dump_open

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -244,6 +244,7 @@ typedef enum {
 typedef struct scap_open_args
 {
 	scap_mode_t mode;
+	int fd; // If non-zero, will be used instead of fname.
 	const char* fname; ///< The name of the file to open. NULL for live captures.
 	proc_entry_callback proc_callback; ///< Callback to be invoked for each thread/fd that is extracted from /proc, or NULL if no callback is needed.
 	void* proc_callback_context; ///< Opaque pointer that will be included in the calls to proc_callback. Ignored if proc_callback is NULL.
@@ -498,6 +499,17 @@ scap_t* scap_open_live(char *error);
 scap_t* scap_open_offline(const char* fname, char *error);
 
 /*!
+  \brief Start an event capture from an already opened file descriptor.
+
+  \param fd The fd to use.
+  \param error Pointer to a buffer that will contain the error string in case the
+    function fails. The buffer must have size SCAP_LASTERR_SIZE.
+
+  \return The capture instance handle in case of success. NULL in case of failure.
+*/
+scap_t* scap_open_offline_fd(int fd, char *error);
+
+/*!
   \brief Advanced function to start a capture.
 
   \param args a \ref scap_open_args structure containing the open paraneters.
@@ -577,6 +589,13 @@ uint64_t scap_event_get_ts(scap_evt* e);
 uint64_t scap_event_get_num(scap_t* handle);
 
 /*!
+  \brief Reset the event count to 0.
+
+  \param handle Handle to the capture instance.
+*/
+void scap_event_reset_count(scap_t* handle);
+
+/*!
   \brief Return the meta-information describing the given event
 
   \param e pointer to an event returned by \ref scap_next.
@@ -611,6 +630,16 @@ int64_t scap_get_readfile_offset(scap_t* handle);
   \return Dump handle that can be used to identify this specific dump instance.
 */
 scap_dumper_t* scap_dump_open(scap_t *handle, const char *fname, compression_mode compress);
+
+/*!
+  \brief Open a tracefile for writing, using the provided fd.
+
+n  \param handle Handle to the capture instance.
+  \param fname The name of the tracefile.
+
+  \return Dump handle that can be used to identify this specific dump instance.
+*/
+scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compress);
 
 /*!
   \brief Close a tracefile.

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -634,12 +634,12 @@ scap_dumper_t* scap_dump_open(scap_t *handle, const char *fname, compression_mod
 /*!
   \brief Open a tracefile for writing, using the provided fd.
 
-n  \param handle Handle to the capture instance.
-  \param fname The name of the tracefile.
+  \param handle Handle to the capture instance.
+  \param fd A file descriptor to which the dumper will write
 
   \return Dump handle that can be used to identify this specific dump instance.
 */
-scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compress);
+scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compress, bool skip_proc_scan);
 
 /*!
   \brief Close a tracefile.

--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -60,6 +60,11 @@ uint64_t scap_event_get_num(scap_t* handle)
 	return handle->m_evtcnt;
 }
 
+void scap_event_reset_count(scap_t* handle)
+{
+	handle->m_evtcnt = 0;
+}
+
 uint64_t scap_event_get_ts(scap_evt* e)
 {
 	return e->ts;

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -916,6 +916,18 @@ int64_t scap_dump_get_offset(scap_dumper_t *d)
 	}
 }
 
+int64_t scap_dump_ftell(scap_dumper_t *d)
+{
+	if(d->m_type == DT_FILE)
+	{
+		return gztell(d->m_f);
+	}
+	else
+	{
+		return (int64_t)d->m_targetbufcurpos - (int64_t)d->m_targetbuf;
+	}
+}
+
 void scap_dump_flush(scap_dumper_t *d)
 {
 	if(d->m_type == DT_FILE)

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -744,6 +744,24 @@ int32_t scap_setup_dump(scap_t *handle, scap_dumper_t* d, const char *fname)
 	return SCAP_SUCCESS;
 }
 
+// fname is only used for log messages in scap_setup_dump
+static scap_dumper_t *scap_dump_open_gzfile(scap_t *handle, gzFile gzfile, const char *fname)
+{
+	scap_dumper_t* res = (scap_dumper_t*)malloc(sizeof(scap_dumper_t));
+	res->m_f = gzfile;
+	res->m_type = DT_FILE;
+	res->m_targetbuf = NULL;
+	res->m_targetbufcurpos = NULL;
+	res->m_targetbufend = NULL;
+
+	if(scap_setup_dump(handle, res, fname) != SCAP_SUCCESS)
+	{
+		res = NULL;
+	}
+
+	return res;
+}
+
 //
 // Open a "savefile" for writing.
 //
@@ -798,19 +816,39 @@ scap_dumper_t *scap_dump_open(scap_t *handle, const char *fname, compression_mod
 		return NULL;
 	}
 
-	scap_dumper_t* res = (scap_dumper_t*)malloc(sizeof(scap_dumper_t));
-	res->m_f = f;
-	res->m_type = DT_FILE;
-	res->m_targetbuf = NULL;
-	res->m_targetbufcurpos = NULL;
-	res->m_targetbufend = NULL;
+	return scap_dump_open_gzfile(handle, f, fname);
+}
 
-	if(scap_setup_dump(handle, res, fname) != SCAP_SUCCESS)
+//
+// Open a savefile for writing, using the provided fd
+scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compress)
+{
+	gzFile f = NULL;
+	const char* mode;
+
+	switch(compress)
 	{
-		res = NULL;
+	case SCAP_COMPRESSION_GZIP:
+		mode = "wb";
+		break;
+	case SCAP_COMPRESSION_NONE:
+		mode = "wbT";
+		break;
+	default:
+		ASSERT(false);
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "invalid compression mode");
+		return NULL;
 	}
 
-	return res;
+	f = gzdopen(fd, mode);
+
+	if(f == NULL)
+	{
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't open fd %d", fd);
+		return NULL;
+	}
+
+	return scap_dump_open_gzfile(handle, f, "");
 }
 
 //
@@ -1008,7 +1046,7 @@ static int32_t scap_read_proclist(scap_t *handle, gzFile f, uint32_t block_lengt
 	tinfo.sid = -1;
 	tinfo.clone_ts = 0;
 	tinfo.tty = 0;
-	
+
 	while(((int32_t)block_length - (int32_t)totreadsize) >= 4)
 	{
 		//
@@ -1370,6 +1408,7 @@ static int32_t scap_read_proclist(scap_t *handle, gzFile f, uint32_t block_lengt
 	if(totreadsize > block_length)
 	{
 		ASSERT(false);
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_read_proclist read more %lu than a block %u", totreadsize, block_length);
 		return SCAP_FAILURE;
 	}
 	padding_len = block_length - totreadsize;
@@ -1905,6 +1944,7 @@ static int32_t scap_read_userlist(scap_t *handle, gzFile f, uint32_t block_lengt
 	if(totreadsize > block_length)
 	{
 		ASSERT(false);
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_read_userlist read more %lu than a block %u", totreadsize, block_length);
 		return SCAP_FAILURE;
 	}
 	padding_len = block_length - totreadsize;
@@ -2006,6 +2046,7 @@ static int32_t scap_read_fdlist(scap_t *handle, gzFile f, uint32_t block_length)
 	if(totreadsize > block_length)
 	{
 		ASSERT(false);
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_read_fdlist read more %lu than a block %u", totreadsize, block_length);
 		return SCAP_FAILURE;
 	}
 	padding_len = block_length - totreadsize;

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -27,6 +27,7 @@ sinsp_dumper::sinsp_dumper(sinsp* inspector)
 	m_dumper = NULL;
 	m_target_memory_buffer = NULL;
 	m_target_memory_buffer_size = 0;
+	m_nevts = 0;
 }
 
 sinsp_dumper::sinsp_dumper(sinsp* inspector, uint8_t* target_memory_buffer, uint64_t target_memory_buffer_size)
@@ -79,6 +80,39 @@ void sinsp_dumper::open(const string& filename, bool compress, bool threads_from
 	}
 
 	m_inspector->m_container_manager.dump_containers(m_dumper);
+
+	m_nevts = 0;
+}
+
+void sinsp_dumper::fdopen(int fd, bool compress, bool threads_from_sinsp)
+{
+	if(m_inspector->m_h == NULL)
+	{
+		throw sinsp_exception("can't start event dump, inspector not opened yet");
+	}
+
+	if(threads_from_sinsp)
+	{
+		m_inspector->m_thread_manager->to_scap();
+	}
+
+	if(compress)
+	{
+		m_dumper = scap_dump_open_fd(m_inspector->m_h, fd, SCAP_COMPRESSION_GZIP);
+	}
+	else
+	{
+		m_dumper = scap_dump_open_fd(m_inspector->m_h, fd, SCAP_COMPRESSION_NONE);
+	}
+
+	if(m_dumper == NULL)
+	{
+		throw sinsp_exception(scap_getlasterr(m_inspector->m_h));
+	}
+
+	m_inspector->m_container_manager.dump_containers(m_dumper);
+
+	m_nevts = 0;
 }
 
 void sinsp_dumper::close()
@@ -88,6 +122,16 @@ void sinsp_dumper::close()
 		scap_dump_close(m_dumper);
 		m_dumper = NULL;
 	}
+}
+
+bool sinsp_dumper::is_open()
+{
+	return (m_dumper != NULL);
+}
+
+bool sinsp_dumper::written_events()
+{
+	return m_nevts;
 }
 
 void sinsp_dumper::dump(sinsp_evt* evt)
@@ -106,6 +150,8 @@ void sinsp_dumper::dump(sinsp_evt* evt)
 	{
 		throw sinsp_exception(scap_getlasterr(m_inspector->m_h));
 	}
+
+	m_nevts++;
 }
 
 uint64_t sinsp_dumper::written_bytes()

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -170,6 +170,22 @@ uint64_t sinsp_dumper::written_bytes()
 	return written_bytes;
 }
 
+uint64_t sinsp_dumper::next_write_position()
+{
+	if(m_dumper == NULL)
+	{
+		return 0;
+	}
+
+	int64_t position = scap_dump_ftell(m_dumper);
+	if(position == -1)
+	{
+		throw sinsp_exception("error getting offset");
+	}
+
+	return position;
+}
+
 void sinsp_dumper::flush()
 {
 	if(m_dumper == NULL)

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -91,23 +91,23 @@ void sinsp_dumper::fdopen(int fd, bool compress, bool threads_from_sinsp)
 		throw sinsp_exception("can't start event dump, inspector not opened yet");
 	}
 
-	if(threads_from_sinsp)
-	{
-		m_inspector->m_thread_manager->to_scap();
-	}
-
 	if(compress)
 	{
-		m_dumper = scap_dump_open_fd(m_inspector->m_h, fd, SCAP_COMPRESSION_GZIP);
+		m_dumper = scap_dump_open_fd(m_inspector->m_h, fd, SCAP_COMPRESSION_GZIP, true);
 	}
 	else
 	{
-		m_dumper = scap_dump_open_fd(m_inspector->m_h, fd, SCAP_COMPRESSION_NONE);
+		m_dumper = scap_dump_open_fd(m_inspector->m_h, fd, SCAP_COMPRESSION_NONE, true);
 	}
 
 	if(m_dumper == NULL)
 	{
 		throw sinsp_exception(scap_getlasterr(m_inspector->m_h));
+	}
+
+	if(threads_from_sinsp)
+	{
+		m_inspector->m_thread_manager->dump_threads_to_file(m_dumper);
 	}
 
 	m_inspector->m_container_manager.dump_containers(m_dumper);

--- a/userspace/libsinsp/dumper.h
+++ b/userspace/libsinsp/dumper.h
@@ -97,6 +97,15 @@ public:
 	uint64_t written_bytes();
 
 	/*!
+	  \brief Return the starting position for the next write into
+          	  the file. (Under the covers, this uses gztell while
+        	  written_bytes uses gzoffset, which represent different values).
+
+	  \return The starting position for the next write.
+	*/
+	uint64_t next_write_position();
+
+	/*!
 	  \brief Flush all pending output into the file.
 	*/
 	void flush();

--- a/userspace/libsinsp/dumper.h
+++ b/userspace/libsinsp/dumper.h
@@ -69,10 +69,25 @@ public:
 		bool compress,
 		bool threads_from_sinsp=false);
 
+	void fdopen(int fd,
+		    bool compress,
+		    bool threads_from_sinsp=false);
+
 	/*!
 	  \brief Closes the dump file.
 	*/
 	void close();
+
+	/*!
+	  \brief Return whether or not the underling scap file has been
+	         opened.
+	*/
+	bool is_open();
+
+	/*!
+	  \brief Return the number of events dumped so far.
+	*/
+	bool written_events();
 
 	/*!
 	  \brief Return the current size of a tracefile.
@@ -103,6 +118,7 @@ private:
 	scap_dumper_t* m_dumper;
 	uint8_t* m_target_memory_buffer;
 	uint64_t m_target_memory_buffer_size;
+	uint64_t m_nevts;
 };
 
 /*@}*/

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -253,6 +253,16 @@ public:
 	*/
 	void open(string filename);
 
+	/*!
+	  \brief Start an event capture from a file descriptor.
+
+	  \param filename the trace file name.
+
+	  @throws a sinsp_exception containing the error string is thrown in case
+	   of failure.
+	*/
+	void fdopen(int fd);
+
 	void open_nodriver();
 
 	/*!
@@ -763,6 +773,7 @@ VISIBILITY_PRIVATE
 private:
 #endif
 
+	void open_int();
 	void init();
 	void import_thread_table();
 	void import_ifaddr_list();
@@ -834,11 +845,20 @@ private:
 
 	void restart_capture_at_filepos(uint64_t filepos);
 
+	void fseek(uint64_t filepos)
+	{
+		scap_fseek(m_h, filepos);
+	}
+
 	scap_t* m_h;
 	uint32_t m_nevts;
 	int64_t m_filesize;
 
 	scap_mode_t m_mode;
+
+        // If non-zero, reading from this fd and m_input_filename contains "fd
+        // <m_input_fd>". Otherwise, reading from m_input_filename.
+	int m_input_fd;
 	string m_input_filename;
 	bool m_isdebug_enabled;
 	bool m_isfatfile_enabled;


### PR DESCRIPTION
Add the ability to open scap files or inspectors from a fd. Makes it
possible to open other objects that return a fd and treat those objects
as if they were a file.

 - Add new functions scap_open_offline_fd, scap_dump_open_fd that take
   all the same arguments as their filename versions but take a fd
   instead of a filename. scap_open_offline_int now takes a gzfile which
   has been opened by one of the top-level functions.
 - scap_open's args struct now contains a fd. If non-zero, it takes
   precedence over filename and the fd is used to open a gzfile via
   gzdopen().
 - New function scap_event_reset_count sets the read event count to
   0. Used when rewinding a scap file to start over.
 - Add some more useful error messages to
   scap_read_{proclist,userlist,fdlist} when reading more than expected.
 - also add fdopen variants to sinsp_dumper/sinsp. They call the
   appropriate scap fd variants. most of sinsp::open moves to sinsp::open_int().
 - Add is_open() and written_events() methods to sinsp_dumper(). Useful
   when writing files via fd to track progress.
 - In sinsp::init(), after rewinding the file also reset the event
   count.
 - Add a sinsp::fseek() which just uses scap_fseek().