### PR TITLE
Perf scaling for excessive close() events

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -1305,7 +1305,7 @@ static inline int drop_event(struct ppm_consumer_t *consumer,
 			files = current->files;
 			spin_lock(&files->file_lock);
 			fdt = files_fdtable(files);
-			if (close_fd >= fdt->max_fds ||
+			if (close_fd < 0 || close_fd >= fdt->max_fds ||
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 4, 0))
 			    !FD_ISSET(close_fd, fdt->open_fds)
 #else

--- a/driver/main.c
+++ b/driver/main.c
@@ -1282,7 +1282,8 @@ static inline int drop_event(struct ppm_consumer_t *consumer,
 			     struct timespec *ts,
 			     struct pt_regs *regs)
 {
-	unsigned long close_fd = -1;
+	unsigned long close_arg = 0;
+	int close_fd = -1;
 	struct files_struct *files;
 	struct fdtable *fdt;
 	bool close_return = false;
@@ -1300,7 +1301,8 @@ static inline int drop_event(struct ppm_consumer_t *consumer,
 			if (syscall_get_return_value(current, regs) < 0)
 				close_return = true;
 		} else if (event_type == PPME_SYSCALL_CLOSE_E) {
-			syscall_get_arguments(current, regs, 0, 1, &close_fd);
+			syscall_get_arguments(current, regs, 0, 1, &close_arg);
+			close_fd = (int)close_arg;
 
 			files = current->files;
 			spin_lock(&files->file_lock);

--- a/driver/main.c
+++ b/driver/main.c
@@ -1299,6 +1299,7 @@ static inline int drop_event(struct ppm_consumer_t *consumer,
 	if (drop_flags & UF_NEVER_DROP) {
 		ASSERT((drop_flags & UF_ALWAYS_DROP) == 0);
 
+/*
 		// It's annoying but valid for a program to make a large number of
 		// close() calls on nonexistent fds. That can cause driver cpu usage
 		// to spike dramatically, so drop close events if the fd is not valid.
@@ -1321,6 +1322,7 @@ static inline int drop_event(struct ppm_consumer_t *consumer,
 			//	return 1;
 			//}
 		}
+*/
 
 		return 0;
 	}
@@ -1356,6 +1358,11 @@ static void record_event_all_consumers_ret(enum ppm_event_type event_type,
 {
 	struct ppm_consumer_t *consumer;
 	struct timespec ts;
+
+	if (event_type == PPME_SYSCALL_CLOSE_X && ret < 0) {
+		//&& consumer->dropping_mode ) {
+		return 1;
+	}
 
 	getnstimeofday(&ts);
 

--- a/driver/main.c
+++ b/driver/main.c
@@ -1301,8 +1301,15 @@ static inline int drop_event(struct ppm_consumer_t *consumer,
 			files = current->files;
 			spin_lock(&files->file_lock);
 			fdt = files_fdtable(files);
-			if (close_fd >= fdt->max_fds || !fd_is_open(close_fd, fdt)) {
-				close_return = true;
+			if (close_fd >= fdt->max_fds) {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 4, 0))
+				if (!FD_ISSET(close_fd, fdt->open_fds))
+#else
+				if (!fd_is_open(close_fd, fdt))
+#endif
+				{
+					close_return = true;
+				}
 			}
 			spin_unlock(&files->file_lock);
 		}


### PR DESCRIPTION
Check close() exit/enter events for a valid and open fd before doing any further processing. This prevents us from getting overwhelmed by applications who call close() on a large number of potentially invalid fds.