### PR TITLE
use `class_device_destroy` on older kernel versions

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -2215,7 +2215,13 @@ int sysdig_init(void)
 
 init_module_err:
 	for (j = 0; j < n_created_devices; ++j) {
-		device_destroy(g_ppm_class, g_ppm_devs[j].dev);
+#if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)
+		device_destroy(
+#else
+		class_device_destroy(
+#endif
+				g_ppm_class, g_ppm_devs[j].dev);
+
 		cdev_del(&g_ppm_devs[j].cdev);
 	}
 
@@ -2237,7 +2243,12 @@ void sysdig_exit(void)
 	pr_info("driver unloading\n");
 
 	for (j = 0; j < g_ppm_numdevs; ++j) {
-		device_destroy(g_ppm_class, g_ppm_devs[j].dev);
+#if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)
+		device_destroy(
+#else
+		class_device_destroy(
+#endif
+				g_ppm_class, g_ppm_devs[j].dev);
 		cdev_del(&g_ppm_devs[j].cdev);
 	}
 


### PR DESCRIPTION
Currently, the `device_destroy()` function doesn't clean the `/dev/sysdig*` devices on older kernels
sysdig-CLA-1.0-contributing-entity: Amir Rossert
sysdig-CLA-1.0-signed-off-by: John Tsai johntsai@paypal.com