### PR TITLE
Change initial read to byte limit + increase

### DIFF
--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -368,11 +368,15 @@ public:
 				//g_logger.log("Socket handler (" + m_id + ") received=" + std::to_string(rec) +
 				//			 "\n\n" + data + "\n\n", sinsp_logger::SEV_TRACE);
 			}
-			if(++counter > 100)
+
+                        // To prevent reads from entirely stalling (like in gigantic k8s
+                        // environments), give up after reading 30mb.
+			++counter;
+			if(processed > 30 * 1024 * 1024)
 			{
 				throw sinsp_exception("Socket handler (" + m_id + "): "
-						      "unable to retrieve data from " + m_url.to_string(false) + m_path +
-						      " (" + std::to_string(counter) + " attempts, read " + std::to_string(processed) + " bytes)");
+						      "read more than 30MB of data from " + m_url.to_string(false) + m_path +
+						      " (" + std::to_string(processed) + " bytes, " + std::to_string(counter) + " reads). Giving up");
 			}
 			else { usleep(10000); }
 		} while(!m_msg_completed);


### PR DESCRIPTION
In get_all_data(), which is used when initially reading k8s environment
data, there used to be a limit on the number of reads performed. This
was a bit sensitive to the packet size and delivery pattern, and in some
cases could give up after as few as 50-100k.

Change this to a limit on the number of bytes read, and change the limit
to 30mb.

This fixes https://github.com/draios/sysdig/issues/856.