### PR TITLE
Fix rkt podid detection

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -399,7 +399,7 @@ bool sinsp_container_manager::resolve_container(sinsp_threadinfo* tinfo, bool qu
 					container_info.m_name = rkt_appname;
 					valid_id = true;
 					break;
-                                }
+				}
 			}
 		}
 	}

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -366,7 +366,7 @@ bool sinsp_container_manager::resolve_container(sinsp_threadinfo* tinfo, bool qu
 					string::size_type dot_pos = tokens[2].find('.');
 					if (dot_pos == string::npos)
 						continue;
-					string rkt_podid = tokens[2].substr(sizeof("machine-rkt") + 2, dot_pos - sizeof("machine-rkt") - 2);
+					string rkt_podid = tokens[2].substr(sizeof("machine-rkt") + 3, dot_pos - sizeof("machine-rkt") - 3);
 					replace_in_place(rkt_podid, "\\x2d", "-");
 					dot_pos = tokens[4].find('.');
 					if (dot_pos == string::npos)


### PR DESCRIPTION
cgroup layout of rkt is:

```
10:devices:/machine.slice/machine-rkt\x2d00b020fd\x2d32d6\x2d4d50\x2d95bb\x2d2a5983c17a4e.scope/system.slice/statsd-example.service
```

my container was given this id: `d00b020fd-32d6-4d50-95bb-2a5983c17a4e`

instead of: `00b020fd-d32d6-4d50-95bb-2a5983c17a4e`

this fix should cut out the extra `d`