### PR TITLE
scap_open error when incorrect mode is provided

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -549,6 +549,7 @@ scap_t* scap_open(scap_open_args args, char *error)
 									  args.proc_callback_context,
 									  args.import_users);
 	default:
+		snprintf(error, SCAP_LASTERR_SIZE, "incorrect mode %d", args.mode);
 		return NULL;
 	}
 }


### PR DESCRIPTION
Added error message when `args.mode` is incorrect