### PR TITLE
fix V549 from PVS-Studio

### DIFF
--- a/userspace/libscap/scap.vcxproj
+++ b/userspace/libscap/scap.vcxproj
@@ -1,115 +1,277 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
+    <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
+    <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="MinSizeRel|x64">
+      <Configuration>MinSizeRel</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="RelWithDebInfo|x64">
+      <Configuration>RelWithDebInfo</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{A45C5520-F4BA-480A-A7D3-EB1E9DDFBE6C}</ProjectGuid>
+    <ProjectGuid>{F647D184-0F78-3A74-B2D6-AA26D50C0E4E}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
+    <Platform>x64</Platform>
+    <ProjectName>scap</ProjectName>
+    <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(VCInstallDir)include;$(VCInstallDir)atlmfc\include;$(WindowsSDK_IncludePath);.;../../driver</IncludePath>
-    <OutDir>$(ProjectDir)\..\Debug\</OutDir>
-    <IntDir>$(ProjectDir)\..\Debug\</IntDir>
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.20506.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">D:\Git\sysdig\userspace\libscap\Debug\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">scap.dir\Debug\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">scap</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.lib</TargetExt>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">D:\Git\sysdig\userspace\libscap\Release\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">scap.dir\Release\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">scap</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.lib</TargetExt>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">D:\Git\sysdig\userspace\libscap\MinSizeRel\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">scap.dir\MinSizeRel\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">scap</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">.lib</TargetExt>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">D:\Git\sysdig\userspace\libscap\RelWithDebInfo\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">scap.dir\RelWithDebInfo\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">scap</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">.lib</TargetExt>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(VCInstallDir)include;$(VCInstallDir)atlmfc\include;$(WindowsSDK_IncludePath);.;../../driver</IncludePath>
-    <OutDir>$(ProjectDir)\..\Release\</OutDir>
-    <IntDir>$(ProjectDir)\..\Release\</IntDir>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;PLATFORM_NAME="Windows";_DEBUG;_WINDOWS;_USRDLL;SCAP_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\common;D:\Git\sysdig\zlib-prefix\src\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>Debug/</AssemblerListingLocation>
+      <CompileAs>CompileAsC</CompileAs>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>../../common;../../build/zlib-prefix/src/zlib</AdditionalIncludeDirectories>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;PLATFORM_NAME="Windows";K8S_DISABLE_THREAD;CMAKE_INTDIR="Debug";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
     </ClCompile>
-    <Link>
-      <TargetMachine>MachineX86</TargetMachine>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Console</SubSystem>
-      <ImportLibrary>$(ProjectDir)\..\Debug\$(TargetName).lib</ImportLibrary>
-      <ModuleDefinitionFile>scap.def</ModuleDefinitionFile>
-      <OutputFile>$(SolutionDir)Debug\$(TargetName)$(TargetExt)</OutputFile>
-      <ProgramDatabaseFile>$(OutDir)scap.pdb</ProgramDatabaseFile>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Ws2_32.lib;%(AdditionalDependencies);../../build/zlib-prefix/src/zlib/zdll.lib</AdditionalDependencies>
-    </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CRT_SECURE_NO_WARNINGS;PLATFORM_NAME=\"Windows\";K8S_DISABLE_THREAD;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\common;D:\Git\sysdig\zlib-prefix\src\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\common;D:\Git\sysdig\zlib-prefix\src\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Lib>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+    </Lib>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;PLATFORM_NAME="Windows";NDEBUG;_WINDOWS;_USRDLL;SCAP_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\common;D:\Git\sysdig\zlib-prefix\src\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>Release/</AssemblerListingLocation>
+      <CompileAs>CompileAsC</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;PLATFORM_NAME="Windows";K8S_DISABLE_THREAD;CMAKE_INTDIR="Release";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;PLATFORM_NAME=\"Windows\";K8S_DISABLE_THREAD;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\common;D:\Git\sysdig\zlib-prefix\src\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\common;D:\Git\sysdig\zlib-prefix\src\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Lib>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\common;D:\Git\sysdig\zlib-prefix\src\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>MinSizeRel/</AssemblerListingLocation>
+      <CompileAs>CompileAsC</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <Optimization>MinSpace</Optimization>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../common;../../build/zlib-prefix/src/zlib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;PLATFORM_NAME="Windows";K8S_DISABLE_THREAD;CMAKE_INTDIR="MinSizeRel";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
     </ClCompile>
