### PR TITLE
Write trailing newlines immediately even in JSON mode

### DIFF
--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -284,8 +284,7 @@ bool sinsp_evt_formatter::tostring(sinsp_evt* evt, OUT string* res)
 	   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONHEXASCII
 	   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONBASE64)
 	{
-		(*res) = "\n";
-		(*res) += m_writer.write(m_root);
+		(*res) = m_writer.write(m_root);
 		(*res) = res->substr(0, res->size() - 1);
 	}
 

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -712,11 +712,7 @@ captureinfo do_inspect(sinsp* inspector,
 					}
 				}
 
-				cout << line;
-				if(!json)
-				{
-					cout << endl;
-				}
+				cout << line << endl;
 			}
 		}
 


### PR DESCRIPTION
Otherwise, even in unbuffered mode, we would not write a complete line
corresponding to an event until the next event had come in, when JSON output
was enabled.