### PR TITLE
Don't terminate chunked http transfers

### DIFF
--- a/userspace/libsinsp/mesos_http.cpp
+++ b/userspace/libsinsp/mesos_http.cpp
@@ -565,7 +565,7 @@ void mesos_http::send_request()
 
 bool purge_chunked_markers(std::string& data)
 {
-	std::string::size_type pos = data.find("}\r\n\0");
+	std::string::size_type pos = data.find("}\r\n0");
 	if(pos != std::string::npos)
 	{
 		data = data.substr(0, pos);


### PR DESCRIPTION
If a chunked transfer of mesos has a chunk that happens to end in '}',
the mesos code will incorrectly truncate the json document on '}' + crlf + '\0'.

I think the intent was to strip out a final chunk marker which is sent
as a chunk with size 0, as is already done in
mesos_http::extract_data. However there's a typo '0' -> '\0'.

The fix is to use '0', which prevents the json document from being
truncated.

This fixes SMAGENT-730.