-    <Link>
-      <TargetMachine>MachineX86</TargetMachine>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <ImportLibrary>$(ProjectDir)\..\Release\$(TargetName).lib</ImportLibrary>
-      <ModuleDefinitionFile>scap.def</ModuleDefinitionFile>
-      <OutputFile>$(SolutionDir)\Release\$(TargetName)$(TargetExt)</OutputFile>
-      <ProgramDatabaseFile>$(OutDir)scap.pdb</ProgramDatabaseFile>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Ws2_32.lib;%(AdditionalDependencies);../../build/zlib-prefix/src/zlib/zdll.lib</AdditionalDependencies>
-    </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;PLATFORM_NAME=\"Windows\";K8S_DISABLE_THREAD;CMAKE_INTDIR=\"MinSizeRel\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\common;D:\Git\sysdig\zlib-prefix\src\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\common;D:\Git\sysdig\zlib-prefix\src\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Lib>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\common;D:\Git\sysdig\zlib-prefix\src\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>RelWithDebInfo/</AssemblerListingLocation>
+      <CompileAs>CompileAsC</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <Optimization>MaxSpeed</Optimization>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;PLATFORM_NAME="Windows";K8S_DISABLE_THREAD;CMAKE_INTDIR="RelWithDebInfo";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;PLATFORM_NAME=\"Windows\";K8S_DISABLE_THREAD;CMAKE_INTDIR=\"RelWithDebInfo\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\common;D:\Git\sysdig\zlib-prefix\src\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\common;D:\Git\sysdig\zlib-prefix\src\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Lib>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="dynamic_params_table.c" />
-    <ClCompile Include="event_table.c" />
-    <ClCompile Include="flags_table.c" />
-    <ClCompile Include="scap.c" />
-    <ClCompile Include="scap_event.c" />
-    <ClCompile Include="scap_fds.c" />
-    <ClCompile Include="scap_iflist.c" />
-    <ClCompile Include="scap_procs.c" />
-    <ClCompile Include="scap_savefile.c" />
-    <ClCompile Include="scap_userlist.c" />
-    <ClCompile Include="syscall_info_table.c" />
+    <CustomBuild Include="D:\Git\sysdig\userspace\libscap\CMakeLists.txt">
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Building Custom Rule D:/Git/sysdig/userspace/libscap/CMakeLists.txt</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -HD:/Git/sysdig -BD:/Git/sysdig --check-stamp-file D:/Git/sysdig/userspace/libscap/CMakeFiles/generate.stamp
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">D:/Git/sysdig/userspace/libscap/CMakeLists.txt;D:\Git\sysdig\userspace\libscap\CMakeLists.txt;D:\Git\sysdig\userspace\libscap\CMakeLists.txt;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">D:\Git\sysdig\userspace\libscap\CMakeFiles\generate.stamp</Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</LinkObjects>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Building Custom Rule D:/Git/sysdig/userspace/libscap/CMakeLists.txt</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -HD:/Git/sysdig -BD:/Git/sysdig --check-stamp-file D:/Git/sysdig/userspace/libscap/CMakeFiles/generate.stamp
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">D:/Git/sysdig/userspace/libscap/CMakeLists.txt;D:\Git\sysdig\userspace\libscap\CMakeLists.txt;D:\Git\sysdig\userspace\libscap\CMakeLists.txt;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">D:\Git\sysdig\userspace\libscap\CMakeFiles\generate.stamp</Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkObjects>
+      <Message Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">Building Custom Rule D:/Git/sysdig/userspace/libscap/CMakeLists.txt</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -HD:/Git/sysdig -BD:/Git/sysdig --check-stamp-file D:/Git/sysdig/userspace/libscap/CMakeFiles/generate.stamp
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">D:/Git/sysdig/userspace/libscap/CMakeLists.txt;D:\Git\sysdig\userspace\libscap\CMakeLists.txt;D:\Git\sysdig\userspace\libscap\CMakeLists.txt;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">D:\Git\sysdig\userspace\libscap\CMakeFiles\generate.stamp</Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">false</LinkObjects>
+      <Message Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">Building Custom Rule D:/Git/sysdig/userspace/libscap/CMakeLists.txt</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -HD:/Git/sysdig -BD:/Git/sysdig --check-stamp-file D:/Git/sysdig/userspace/libscap/CMakeFiles/generate.stamp
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">D:/Git/sysdig/userspace/libscap/CMakeLists.txt;D:\Git\sysdig\userspace\libscap\CMakeLists.txt;D:\Git\sysdig\userspace\libscap\CMakeLists.txt;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">D:\Git\sysdig\userspace\libscap\CMakeFiles\generate.stamp</Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">false</LinkObjects>
+    </CustomBuild>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\driver\ppm_events_public.h" />
-    <ClInclude Include="..\..\driver\ppm_ringbuffer.h" />
-    <ClInclude Include="..\..\driver\ppm_types.h" />
-    <ClInclude Include="scap-int.h" />
-    <ClInclude Include="scap.h" />
-    <ClInclude Include="scap_savefile.h" />
-    <ClInclude Include="settings.h" />
-    <ClInclude Include="uthash.h" />
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap.c"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap_event.c"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap_fds.c"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap_iflist.c"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap_savefile.c"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap_procs.c"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap_userlist.c"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\flags_table.c"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\dynamic_params_table.c"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\event_table.c"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\syscall_info_table.c"  />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="D:\Git\sysdig\ZERO_CHECK.vcxproj">
+      <Project>{1CB35481-DC21-3DE3-B75E-B7BC16F1E648}</Project>
+      <Name>ZERO_CHECK</Name>
+    </ProjectReference>
+    <ProjectReference Include="D:\Git\sysdig\zlib.vcxproj">
+      <Project>{4AF0E3FC-57E6-3AFD-AC54-1200A498902C}</Project>
+      <Name>zlib</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/userspace/libscap/scap.vcxproj.filters
+++ b/userspace/libscap/scap.vcxproj.filters
@@ -1,78 +1,46 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap_event.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap_fds.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap_iflist.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap_savefile.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap_procs.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\scap_userlist.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\flags_table.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\dynamic_params_table.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\event_table.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libscap\syscall_info_table.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="D:\Git\sysdig\userspace\libscap\CMakeLists.txt" />
+  </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">
-      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
-      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+      <UniqueIdentifier>{B65E308C-01A2-3FB7-8317-610DB05CED03}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
-      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
-    </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
-    </Filter>
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="scap.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="scap_fds.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="scap_procs.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="scap_savefile.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="scap_event.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="scap_iflist.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="scap_userlist.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="event_table.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="flags_table.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="syscall_info_table.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="dynamic_params_table.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="scap-int.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="scap.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="scap_savefile.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="uthash.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\driver\ppm_events_public.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\driver\ppm_ringbuffer.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\driver\ppm_types.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="settings.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
   </ItemGroup>
 </Project>

