### PR TITLE
Filterchecks fixes

### DIFF
--- a/userspace/libsinsp/chisel_api.cpp
+++ b/userspace/libsinsp/chisel_api.cpp
@@ -109,6 +109,7 @@ uint32_t lua_cbacks::rawval_to_lua_stack(lua_State *ls, uint8_t* rawval, const f
 			lua_pushnumber(ls, *(double*)rawval);
 			return 1;
 		case PT_CHARBUF:
+		case PT_FSPATH:
 			lua_pushlstring(ls, (char*)rawval, len);
 			return 1;
 		case PT_BYTEBUF:

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -31,11 +31,11 @@ typedef class sinsp_threadinfo sinsp_threadinfo;
 ///////////////////////////////////////////////////////////////////////////////
 typedef enum filtercheck_field_flags
 {
-	EPF_NONE = 0,
-	EPF_FILTER_ONLY, ///< this field can only be used as a filter.
-	EPF_PRINT_ONLY, ///< this field can only be printed.
-	EPF_REQUIRES_ARGUMENT, ///< this field includes an argument, under the form 'property.argument'.
-	EPF_TABLE_ONLY, ///< this field is desgned to be used in a table and won't appear in the list created by sysdig's '-l'.
+	EPF_NONE              = 0,
+	EPF_FILTER_ONLY       = 1 << 0, ///< this field can only be used as a filter.
+	EPF_PRINT_ONLY        = 1 << 1, ///< this field can only be printed.
+	EPF_REQUIRES_ARGUMENT = 1 << 2, ///< this field includes an argument, under the form 'property.argument'.
+	EPF_TABLE_ONLY        = 1 << 3, ///< this field is desgned to be used in a table and won't appear in the list created by sysdig's '-l'.
 }filtercheck_field_flags;
 
 /*!

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -694,6 +694,7 @@ Json::Value sinsp_filter_check::rawval_to_json(uint8_t* rawval, const filterchec
 			return Json::Value((bool)(*(uint32_t*)rawval != 0));
 
 		case PT_CHARBUF:
+		case PT_FSPATH:
 		case PT_BYTEBUF:
 		case PT_IPV4ADDR:
 			return rawval_to_string(rawval, finfo, len);
@@ -887,6 +888,7 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval, const filtercheck_fi
 					 prfmt, *(uint64_t *)rawval);
 			return m_getpropertystr_storage;
 		case PT_CHARBUF:
+		case PT_FSPATH:
 			return (char*)rawval;
 		case PT_BYTEBUF:
 			if(rawval[len] == 0)


### PR DESCRIPTION
- Filter field flags should be a bitmask

- Make sure rawval fields work also on PT_FSPATH, so a user can consume them (although the cwd won't be patched in that case)