### PR TITLE
Found addl location to log json parse errors

### DIFF
--- a/userspace/libsinsp/mesos_http.h
+++ b/userspace/libsinsp/mesos_http.h
@@ -168,6 +168,13 @@ inline mesos_http::json_ptr_t mesos_http::try_parse(const std::string& json)
 		{
 			return root;
 		}
+		else
+		{
+			std::string errstr;
+			errstr = Json::Reader().getFormattedErrorMessages();
+			g_logger.log("mesos_http::try_parse could not parse json (" + errstr + ")", sinsp_logger::SEV_WARNING);
+			g_json_error_log.log(json, errstr);
+		}
 	}
 	catch(const Json::Exception &e)
 	{


### PR DESCRIPTION
mesos_http::try_parse, which is used in a few places to parse
mesos/marathon-related json, did catch JSON::Exception exceptions and
log them, but it didn't log errors when Parse itself returned
false. Just in case, also log json parse errors when parse returns
false.