--- a/userspace/libsinsp/sinsp.vcxproj
+++ b/userspace/libsinsp/sinsp.vcxproj
@@ -1,135 +1,349 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
+    <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
+    <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="MinSizeRel|x64">
+      <Configuration>MinSizeRel</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="RelWithDebInfo|x64">
+      <Configuration>RelWithDebInfo</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{A45C552E-F4BA-480A-A7D3-EB1E9DDFBE6C}</ProjectGuid>
+    <ProjectGuid>{0F87D5C2-A45F-3DAD-BFB0-05ECE8B3D125}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
+    <Platform>x64</Platform>
+    <ProjectName>sinsp</ProjectName>
+    <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(VCInstallDir)include;$(VCInstallDir)atlmfc\include;$(WindowsSDK_IncludePath);.;../../driver</IncludePath>
-    <OutDir>$(ProjectDir)\..\Debug\</OutDir>
-    <IntDir>$(ProjectDir)\..\Debug\</IntDir>
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.20506.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">D:\Git\sysdig\userspace\libsinsp\Debug\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">sinsp.dir\Debug\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">sinsp</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.lib</TargetExt>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">D:\Git\sysdig\userspace\libsinsp\Release\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">sinsp.dir\Release\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">sinsp</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.lib</TargetExt>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">D:\Git\sysdig\userspace\libsinsp\MinSizeRel\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">sinsp.dir\MinSizeRel\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">sinsp</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">.lib</TargetExt>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">D:\Git\sysdig\userspace\libsinsp\RelWithDebInfo\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">sinsp.dir\RelWithDebInfo\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">sinsp</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">.lib</TargetExt>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(VCInstallDir)include;$(VCInstallDir)atlmfc\include;$(WindowsSDK_IncludePath);.;../../driver</IncludePath>
-    <OutDir>$(ProjectDir)\..\Release\</OutDir>
-    <IntDir>$(ProjectDir)\..\Release\</IntDir>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;PLATFORM_NAME="Windows";_DEBUG;_WINDOWS;_USRDLL;SINSP_EXPORTS;_NO_DEBUG_HEAP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\.;D:\Git\sysdig\userspace\libsinsp\..\..\common;D:\Git\sysdig\userspace\libsinsp\..\libscap;D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\luajit-prefix\src\luajit\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>Debug/</AssemblerListingLocation>
+      <CompileAs>CompileAsCpp</CompileAs>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>third-party/jsoncpp;../../common;../libscap;../../../draios_win32_deps/LuaJIT/src</AdditionalIncludeDirectories>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;PLATFORM_NAME="Windows";K8S_DISABLE_THREAD;CMAKE_INTDIR="Debug";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
     </ClCompile>
-    <Link>
-      <TargetMachine>MachineX86</TargetMachine>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Console</SubSystem>
-      <ImportLibrary>$(ProjectDir)\..\Debug\$(TargetName).lib</ImportLibrary>
-      <ModuleDefinitionFile>
-      </ModuleDefinitionFile>
-      <AdditionalDependencies>../../../draios_win32_deps/LuaJIT/src/lua51.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Ws2_32.lib;%(AdditionalDependencies);../Debug/scap.lib</AdditionalDependencies>
-      <OutputFile>$(ProjectDir)\..\Debug\$(TargetName)$(TargetExt)</OutputFile>
-    </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CRT_SECURE_NO_WARNINGS;PLATFORM_NAME=\"Windows\";K8S_DISABLE_THREAD;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\.;D:\Git\sysdig\userspace\libsinsp\..\..\common;D:\Git\sysdig\userspace\libsinsp\..\libscap;D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\luajit-prefix\src\luajit\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\.;D:\Git\sysdig\userspace\libsinsp\..\..\common;D:\Git\sysdig\userspace\libsinsp\..\libscap;D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\luajit-prefix\src\luajit\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Lib>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+    </Lib>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;PLATFORM_NAME="Windows";NDEBUG;_WINDOWS;_USRDLL;SINSP_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\.;D:\Git\sysdig\userspace\libsinsp\..\..\common;D:\Git\sysdig\userspace\libsinsp\..\libscap;D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\luajit-prefix\src\luajit\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>Release/</AssemblerListingLocation>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;PLATFORM_NAME="Windows";K8S_DISABLE_THREAD;CMAKE_INTDIR="Release";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;PLATFORM_NAME=\"Windows\";K8S_DISABLE_THREAD;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\.;D:\Git\sysdig\userspace\libsinsp\..\..\common;D:\Git\sysdig\userspace\libsinsp\..\libscap;D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\luajit-prefix\src\luajit\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\.;D:\Git\sysdig\userspace\libsinsp\..\..\common;D:\Git\sysdig\userspace\libsinsp\..\libscap;D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\luajit-prefix\src\luajit\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Lib>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\.;D:\Git\sysdig\userspace\libsinsp\..\..\common;D:\Git\sysdig\userspace\libsinsp\..\libscap;D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\luajit-prefix\src\luajit\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>MinSizeRel/</AssemblerListingLocation>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <Optimization>MinSpace</Optimization>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>third-party/jsoncpp;../../common;../libscap;../../../draios_win32_deps/LuaJIT/src</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;PLATFORM_NAME="Windows";K8S_DISABLE_THREAD;CMAKE_INTDIR="MinSizeRel";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
     </ClCompile>
