### PR TITLE
Use dithered boxes to increase number of available colors 

### DIFF
--- a/userspace/sysdig/chisels/ansiterminal.lua
+++ b/userspace/sysdig/chisels/ansiterminal.lua
@@ -94,6 +94,10 @@ function ansiterminal.showcursor()
     io.write(schar(27) .. '[' .. "?25h")
 end
 
+function ansiterminal.setfgcol(color)
+    io.write(schar(27) .. '[' .. "38;5;" .. color .. "m")
+end
+
 function ansiterminal.setbgcol(color)
     io.write(schar(27) .. '[' .. "48;5;" .. color .. "m")
 end

--- a/userspace/sysdig/chisels/spectrogram.lua
+++ b/userspace/sysdig/chisels/spectrogram.lua
@@ -103,17 +103,18 @@ function on_event()
 end
 
 function mkcol(n)
-	local col = math.floor(math.log10(n * refresh_per_sec + 1) / math.log10(1.6))
+	local col = math.log10(n * refresh_per_sec + 1) / math.log10(1.6)
 
 	if col < 1 then
 		col = 1
-	end
-
-	if col > #colpalette then
+	elseif col > #colpalette then
 		col = #colpalette
 	end
 
-	return colpalette[col]
+	local low_col = math.floor(col)
+	local high_col = math.ceil(col)
+
+	return colpalette[low_col], colpalette[high_col] 
 end
 
 -- Periodic timeout callback
@@ -122,13 +123,18 @@ function on_interval(ts_s, ts_ns, delta)
 
 	for x = 1, w do
 		local fr = frequencies[x]
+		local fg, bg
+
 		if fr == nil or fr == 0 then
+			terminal.setfgcol(0)
 			terminal.setbgcol(0)
 		else
-			terminal.setbgcol(mkcol(fr))
+			fg, bg = mkcol(fr)
+			terminal.setfgcol(fg)
+			terminal.setbgcol(bg)
 		end
 
-		io.write(" ")
+		io.write("▒")
 	end
 
 	io.write(terminal.reset .. "\n")

--- a/userspace/sysdig/chisels/spectrogram.lua
+++ b/userspace/sysdig/chisels/spectrogram.lua
@@ -116,7 +116,7 @@ function mkcol(n)
 	local low_col = math.floor(col)
 	local high_col = math.ceil(col)
 	local delta = col - low_col
-	local ch = charpalette[math.floor(1 + delta * 3)]
+	local ch = charpalette[math.floor(1 + delta * #charpalette)]
 
 	return colpalette[low_col], colpalette[high_col], ch
 end

--- a/userspace/sysdig/chisels/spectrogram.lua
+++ b/userspace/sysdig/chisels/spectrogram.lua
@@ -37,6 +37,7 @@ refresh_time = 500000000
 refresh_per_sec = 1000000000 / refresh_time
 frequencies = {}
 colpalette = {22, 28, 64, 34, 2, 76, 46, 118, 154, 191, 227, 226, 11, 220, 209, 208, 202, 197, 9, 1}
+charpalette = {" ", "░", "▒"}
 
 -- Argument initialization Callback
 function on_set_arg(name, val)
@@ -102,6 +103,7 @@ function on_event()
 	return true
 end
 
+-- Calculate colors and character to be used
 function mkcol(n)
 	local col = math.log10(n * refresh_per_sec + 1) / math.log10(1.6)
 
@@ -113,8 +115,10 @@ function mkcol(n)
 
 	local low_col = math.floor(col)
 	local high_col = math.ceil(col)
+	local delta = col - low_col
+	local ch = charpalette[math.floor(1 + delta * 3)]
 
-	return colpalette[low_col], colpalette[high_col] 
+	return colpalette[low_col], colpalette[high_col], ch
 end
 
 -- Periodic timeout callback
@@ -123,18 +127,19 @@ function on_interval(ts_s, ts_ns, delta)
 
 	for x = 1, w do
 		local fr = frequencies[x]
-		local fg, bg
+		local fg, bg, ch
 
 		if fr == nil or fr == 0 then
 			terminal.setfgcol(0)
 			terminal.setbgcol(0)
+			ch = " "
 		else
-			fg, bg = mkcol(fr)
+			fg, bg, ch = mkcol(fr)
 			terminal.setfgcol(fg)
 			terminal.setbgcol(bg)
 		end
 
-		io.write("▒")
+		io.write(ch)
 	end
 
 	io.write(terminal.reset .. "\n")


### PR DESCRIPTION
Following up on a conversation on Slack about the limitations of running the spectrogram chisel on a Linux console, I'm proposing changes to https://github.com/rbanffy/sysdig/blob/dev/userspace/sysdig/chisels/spectrogram.lua and https://github.com/rbanffy/sysdig/blob/dev/userspace/sysdig/chisels/ansiterm.lua so that the 50% dithered boxes at positions 176 (░) and 177 (▒) of the terminal character set can be used to generate dithered colors between the ones available when the col value is between two different palette indexes.