### PR TITLE
Use explicit Docker API versions

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -651,6 +651,7 @@ sinsp_docker_response sinsp_container_manager::get_docker(const string& api_vers
 	string message = "GET " + api_version + "/containers/" + container_id + "/json HTTP/1.0\r\n\n";
 	if(write(sock, message.c_str(), message.length()) != (ssize_t) message.length())
 	{
+		close(sock);
 		return sinsp_docker_response::RESP_ERROR;
 	}
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -644,6 +644,7 @@ sinsp_docker_response sinsp_container_manager::get_docker(const string& api_vers
 
 	if(connect(sock, (struct sockaddr *) &address, sizeof(struct sockaddr_un)) != 0)
 	{
+		close(sock);
 		return sinsp_docker_response::RESP_ERROR;
 	}
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -624,7 +624,7 @@ bool sinsp_container_manager::container_to_sinsp_event(const string& json, sinsp
 }
 
 #ifndef _WIN32
-bool sinsp_container_manager::parse_docker(sinsp_container_info* container)
+sinsp_docker_response sinsp_container_manager::get_docker(const string& api_version, const string& container_id, string& json)
 {
 	string file = string(scap_get_host_root()) + "/var/run/docker.sock";
 
@@ -632,7 +632,7 @@ bool sinsp_container_manager::parse_docker(sinsp_container_info* container)
 	if(sock < 0)
 	{
 		ASSERT(false);
-		return false;
+		return sinsp_docker_response::RESP_ERROR;
 	}
 
 	struct sockaddr_un address;
@@ -644,27 +644,24 @@ bool sinsp_container_manager::parse_docker(sinsp_container_info* container)
 
 	if(connect(sock, (struct sockaddr *) &address, sizeof(struct sockaddr_un)) != 0)
 	{
-		return false;
+		return sinsp_docker_response::RESP_ERROR;
 	}
 
-	string message = "GET /containers/" + container->m_id + "/json HTTP/1.0\r\n\n";
+	string message = "GET " + api_version + "/containers/" + container_id + "/json HTTP/1.0\r\n\n";
 	if(write(sock, message.c_str(), message.length()) != (ssize_t) message.length())
 	{
-		ASSERT(false);
-		close(sock);
-		return false;
+		return sinsp_docker_response::RESP_ERROR;
 	}
 
 	char buf[256];
-	string json;
 	ssize_t res;
+	json.clear();
 	while((res = read(sock, buf, sizeof(buf) - 1)) != 0)
 	{
 		if(res == -1 || json.size() > MAX_JSON_SIZE_B)
 		{
-			ASSERT(false);
 			close(sock);
-			return false;
+			return sinsp_docker_response::RESP_ERROR;
 		}
 
 		buf[res] = 0;
@@ -672,6 +669,34 @@ bool sinsp_container_manager::parse_docker(sinsp_container_info* container)
 	}
 
 	close(sock);
+	if(strncmp(json.c_str(), "HTTP/1.0 200 OK", sizeof("HTTP/1.0 200 OK") -1))
+	{
+		return sinsp_docker_response::RESP_BAD_REQUEST;
+	}
+
+	return sinsp_docker_response::RESP_OK;
+}
+
+bool sinsp_container_manager::parse_docker(sinsp_container_info* container)
+{
+	string json;
+        sinsp_docker_response resp = get_docker("/v1.24", container->m_id, json);
+	switch(resp) {
+		case sinsp_docker_response::RESP_BAD_REQUEST:
+			resp = get_docker("", container->m_id, json);
+			if (resp == sinsp_docker_response::RESP_OK)
+			{
+				break;
+			}
+			/* FALLTHRU */
+
+		case sinsp_docker_response::RESP_ERROR:
+			ASSERT(false);
+			return false;
+
+		case sinsp_docker_response::RESP_OK:
+			break;
+	}
 
 	size_t pos = json.find("{");
 	if(pos == string::npos)

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -27,6 +27,13 @@ enum sinsp_container_type
 	CT_RKT = 4
 };
 
+enum sinsp_docker_response
+{
+	RESP_OK = 0,
+	RESP_BAD_REQUEST = 1,
+	RESP_ERROR = 2
+};
+
 class sinsp_container_info
 {
 public:
@@ -153,6 +160,7 @@ public:
 private:
 	string container_to_json(const sinsp_container_info& container_info);
 	bool container_to_sinsp_event(const string& json, sinsp_evt* evt);
+	sinsp_docker_response get_docker(const string& api_version, const string& container_id, string& json);
 	bool parse_docker(sinsp_container_info* container);
 	string get_docker_env(const Json::Value &env_vars, const string &mti);
 	bool parse_rkt(sinsp_container_info* container, const string& podid, const string& appname);

--- a/userspace/libsinsp/docker.h
+++ b/userspace/libsinsp/docker.h
@@ -25,7 +25,7 @@ public:
 	static const int default_timeout_ms = 1000L;
 
 	docker(std::string url = "",
-		const std::string& path = "/events",
+		const std::string& path = "/v1.24/events",
 		const std::string& http_version = "1.0",
 		int timeout_ms = default_timeout_ms,
 		bool is_captured = false,


### PR DESCRIPTION
Per #900, using unversioned API endpoints is deprecated and will be removed soon. Add explicit version numbers to the Docker API requests. Use v1.24 according to Docker's recommendation at the time of this writing.

For requesting container metadata, if the v1.24 request fails, fall back to using an unversioned request, so that we get container metadata from as many Docker versions as possible.