-    <Link>
-      <TargetMachine>MachineX86</TargetMachine>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Console</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <ImportLibrary>$(ProjectDir)\..\Release\$(TargetName).lib</ImportLibrary>
-      <ModuleDefinitionFile>
-      </ModuleDefinitionFile>
-      <AdditionalDependencies>../../../draios_win32_deps/LuaJIT/src/lua51.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Ws2_32.lib;../Release/scap.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(ProjectDir)\..\Release\$(TargetName)$(TargetExt)</OutputFile>
-    </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;PLATFORM_NAME=\"Windows\";K8S_DISABLE_THREAD;CMAKE_INTDIR=\"MinSizeRel\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\.;D:\Git\sysdig\userspace\libsinsp\..\..\common;D:\Git\sysdig\userspace\libsinsp\..\libscap;D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\luajit-prefix\src\luajit\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\.;D:\Git\sysdig\userspace\libsinsp\..\..\common;D:\Git\sysdig\userspace\libsinsp\..\libscap;D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\luajit-prefix\src\luajit\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Lib>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\.;D:\Git\sysdig\userspace\libsinsp\..\..\common;D:\Git\sysdig\userspace\libsinsp\..\libscap;D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\luajit-prefix\src\luajit\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>RelWithDebInfo/</AssemblerListingLocation>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <Optimization>MaxSpeed</Optimization>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;PLATFORM_NAME="Windows";K8S_DISABLE_THREAD;CMAKE_INTDIR="RelWithDebInfo";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;PLATFORM_NAME=\"Windows\";K8S_DISABLE_THREAD;CMAKE_INTDIR=\"RelWithDebInfo\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\.;D:\Git\sysdig\userspace\libsinsp\..\..\common;D:\Git\sysdig\userspace\libsinsp\..\libscap;D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\luajit-prefix\src\luajit\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\.;D:\Git\sysdig\userspace\libsinsp\..\..\common;D:\Git\sysdig\userspace\libsinsp\..\libscap;D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\luajit-prefix\src\luajit\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Lib>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="chisel.cpp" />
-    <ClCompile Include="dumper.cpp" />
-    <ClCompile Include="event.cpp" />
-    <ClCompile Include="eventformatter.cpp" />
-    <ClCompile Include="fdinfo.cpp" />
-    <ClCompile Include="filter.cpp" />
-    <ClCompile Include="filterchecks.cpp" />
-    <ClCompile Include="ifinfo.cpp" />
-    <ClCompile Include="internal_metrics.cpp" />
-    <ClCompile Include="logger.cpp" />
-    <ClCompile Include="memmem.cpp" />
-    <ClCompile Include="sinsp.cpp" />
-    <ClCompile Include="parsers.cpp" />
-    <ClCompile Include="stats.cpp" />
-    <ClCompile Include="third-party\jsoncpp\jsoncpp.cpp" />
-    <ClCompile Include="threadinfo.cpp" />
-    <ClCompile Include="utils.cpp" />
+    <CustomBuild Include="D:\Git\sysdig\userspace\libsinsp\CMakeLists.txt">
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Building Custom Rule D:/Git/sysdig/userspace/libsinsp/CMakeLists.txt</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -HD:/Git/sysdig -BD:/Git/sysdig --check-stamp-file D:/Git/sysdig/userspace/libsinsp/CMakeFiles/generate.stamp
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">D:/Git/sysdig/userspace/libsinsp/CMakeLists.txt;D:\Git\sysdig\userspace\libsinsp\CMakeLists.txt;D:\Git\sysdig\userspace\libsinsp\CMakeLists.txt;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">D:\Git\sysdig\userspace\libsinsp\CMakeFiles\generate.stamp</Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</LinkObjects>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Building Custom Rule D:/Git/sysdig/userspace/libsinsp/CMakeLists.txt</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -HD:/Git/sysdig -BD:/Git/sysdig --check-stamp-file D:/Git/sysdig/userspace/libsinsp/CMakeFiles/generate.stamp
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">D:/Git/sysdig/userspace/libsinsp/CMakeLists.txt;D:\Git\sysdig\userspace\libsinsp\CMakeLists.txt;D:\Git\sysdig\userspace\libsinsp\CMakeLists.txt;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">D:\Git\sysdig\userspace\libsinsp\CMakeFiles\generate.stamp</Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkObjects>
+      <Message Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">Building Custom Rule D:/Git/sysdig/userspace/libsinsp/CMakeLists.txt</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -HD:/Git/sysdig -BD:/Git/sysdig --check-stamp-file D:/Git/sysdig/userspace/libsinsp/CMakeFiles/generate.stamp
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">D:/Git/sysdig/userspace/libsinsp/CMakeLists.txt;D:\Git\sysdig\userspace\libsinsp\CMakeLists.txt;D:\Git\sysdig\userspace\libsinsp\CMakeLists.txt;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">D:\Git\sysdig\userspace\libsinsp\CMakeFiles\generate.stamp</Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">false</LinkObjects>
+      <Message Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">Building Custom Rule D:/Git/sysdig/userspace/libsinsp/CMakeLists.txt</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -HD:/Git/sysdig -BD:/Git/sysdig --check-stamp-file D:/Git/sysdig/userspace/libsinsp/CMakeFiles/generate.stamp
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">D:/Git/sysdig/userspace/libsinsp/CMakeLists.txt;D:\Git\sysdig\userspace\libsinsp\CMakeLists.txt;D:\Git\sysdig\userspace\libsinsp\CMakeLists.txt;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">D:\Git\sysdig\userspace\libsinsp\CMakeFiles\generate.stamp</Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">false</LinkObjects>
+    </CustomBuild>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\driver\ppm_events_public.h" />
-    <ClInclude Include="..\..\driver\ppm_ringbuffer.h" />
-    <ClInclude Include="..\..\driver\ppm_types.h" />
-    <ClInclude Include="chisel.h" />
-    <ClInclude Include="dumper.h" />
-    <ClInclude Include="event.h" />
-    <ClInclude Include="eventformatter.h" />
-    <ClInclude Include="fdinfo.h" />
-    <ClInclude Include="filter.h" />
-    <ClInclude Include="filterchecks.h" />
-    <ClInclude Include="ifinfo.h" />
-    <ClInclude Include="internal_metrics.h" />
-    <ClInclude Include="logger.h" />
-    <ClInclude Include="sinsp_signal.h" />
-    <ClInclude Include="stats.h" />
-    <ClInclude Include="threadinfo.h" />
-    <ClInclude Include="sinsp_errno.h" />
-    <ClInclude Include="utils.h" />
-    <ClInclude Include="settings.h" />
-    <ClInclude Include="sinsp.h" />
-    <ClInclude Include="sinsp_int.h" />
-    <ClInclude Include="parsers.h" />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\chisel.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\chisel_api.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\container.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\ctext.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\cyclewriter.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\cursescomponents.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\cursestable.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\cursesspectro.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\cursesui.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\event.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\eventformatter.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\docker.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\dumper.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\fdinfo.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\filter.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\filterchecks.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\http_parser.c" >
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">CompileAsC</CompileAs>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\http_reason.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\ifinfo.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\json_query.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_api_error.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_api_handler.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_component.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_daemonset_handler.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_deployment_handler.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_dispatcher.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_event_data.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_event_handler.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_handler.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_namespace_handler.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_net.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_node_handler.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_pod_handler.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_replicationcontroller_handler.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_replicaset_handler.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_service_handler.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_state.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\lua_parser.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\lua_parser_api.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\marathon_component.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\marathon_http.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\memmem.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\tracers.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\mesos_auth.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\mesos.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\mesos_collector.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\mesos_component.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\mesos_http.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\mesos_state.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\internal_metrics.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp\jsoncpp.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\logger.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\parsers.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\prefix_search.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\protodecoder.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\threadinfo.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\sinsp.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\stats.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\table.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\sinsp_auth.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\sinsp_curl.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\stopwatch.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\uri_parser.c" >
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">CompileAsC</CompileAs>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\uri.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\utils.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\user_event.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\value_parser.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\viewinfo.cpp"  />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="D:\Git\sysdig\ZERO_CHECK.vcxproj">
+      <Project>{1CB35481-DC21-3DE3-B75E-B7BC16F1E648}</Project>
+      <Name>ZERO_CHECK</Name>
+    </ProjectReference>
+    <ProjectReference Include="D:\Git\sysdig\luajit.vcxproj">
+      <Project>{B851DB22-5C48-369B-8445-D27F9BC1B04F}</Project>
+      <Name>luajit</Name>
+    </ProjectReference>
+    <ProjectReference Include="D:\Git\sysdig\userspace\libscap\scap.vcxproj">
+      <Project>{F647D184-0F78-3A74-B2D6-AA26D50C0E4E}</Project>
+      <Name>scap</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/userspace/libsinsp/sinsp.vcxproj.filters
+++ b/userspace/libsinsp/sinsp.vcxproj.filters
@@ -1,132 +1,220 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="event.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\chisel.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="fdinfo.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\chisel_api.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="ifinfo.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\container.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="internal_metrics.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\ctext.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="parsers.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\cyclewriter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="sinsp.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\cursescomponents.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="utils.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\cursestable.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="stats.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\cursesspectro.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="logger.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\cursesui.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="threadinfo.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\event.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="filter.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\eventformatter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="filterchecks.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\docker.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="eventformatter.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\dumper.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="dumper.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\fdinfo.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="chisel.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\filter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="third-party\jsoncpp\jsoncpp.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\filterchecks.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="memmem.cpp">
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\http_parser.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\http_reason.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\ifinfo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\json_query.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_api_error.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_api_handler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_component.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_daemonset_handler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_deployment_handler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_dispatcher.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_event_data.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_event_handler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_handler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_namespace_handler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_net.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_node_handler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_pod_handler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_replicationcontroller_handler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_replicaset_handler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_service_handler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\k8s_state.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\lua_parser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\lua_parser_api.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\marathon_component.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\marathon_http.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\memmem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\tracers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\mesos_auth.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\mesos.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\mesos_collector.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\mesos_component.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\mesos_http.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\mesos_state.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\internal_metrics.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp\jsoncpp.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\logger.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\parsers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\prefix_search.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\protodecoder.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\threadinfo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\sinsp.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\stats.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\table.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\sinsp_auth.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\sinsp_curl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\stopwatch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\uri_parser.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\uri.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\utils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\user_event.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\value_parser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D:\Git\sysdig\userspace\libsinsp\viewinfo.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="event.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="fdinfo.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="ifinfo.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="internal_metrics.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="parsers.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\driver\ppm_events_public.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\driver\ppm_ringbuffer.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\driver\ppm_types.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="settings.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="sinsp.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="sinsp_errno.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="sinsp_int.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="sinsp_signal.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="stats.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="utils.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="logger.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="threadinfo.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="filter.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="filterchecks.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="eventformatter.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="dumper.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="chisel.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
+    <CustomBuild Include="D:\Git\sysdig\userspace\libsinsp\CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">
-      <UniqueIdentifier>{0c4ca121-756a-4ac8-84db-8e9eb7d79d8a}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{7a30d38b-3fdd-4205-82aa-01206446965d}</UniqueIdentifier>
+      <UniqueIdentifier>{B65E308C-01A2-3FB7-8317-610DB05CED03}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/userspace/libsinsp/user_event.h
+++ b/userspace/libsinsp/user_event.h
@@ -232,7 +232,7 @@ inline bool user_event_filter_t::ci_compare_str(const std::string& a, const std:
 #ifndef _WIN32
 	return strcasecmp(a.c_str(), b.c_str()) == 0;
 #else
-	return lstrcmpiA(a.c_str(), b.c_str()) == 0;
+	return lstrcmpiA(a.c_str(), a.c_str()) < 0;
 #endif // _WIN32
 }
 

