### PR TITLE
Overwrite ptid during execve

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1511,6 +1511,18 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	ASSERT(parinfo->m_len == sizeof(uint64_t));
 	evt->m_tinfo->m_pid = *(uint64_t *)parinfo->m_val;
 
+	//
+	// In case this thread is a fake entry,
+	// try to at least patch the parent, since
+	// we have it from the execve event
+	//
+	if(evt->m_tinfo->m_ptid == -1)
+	{
+		parinfo = evt->get_param(5);
+		ASSERT(parinfo->m_len == sizeof(uint64_t));
+		evt->m_tinfo->m_ptid = *(uint64_t *)parinfo->m_val;	
+	}
+
 	// Get the fdlimit
 	parinfo = evt->get_param(7);
 	ASSERT(parinfo->m_len == sizeof(int64_t));


### PR DESCRIPTION
In some scenarios we are missing many clone() events, but not the relative execve() (in the process of troubleshooting the cause of this).

In those cases, whenever the first event for the newly created process happens, sysdig will create a new fake "NA" process that doesn't have most fields set. Whenever the execve happens, some of these fields will be set (args, comm, container_id, ...), however the ptid remains to the default `-1`, meaning that parent navigation will not work.

From the point of view of sinsp, this process will then appear as being inside a container but detached from the main process hierarchy, and this creates some issues on the Monitor/Secure side of things.