### PR TITLE
Avoid overly-short 'lo' for log shortcut

### DIFF
--- a/userspace/libsinsp/cursestable.cpp
+++ b/userspace/libsinsp/cursestable.cpp
@@ -259,7 +259,7 @@ void curses_table::print_line_centered(string line, int32_t off)
 		for(uint32_t j = 0;; j++)
 		{
 			string ss = line.substr(spos, spos + m_parent->m_screenw);
-lo("2, %d %s\n", spos, ss.c_str());
+glogf("2, %d %s\n", spos, ss.c_str());
 
 			mvwprintw(m_tblwin, 
 				m_parent->m_screenh / 2 + off + j,

--- a/userspace/libsinsp/sinsp_int.h
+++ b/userspace/libsinsp/sinsp_int.h
@@ -98,7 +98,7 @@ using namespace std;
 // The logger
 //
 extern sinsp_logger g_logger;
-#define lo g_logger.format
+#define glogf g_logger.format
 
 //
 // Prototype of the callback invoked by the thread table when a thread is 


### PR DESCRIPTION
The define for lo is really short and can cause other strings that
contain lo to get redefined. Use glogf instead, which is a bit longer
but less likely to overlap.