--- a/userspace/libsinsp/user_event.h
+++ b/userspace/libsinsp/user_event.h
@@ -232,7 +232,7 @@ inline bool user_event_filter_t::ci_compare_str(const std::string& a, const std:
 #ifndef _WIN32
 	return strcasecmp(a.c_str(), b.c_str()) == 0;
 #else
-	return lstrcmpiA(a.c_str(), a.c_str()) < 0;
+	return lstrcmpiA(a.c_str(), b.c_str()) == 0;
 #endif // _WIN32
 }
 

--- a/userspace/sysdig/sysdig.vcxproj
+++ b/userspace/sysdig/sysdig.vcxproj
@@ -1,92 +1,486 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
+    <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
+    <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="MinSizeRel|x64">
+      <Configuration>MinSizeRel</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="RelWithDebInfo|x64">
+      <Configuration>RelWithDebInfo</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{BD7F8F60-0014-4800-A6B3-ABD9A5A458FD}</ProjectGuid>
+    <ProjectGuid>{FFED1BCD-EFBB-32E3-A822-C4226C56CD23}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
+    <Platform>x64</Platform>
+    <ProjectName>sysdig</ProjectName>
+    <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-    <OutDir>..\..\..\Debug\</OutDir>
-    <IntDir>..\..\..\Debug\</IntDir>
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.20506.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">D:\Git\sysdig\userspace\sysdig\Debug\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">sysdig.dir\Debug\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">sysdig</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.exe</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</GenerateManifest>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">D:\Git\sysdig\userspace\sysdig\Release\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">sysdig.dir\Release\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">sysdig</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.exe</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</GenerateManifest>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">D:\Git\sysdig\userspace\sysdig\MinSizeRel\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">sysdig.dir\MinSizeRel\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">sysdig</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">.exe</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">false</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">true</GenerateManifest>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">D:\Git\sysdig\userspace\sysdig\RelWithDebInfo\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">sysdig.dir\RelWithDebInfo\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">sysdig</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">.exe</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">true</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">true</GenerateManifest>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-    <OutDir>..\..\..\Release\</OutDir>
-    <IntDir>..\..\..\Release\</IntDir>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;PLATFORM_NAME="Windows";_DEBUG;_CONSOLE;_NO_DEBUG_HEAP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>./;../libsinsp;../libscap;../../common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\common;D:\Git\sysdig\userspace\libscap;D:\Git\sysdig\userspace\libsinsp;D:\Git\sysdig\userspace\sysdig;D:\Git\sysdig\userspace\sysdig\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>Debug/</AssemblerListingLocation>
+      <CompileAs>CompileAsCpp</CompileAs>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <Optimization>Disabled</Optimization>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;PLATFORM_NAME="Windows";K8S_DISABLE_THREAD;CMAKE_INTDIR="Debug";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
     </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CRT_SECURE_NO_WARNINGS;PLATFORM_NAME=\"Windows\";K8S_DISABLE_THREAD;CMAKE_INTDIR=\"Debug\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\common;D:\Git\sysdig\userspace\libscap;D:\Git\sysdig\userspace\libsinsp;D:\Git\sysdig\userspace\sysdig;D:\Git\sysdig\userspace\sysdig\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\common;D:\Git\sysdig\userspace\libscap;D:\Git\sysdig\userspace\libsinsp;D:\Git\sysdig\userspace\sysdig;D:\Git\sysdig\userspace\sysdig\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <PostBuildEvent>
