### PR TITLE
Don't include curlbuild.h

### DIFF
--- a/userspace/libsinsp/marathon_http.cpp
+++ b/userspace/libsinsp/marathon_http.cpp
@@ -7,7 +7,6 @@
 #include "marathon_http.h"
 #include "curl/curl.h"
 #include "curl/easy.h"
-#include "curl/curlbuild.h"
 #define BUFFERSIZE 512 // b64 needs this macro
 #include "b64/encode.h"
 #include "sinsp.h"

--- a/userspace/libsinsp/mesos_http.cpp
+++ b/userspace/libsinsp/mesos_http.cpp
@@ -7,7 +7,6 @@
 #include "mesos_http.h"
 #include "curl/curl.h"
 #include "curl/easy.h"
-#include "curl/curlbuild.h"
 #include "sinsp.h"
 #include "sinsp_int.h"
 #include "sinsp_curl.h"

--- a/userspace/sysdig.project
+++ b/userspace/sysdig.project
@@ -752,7 +752,6 @@
             </VirtualDirectory>
             <VirtualDirectory Name="include">
               <VirtualDirectory Name="curl">
-                <File Name="../build/release/curl-prefix/src/curl/include/curl/curlbuild.h"/>
                 <File Name="../build/release/curl-prefix/src/curl/include/curl/easy.h"/>
                 <File Name="../build/release/curl-prefix/src/curl/include/curl/stdcheaders.h"/>
                 <File Name="../build/release/curl-prefix/src/curl/include/curl/curlrules.h"/>


### PR DESCRIPTION
It's not required to build and it's not present with some newer versions
of libcurl, so removing it.

Thanks to https://github.com/hhoffstaette for the tip.

This fixes https://github.com/draios/sysdig/issues/895.