### PR TITLE
remove IRC and add Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Join the Community
 * Contact the [official mailing list](https://groups.google.com/forum/#!forum/sysdig) for support and to talk with other users
 * Follow us on [Twitter](https://twitter.com/sysdig) for the Chisel of the Week
 * This is our [blog](https://sysdig.com/blog/). There are many like it, but this one is ours.
-* Join our IRC channel `#sysdig` on [Freenode](http://webchat.freenode.net/?channels=sysdig)
+* Join our [Public Slack](https://slack.sysdig.com) channel for sysdig announcements and discussions.
 
 License Terms
 ---


### PR DESCRIPTION
I joined the freenode channel the other day and doesn't look like it's active, whereas Slack is.