+      <Message>			</Message>
+      <Command>setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/Git/sysdig/luajit-prefix/src/luajit/src/lua51.dll D:/Git/sysdig/$(Configuration)/lua51.dll
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd
+setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/Git/sysdig/zlib-prefix/src/zlib/zlib1.dll D:/Git/sysdig/$(Configuration)/
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd
+setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_directory D:/Git/sysdig/userspace/sysdig/chisels D:/Git/sysdig/$(Configuration)/chisels
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd
+setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/Git/sysdig/userspace/sysdig/Debug/sysdig.exe D:/Git/sysdig/$(Configuration)/sysdig.exe
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+    </PostBuildEvent>
     <Link>
-      <TargetMachine>MachineX86</TargetMachine>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>..\libsinsp\Debug\sinsp.lib;odbc32.lib;odbccp32.lib;..\libscap\Debug\scap.lib;Ws2_32.lib;..\..\zlib-prefix\src\zlib\zdll.lib;..\..\luajit-prefix\src\luajit\src\lua51.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+      <GenerateDebugInformation>Debug</GenerateDebugInformation>
+      <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <ImportLibrary>D:/Git/sysdig/userspace/sysdig/Debug/sysdig.lib</ImportLibrary>
+      <ProgramDataBaseFile>D:/Git/sysdig/userspace/sysdig/Debug/sysdig.pdb</ProgramDataBaseFile>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Ws2_32.lib;$(ProjectDir)..\Debug\scap.lib;$(ProjectDir)..\Debug\sinsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>..\Debug\sysdig.exe</OutputFile>
+      <Version></Version>
     </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;PLATFORM_NAME="Windows";NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>./;../libsinsp;../libscap;../../common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\common;D:\Git\sysdig\userspace\libscap;D:\Git\sysdig\userspace\libsinsp;D:\Git\sysdig\userspace\sysdig;D:\Git\sysdig\userspace\sysdig\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>Release/</AssemblerListingLocation>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;PLATFORM_NAME="Windows";K8S_DISABLE_THREAD;CMAKE_INTDIR="Release";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;PLATFORM_NAME=\"Windows\";K8S_DISABLE_THREAD;CMAKE_INTDIR=\"Release\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\common;D:\Git\sysdig\userspace\libscap;D:\Git\sysdig\userspace\libsinsp;D:\Git\sysdig\userspace\sysdig;D:\Git\sysdig\userspace\sysdig\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\common;D:\Git\sysdig\userspace\libscap;D:\Git\sysdig\userspace\libsinsp;D:\Git\sysdig\userspace\sysdig;D:\Git\sysdig\userspace\sysdig\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <PostBuildEvent>
