### PR TITLE
Collect flags when parsing regular files from /proc

### DIFF
--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -86,13 +86,13 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #define PPM_O_WRONLY	(1 << 1)	/* Open for writing only */
 #define PPM_O_RDWR	(PPM_O_RDONLY | PPM_O_WRONLY)	/* Open for reading and writing */
 #define PPM_O_CREAT	(1 << 2)	/* Create a new file if it doesn't exist. */
-#define PPM_O_APPEND (1 << 3)	/* If set, the file offset shall be set to the end of the file prior to each write. */
+#define PPM_O_APPEND	(1 << 3)	/* If set, the file offset shall be set to the end of the file prior to each write. */
 #define PPM_O_DSYNC	(1 << 4)
 #define PPM_O_EXCL	(1 << 5)
 #define PPM_O_NONBLOCK	(1 << 6)
 #define PPM_O_SYNC	(1 << 7)
 #define PPM_O_TRUNC	(1 << 8)
-#define PPM_O_DIRECT (1 << 9)
+#define PPM_O_DIRECT	(1 << 9)
 #define PPM_O_DIRECTORY (1 << 10)
 #define PPM_O_LARGEFILE (1 << 11)
 #define PPM_O_CLOEXEC	(1 << 12)

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -187,6 +187,7 @@ typedef struct scap_fdinfo
 		struct
 		{
 			uint32_t open_flags; ///< Flags associated with the file
+			char fname[SCAP_MAX_PATH_SIZE]; ///< Name associated to this file
 		} regularinfo; ///< Information specific to regular files
 		char fname[SCAP_MAX_PATH_SIZE];  ///< The name for file system FDs
 	}info;

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -123,7 +123,8 @@ typedef enum scap_fd_type
 	SCAP_FD_EVENTPOLL = 12,
 	SCAP_FD_INOTIFY = 13,
 	SCAP_FD_TIMERFD = 14,
