### PR TITLE
Better cleanup of loop device and mounted directory

### DIFF
--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -174,6 +174,14 @@ function coreos_build_new {
 
 	cd $COREOS_DIR
 
+	# If past runs fail, /tmp/loop and relative device
+	# may be hanging around
+	if mount | grep /tmp/loop; then
+		LOOPDEV=$(mount |grep /tmp/loop|cut -d" " -f1|egrep -o "loop[0-9]+")
+		sudo umount /tmp/loop
+		sudo kpartx -dv /dev/$LOOPDEV
+	fi
+
 	if [ ! -f coreos_developer_container.bin ]; then
 		wget --timeout=${URL_TIMEOUT} --tries=${RETRY} ${VERSION_URL}coreos_developer_container.bin.bz2
 		bunzip2 coreos_developer_container.bin.bz2
@@ -195,13 +203,7 @@ function coreos_build_new {
 	cd $BASEDIR
 	export KERNELDIR=$(readlink -f /tmp/loop/lib/modules/$KERNEL_RELEASE/build)
 
-	# If build fails the script should exit immediately
-	# but in this case it's important to umount the loop device
-	# and release resources. So keep running and fail afterwards.
-	set +e
 	build_probe
-	BUILD_RET=$?
-	set -e
 
 	cd $COREOS_DIR
 	# cleanup
@@ -210,7 +212,7 @@ function coreos_build_new {
 
 	cd $BASEDIR
 
-	return $BUILD_RET
+	return
 }
 
 function boot2docker_build {


### PR DESCRIPTION
Currently if a coreos build fails, there is a mountpoint hanging around that will make all subsequent builds fail as well and requires manual cleanup, this fix addresses that.