+      <Message>			</Message>
+      <Command>setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/Git/sysdig/luajit-prefix/src/luajit/src/lua51.dll D:/Git/sysdig/$(Configuration)/lua51.dll
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd
+setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/Git/sysdig/zlib-prefix/src/zlib/zlib1.dll D:/Git/sysdig/$(Configuration)/
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd
+setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_directory D:/Git/sysdig/userspace/sysdig/chisels D:/Git/sysdig/$(Configuration)/chisels
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd
+setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/Git/sysdig/userspace/sysdig/Release/sysdig.exe D:/Git/sysdig/$(Configuration)/sysdig.exe
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+    </PostBuildEvent>
+    <Link>
+      <AdditionalDependencies>..\libsinsp\Release\sinsp.lib;odbc32.lib;odbccp32.lib;..\libscap\Release\scap.lib;Ws2_32.lib;..\..\zlib-prefix\src\zlib\zdll.lib;..\..\luajit-prefix\src\luajit\src\lua51.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+      <GenerateDebugInformation>No</GenerateDebugInformation>
+      <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <ImportLibrary>D:/Git/sysdig/userspace/sysdig/Release/sysdig.lib</ImportLibrary>
+      <ProgramDataBaseFile>D:/Git/sysdig/userspace/sysdig/Release/sysdig.pdb</ProgramDataBaseFile>
+      <SubSystem>Console</SubSystem>
+      <Version></Version>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\common;D:\Git\sysdig\userspace\libscap;D:\Git\sysdig\userspace\libsinsp;D:\Git\sysdig\userspace\sysdig;D:\Git\sysdig\userspace\sysdig\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>MinSizeRel/</AssemblerListingLocation>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <Optimization>MinSpace</Optimization>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;PLATFORM_NAME="Windows";K8S_DISABLE_THREAD;CMAKE_INTDIR="MinSizeRel";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
     </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;PLATFORM_NAME=\"Windows\";K8S_DISABLE_THREAD;CMAKE_INTDIR=\"MinSizeRel\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\common;D:\Git\sysdig\userspace\libscap;D:\Git\sysdig\userspace\libsinsp;D:\Git\sysdig\userspace\sysdig;D:\Git\sysdig\userspace\sysdig\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\common;D:\Git\sysdig\userspace\libscap;D:\Git\sysdig\userspace\libsinsp;D:\Git\sysdig\userspace\sysdig;D:\Git\sysdig\userspace\sysdig\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <PostBuildEvent>
+      <Message>			</Message>
+      <Command>setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/Git/sysdig/luajit-prefix/src/luajit/src/lua51.dll D:/Git/sysdig/$(Configuration)/lua51.dll
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd
+setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/Git/sysdig/zlib-prefix/src/zlib/zlib1.dll D:/Git/sysdig/$(Configuration)/
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd
+setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_directory D:/Git/sysdig/userspace/sysdig/chisels D:/Git/sysdig/$(Configuration)/chisels
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd
+setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/Git/sysdig/userspace/sysdig/MinSizeRel/sysdig.exe D:/Git/sysdig/$(Configuration)/sysdig.exe
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+    </PostBuildEvent>
     <Link>
-      <TargetMachine>MachineX86</TargetMachine>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>..\libsinsp\MinSizeRel\sinsp.lib;odbc32.lib;odbccp32.lib;..\libscap\MinSizeRel\scap.lib;Ws2_32.lib;..\..\zlib-prefix\src\zlib\zdll.lib;..\..\luajit-prefix\src\luajit\src\lua51.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+      <GenerateDebugInformation>No</GenerateDebugInformation>
+      <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <ImportLibrary>D:/Git/sysdig/userspace/sysdig/MinSizeRel/sysdig.lib</ImportLibrary>
+      <ProgramDataBaseFile>D:/Git/sysdig/userspace/sysdig/MinSizeRel/sysdig.pdb</ProgramDataBaseFile>
       <SubSystem>Console</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Ws2_32.lib;..\Release\scap.lib;..\Release\sinsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>..\Release\sysdig.exe</OutputFile>
+      <Version></Version>
     </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\common;D:\Git\sysdig\userspace\libscap;D:\Git\sysdig\userspace\libsinsp;D:\Git\sysdig\userspace\sysdig;D:\Git\sysdig\userspace\sysdig\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>RelWithDebInfo/</AssemblerListingLocation>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <Optimization>MaxSpeed</Optimization>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;PLATFORM_NAME="Windows";K8S_DISABLE_THREAD;CMAKE_INTDIR="RelWithDebInfo";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;PLATFORM_NAME=\"Windows\";K8S_DISABLE_THREAD;CMAKE_INTDIR=\"RelWithDebInfo\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\common;D:\Git\sysdig\userspace\libscap;D:\Git\sysdig\userspace\libsinsp;D:\Git\sysdig\userspace\sysdig;D:\Git\sysdig\userspace\sysdig\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>D:\Git\sysdig\userspace\libsinsp\third-party\jsoncpp;D:\Git\sysdig\common;D:\Git\sysdig\userspace\libscap;D:\Git\sysdig\userspace\libsinsp;D:\Git\sysdig\userspace\sysdig;D:\Git\sysdig\userspace\sysdig\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <PostBuildEvent>
