### PR TITLE
Fix targetViewFilter for "Accessed Files" in wsysdig_summary chisel

### DIFF
--- a/userspace/sysdig/chisels/wsysdig_summary.lua
+++ b/userspace/sysdig/chisels/wsysdig_summary.lua
@@ -937,7 +937,7 @@ function build_output(captureDuration)
 			desc = 'Number of files that have been accessed during the capture',
 			category = 'file',
 			targetView = 'files',
-			targetViewFilter = 'evt.is_io_write=true',
+			targetViewFilter = 'evt.is_io_read=true',
 			drillDownKey = 'fd.directory',
 			targetViewSortingCol = 2,
 			data = gsummary.fileCount


### PR DESCRIPTION
It was wrongly set to `is_io_write` instead of `is_io_read`. So the drilldown view in Sysdig Inspect was showing wrong/no files even though the summary page was giving a number for accessed files.