### PR TITLE
Return container meta events.

### DIFF
--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -302,7 +302,7 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_SYSCALL_MKDIR_2_X */{"mkdir", EC_FILE, EF_NONE, 2, {{"res", PT_ERRNO, PF_DEC}, {"path", PT_FSPATH, PF_NA} } },
 	/* PPME_SYSCALL_RMDIR_2_E */{"rmdir", EC_FILE, EF_NONE, 0},
 	/* PPME_SYSCALL_RMDIR_2_X */{"rmdir", EC_FILE, EF_NONE, 2, {{"res", PT_ERRNO, PF_DEC}, {"path", PT_FSPATH, PF_NA} } },
-	/* PPME_NOTIFICATION_E */{"notification", EC_OTHER, EF_SKIPPARSERESET, 2, {{"id", PT_CHARBUF, PF_DEC}, {"desc", PT_CHARBUF, PF_NA}, } },
+	/* PPME_NOTIFICATION_E */{"notification", EC_INTERNAL, EF_SKIPPARSERESET, 2, {{"id", PT_CHARBUF, PF_DEC}, {"desc", PT_CHARBUF, PF_NA}, } },
 	/* PPME_NOTIFICATION_X */{"NA4", EC_SYSTEM, EF_UNUSED, 0},
 	/* PPME_SYSCALL_EXECVE_17_E */{"execve", EC_PROCESS, EF_MODIFIES_STATE, 0},
 	/* PPME_SYSCALL_EXECVE_17_X */{"execve", EC_PROCESS, EF_MODIFIES_STATE, 17, {{"res", PT_ERRNO, PF_DEC}, {"exe", PT_CHARBUF, PF_NA}, {"args", PT_BYTEBUF, PF_NA}, {"tid", PT_PID, PF_DEC}, {"pid", PT_PID, PF_DEC}, {"ptid", PT_PID, PF_DEC}, {"cwd", PT_CHARBUF, PF_NA}, {"fdlimit", PT_UINT64, PF_DEC}, {"pgft_maj", PT_UINT64, PF_DEC}, {"pgft_min", PT_UINT64, PF_DEC}, {"vm_size", PT_UINT32, PF_DEC}, {"vm_rss", PT_UINT32, PF_DEC}, {"vm_swap", PT_UINT32, PF_DEC}, {"comm", PT_CHARBUF, PF_NA}, {"cgroups", PT_BYTEBUF, PF_NA}, {"env", PT_BYTEBUF, PF_NA}, {"tty", PT_INT32, PF_DEC} } },

--- a/userspace/libscap/event_table.c
+++ b/userspace/libscap/event_table.c
@@ -302,7 +302,7 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_SYSCALL_MKDIR_2_X */{"mkdir", EC_FILE, EF_NONE, 2, {{"res", PT_ERRNO, PF_DEC}, {"path", PT_FSPATH, PF_NA} } },
 	/* PPME_SYSCALL_RMDIR_2_E */{"rmdir", EC_FILE, EF_NONE, 0},
 	/* PPME_SYSCALL_RMDIR_2_X */{"rmdir", EC_FILE, EF_NONE, 2, {{"res", PT_ERRNO, PF_DEC}, {"path", PT_FSPATH, PF_NA} } },
-	/* PPME_NOTIFICATION_E */{"notification", EC_OTHER, EF_SKIPPARSERESET, 2, {{"id", PT_CHARBUF, PF_DEC}, {"desc", PT_CHARBUF, PF_NA}, } },
+	/* PPME_NOTIFICATION_E */{"notification", EC_INTERNAL, EF_SKIPPARSERESET, 2, {{"id", PT_CHARBUF, PF_DEC}, {"desc", PT_CHARBUF, PF_NA}, } },
 	/* PPME_NOTIFICATION_X */{"NA4", EC_SYSTEM, EF_UNUSED, 0},
 	/* PPME_SYSCALL_EXECVE_17_E */{"execve", EC_PROCESS, EF_MODIFIES_STATE, 0},
 	/* PPME_SYSCALL_EXECVE_17_X */{"execve", EC_PROCESS, EF_MODIFIES_STATE, 17, {{"res", PT_ERRNO, PF_DEC}, {"exe", PT_CHARBUF, PF_NA}, {"args", PT_BYTEBUF, PF_NA}, {"tid", PT_PID, PF_DEC}, {"pid", PT_PID, PF_DEC}, {"ptid", PT_PID, PF_DEC}, {"cwd", PT_CHARBUF, PF_NA}, {"fdlimit", PT_UINT64, PF_DEC}, {"pgft_maj", PT_UINT64, PF_DEC}, {"pgft_min", PT_UINT64, PF_DEC}, {"vm_size", PT_UINT32, PF_DEC}, {"vm_rss", PT_UINT32, PF_DEC}, {"vm_swap", PT_UINT32, PF_DEC}, {"comm", PT_CHARBUF, PF_NA}, {"cgroups", PT_BYTEBUF, PF_NA}, {"env", PT_BYTEBUF, PF_NA}, {"tty", PT_INT32, PF_DEC} } },

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -599,6 +599,7 @@ bool sinsp_container_manager::container_to_sinsp_event(const string& json, sinsp
 
 	evt->m_cpuid = 0;
 	evt->m_evtnum = 0;
+	evt->m_inspector = m_inspector;
 
 	scap_evt* scapevt = evt->m_pevt;
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1779,7 +1779,7 @@ void schedule_more_k8s_evts(sinsp* inspector, void* data)
 	schedule_more_evts(inspector, data, inspector->get_k8s_client(), PPME_K8S_E);
 }
 