+      <Message>			</Message>
+      <Command>setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/Git/sysdig/luajit-prefix/src/luajit/src/lua51.dll D:/Git/sysdig/$(Configuration)/lua51.dll
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd
+setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/Git/sysdig/zlib-prefix/src/zlib/zlib1.dll D:/Git/sysdig/$(Configuration)/
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd
+setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_directory D:/Git/sysdig/userspace/sysdig/chisels D:/Git/sysdig/$(Configuration)/chisels
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd
+setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/Git/sysdig/userspace/sysdig/RelWithDebInfo/sysdig.exe D:/Git/sysdig/$(Configuration)/sysdig.exe
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+    </PostBuildEvent>
+    <Link>
+      <AdditionalDependencies>..\libsinsp\RelWithDebInfo\sinsp.lib;odbc32.lib;odbccp32.lib;..\libscap\RelWithDebInfo\scap.lib;Ws2_32.lib;..\..\zlib-prefix\src\zlib\zdll.lib;..\..\luajit-prefix\src\luajit\src\lua51.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+      <GenerateDebugInformation>Debug</GenerateDebugInformation>
+      <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <ImportLibrary>D:/Git/sysdig/userspace/sysdig/RelWithDebInfo/sysdig.lib</ImportLibrary>
+      <ProgramDataBaseFile>D:/Git/sysdig/userspace/sysdig/RelWithDebInfo/sysdig.pdb</ProgramDataBaseFile>
+      <SubSystem>Console</SubSystem>
+      <Version></Version>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="fields_info.cpp" />
-    <ClCompile Include="sysdig.cpp" />
-    <ClCompile Include="win32\getopt.c" />
+    <CustomBuild Include="D:\Git\sysdig\userspace\sysdig\CMakeLists.txt">
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Building Custom Rule D:/Git/sysdig/userspace/sysdig/CMakeLists.txt</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -HD:/Git/sysdig -BD:/Git/sysdig --check-stamp-file D:/Git/sysdig/userspace/sysdig/CMakeFiles/generate.stamp
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">D:/Git/sysdig/userspace/sysdig/CMakeLists.txt;D:\Git\sysdig\userspace\sysdig\CMakeLists.txt;D:\Git\sysdig\userspace\sysdig\config_sysdig.h.in;D:\Git\sysdig\userspace\sysdig\CMakeLists.txt;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">D:\Git\sysdig\userspace\sysdig\CMakeFiles\generate.stamp</Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</LinkObjects>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Building Custom Rule D:/Git/sysdig/userspace/sysdig/CMakeLists.txt</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -HD:/Git/sysdig -BD:/Git/sysdig --check-stamp-file D:/Git/sysdig/userspace/sysdig/CMakeFiles/generate.stamp
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">D:/Git/sysdig/userspace/sysdig/CMakeLists.txt;D:\Git\sysdig\userspace\sysdig\CMakeLists.txt;D:\Git\sysdig\userspace\sysdig\config_sysdig.h.in;D:\Git\sysdig\userspace\sysdig\CMakeLists.txt;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">D:\Git\sysdig\userspace\sysdig\CMakeFiles\generate.stamp</Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkObjects>
+      <Message Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">Building Custom Rule D:/Git/sysdig/userspace/sysdig/CMakeLists.txt</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -HD:/Git/sysdig -BD:/Git/sysdig --check-stamp-file D:/Git/sysdig/userspace/sysdig/CMakeFiles/generate.stamp
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">D:/Git/sysdig/userspace/sysdig/CMakeLists.txt;D:\Git\sysdig\userspace\sysdig\CMakeLists.txt;D:\Git\sysdig\userspace\sysdig\config_sysdig.h.in;D:\Git\sysdig\userspace\sysdig\CMakeLists.txt;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">D:\Git\sysdig\userspace\sysdig\CMakeFiles\generate.stamp</Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">false</LinkObjects>
+      <Message Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">Building Custom Rule D:/Git/sysdig/userspace/sysdig/CMakeLists.txt</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">setlocal
+"D:\Program Files\CMake\bin\cmake.exe" -HD:/Git/sysdig -BD:/Git/sysdig --check-stamp-file D:/Git/sysdig/userspace/sysdig/CMakeFiles/generate.stamp
+if %errorlevel% neq 0 goto :cmEnd
+:cmEnd
+endlocal &amp; call :cmErrorLevel %errorlevel% &amp; goto :cmDone
+:cmErrorLevel
+exit /b %1
+:cmDone
+if %errorlevel% neq 0 goto :VCEnd</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">D:/Git/sysdig/userspace/sysdig/CMakeLists.txt;D:\Git\sysdig\userspace\sysdig\CMakeLists.txt;D:\Git\sysdig\userspace\sysdig\config_sysdig.h.in;D:\Git\sysdig\userspace\sysdig\CMakeLists.txt;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">D:\Git\sysdig\userspace\sysdig\CMakeFiles\generate.stamp</Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">false</LinkObjects>
+    </CustomBuild>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="sysdig.h" />
+    <ClCompile Include="D:\Git\sysdig\userspace\sysdig\fields_info.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\sysdig\sysdig.cpp"  />
+    <ClCompile Include="D:\Git\sysdig\userspace\sysdig\win32\getopt.c" >
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">CompileAsC</CompileAs>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="D:\Git\sysdig\ZERO_CHECK.vcxproj">
+      <Project>{1CB35481-DC21-3DE3-B75E-B7BC16F1E648}</Project>
+      <Name>ZERO_CHECK</Name>
+    </ProjectReference>
+    <ProjectReference Include="D:\Git\sysdig\userspace\libscap\scap.vcxproj">
+      <Project>{F647D184-0F78-3A74-B2D6-AA26D50C0E4E}</Project>
+      <Name>scap</Name>
+    </ProjectReference>
+    <ProjectReference Include="D:\Git\sysdig\userspace\libsinsp\sinsp.vcxproj">
+      <Project>{0F87D5C2-A45F-3DAD-BFB0-05ECE8B3D125}</Project>
+      <Name>sinsp</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: [V549](https://www.viva64.com/en/w/v549/) The first argument of 'lstrcmpiA' function is equal to the second argument.

(https://github.com/ip-gpu/sysdig/blob/dev/userspace/libsinsp/user_event.h#L235)