-	SCAP_FD_NETLINK = 15
+	SCAP_FD_NETLINK = 15,
+	SCAP_FD_FILE_V2 = 16
 }scap_fd_type;
 
 /*!
@@ -183,6 +184,10 @@ typedef struct scap_fdinfo
 		  	uint64_t destination; ///< Destination socket endpoint
 			char fname[SCAP_MAX_PATH_SIZE]; ///< Name associated to this unix socket
 		} unix_socket_info; ///< Information specific to unix sockets
+		struct
+		{
+			uint32_t open_flags; ///< Flags associated with the file
+		} regularinfo; ///< Information specific to regular files
 		char fname[SCAP_MAX_PATH_SIZE];  ///< The name for file system FDs
 	}info;
 	UT_hash_handle hh; ///< makes this structure hashable

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -53,6 +53,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #define SOCKET_SCAN_BUFFER_SIZE 1024 * 1024
+#define NAME_SIZE 1024
 
 int32_t scap_fd_print_ipv6_socket_info(scap_fdinfo *fdi, OUT char *str, uint32_t stlen)
 {
@@ -583,12 +584,12 @@ int32_t scap_add_fd_to_proc_table(scap_t *handle, scap_threadinfo *tinfo, scap_f
 
 int32_t scap_fd_handle_pipe(scap_t *handle, char *fname, scap_threadinfo *tinfo, scap_fdinfo *fdi, char *error)
 {
-	char link_name[1024];
+	char link_name[NAME_SIZE];
 	ssize_t r;
 	uint64_t ino;
 	struct stat sb;
 
-	r = readlink(fname, link_name, 1024);
+	r = readlink(fname, link_name, NAME_SIZE);
 	if (r <= 0)
 	{
 		return SCAP_FAILURE;
@@ -612,10 +613,10 @@ int32_t scap_fd_handle_pipe(scap_t *handle, char *fname, scap_threadinfo *tinfo,
 
 int32_t scap_fd_handle_regular_file(scap_t *handle, char *fname, scap_threadinfo *tinfo, scap_fdinfo *fdi, char *error)
 {
-	char link_name[1024];
+	char link_name[NAME_SIZE];
 	ssize_t r;
 
-	r = readlink(fname, link_name, 1024);
+	r = readlink(fname, link_name, NAME_SIZE);
 	if (r <= 0)
 	{
 		return SCAP_SUCCESS;
@@ -651,7 +652,7 @@ int32_t scap_fd_handle_regular_file(scap_t *handle, char *fname, scap_threadinfo
 		if(SCAP_FD_UNSUPPORTED == fdi->type)
 		{
 			// still not able to classify
-//			printf("unsupported %s -> %s\n",fname,link_name);
+			// printf("unsupported %s -> %s\n",fname,link_name);
 		}
 		fdi->info.fname[0] = '\0';
 	} else {
@@ -663,7 +664,7 @@ int32_t scap_fd_handle_regular_file(scap_t *handle, char *fname, scap_threadinfo
 
 int32_t scap_fd_handle_socket(scap_t *handle, char *fname, scap_threadinfo *tinfo, scap_fdinfo *fdi, char* procdir, uint64_t net_ns, struct scap_ns_socket_list **sockets_by_ns, char *error)
 {
-	char link_name[1024];
+	char link_name[NAME_SIZE];
 	ssize_t r;
 	scap_fdinfo *tfdi;
 	uint64_t ino;
@@ -698,7 +699,7 @@ int32_t scap_fd_handle_socket(scap_t *handle, char *fname, scap_threadinfo *tinf
 		}
 	}
 
-	r = readlink(fname, link_name, 1024);
+	r = readlink(fname, link_name, NAME_SIZE);
 	if(r <= 0)
 	{
 		return SCAP_SUCCESS;
@@ -736,7 +737,7 @@ int32_t scap_fd_handle_socket(scap_t *handle, char *fname, scap_threadinfo *tinf
 int32_t scap_fd_read_unix_sockets_from_proc_fs(scap_t *handle, const char* filename, scap_fdinfo **sockets)
 {
 	FILE *f;
-	char line[1024];
+	char line[NAME_SIZE];
 	int first_line = false;
 	char *delimiters = " \t";
 	char *token;
@@ -861,7 +862,7 @@ int32_t scap_fd_read_unix_sockets_from_proc_fs(scap_t *handle, const char* filen
 int32_t scap_fd_read_netlink_sockets_from_proc_fs(scap_t *handle, const char* filename, scap_fdinfo **sockets)
 {
 	FILE *f;
-	char line[1024];
+	char line[NAME_SIZE];
 	int first_line = false;
 	char *delimiters = " \t";
 	char *token;
@@ -1529,9 +1530,9 @@ int32_t scap_fd_scan_fd_dir(scap_t *handle, char *procdir, scap_threadinfo *tinf
 	DIR *dir_p;
 	struct dirent *dir_entry_p;
 	int32_t res = SCAP_SUCCESS;
-	char fd_dir_name[1024];
-	char f_name[1024];
-	char link_name[1024];
+	char fd_dir_name[NAME_SIZE];
+	char f_name[NAME_SIZE];
+	char link_name[NAME_SIZE];
 	struct stat sb;
 	uint64_t fd;
 	scap_fdinfo *fdi = NULL;
@@ -1539,7 +1540,7 @@ int32_t scap_fd_scan_fd_dir(scap_t *handle, char *procdir, scap_threadinfo *tinf
 	ssize_t r;
 	uint16_t fd_added = 0;
 
-	snprintf(fd_dir_name, 1024, "%sfd", procdir);
+	snprintf(fd_dir_name, NAME_SIZE, "%sfd", procdir);
 	dir_p = opendir(fd_dir_name);
 	if(dir_p == NULL)
 	{
@@ -1569,7 +1570,7 @@ int32_t scap_fd_scan_fd_dir(scap_t *handle, char *procdir, scap_threadinfo *tinf
 		(handle->m_fd_lookup_limit == 0 || fd_added < handle->m_fd_lookup_limit))
 	{
 		fdi = NULL;
-		snprintf(f_name, 1024, "%s/%s", fd_dir_name, dir_entry_p->d_name);
+		snprintf(f_name, NAME_SIZE, "%s/%s", fd_dir_name, dir_entry_p->d_name);
 
 		if(-1 == stat(f_name, &sb) || 1 != sscanf(dir_entry_p->d_name, "%"PRIu64, &fd))
 		{

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -54,7 +54,6 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #define SOCKET_SCAN_BUFFER_SIZE 1024 * 1024
-#define NAME_SIZE 1024
 
 int32_t scap_fd_print_ipv6_socket_info(scap_fdinfo *fdi, OUT char *str, uint32_t stlen)
 {
@@ -614,12 +613,12 @@ int32_t scap_add_fd_to_proc_table(scap_t *handle, scap_threadinfo *tinfo, scap_f
 
 int32_t scap_fd_handle_pipe(scap_t *handle, char *fname, scap_threadinfo *tinfo, scap_fdinfo *fdi, char *error)
 {
-	char link_name[NAME_SIZE];
+	char link_name[SCAP_MAX_PATH_SIZE];
 	ssize_t r;
 	uint64_t ino;
 	struct stat sb;
 
-	r = readlink(fname, link_name, NAME_SIZE);
+	r = readlink(fname, link_name, SCAP_MAX_PATH_SIZE);
 	if (r <= 0)
 	{
 		return SCAP_FAILURE;
@@ -705,11 +704,11 @@ void scap_fd_flags_file(scap_t *handle, scap_fdinfo *fdi, const char *procdir)
 {
 	int is_first_line = true;
 	const char *delimiters = " \t";
-	char fd_dir_name[NAME_SIZE];
-	char line[NAME_SIZE];
+	char fd_dir_name[SCAP_MAX_PATH_SIZE];
+	char line[SCAP_MAX_PATH_SIZE];
 	FILE *finfo;
 
-	snprintf(fd_dir_name, NAME_SIZE, "%sfdinfo/%ld", procdir, fdi->fd);
+	snprintf(fd_dir_name, SCAP_MAX_PATH_SIZE, "%sfdinfo/%ld", procdir, fdi->fd);
 	finfo = fopen(fd_dir_name, "r");
 	if(finfo == NULL)
 	{
@@ -769,10 +768,10 @@ void scap_fd_flags_file(scap_t *handle, scap_fdinfo *fdi, const char *procdir)
 
 int32_t scap_fd_handle_regular_file(scap_t *handle, char *fname, scap_threadinfo *tinfo, scap_fdinfo *fdi, const char *procdir, char *error)
 {
-	char link_name[NAME_SIZE];
+	char link_name[SCAP_MAX_PATH_SIZE];
 	ssize_t r;
 
-	r = readlink(fname, link_name, NAME_SIZE);
+	r = readlink(fname, link_name, SCAP_MAX_PATH_SIZE);
 	if (r <= 0)
 	{
 		return SCAP_SUCCESS;
@@ -827,7 +826,7 @@ int32_t scap_fd_handle_regular_file(scap_t *handle, char *fname, scap_threadinfo
 
 int32_t scap_fd_handle_socket(scap_t *handle, char *fname, scap_threadinfo *tinfo, scap_fdinfo *fdi, char* procdir, uint64_t net_ns, struct scap_ns_socket_list **sockets_by_ns, char *error)
 {
-	char link_name[NAME_SIZE];
+	char link_name[SCAP_MAX_PATH_SIZE];
 	ssize_t r;
 	scap_fdinfo *tfdi;
 	uint64_t ino;
@@ -862,7 +861,7 @@ int32_t scap_fd_handle_socket(scap_t *handle, char *fname, scap_threadinfo *tinf
 		}
 	}
 
-	r = readlink(fname, link_name, NAME_SIZE);
+	r = readlink(fname, link_name, SCAP_MAX_PATH_SIZE);
 	if(r <= 0)
 	{
 		return SCAP_SUCCESS;
@@ -900,7 +899,7 @@ int32_t scap_fd_handle_socket(scap_t *handle, char *fname, scap_threadinfo *tinf
 int32_t scap_fd_read_unix_sockets_from_proc_fs(scap_t *handle, const char* filename, scap_fdinfo **sockets)
 {
 	FILE *f;
-	char line[NAME_SIZE];
+	char line[SCAP_MAX_PATH_SIZE];
 	int first_line = false;
 	char *delimiters = " \t";
 	char *token;
@@ -1025,7 +1024,7 @@ int32_t scap_fd_read_unix_sockets_from_proc_fs(scap_t *handle, const char* filen
 int32_t scap_fd_read_netlink_sockets_from_proc_fs(scap_t *handle, const char* filename, scap_fdinfo **sockets)
 {
 	FILE *f;
-	char line[NAME_SIZE];
+	char line[SCAP_MAX_PATH_SIZE];
 	int first_line = false;
 	char *delimiters = " \t";
 	char *token;
@@ -1693,9 +1692,9 @@ int32_t scap_fd_scan_fd_dir(scap_t *handle, char *procdir, scap_threadinfo *tinf
 	DIR *dir_p;
 	struct dirent *dir_entry_p;
 	int32_t res = SCAP_SUCCESS;
-	char fd_dir_name[NAME_SIZE];
-	char f_name[NAME_SIZE];
-	char link_name[NAME_SIZE];
+	char fd_dir_name[SCAP_MAX_PATH_SIZE];
+	char f_name[SCAP_MAX_PATH_SIZE];
+	char link_name[SCAP_MAX_PATH_SIZE];
 	struct stat sb;
 	uint64_t fd;
 	scap_fdinfo *fdi = NULL;
@@ -1703,7 +1702,7 @@ int32_t scap_fd_scan_fd_dir(scap_t *handle, char *procdir, scap_threadinfo *tinf
 	ssize_t r;
 	uint16_t fd_added = 0;
 
-	snprintf(fd_dir_name, NAME_SIZE, "%sfd", procdir);
+	snprintf(fd_dir_name, SCAP_MAX_PATH_SIZE, "%sfd", procdir);
 	dir_p = opendir(fd_dir_name);
 	if(dir_p == NULL)
 	{
@@ -1733,7 +1732,7 @@ int32_t scap_fd_scan_fd_dir(scap_t *handle, char *procdir, scap_threadinfo *tinf
 		(handle->m_fd_lookup_limit == 0 || fd_added < handle->m_fd_lookup_limit))
 	{
 		fdi = NULL;
-		snprintf(f_name, NAME_SIZE, "%s/%s", fd_dir_name, dir_entry_p->d_name);
+		snprintf(f_name, SCAP_MAX_PATH_SIZE, "%s/%s", fd_dir_name, dir_entry_p->d_name);
 
 		if(-1 == stat(f_name, &sb) || 1 != sscanf(dir_entry_p->d_name, "%"PRIu64, &fd))
 		{

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -815,6 +815,7 @@ int32_t scap_fd_handle_regular_file(scap_t *handle, char *fname, scap_threadinfo
 	else if(fdi->type == SCAP_FD_FILE_V2)
 	{
 		scap_fd_flags_file(handle, fdi, procdir);
+		strncpy(fdi->info.regularinfo.fname, link_name, SCAP_MAX_PATH_SIZE);
 	}
 	else
 	{

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2360,6 +2360,7 @@ void sinsp_evt::get_category(OUT sinsp_evt::category* cat)
 				switch(m_fdinfo->m_type)
 				{
 					case SCAP_FD_FILE:
+					case SCAP_FD_FILE_V2:
 					case SCAP_FD_DIRECTORY:
 						cat->m_subcategory = SC_FILE;
 						break;

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -53,6 +53,7 @@ template<> char sinsp_fdinfo_t::get_typechar()
 {
 	switch(m_type)
 	{
+	case SCAP_FD_FILE_V2:
 	case SCAP_FD_FILE:
 		return CHAR_FD_FILE;
 	case SCAP_FD_IPV4_SOCK:
@@ -95,6 +96,7 @@ template<> char* sinsp_fdinfo_t::get_typestring()
 {
 	switch(m_type)
 	{
+	case SCAP_FD_FILE_V2:
 	case SCAP_FD_FILE:
 		return (char*)"file";
 	case SCAP_FD_DIRECTORY:

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -219,7 +219,7 @@ public:
 	*/
 	bool is_file()
 	{
-		return m_type == SCAP_FD_FILE;
+		return m_type == SCAP_FD_FILE || m_type == SCAP_FD_FILE_V2;
 	}
 
 	/*!

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -3662,6 +3662,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 			if(fdinfo != NULL)
 			{
 				if(fdinfo->m_type == SCAP_FD_FILE ||
+					fdinfo->m_type == SCAP_FD_FILE_V2 ||
 					fdinfo->m_type == SCAP_FD_DIRECTORY)
 				{
 					return extract_error_count(evt, len);
@@ -3730,6 +3731,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 			if(fdinfo != NULL)
 			{
 				if(!(fdinfo->m_type == SCAP_FD_FILE ||
+					fdinfo->m_type == SCAP_FD_FILE_V2 ||
 					fdinfo->m_type == SCAP_FD_DIRECTORY ||
 					fdinfo->m_type == SCAP_FD_IPV4_SOCK ||
 					fdinfo->m_type == SCAP_FD_IPV6_SOCK ||
@@ -3818,7 +3820,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 	case TYPE_BUFLEN_FILE:
 		if(evt->m_fdinfo && evt->get_category() & EC_IO_BASE)
 		{
-			if(evt->m_fdinfo->m_type == SCAP_FD_FILE)
+			if(evt->m_fdinfo->m_type == SCAP_FD_FILE || evt->m_fdinfo->m_type == SCAP_FD_FILE_V2)
 			{
 				return extract_buflen(evt);
 			}
@@ -3828,7 +3830,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 	case TYPE_BUFLEN_FILE_IN:
 		if(evt->m_fdinfo && evt->get_category() == EC_IO_READ)
 		{
-			if(evt->m_fdinfo->m_type == SCAP_FD_FILE)
+			if(evt->m_fdinfo->m_type == SCAP_FD_FILE || evt->m_fdinfo->m_type == SCAP_FD_FILE_V2)
 			{
 				return extract_buflen(evt);
 			}
@@ -3838,7 +3840,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 	case TYPE_BUFLEN_FILE_OUT:
 		if(evt->m_fdinfo && evt->get_category() == EC_IO_WRITE)
 		{
-			if(evt->m_fdinfo->m_type == SCAP_FD_FILE)
+			if(evt->m_fdinfo->m_type == SCAP_FD_FILE || evt->m_fdinfo->m_type == SCAP_FD_FILE_V2)
 			{
 				return extract_buflen(evt);
 			}

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1918,7 +1918,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 		}
 		else
 		{
-			fdi.m_type = SCAP_FD_FILE;
+			fdi.m_type = SCAP_FD_FILE_V2;
 		}
 
 		fdi.m_openflags = flags;

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -299,6 +299,7 @@ void sinsp_threadinfo::add_fd_from_scap(scap_fdinfo *fdi, OUT sinsp_fdinfo_t *re
 		break;
 	case SCAP_FD_FILE_V2:
 		newfdi->m_openflags = fdi->info.regularinfo.open_flags;
+		newfdi->m_name = fdi->info.regularinfo.fname;
 		break;
 	case SCAP_FD_FIFO:
 	case SCAP_FD_FILE:
@@ -1056,6 +1057,7 @@ void sinsp_threadinfo::fd_to_scap(scap_fdinfo *dst, sinsp_fdinfo_t* src)
 		break;
 	case SCAP_FD_FILE_V2:
 		dst->info.regularinfo.open_flags = src->m_openflags;
+		strncpy(dst->info.regularinfo.fname, src->m_name.c_str(), SCAP_MAX_PATH_SIZE);
 		break;
 	case SCAP_FD_FIFO:
 	case SCAP_FD_FILE:

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1054,6 +1054,9 @@ void sinsp_threadinfo::fd_to_scap(scap_fdinfo *dst, sinsp_fdinfo_t* src)
 		dst->info.unix_socket_info.destination = src->m_sockinfo.m_unixinfo.m_fields.m_dest;
 		strncpy(dst->info.unix_socket_info.fname, src->m_name.c_str(), SCAP_MAX_PATH_SIZE);
 		break;
+	case SCAP_FD_FILE_V2:
+		dst->info.regularinfo.open_flags = src->m_openflags;
+		break;
 	case SCAP_FD_FIFO:
 	case SCAP_FD_FILE:
 	case SCAP_FD_DIRECTORY:

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -297,6 +297,9 @@ void sinsp_threadinfo::add_fd_from_scap(scap_fdinfo *fdi, OUT sinsp_fdinfo_t *re
 			newfdi->set_role_server();
 		}
 		break;
+	case SCAP_FD_FILE_V2:
+		newfdi->m_openflags = fdi->info.regularinfo.open_flags;
+		break;
 	case SCAP_FD_FIFO:
 	case SCAP_FD_FILE:
 	case SCAP_FD_DIRECTORY:


### PR DESCRIPTION
An overview of the patch:
* it gets flags info from /proc/XXX/fdinfo/YY for each regular file and uses them in `sinsp_fdinfo.open_flags`
* it introduces a V2 of SCAP_FD_INFO in `scap_fd_type`, so that we can still read old SCAP_FD_FILE. This actually leads to more changes in the code than I'd like, but I think the right thing to do in the future would be to create a new type sinsp_fd_type used by sinsp and keep using scap_fd_type in scap. 