### PR TITLE
Fix faults when reading args/env from the stack

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1229,13 +1229,10 @@ static int f_proc_startupdate(struct event_filler_arguments *args)
 					args_len = PAGE_SIZE;
 
 				if (unlikely(ppm_copy_from_user(args->str_storage, (const void __user *)mm->arg_start, args_len)))
-					return PPM_FAILURE_INVALID_USER_MEMORY;
-
-				args->str_storage[args_len - 1] = 0;
-			} else {
-				*args->str_storage = 0;
+					args_len = 0;
+				else
+					args->str_storage[args_len - 1] = 0;
 			}
-
 		} else {
 
 			/*
@@ -1254,9 +1251,13 @@ static int f_proc_startupdate(struct event_filler_arguments *args)
 #endif
 				args_len = accumulate_argv_or_env((const char __user * __user *)val,
 							   args->str_storage, available);
+
 			if (unlikely(args_len < 0))
-				return args_len;
+				args_len = 0;
 		}
+
+		if (args_len == 0)
+			*args->str_storage = 0;
 
 		exe_len = strnlen(args->str_storage, args_len);
 		if (exe_len < args_len)
@@ -1476,11 +1477,9 @@ cgroups_error:
 					env_len = PAGE_SIZE;
 
 				if (unlikely(ppm_copy_from_user(args->str_storage, (const void __user *)mm->env_start, env_len)))
-					return PPM_FAILURE_INVALID_USER_MEMORY;
-
-				args->str_storage[env_len - 1] = 0;
-			} else {
-				*args->str_storage = 0;
+					env_len = 0;
+				else
+					args->str_storage[env_len - 1] = 0;
 			}
 		} else {
 			/*
@@ -1495,9 +1494,13 @@ cgroups_error:
 #endif
 				env_len = accumulate_argv_or_env((const char __user * __user *)val,
 							  args->str_storage, available);
+
 			if (unlikely(env_len < 0))
-				return env_len;
+				env_len = 0;
 		}
+
+		if (env_len == 0)
+			*args->str_storage = 0;
 
 		/*
 		 * environ


### PR DESCRIPTION
This is the continuation of https://github.com/draios/sysdig/pull/914

It seems like it's actually possible to drop `clone` events because of page faults when reading `mm->arg_start` et al. I thought this was impossible, but it seems to happen, especially on systems with transparent huge tables enabled (like m4.10xl on EC2).

The part I never cared to notice is that those addresses are actually the same ones accessible from userspace, in the upper portion of the stack. To reproduce, we can simply force the stack to be swapped out (in typical cases the page fault is minor, so not this severe, but this proves the point regardless).

With a simple tool I wrote to explore the page table content, I can explore the mapping of the stack:

```
gianluca@sid:~/src/go/bin$ sudo ./ptexplore --areas stack -pid 99251                                                

Area '[stack]', range 0x00007ffe94155000 - 0x00007ffe94176000 (135 kB)                                              

... 10 non mapped pages ...  
0x00007ffe9415f000: physical address: 0x0000000119849000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94160000: physical address: 0x00000001bc7f4000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94161000: physical address: 0x00000002252f0000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94162000: physical address: 0x00000001cdfce000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94163000: physical address: 0x00000001b5fd5000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94164000: physical address: 0x0000000103697000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94165000: physical address: 0x00000001c007c000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94166000: physical address: 0x00000001cc164000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94167000: physical address: 0x000000022454f000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94168000: physical address: 0x00000001fffe6000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94169000: physical address: 0x00000002133fe000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe9416a000: physical address: 0x0000000101b00000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe9416b000: physical address: 0x000000020e5e7000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe9416c000: physical address: 0x00000001c82f6000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe9416d000: physical address: 0x0000000105f72000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe9416e000: physical address: 0x0000000204edf000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe9416f000: physical address: 0x00000001e25fa000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94170000: physical address: 0x00000001496f5000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94171000: physical address: 0x000000020e5ba000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94172000: physical address: 0x00000001de27f000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94173000: physical address: 0x00000001e7fbd000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94174000: physical address: 0x0000000224fa7000 exclusive soft-dirty count:1 flags:UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
0x00007ffe94175000: physical address: 0x000000014adc4000 exclusive soft-dirty count:1 flags:REFERENCED,UPTODATE,LRU,ACTIVE,MMAP,ANON,SWAPBACKED
```

The upper portion of the stack is correctly paged in, and the highest page actually contains the various command line parameters (in this case the strings pointed by `argv` start at `0x7ffe941756bf`).

Now, if the process clones itself, everything works fine. However, if I force the process to be swapped (e.g. by launching a process that consumes the whole memory), now the stack is swapped out:

```
gianluca@sid:~/src/go/bin$ sudo ./ptexplore --areas stack -pid 99251

Area '[stack]', range 0x00007ffe94155000 - 0x00007ffe94176000 (135 kB)

... 10 non mapped pages ...
0x00007ffe9415f000: swapped type: 0 offset: 0x000000000001fe47
0x00007ffe94160000: swapped type: 0 offset: 0x000000000001fe46
0x00007ffe94161000: swapped type: 0 offset: 0x000000000001fe48
0x00007ffe94162000: swapped type: 0 offset: 0x000000000001fe49
0x00007ffe94163000: swapped type: 0 offset: 0x000000000001fe4a
0x00007ffe94164000: swapped type: 0 offset: 0x000000000001fe4b
0x00007ffe94165000: swapped type: 0 offset: 0x000000000001fe4c
0x00007ffe94166000: swapped type: 0 offset: 0x0000000000020bce
0x00007ffe94167000: swapped type: 0 offset: 0x0000000000020bcf
0x00007ffe94168000: swapped type: 0 offset: 0x0000000000020bd0
0x00007ffe94169000: swapped type: 0 offset: 0x0000000000020bd1
0x00007ffe9416a000: swapped type: 0 offset: 0x000000000001fe7b
0x00007ffe9416b000: swapped type: 0 offset: 0x000000000001fe7c
0x00007ffe9416c000: swapped type: 0 offset: 0x000000000001fe7d
0x00007ffe9416d000: swapped type: 0 offset: 0x000000000001fe7e
0x00007ffe9416e000: swapped type: 0 offset: 0x000000000001fe7f
0x00007ffe9416f000: swapped type: 0 offset: 0x000000000001fe80
0x00007ffe94170000: swapped type: 0 offset: 0x000000000001fe81
0x00007ffe94171000: swapped type: 0 offset: 0x000000000001fe82
0x00007ffe94172000: swapped type: 0 offset: 0x000000000001fe83
0x00007ffe94173000: swapped type: 0 offset: 0x000000000001fe38
0x00007ffe94174000: swapped type: 0 offset: 0x000000000001fe34
0x00007ffe94175000: swapped type: 0 offset: 0x000000000001fe31
```

So, if the process now forks itself, the clone event will be lost (both the parent and the child ones).

Since losing clone events is bad because the child thread creation happens during the clone, this patch doesn't discard the events in such cases, and simply passes NUL to userspace.

I could also pass a string such as `(NA)` but it wouldn't be terribly better since this is a corner case, and I didn't have enough patience to do it.