### PR TITLE
fix compile errors when O_DIRECTORY not defined

### DIFF
--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -684,8 +684,10 @@ static inline uint32_t open_flags_to_scap(unsigned long flags)
 		res |= PPM_O_DIRECT;
 #endif
 
+#ifdef O_DIRECTORY
 	if (flags & O_DIRECTORY)
 		res |= PPM_O_DIRECTORY;
+#endif
 
 #ifdef O_LARGEFILE
 	if (flags & O_LARGEFILE)


### PR DESCRIPTION
sysdig-CLA-1.0-contributing-entity: Amir Rossert
sysdig-CLA-1.0-signed-off-by: John Tsai johntsai@paypal.com