### PR TITLE
Fix off-by-one data corruption

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -653,7 +653,7 @@ bool sinsp_container_manager::parse_docker(sinsp_container_info* container)
 	char buf[256];
 	string json;
 	ssize_t res;
-	while((res = read(sock, buf, sizeof(buf))) != 0)
+	while((res = read(sock, buf, sizeof(buf) - 1)) != 0)
 	{
 		if(res == -1 || json.size() > MAX_JSON_SIZE_B)
 		{


### PR DESCRIPTION
This morning I noticed that running sysdig in debug mode occasionally caused a heap corruption warning:

```
*** Error in `./userspace/sysdig/sysdig': free(): invalid pointer: 0x000056422de67900 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x70bfb)[0x7f25513f5bfb]
/lib/x86_64-linux-gnu/libc.so.6(+0x76fc6)[0x7f25513fbfc6]
/lib/x86_64-linux-gnu/libc.so.6(+0x7780e)[0x7f25513fc80e]
./userspace/sysdig/sysdig(_ZN23sinsp_container_manager12parse_dockerEP20sinsp_container_info+0x148b)[0x56422d34531f]
./userspace/sysdig/sysdig(_ZN23sinsp_container_manager17resolve_containerEP16sinsp_threadinfob+0x1455)[0x56422d343153]
./userspace/sysdig/sysdig(_ZN16sinsp_threadinfo4initEP15scap_threadinfo+0x441)[0x56422d47ceed]
./userspace/sysdig/sysdig(_ZN5sinsp22on_new_entry_from_procEPvlP15scap_threadinfoP11scap_fdinfoP4scap+0x17c)[0x56422d48788a]
./userspace/sysdig/sysdig(_Z22on_new_entry_from_procPvlP15scap_threadinfoP11scap_fdinfoP4scap+0x4a)[0x56422d487b40]
```

The reason is an off-by-one error caused by writing one more byte past the end of the `buf` array, which corrupts the local stack variable `message` and ultimately causes the heap corruption when the function ends and the destructor is called.