-void sinsp_parser::schedule_k8s_events(sinsp_evt *evt)
+void sinsp_parser::schedule_k8s_events()
 {
 #ifdef HAS_CAPTURE
 	//
@@ -1791,7 +1791,7 @@ void sinsp_parser::schedule_k8s_events(sinsp_evt *evt)
 		int event_count = k8s_client->get_capture_events().size();
 		if(event_count)
 		{
-			m_k8s_metaevents_state.m_piscapevt->tid = evt->get_tid();
+			m_k8s_metaevents_state.m_piscapevt->tid = 0;
 			m_k8s_metaevents_state.m_piscapevt->ts = m_inspector->m_lastevent_ts;
 			m_k8s_metaevents_state.m_new_group = true;
 			m_k8s_metaevents_state.m_n_additional_events_to_add = event_count;
@@ -1808,7 +1808,7 @@ void schedule_more_mesos_evts(sinsp* inspector, void* data)
 	schedule_more_evts(inspector, data, inspector->get_mesos_client(), PPME_MESOS_E);
 }
 
-void sinsp_parser::schedule_mesos_events(sinsp_evt *evt)
+void sinsp_parser::schedule_mesos_events()
 {
 #ifdef HAS_CAPTURE
 	//
@@ -1820,7 +1820,7 @@ void sinsp_parser::schedule_mesos_events(sinsp_evt *evt)
 		int event_count = mesos_client->get_capture_events().size();
 		if(event_count)
 		{
-			m_mesos_metaevents_state.m_piscapevt->tid = evt->get_tid();
+			m_mesos_metaevents_state.m_piscapevt->tid = 0;
 			m_mesos_metaevents_state.m_piscapevt->ts = m_inspector->m_lastevent_ts;
 			m_mesos_metaevents_state.m_new_group = true;
 			m_mesos_metaevents_state.m_n_additional_events_to_add = event_count;

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -63,8 +63,8 @@ public:
 	sinsp_protodecoder* add_protodecoder(string decoder_name);
 	void register_event_callback(sinsp_pd_callback_type etype, sinsp_protodecoder* dec);
 
-	void schedule_k8s_events(sinsp_evt *evt);
-	void schedule_mesos_events(sinsp_evt *evt);
+	void schedule_k8s_events();
+	void schedule_mesos_events();
 
 	//
 	// Protocol decoders callback lists

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -63,7 +63,6 @@ sinsp::sinsp() :
 	m_dumper = NULL;
 	m_is_dumping = false;
 	m_metaevt = NULL;
-	m_skipped_evt = NULL;
 	m_meinfo.m_piscapevt = NULL;
 	m_network_interfaces = NULL;
 	m_parser = new sinsp_parser(this);
@@ -849,12 +848,6 @@ void sinsp::add_meta_event(sinsp_evt *metaevt)
 	m_metaevt = metaevt;
 }
 
-void sinsp::add_meta_event_and_repeat(sinsp_evt *metaevt)
-{
-	m_metaevt = metaevt;
-	m_skipped_evt = &m_evt;
-}
-
 void sinsp::add_meta_event_callback(meta_event_callback cback, void* data)
 {
 	m_meta_event_callback = cback;
@@ -941,16 +934,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 	{
 		res = SCAP_SUCCESS;
 		evt = m_metaevt;
-
-		if(m_skipped_evt)
-		{
-			m_metaevt = m_skipped_evt;
-			m_skipped_evt = NULL;
-		}
-		else
-		{
-			m_metaevt = NULL;
-		}
+		m_metaevt = NULL;
 
 		if(m_meta_event_callback != NULL)
 		{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1952,7 +1952,7 @@ void sinsp::collect_k8s()
 					g_logger.log("K8s updating state ...", sinsp_logger::SEV_DEBUG);
 					uint64_t delta = sinsp_utils::get_current_time_ns();
 					m_k8s_client->watch();
-					m_parser->schedule_k8s_events(&m_meta_evt);
+					m_parser->schedule_k8s_events();
 					delta = sinsp_utils::get_current_time_ns() - delta;
 					g_logger.format(sinsp_logger::SEV_DEBUG, "Updating Kubernetes state took %" PRIu64 " ms", delta / 1000000LL);
 				}
@@ -2145,7 +2145,7 @@ void sinsp::update_mesos_state()
 			uint64_t delta = sinsp_utils::get_current_time_ns();
 			if(m_parser && get_mesos_data())
 			{
-				m_parser->schedule_mesos_events(&m_meta_evt);
+				m_parser->schedule_mesos_events();
 				delta = sinsp_utils::get_current_time_ns() - delta;
 				g_logger.format(sinsp_logger::SEV_DEBUG, "Updating Mesos state took %" PRIu64 " ms", delta / 1000000LL);
 			}

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -766,7 +766,6 @@ public:
 	bool setup_cycle_writer(string base_file_name, int rollover_mb, int duration_seconds, int file_limit, unsigned long event_limit, bool compress);
 	void import_ipv4_interface(const sinsp_ipv4_ifinfo& ifinfo);
 	void add_meta_event(sinsp_evt *metaevt);
-	void add_meta_event_and_repeat(sinsp_evt *metaevt);
 	void add_meta_event_callback(meta_event_callback cback, void* data);
 	void remove_meta_event_callback();
 	void filter_proc_table_when_saving(bool filter);
@@ -1036,7 +1035,6 @@ public:
 	// meta event management for other sources like k8s, mesos.
 	//
 	sinsp_evt* m_metaevt;
-	sinsp_evt* m_skipped_evt;
 	meta_event_callback m_meta_event_callback;
 	void* m_meta_event_callback_data;
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -627,6 +627,19 @@ public:
 	void set_fatfile_dump_mode(bool enable_fatfile);
 
 	/*!
+	  \brief Set internal events mode.
+
+	  \note By default, internal events, such as events that note
+                when new containers or orchestration entities have
+                been created, are not returned in sinsp::next(). (They
+                are always written to capture files, to ensure that
+                the full state can be reconstructed when capture files
+                are read). Enabling internal events mode will result
+                in these events being returned.
+	*/
+	void set_internal_events_mode(bool enable_internal_events);
+
+	/*!
 	  \brief Set whether Sysdig should resolve hostnames and port protocols or not.
 
 	  \note Sysdig can use the system library functions getservbyport and so to
@@ -862,6 +875,7 @@ private:
 	string m_input_filename;
 	bool m_isdebug_enabled;
 	bool m_isfatfile_enabled;
+	bool m_isinternal_events_enabled;
 	bool m_hostname_and_port_resolution_enabled;
 	char m_output_time_flag;
 	uint32_t m_max_evt_output_len;
@@ -1014,6 +1028,13 @@ public:
 	sinsp_evt m_meta_evt; // XXX this should go away
 	char* m_meta_evt_buf; // XXX this should go away
 	bool m_meta_evt_pending; // XXX this should go away
+
+	int32_t m_meta_skipped_evt_res;
+	sinsp_evt* m_meta_skipped_evt;
+
+	//
+	// meta event management for other sources like k8s, mesos.
+	//
 	sinsp_evt* m_metaevt;
 	sinsp_evt* m_skipped_evt;
 	meta_event_callback m_meta_event_callback;

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -91,7 +91,8 @@ static void usage()
 "                    after being parsed by the state system. Events are\n"
 "                    normally filtered before being analyzed, which is more\n"
 "                    efficient, but can cause state (e.g. FD names) to be lost.\n"
-" -D, --debug        Capture events about sysdig itself and print additional\n"
+" -D, --debug        Capture events about sysdig itself, display internal events\n"
+"                    in addition to system events, and print additional\n"
 "                    logging on standard error.\n"
 " -E, --exclude-users\n"
 "                    Don't create the user/group tables by querying the OS when\n"
@@ -882,6 +883,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				break;
 			case 'D':
 				inspector->set_debug_mode(true);
+				inspector->set_internal_events_mode(true);
 				inspector->set_log_stderr();
 				break;
 			case 'E':


### PR DESCRIPTION
Previously, container meta events, which included information about a
newly created container, were dumped directly to capture files but not
returned in sinsp::next().

This causes problems if you're using a sinsp_dumper outside of the
inspector and want to dump events to a file yourself.

This change checks if m_meta_evt_pending is true and sets the event to
that meta event.

Additionally, container meta events used to be handled differently and
unconditionally written to capture files. This gets rid of the special
handling, using the standard path for dumping events to a file. It does
preserve the semantics, though, by checking for evt ==
m_meta_evt (i.e. this event is a container meta event) and never
skipping them.