### PR TITLE
Checking Sysdig with PVS-Studio static analyzer (#811)

### DIFF
--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -225,6 +225,17 @@ int32_t scap_proc_fill_cgroups(struct scap_threadinfo* tinfo, const char* procdi
 		return SCAP_FAILURE;\
 	}
 
+#define CHECK_READ_SIZE_WITH_FREE(alloc_buffer, read_size, expected_size) if(read_size != expected_size) \
+	{\
+		snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "expecting %d bytes, read %d at %s, line %d. Is the file truncated?",\
+			(int)expected_size,\
+			(int)read_size,\
+			__FILE__,\
+			__LINE__);\
+		free(alloc_buffer);\
+		return SCAP_FAILURE;\
+	}
+
 //
 // Useful stuff
 //

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -566,24 +566,24 @@ void scap_close(scap_t* handle)
 
 		ASSERT(handle->m_file == NULL);
 
-		//
-		// Destroy all the device descriptors
-		//
-		for(j = 0; j < handle->m_ndevs; j++)
-		{
-			if(handle->m_devs[j].m_buffer != MAP_FAILED)
-			{
-				munmap(handle->m_devs[j].m_bufinfo, sizeof(struct ppm_ring_buffer_info));
-				munmap(handle->m_devs[j].m_buffer, RING_BUF_SIZE * 2);
-				close(handle->m_devs[j].m_fd);
-			}
-		}
-
-		//
-		// Free the memory
-		//
 		if(handle->m_devs != NULL)
 		{
+			//
+			// Destroy all the device descriptors
+			//
+			for(j = 0; j < handle->m_ndevs; j++)
+			{
+				if(handle->m_devs[j].m_buffer != MAP_FAILED)
+				{
+				    munmap(handle->m_devs[j].m_bufinfo, sizeof(struct ppm_ring_buffer_info));
+				    munmap(handle->m_devs[j].m_buffer, RING_BUF_SIZE * 2);
+				    close(handle->m_devs[j].m_fd);
+				}
+			}
+
+			//
+			// Free the memory
+			//
 			free(handle->m_devs);
 		}
 #endif // HAS_CAPTURE

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1481,7 +1481,7 @@ static int32_t scap_read_iflist(scap_t *handle, gzFile f, uint32_t block_length)
 	}
 
 	readsize = gzread(f, readbuf, block_length);
-	CHECK_READ_SIZE(readsize, block_length);
+	CHECK_READ_SIZE_WITH_FREE(readbuf, readsize, block_length);
 
 	//
 	// First pass, count the number of addresses

--- a/userspace/libscap/scap_userlist.c
+++ b/userspace/libscap/scap_userlist.c
@@ -82,8 +82,8 @@ int32_t scap_create_userlist(scap_t* handle)
 	if(handle->m_userlist->groups == NULL)
 	{
 		snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "grouplist allocation failed(2)");
-		free(handle->m_userlist);
 		free(handle->m_userlist->users);
+		free(handle->m_userlist);
 		return SCAP_FAILURE;		
 	}
 

