### PR TITLE
Use unique_ptr instead of scoped_ptr (from boost)

### DIFF
--- a/userspace/libsinsp/third-party/jsoncpp/jsoncpp.cpp
+++ b/userspace/libsinsp/third-party/jsoncpp/jsoncpp.cpp
@@ -231,7 +231,7 @@ static int       stackDepth_g = 0;  // see readValue()
 namespace Json {
 
 #if __GNUC__ >= 6
-typedef std::scoped_ptr<CharReader> const  CharReaderPtr;
+typedef std::unique_ptr<CharReader> const  CharReaderPtr;
 #else
 typedef std::auto_ptr<CharReader>          CharReaderPtr;
 #endif
@@ -3800,7 +3800,7 @@ Value& Path::make(Value& root) const {
 namespace Json {
 
 #if __GNUC__ >= 6
-typedef std::scoped_ptr<StreamWriter> const  StreamWriterPtr;
+typedef std::unique_ptr<StreamWriter> const  StreamWriterPtr;
 #else
 typedef std::auto_ptr<StreamWriter>          StreamWriterPtr;
 #endif


### PR DESCRIPTION
The released version 0.10.6 referred to std::scoped_ptr, which is in
boost. The master version of this code uses
unique_ptr (https://github.com/open-source-parsers/jsoncpp/blob/master/src/lib_json/json_reader.cpp#L57),
so use that as well.