### PR TITLE
Fix IN operator on non-charbuf filter checks.

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1803,7 +1803,6 @@ void sinsp_filter_compiler::parse_check()
 			//
 			// Create the 'or' sequence
 			//
-			uint32_t num_values = 0;
 			while(true)
 			{
 				// 'in' clause aware
@@ -1815,8 +1814,7 @@ void sinsp_filter_compiler::parse_check()
 				sinsp_filter_check* newchk = g_filterlist.new_filter_check_from_another(chk);
 				newchk->m_boolop = op;
 				newchk->m_cmpop = CO_EQ;
-				newchk->add_filter_value((char *)&operand2[0], (uint32_t)operand2.size() - 1, num_values);
-				num_values++;
+				newchk->add_filter_value((char *)&operand2[0], (uint32_t)operand2.size() - 1);
 
 				m_filter->add_check(newchk);
 


### PR DESCRIPTION
"thread.tid in (42, 43)" didn't use to work because the second value (43) was added as a second element in the val_storage array of the second filter check, so the first one was always 0.