--- a/userspace/libsinsp/ctext.cpp
+++ b/userspace/libsinsp/ctext.cpp
@@ -240,12 +240,13 @@ int8_t ctext::str_search_single(ctext_search *to_search_in, ctext_search *new_po
 	size_t found;
 	string haystack;
 	ctext_search res, *out;
-	string query = to_search_in->_query; 
 
 	if(!to_search_in)
 	{
 		return -1;
 	}
+
+	string query = to_search_in->_query;
 
 	if(!new_pos_out) 
 	{

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -5456,7 +5456,7 @@ int32_t sinsp_filter_check_container::extract_arg(const string &val, size_t base
 	try
 	{
 		m_argid = sinsp_numparser::parsed32(numstr);
-	} catch (sinsp_exception e)
+	} catch (sinsp_exception &e)
 	{
 		if(strstr(e.what(), "is not a valid number") == NULL)
 		{

--- a/userspace/libsinsp/socket_collector.h
+++ b/userspace/libsinsp/socket_collector.h
@@ -60,7 +60,8 @@ public:
 			handler->enable();
 			return;
 		}
-		g_logger.log("Socket collector: attempt to enable non-existing handler: " + handler->get_id());
+		g_logger.log("Socket collector: attempt to enable non-existing handler.",
+			     sinsp_logger::SEV_ERROR);
 	}
 
 	int get_socket(std::shared_ptr<T> handler) const


### PR DESCRIPTION
commit 9f1bc35e10cef0a59e3640947794df23b27c211d
Author: Phillip Khandeliants <khandeliants@viva64.com>
Date:   Fri Apr 14 16:11:10 2017 +0300

    Fixed V746 : Type slicing

    It is much better and safer to catch the exception by reference, not by the value.

    sysdig-CLA-1.0-contributing-entity: "Program Verification Systems" (Co Ltd)
    sysdig-CLA-1.0-signed-off-by: Phillip Khandeliants <khandeliants@viva64.com>

commit 98aa8b4fb6cea2c7c2d3e56cacb5f16b6d968d03
Author: Phillip Khandeliants <khandeliants@viva64.com>
Date:   Fri Apr 14 15:58:27 2017 +0300

    Fixed CWE-476: NULL Pointer Dereference (Analyzer warning: V595)

    Potential dereference of the null pointer is possible,
    since immediately after dereferencing, a 'to_search_in' pointer checked against nullptr.

    sysdig-CLA-1.0-contributing-entity: "Program Verification Systems" (Co Ltd)
    sysdig-CLA-1.0-signed-off-by: Phillip Khandeliants <khandeliants@viva64.com>

commit dd242fdd8962a3fbfa4c745e12de8090e881bc1e
Author: Phillip Khandeliants <khandeliants@viva64.com>
Date:   Fri Apr 14 15:54:09 2017 +0300

    Fixed CWE-476: NULL Pointer Dereference (Analyzer warning: V595)

    The pointer is dereferenced in a loop.
    Below in the code there is a check of this pointer to the nullptr,
    therefore, in the loop might be potential null pointer dereference.

    sysdig-CLA-1.0-contributing-entity: "Program Verification Systems" (Co Ltd)
    sysdig-CLA-1.0-signed-off-by: Phillip Khandeliants <khandeliants@viva64.com>

commit e9234751aa9afa1cfdbc88b4393d07ea9ebee587
Author: Phillip Khandeliants <khandeliants@viva64.com>
Date:   Fri Apr 14 15:48:06 2017 +0300

    Fixed CWE-476: NULL Pointer Dereference (Analyzer warning: V522)

    If the condition fails, the 'handler' will be guaranteed to be a null pointer,
    accordingly, the null pointer will be dereferenced.

    sysdig-CLA-1.0-contributing-entity: "Program Verification Systems" (Co Ltd)
    sysdig-CLA-1.0-signed-off-by: Phillip Khandeliants <khandeliants@viva64.com>

commit 6aecf7b7ca75ecf0e5eda81f067c754ea7fc4b53
Author: Phillip Khandeliants <khandeliants@viva64.com>
Date:   Fri Apr 14 15:44:05 2017 +0300

    Fixed CWE-416: Use after free (Analyzer warning: V774)

    There is an incorrect order of release:
    It is necessary to first free memory by pointer 'handle->m_userlist->users',
    only then by the pointer 'handle->m_userlist'.

    sysdig-CLA-1.0-contributing-entity: "Program Verification Systems" (Co Ltd)
    sysdig-CLA-1.0-signed-off-by: Phillip Khandeliants <khandeliants@viva64.com>

commit 83c42bd5b5d43a0433780ae4ded7279694014b50
Author: Phillip Khandeliants <khandeliants@viva64.com>
Date:   Fri Apr 14 15:36:58 2017 +0300

    Fixed the CWE-401: Memory Leak (Analyzer warning: V773)

    When the macro 'CHECK_READ_SIZE' is expanded,
    if the number of bytes read does not match the expected one,
    the function exits without releasing the 'readbuf' buffer.

    sysdig-CLA-1.0-contributing-entity: "Program Verification Systems" (Co Ltd)
    sysdig-CLA-1.0-signed-off-by: Phillip Khandeliants <khandeliants@viva64.com>