### PR TITLE
fix build with LuaJIT 2.1 betas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system
 option(USE_BUNDLED_LUAJIT "Enable building of the bundled LuaJIT" ${USE_BUNDLED_DEPS})
 
 if(NOT USE_BUNDLED_LUAJIT)
-	find_path(LUAJIT_INCLUDE luajit.h PATH_SUFFIXES luajit-2.0 luajit)
+	find_path(LUAJIT_INCLUDE luajit.h PATH_SUFFIXES luajit-2.1 luajit-2.0 luajit)
 	find_library(LUAJIT_LIB NAMES luajit luajit-5.1)
 	if(LUAJIT_INCLUDE AND LUAJIT_LIB)
 		message(STATUS "Found LuaJIT: include: ${LUAJIT_INCLUDE}, lib: ${LUAJIT_LIB}")

--- a/userspace/libsinsp/chisel.cpp
+++ b/userspace/libsinsp/chisel.cpp
@@ -96,7 +96,7 @@ void lua_stackdump(lua_State *L)
 // Lua callbacks
 ///////////////////////////////////////////////////////////////////////////////
 #ifdef HAS_LUA_CHISELS
-const static struct luaL_reg ll_sysdig [] =
+const static struct luaL_Reg ll_sysdig [] =
 {
 	{"set_filter", &lua_cbacks::set_global_filter},
 	{"set_snaplen", &lua_cbacks::set_snaplen},
@@ -124,7 +124,7 @@ const static struct luaL_reg ll_sysdig [] =
 	{NULL,NULL}
 };
 
-const static struct luaL_reg ll_chisel [] =
+const static struct luaL_Reg ll_chisel [] =
 {
 	{"request_field", &lua_cbacks::request_field},
 	{"set_filter", &lua_cbacks::set_filter},
@@ -135,7 +135,7 @@ const static struct luaL_reg ll_chisel [] =
 	{NULL,NULL}
 };
 
-const static struct luaL_reg ll_evt [] =
+const static struct luaL_Reg ll_evt [] =
 {
 	{"field", &lua_cbacks::field},
 	{"get_num", &lua_cbacks::get_num},

--- a/userspace/libsinsp/lua_parser.cpp
+++ b/userspace/libsinsp/lua_parser.cpp
@@ -14,7 +14,7 @@ extern "C" {
 #include "lauxlib.h"
 }
 
-const static struct luaL_reg ll_filter [] =
+const static struct luaL_Reg ll_filter [] =
 {
 	{"rel_expr", &lua_parser_cbacks::rel_expr},
 	{"bool_op", &lua_parser_cbacks::bool_op},

--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -228,7 +228,7 @@ int lua_parser_cbacks::rel_expr(lua_State *ls)
 					fprintf(stderr, "%s\n", err.c_str());
 					throw sinsp_exception("parser API error");
 				}
-				int n = luaL_getn(ls, 3);  /* get size of table */
+				int n = (int)lua_objlen(ls, 3);  /* get size of table */
 				for (i=1; i<=n; i++)
 				{
 					lua_rawgeti(ls, 3, i);


### PR DESCRIPTION
LuaJIT 2.1 drops some compat symbols [1]. And while I think that this is
wrong, as it breaks compatibility with Lua 5.1 [2], it is quite easy to
adopt the code to work with both versions (2.0 and 2.1) of LuaJIT and
remain Lua 5.1 compatible.

[1] https://github.com/LuaJIT/LuaJIT/commit/dc320ca70f2c5bb3977b82853bcee6dad2523d01
[2] https://github.com/LuaJIT/LuaJIT/issues/325