### PR TITLE
use 'linux/file.h' on older kernels

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -49,7 +49,11 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include <linux/tracepoint.h>
 #include <linux/cpu.h>
 #include <linux/jiffies.h>
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 26))
+#include <linux/file.h>
+#else
 #include <linux/fdtable.h>
+#endif
 #include <net/sock.h>
 #include <asm/asm-offsets.h>	/* For NR_syscalls */
 #include <asm/unistd.h>


### PR DESCRIPTION
Following PR #852: 
`linux/fdtable.h` was introduced in kernel 2.6.26, use `linux/file.h` instead.
sysdig-CLA-1.0-contributing-entity: Amir Rossert
sysdig-CLA-1.0-signed-off-by: John Tsai johntsai@paypal.com