### PR TITLE
Add per-cpu counters when a tracepoint is hit

### DIFF
--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1326,6 +1326,7 @@ struct ppm_evt_hdr {
 #define PPM_IOCTL_SET_TRACERS_CAPTURE _IO(PPM_IOCTL_MAGIC, 17)
 #define PPM_IOCTL_SET_SIMPLE_MODE _IO(PPM_IOCTL_MAGIC, 18)
 #define PPM_IOCTL_ENABLE_PAGE_FAULTS _IO(PPM_IOCTL_MAGIC, 19)
+#define PPM_IOCTL_GET_N_TRACEPOINT_HIT _IO(PPM_IOCTL_MAGIC, 20)
 
 extern const struct ppm_name_value socket_families[];
 extern const struct ppm_name_value file_flags[];

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1524,3 +1524,30 @@ int32_t scap_enable_simpledriver_mode(scap_t* handle)
 	return SCAP_SUCCESS;
 #endif
 }
+
+int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret)
+{
+	//
+	// Not supported on files
+	//
+	if(handle->m_mode != SCAP_MODE_LIVE)
+	{
+		snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "getting n_tracepoint_hit not supported on this scap mode");
+		return SCAP_FAILURE;
+	}
+
+#if !defined(HAS_CAPTURE)
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
+	return SCAP_FAILURE;
+#else
+
+	if(ioctl(handle->m_devs[0].m_fd, PPM_IOCTL_GET_N_TRACEPOINT_HIT, ret))
+	{
+		snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "scap_get_n_tracepoint_hit failed");
+		ASSERT(false);
+		return SCAP_FAILURE;
+	}
+
+	return SCAP_SUCCESS;
+#endif
+}

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -944,6 +944,7 @@ int32_t scap_write_proclist_header(scap_t *handle, scap_dumper_t *d, uint32_t to
 int32_t scap_write_proclist_trailer(scap_t *handle, scap_dumper_t *d, uint32_t totlen);
 int32_t scap_write_proclist_entry(scap_t *handle, scap_dumper_t *d, struct scap_threadinfo *tinfo);
 int32_t scap_enable_simpledriver_mode(scap_t* handle);
+int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret);
 
 #ifdef __cplusplus
 }

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -519,8 +519,34 @@ void sinsp::set_simpledriver_mode()
 {
 	if(scap_enable_simpledriver_mode(m_h) != SCAP_SUCCESS)
 	{
-		throw sinsp_exception(scap_getlasterr(m_h));		
+		throw sinsp_exception(scap_getlasterr(m_h));
 	}
+}
+
+unsigned sinsp::m_num_possible_cpus = 0;
+
+unsigned sinsp::num_possible_cpus()
+{
+	if(m_num_possible_cpus == 0)
+	{
+		m_num_possible_cpus = read_num_possible_cpus();
+		if(m_num_possible_cpus == 0)
+		{
+			g_logger.log("Unable to read num_possible_cpus, falling back to 128", sinsp_logger::SEV_WARNING);
+			m_num_possible_cpus = 128;
+		}
+	}
+	return m_num_possible_cpus;
+}
+
+vector<long> sinsp::get_n_tracepoint_hit()
+{
+	vector<long> ret(num_possible_cpus(), 0);
+	if(scap_get_n_tracepoint_hit(m_h, ret.data()) != SCAP_SUCCESS)
+	{
+		throw sinsp_exception(scap_getlasterr(m_h));
+	}
+	return ret;
 }
 
 std::string sinsp::get_error_desc(const std::string& msg)

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -780,7 +780,9 @@ public:
 		scap_refresh_proc_table(m_h);
 	}
 	void set_simpledriver_mode();
+	vector<long> get_n_tracepoint_hit();
 
+	static unsigned num_possible_cpus();
 VISIBILITY_PRIVATE
 
 // Doxygen doesn't understand VISIBILITY_PRIVATE
@@ -1049,6 +1051,7 @@ public:
 	uint64_t m_last_procrequest_tod;
 	sinsp_proc_metainfo m_meinfo;
 
+	static unsigned int m_num_possible_cpus;
 #if defined(HAS_CAPTURE)
 	int64_t m_sysdig_pid;
 #endif

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1417,3 +1417,28 @@ bool set_socket_blocking(int sock, bool block)
 	}
 	return true;
 }
+
+unsigned int read_num_possible_cpus(void)
+{
+	static const char *fcpu = "/sys/devices/system/cpu/possible";
+	unsigned int start, end, possible_cpus = 0;
+	char buff[128];
+	FILE *fp;
+
+	fp = fopen(fcpu, "r");
+	if (!fp) {
+		printf("Failed to open %s: '%s'!\n", fcpu, strerror(errno));
+		exit(1);
+	}
+
+	while (fgets(buff, sizeof(buff), fp)) {
+		if (sscanf(buff, "%u-%u", &start, &end) == 2) {
+			possible_cpus = start == 0 ? end + 1 : 0;
+			break;
+		}
+	}
+
+	fclose(fp);
+
+	return possible_cpus;
+}

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1427,8 +1427,7 @@ unsigned int read_num_possible_cpus(void)
 
 	fp = fopen(fcpu, "r");
 	if (!fp) {
-		printf("Failed to open %s: '%s'!\n", fcpu, strerror(errno));
-		exit(1);
+		return possible_cpus;
 	}
 
 	while (fgets(buff, sizeof(buff), fp)) {

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -350,3 +350,5 @@ struct ci_compare
 ///////////////////////////////////////////////////////////////////////////////
 
 bool set_socket_blocking(int sock, bool block);
+
+unsigned int read_num_possible_cpus(void);


### PR DESCRIPTION
A counter is defined for each possible CPU. userspace knows how many possible CPUs there are and sends to the `ioctl` a properly sized array to store all these values