### PR TITLE
Change inactive container scan time to 30s (was 20m)

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -95,7 +95,7 @@ bool sinsp_container_manager::remove_inactive_containers()
 	}
 
 	if(m_inspector->m_lastevent_ts >
-		m_last_flush_time_ns + m_inspector->m_inactive_thread_scan_time_ns)
+		m_last_flush_time_ns + m_inspector->m_inactive_container_scan_time_ns)
 	{
 		res = true;
 

--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -72,9 +72,9 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #define DEFAULT_INACTIVE_THREAD_SCAN_TIME_S 1200
 
 //
-// How often the thread table is scanned for inactive threads
+// How often the container table is scanned for inactive containers
 //
-#define DEFAULT_INACTIVE_CONTAINER_SCAN_TIME_S DEFAULT_INACTIVE_THREAD_SCAN_TIME_S
+#define DEFAULT_INACTIVE_CONTAINER_SCAN_TIME_S 30
 
 //
 // Enables Lua chisel scripts support


### PR DESCRIPTION
Also fixed copy/paste error and comments.

on_remove_container() only gets called from sinsp_container_manager::remove_inactive_containers() which currently only scans once every 20 minutes.
We need more frequent updates and we don't seem to be doing much more than walking through the thread and container tables, so I figured 30 seconds should be safe enough.