### PR TITLE
Containers networking fixes

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -704,11 +704,29 @@ bool sinsp_container_manager::parse_docker(sinsp_container_info* container)
 	const Json::Value& net_obj = root["NetworkSettings"];
 
 	string ip = net_obj["IPAddress"].asString();
-	if(inet_pton(AF_INET, ip.c_str(), &container->m_container_ip) == -1)
+	if(ip.empty())
 	{
-		ASSERT(false);
+		const Json::Value& hconfig_obj = root["HostConfig"];
+		string net_mode = hconfig_obj["NetworkMode"].asString();
+		if(strncmp(net_mode.c_str(), "container:", strlen("container:")) == 0)
+		{
+			sinsp_container_info pcnt;
+			pcnt.m_id = net_mode.substr(net_mode.find(":") + 1);
+			if (!get_container(pcnt.m_id, &pcnt))
+			{
+				parse_docker(&pcnt);
+			}
+			container->m_container_ip = pcnt.m_container_ip;
+		}
 	}
-	container->m_container_ip = ntohl(container->m_container_ip);
+	else
+	{
+		if(inet_pton(AF_INET, ip.c_str(), &container->m_container_ip) == -1)
+		{
+			ASSERT(false);
+		}
+		container->m_container_ip = ntohl(container->m_container_ip);
+	}
 
 	vector<string> ports = net_obj["Ports"].getMemberNames();
 	for(vector<string>::const_iterator it = ports.begin(); it != ports.end(); ++it)

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -574,7 +574,7 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 	container["Mounts"] = mounts;
 
 	char addrbuff[100];
-	uint32_t iph = ntohl(container_info.m_container_ip);
+	uint32_t iph = htonl(container_info.m_container_ip);
 	inet_ntop(AF_INET, &iph, addrbuff, sizeof(addrbuff));
 	container["ip"] = addrbuff;
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -712,7 +712,7 @@ bool sinsp_container_manager::parse_docker(sinsp_container_info* container)
 		{
 			sinsp_container_info pcnt;
 			pcnt.m_id = net_mode.substr(net_mode.find(":") + 1);
-			if (!get_container(pcnt.m_id, &pcnt))
+			if(!get_container(pcnt.m_id, &pcnt))
 			{
 				parse_docker(&pcnt);
 			}

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -184,7 +184,7 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 				//
 				// We have a container info with a valid container IP. Let's use it.
 				//
-				if(addr == container_info.m_container_ip)
+				if(addr == htonl(container_info.m_container_ip))
 				{
 					return true;
 				}
@@ -203,7 +203,7 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 
 				for(auto it = clist->begin(); it != clist->end(); ++it)
 				{
-					if(it->second.m_container_ip == addr)
+					if(htonl(it->second.m_container_ip) == addr)
 					{
 						return true;
 					}

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -193,11 +193,9 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 			{
 				//
 				// Container info is valid, but the IP address is zero.
-				// This happens for example in the case of kubernetes pods, where we are
-				// typically unable to get the address for one of the containers in the pod.
-				// In that case, the address can be fetched from another of the containers
-				// in the pod, so we scan the list looking for matches. If no match is found,
-				// We just jump to checking the host interfaces.
+				// Scan the list of the containers looking for matches.
+				// If no match is found, we just jump to checking the
+				// host interfaces.
 				//
 				const unordered_map<string, sinsp_container_info>* clist = m_inspector->m_container_manager.get_containers();
 


### PR DESCRIPTION
This PR does two things:

1. Add support for "mapped container" docker network mode, currently used by kubernetes pods
2. Fix a bug inside `sinsp_network_interfaces::is_ipv4addr_in_local_machine`, where we were comparing IP addresses with different endianness 