### PR TITLE
Add more detail when giving up after 100 reads

### DIFF
--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -371,8 +371,8 @@ public:
 			if(++counter > 100)
 			{
 				throw sinsp_exception("Socket handler (" + m_id + "): "
-									  "unable to retrieve data from " + m_url.to_string(false) + m_path +
-									  " (" + std::to_string(counter) + " attempts)");
+						      "unable to retrieve data from " + m_url.to_string(false) + m_path +
+						      " (" + std::to_string(counter) + " attempts, read " + std::to_string(processed) + " bytes)");
 			}
 			else { usleep(10000); }
 		} while(!m_msg_completed);


### PR DESCRIPTION
Add details on the number of bytes actually read when giving up after
100 reads. This will be used to get more information on the cause of
https://github.com/draios/sysdig/issues/856, which is suspected to be
related to reading really long responses.