### PR TITLE
Mesos custom events

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(sinsp STATIC
 	sinsp.cpp
 	stats.cpp
 	table.cpp
+	token_bucket.cpp
 	sinsp_auth.cpp
 	sinsp_curl.cpp
 	stopwatch.cpp

--- a/userspace/libsinsp/json_error_log.cpp
+++ b/userspace/libsinsp/json_error_log.cpp
@@ -1,26 +1,100 @@
 #include <fstream>
 
+#include <sinsp.h>
+#include <user_event.h>
+#include <logger.h>
+
 #include "json_error_log.h"
 
 json_error_log g_json_error_log;
+
+json_error_log::json_error_log()
+	: m_events_rate(.00333), // one event per 5 minutes
+	  m_events_max_burst(10)
+{
+}
+
+json_error_log::~json_error_log()
+{
+}
 
 void json_error_log::set_json_parse_errors_file(const std::string& filename)
 {
 	m_json_parse_errors_file = filename;
 }
 
-void json_error_log::log(const std::string &json, const std::string &errstr)
+// Note: not changing the rate/burst of any already-created bucket
+void json_error_log::set_events_rate(double events_rate, uint32_t max_burst)
 {
+	m_events_rate = events_rate;
+	m_events_max_burst = max_burst;
+}
+
+void json_error_log::log(const std::string &json, const std::string &errstr,
+			 uint64_t ts_ns, const std::string &uri)
+{
+	time_t now = ts_ns / ONE_SECOND_IN_NS;
+
 	if(m_json_parse_errors_file != "")
 	{
 		std::ofstream errs(m_json_parse_errors_file, std::ofstream::out | std::ofstream::app);
+		char buf[sizeof("YYYY-MM-DDTHH:MM:SSZ")];
+		strftime(buf, sizeof(buf), "%FT%TZ", gmtime(&now));
 
 		errs << "*******************************" << std::endl;
-		errs << errstr << std::endl;
-		errs << json << std::endl;
+		errs << "URI: " << uri << std::endl;
+		errs << "Time (UTC): " << buf << std::endl;
+		errs << "Error: " << errstr << std::endl;
+		errs << "Json: " << json << std::endl;
 		errs << "*******************************" << std::endl;
 
 		errs.close();
 	}
+
+	token_bucket &bucket = get_bucket(uri);
+
+	if(bucket.claim(1, ts_ns))
+	{
+		sinsp_user_event evt;
+		sinsp_user_event::tag_map_t tags;
+		tags["source"] = "json_parser";
+		tags["uri"] = uri;
+		tags["json_prefix"] = json.substr(0, 100);
+		std::string event_name = "json_parse_error";
+		std::string desc = errstr;
+
+		event_scope scope;
+		if(m_machine_id.length())
+		{
+			scope.add("host.mac", m_machine_id);
+		}
+
+		// Also emit a custom event noting the json parse failure.
+		std::string evtstr = sinsp_user_event::to_string(now,
+								 std::move(event_name),
+								 std::move(desc),
+								 std::move(scope),
+								 std::move(tags));
+
+		g_logger.log("Logging user event: " + evtstr, sinsp_logger::SEV_DEBUG);
+
+		g_logger.log(evtstr, sinsp_logger::SEV_EVT_WARNING);
+	}
+}
+
+token_bucket &json_error_log::get_bucket(const std::string &uri)
+{
+	auto it = m_buckets.lower_bound(uri);
+
+	if(it == m_buckets.end() ||
+	   it->first != uri)
+	{
+		it = m_buckets.emplace_hint(it,
+					    std::make_pair(uri, token_bucket()));
+
+		it->second.init(m_events_rate, m_events_max_burst);
+	}
+
+	return it->second;
 }
 

--- a/userspace/libsinsp/json_error_log.h
+++ b/userspace/libsinsp/json_error_log.h
@@ -1,23 +1,49 @@
 #pragma once
 
 #include <string>
+#include <map>
+
+#include "token_bucket.h"
 
 class json_error_log
 {
 public:
+
+	json_error_log();
+	virtual ~json_error_log();
 
 	// Upon any json parsing error, write the error and json
 	// document that had the error to this file. Not enabled by
 	// default.
 	void set_json_parse_errors_file(const std::string& filename);
 
+	void set_events_rate(double events_rate, uint32_t max_burst);
+
 	// Possibly log a json parsing error, depending on whether or
 	// not the above filename was set.
-	void log(const std::string &json, const std::string &errstr);
+	void log(const std::string &json, const std::string &errstr, uint64_t ts_ns, const std::string &uri);
+
+	void set_machine_id(const std::string& machine_id);
 
 private:
+
+	// Return a token bucket limiting errors related to the
+	// configured uri, creating it if necessary.
+	token_bucket &get_bucket(const std::string &uri);
+
 	std::string m_json_parse_errors_file;
+	std::string m_machine_id;
+	double m_events_rate;
+	uint32_t m_events_max_burst;
+
+	// Rate-limit json parse error events by uri.
+	std::map<std::string,token_bucket> m_buckets;
 };
+
+inline void json_error_log::set_machine_id(const std::string& machine_id)
+{
+	m_machine_id = machine_id;
+}
 
 extern json_error_log g_json_error_log;
 

--- a/userspace/libsinsp/marathon_http.cpp
+++ b/userspace/libsinsp/marathon_http.cpp
@@ -43,7 +43,8 @@ marathon_http::~marathon_http()
 bool marathon_http::refresh_data()
 {
 	std::ostringstream os;
-	CURLcode res = get_data(make_uri("/v2/info"), os);
+	std::string uri = make_uri("/v2/info");
+	CURLcode res = get_data(uri, os);
 
 	if(res != CURLE_OK)
 	{
@@ -67,7 +68,7 @@ bool marathon_http::refresh_data()
 			std::string errstr;
 			errstr = reader.getFormattedErrorMessages();
 			g_logger.log("Error parsing framework info (" + errstr + ").\nJSON:\n---\n" + os.str() + "\n---", sinsp_logger::SEV_ERROR);
-			g_json_error_log.log(os.str(), errstr);
+			g_json_error_log.log(os.str(), errstr, sinsp_utils::get_current_time_ns(), uri);
 			return false;
 		}
 	}

--- a/userspace/libsinsp/marathon_http.cpp
+++ b/userspace/libsinsp/marathon_http.cpp
@@ -48,7 +48,9 @@ bool marathon_http::refresh_data()
 
 	if(res != CURLE_OK)
 	{
-		g_logger.log(curl_easy_strerror(res), sinsp_logger::SEV_ERROR);
+		std::string errstr = std::string("Problem accessing /v2/info: ") + curl_easy_strerror(res);
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+		g_json_error_log.log(os.str(), errstr, sinsp_utils::get_current_time_ns(), uri);
 		return false;
 	}
 
@@ -74,7 +76,9 @@ bool marathon_http::refresh_data()
 	}
 	catch(std::exception& ex)
 	{
-		g_logger.log(std::string("Error parsing framework info:") + ex.what(), sinsp_logger::SEV_ERROR);
+		std::string errstr = std::string("Error parsing framework info:") + ex.what();
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+		g_json_error_log.log(os.str(), errstr, sinsp_utils::get_current_time_ns(), uri);
 		return false;
 	}
 	
@@ -84,11 +88,14 @@ bool marathon_http::refresh_data()
 std::string marathon_http::get_groups(const std::string& group_id)
 {
 	std::ostringstream os;
-	CURLcode res = get_data(make_uri("/v2/groups" + group_id), os);
+	std::string uri = make_uri("/v2/groups" + group_id);
+	CURLcode res = get_data(uri, os);
 
 	if(res != CURLE_OK)
 	{
-		g_logger.log(curl_easy_strerror(res), sinsp_logger::SEV_ERROR);
+		std::string errstr = std::string("Problem accessing /v2/groups: ") + curl_easy_strerror(res);
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+		g_json_error_log.log(os.str(), errstr, sinsp_utils::get_current_time_ns(), uri);
 		return "";
 	}
 

--- a/userspace/libsinsp/mesos.cpp
+++ b/userspace/libsinsp/mesos.cpp
@@ -643,7 +643,9 @@ bool mesos::collect_data()
 							}
 							else if((difftime(now, m_last_marathon_refresh) > tout_s) || m_json_error)
 							{
-								g_logger.log("Detected null Marathon app (" + app_it->first + "), resetting current state.", sinsp_logger::SEV_WARNING);
+								std::string errstr = "Detected null Marathon app (" + app_it->first + "), resetting current state.";
+								g_logger.log(errstr, sinsp_logger::SEV_WARNING);
+								g_json_error_log.log(app_it->first, errstr, sinsp_utils::get_current_time_ns(), "marathon-apps-state");
 								m_mesos_state_json.reset();
 								group.second.reset();
 								app_it->second.reset();
@@ -998,7 +1000,9 @@ void mesos::set_marathon_apps_json(json_ptr_t json, const std::string& framework
 	}
 	else
 	{
-		g_logger.log("Received invalid Marathon apps JSON", sinsp_logger::SEV_WARNING);
+		std::string errstr = "Received invalid Marathon apps JSON";
+		g_logger.log(errstr, sinsp_logger::SEV_WARNING);
+		g_json_error_log.log("(null)", errstr, sinsp_utils::get_current_time_ns(), "set-marathon-apps-json");
 	}
 	m_json_error = m_json_error || json_error;
 }

--- a/userspace/libsinsp/mesos.cpp
+++ b/userspace/libsinsp/mesos.cpp
@@ -37,7 +37,7 @@ mesos::mesos(const std::string& mesos_state_json,
 	{
 		throw sinsp_exception("Mesos state AND (both OR none [marathon apps and groups]) are needed");
 	}
-	mesos_http::json_ptr_t state_json = mesos_http::try_parse(mesos_state_json);
+	mesos_http::json_ptr_t state_json = mesos_http::try_parse(mesos_state_json, "fixed-mesos-state");
 	if(state_json)
 	{
 		set_state_json(state_json);
@@ -63,8 +63,8 @@ mesos::mesos(const std::string& mesos_state_json,
 				}
 			}
 			mesos_http::json_ptr_t dummy_group;
-			set_marathon_groups_json(mesos_http::try_parse(marathon_groups_json), framework_id);
-			set_marathon_apps_json(dummy_group/*mesos_http::try_parse(marathon_apps_json)*/, framework_id);
+			set_marathon_groups_json(mesos_http::try_parse(marathon_groups_json, "fixed-marathon-state"), framework_id);
+			set_marathon_apps_json(dummy_group/*mesos_http::try_parse(marathon_apps_json, "fixed-groups-state")*/, framework_id);
 		}
 		collect_data();
 	}
@@ -1045,6 +1045,6 @@ void mesos::simulate_event(const std::string& json)
 		std::string errstr;
 		errstr = reader.getFormattedErrorMessages();
 		g_logger.log("Could not parse json (" + errstr + ")", sinsp_logger::SEV_ERROR);
-		g_json_error_log.log(json, errstr);
+		g_json_error_log.log(json, errstr, sinsp_utils::get_current_time_ns(), "parse-mesos-evt");
 	}
 }

--- a/userspace/libsinsp/mesos.cpp
+++ b/userspace/libsinsp/mesos.cpp
@@ -876,13 +876,16 @@ void mesos::add_tasks_impl(mesos_framework& framework, const Json::Value& tasks)
 					if(!fsid.isNull()) { sid = fsid.asString(); }
 					os << "Failed to add Mesos task: [" << framework.get_name() << ':' << name << ',' << uid << "], running on slave " << sid;
 					g_logger.log(os.str(), sinsp_logger::SEV_ERROR);
+					g_json_error_log.log(framework.get_name(), os.str(), sinsp_utils::get_current_time_ns(), "add_tasks_impl");
 				}
 			}
 		}
 	}
 	else
 	{
-		g_logger.log("Tasks is null", sinsp_logger::SEV_ERROR);
+		std::string errstr = "Tasks is null";
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+		g_json_error_log.log(framework.get_name(), errstr, sinsp_utils::get_current_time_ns(), "add_tasks_impl for framework");
 	}
 }
 
@@ -1042,9 +1045,8 @@ void mesos::simulate_event(const std::string& json)
 	}
 	else
 	{
-		std::string errstr;
-		errstr = reader.getFormattedErrorMessages();
-		g_logger.log("Could not parse json (" + errstr + ")", sinsp_logger::SEV_ERROR);
+		std::string errstr = "Could not parse json (" + reader.getFormattedErrorMessages() + ")";
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
 		g_json_error_log.log(json, errstr, sinsp_utils::get_current_time_ns(), "parse-mesos-evt");
 	}
 }

--- a/userspace/libsinsp/mesos_auth.cpp
+++ b/userspace/libsinsp/mesos_auth.cpp
@@ -83,7 +83,7 @@ void mesos_auth::authenticate()
 			{
 				std::string errstr;
 				errstr = json_reader.getFormattedErrorMessages();
-				g_json_error_log.log(response, errstr);
+				g_json_error_log.log(response, errstr, sinsp_utils::get_current_time_ns(), m_auth_uri.to_string());
 				throw sinsp_exception(string("Cannot parse json (" + errstr + ")"));
 			}
 			else

--- a/userspace/libsinsp/mesos_auth.cpp
+++ b/userspace/libsinsp/mesos_auth.cpp
@@ -98,10 +98,13 @@ void mesos_auth::authenticate()
 	}
 	catch(std::exception& e)
 	{
-		g_logger.format(sinsp_logger::SEV_ERROR,
-				"Could not fetch authentication token via %s: %s",
-				m_auth_uri.to_string().c_str(),
-				e.what());
+		std::string errstr = "Could not fetch authentication token via " +
+			m_auth_uri.to_string() + ": " +
+			e.what();
+
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+
+		g_json_error_log.log("", errstr, sinsp_utils::get_current_time_ns(), m_auth_uri.to_string());
 	}
 #endif // HAS_CAPTURE
 }

--- a/userspace/libsinsp/mesos_component.cpp
+++ b/userspace/libsinsp/mesos_component.cpp
@@ -6,6 +6,7 @@
 #include "marathon_component.h"
 #include "sinsp.h"
 #include "sinsp_int.h"
+#include "json_error_log.h"
 #include <sstream>
 #include <iostream>
 
@@ -302,6 +303,7 @@ void mesos_task::add_labels(mesos_task::ptr_t task, const Json::Value& t_val)
 	{
 		os << "Attempt to add Mesos task labels to null task.";
 		g_logger.log(os.str(), sinsp_logger::SEV_ERROR);
+		g_json_error_log.log("", os.str(), sinsp_utils::get_current_time_ns(), "mesos-task-add-labels");
 	}
 }
 

--- a/userspace/libsinsp/mesos_http.cpp
+++ b/userspace/libsinsp/mesos_http.cpp
@@ -330,7 +330,10 @@ void mesos_http::discover_framework_uris(const Json::Value& frameworks)
 					{
 						if(m_discover_marathon && mesos_framework::is_root_marathon(name))
 						{
-							g_logger.log("mesos_http: Can not obtain URL for Marathon framework.", sinsp_logger::SEV_ERROR);
+							std::string errstr = "mesos_http: Can not obtain URL for Marathon framework.";
+							g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+							g_json_error_log.log("", errstr, sinsp_utils::get_current_time_ns(), m_url.to_string());
+
 						}
 					}
 				}
@@ -417,7 +420,9 @@ bool mesos_http::get_all_data(callback_func_t parse)
 	CURLcode res = get_data(m_url.to_string(), os);
 	if(res != CURLE_OK)
 	{
-		g_logger.log(curl_easy_strerror(res), sinsp_logger::SEV_ERROR);
+		std::string errstr = std::string("Could not fetch url:") + curl_easy_strerror(res);
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+		g_json_error_log.log("", errstr, sinsp_utils::get_current_time_ns(), m_url.to_string());
 		m_connected = false;
 	}
 	else
@@ -597,7 +602,9 @@ void mesos_http::handle_json(std::string::size_type end_pos, bool chunked)
 			m_data_buf = m_data_buf.substr(0, end_pos + 1);
 			if(chunked && !purge_chunked_markers(m_data_buf))
 			{
-				g_logger.log("mesos_http: Invalid Mesos or Marathon JSON data detected (chunked transfer).", sinsp_logger::SEV_ERROR);
+				std::string errstr = "mesos_http: Invalid Mesos or Marathon JSON data detected (chunked transfer).";
+				g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+				g_json_error_log.log(m_data_buf, errstr, sinsp_utils::get_current_time_ns(), m_url.to_string());
 				(m_mesos.*m_callback_func)(nullptr, m_framework_id);
 			}
 			else
@@ -625,10 +632,12 @@ bool mesos_http::detect_chunked_transfer(const std::string& data)
 				long len = strtol(cl.c_str(), NULL, 10);
 				if(len == 0L || len == LONG_MAX || len == LONG_MIN || errno == ERANGE)
 				{
+					std::string errstr = "Invalid HTTP content length from [: " + m_url.to_string(false) + ']' +
+						std::to_string(len);
 					(m_mesos.*m_callback_func)(nullptr, m_framework_id);
 					m_data_buf.clear();
-					g_logger.log("Invalid HTTP content length from [: " + m_url.to_string(false) + ']' +
-							 std::to_string(len), sinsp_logger::SEV_ERROR);
+					g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+					g_json_error_log.log(data, errstr, sinsp_utils::get_current_time_ns(), m_url.to_string());
 					return false;
 				}
 				else
@@ -645,7 +654,9 @@ void mesos_http::extract_data(std::string& data)
 {
 	if(!detect_chunked_transfer(data))
 	{
-		g_logger.log("mesos_http: An error occurred while detecting chunked transfer.", sinsp_logger::SEV_ERROR);
+		string errstr = "mesos_http: An error occurred while detecting chunked transfer.";
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+		g_json_error_log.log(data, errstr, sinsp_utils::get_current_time_ns(), m_url.to_string());
 		return;
 	}
 
@@ -683,8 +694,10 @@ bool mesos_http::on_data()
 
 	size_t iolen = 0;
 	char buf[1024];
+	buf[0] = '\0';
 	std::string data;
 	CURLcode ret;
+	std::string errstr;
 	try
 	{
 		do
@@ -703,13 +716,17 @@ bool mesos_http::on_data()
 	}
 	catch(sinsp_exception& ex)
 	{
-		g_logger.log(std::string("mesos_http: Data receive error [" + m_url.to_string() + "]: ").append(ex.what()), sinsp_logger::SEV_ERROR);
+		errstr = std::string("mesos_http: Data receive error [" + m_url.to_string() + "]: ").append(ex.what());
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+		g_json_error_log.log(buf, errstr, sinsp_utils::get_current_time_ns(), m_url.to_string());
 		return false;
 	}
 	return true;
 
 connection_closed:
-	g_logger.log("mesos_http: Mesos or Marathon API connection [" + m_url.to_string() + "] closed.", sinsp_logger::SEV_ERROR);
+	errstr = "mesos_http: Mesos or Marathon API connection [" + m_url.to_string() + "] closed.";
+	g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+	g_json_error_log.log(buf, errstr, sinsp_utils::get_current_time_ns(), m_url.to_string());
 	m_connected = false;
 	return false;
 }
@@ -759,7 +776,9 @@ Json::Value mesos_http::get_task_labels(const std::string& task_id)
 	Json::Value labels;
 	if(res != CURLE_OK)
 	{
-		g_logger.log(curl_easy_strerror(res), sinsp_logger::SEV_ERROR);
+		std::string errstr = curl_easy_strerror(res);
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+		g_json_error_log.log(task_id, errstr, sinsp_utils::get_current_time_ns(), uri);
 		return labels;
 	}
 
@@ -815,14 +834,16 @@ Json::Value mesos_http::get_task_labels(const std::string& task_id)
 		else
 		{
 			std::string errstr;
-			errstr = reader.getFormattedErrorMessages();
-			g_logger.log("mesos_http: Error parsing tasks (" + errstr + ").\nJSON:\n---\n" + os.str() + "\n---", sinsp_logger::SEV_ERROR);
+			errstr = "mesos_http: Error parsing tasks (" + reader.getFormattedErrorMessages() + ").";
+			g_logger.log(errstr + "\nJSON:\n---\n" + os.str() + "\n---", sinsp_logger::SEV_ERROR);
 			g_json_error_log.log(os.str(), errstr, sinsp_utils::get_current_time_ns(), uri);
 		}
 	}
 	catch(std::exception& ex)
 	{
-		g_logger.log(std::string("mesos_http: Error parsing tasks:") + ex.what(), sinsp_logger::SEV_ERROR);
+		std::string errstr = std::string("mesos_http: Error parsing tasks:") + ex.what();
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+		g_json_error_log.log(os.str(), errstr, sinsp_utils::get_current_time_ns(), uri);
 	}
 
 	return labels;

--- a/userspace/libsinsp/mesos_http.cpp
+++ b/userspace/libsinsp/mesos_http.cpp
@@ -115,7 +115,7 @@ Json::Value mesos_http::get_state_frameworks()
 			std::string errstr;
 			errstr = reader.getFormattedErrorMessages();
 			g_logger.log(os.str(), sinsp_logger::SEV_DEBUG);
-			g_json_error_log.log(os.str(), errstr);
+			g_json_error_log.log(os.str(), errstr, sinsp_utils::get_current_time_ns(), m_url.to_string());
 			throw sinsp_exception("mesos_http: Mesos master leader detection failed in get_state_frameworks(): Invalid JSON (" + errstr + ")");
 		}
 	}
@@ -211,7 +211,7 @@ void mesos_http::discover_mesos_leader()
 				std::string errstr;
 				errstr = reader.getFormattedErrorMessages();
 				g_logger.log(os.str(), sinsp_logger::SEV_DEBUG);
-				g_json_error_log.log(os.str(), errstr);
+				g_json_error_log.log(os.str(), errstr, sinsp_utils::get_current_time_ns(), m_url.to_string());
 				throw sinsp_exception("mesos_http: Mesos master leader [" + m_url.to_string(false) + "] detection failed: Invalid JSON (" + errstr + ")");
 			}
 		}
@@ -452,7 +452,7 @@ bool mesos_http::get_all_data(callback_func_t parse)
 			errstr = reader.getFormattedErrorMessages();
 			g_logger.log("mesos_http: Mesos or Marathon Invalid JSON received from [" + m_url.to_string(false) + "]: " + errstr, sinsp_logger::SEV_WARNING);
 			g_logger.log("JSON: <" + os.str() + '>', sinsp_logger::SEV_DEBUG);
-			g_json_error_log.log(os.str(), errstr);
+			g_json_error_log.log(os.str(), errstr, sinsp_utils::get_current_time_ns(), m_url.to_string());
 		}
 		m_connected = true;
 	}
@@ -602,7 +602,7 @@ void mesos_http::handle_json(std::string::size_type end_pos, bool chunked)
 			}
 			else
 			{
-				(m_mesos.*m_callback_func)(try_parse(m_data_buf), m_framework_id);
+				(m_mesos.*m_callback_func)(try_parse(m_data_buf, m_url.to_string()), m_framework_id);
 			}
 			m_data_buf.clear();
 			m_content_length = std::string::npos;
@@ -753,7 +753,8 @@ std::string mesos_http::make_uri(const std::string& path)
 Json::Value mesos_http::get_task_labels(const std::string& task_id)
 {
 	std::ostringstream os;
-	CURLcode res = get_data(make_uri("/master/tasks"), os);
+	std::string uri = make_uri("/master/tasks");
+	CURLcode res = get_data(uri, os);
 
 	Json::Value labels;
 	if(res != CURLE_OK)
@@ -816,7 +817,7 @@ Json::Value mesos_http::get_task_labels(const std::string& task_id)
 			std::string errstr;
 			errstr = reader.getFormattedErrorMessages();
 			g_logger.log("mesos_http: Error parsing tasks (" + errstr + ").\nJSON:\n---\n" + os.str() + "\n---", sinsp_logger::SEV_ERROR);
-			g_json_error_log.log(os.str(), errstr);
+			g_json_error_log.log(os.str(), errstr, sinsp_utils::get_current_time_ns(), uri);
 		}
 	}
 	catch(std::exception& ex)

--- a/userspace/libsinsp/mesos_http.h
+++ b/userspace/libsinsp/mesos_http.h
@@ -75,7 +75,7 @@ protected:
 
 	callback_func_t get_parse_func();
 	std::string make_request(uri url, curl_version_info_data* m_curl_version = 0);
-	static json_ptr_t try_parse(const std::string& json);
+	static json_ptr_t try_parse(const std::string& json, const std::string &uri);
 	static bool is_framework_active(const Json::Value& framework);
 	std::string get_framework_url(const Json::Value& framework);
 
@@ -159,7 +159,7 @@ inline mesos_http::callback_func_t mesos_http::get_parse_func()
 	return m_callback_func;
 }
 
-inline mesos_http::json_ptr_t mesos_http::try_parse(const std::string& json)
+inline mesos_http::json_ptr_t mesos_http::try_parse(const std::string& json, const std::string &uri)
 {
 	json_ptr_t root(new Json::Value());
 	try
@@ -173,13 +173,13 @@ inline mesos_http::json_ptr_t mesos_http::try_parse(const std::string& json)
 			std::string errstr;
 			errstr = Json::Reader().getFormattedErrorMessages();
 			g_logger.log("mesos_http::try_parse could not parse json (" + errstr + ")", sinsp_logger::SEV_WARNING);
-			g_json_error_log.log(json, errstr);
+			g_json_error_log.log(json, errstr, sinsp_utils::get_current_time_ns(), uri);
 		}
 	}
 	catch(const Json::Exception &e)
 	{
 		g_logger.log("Could not parse JSON document: " + string(e.what()), sinsp_logger::SEV_WARNING);
-		g_json_error_log.log(json, e.what());
+		g_json_error_log.log(json, e.what(), sinsp_utils::get_current_time_ns(), uri);
 	}
 	catch(...) { }
 	return nullptr;
@@ -229,7 +229,7 @@ class mesos_http
 {
 public:
 	typedef std::shared_ptr<Json::Value> json_ptr_t;
-	static json_ptr_t try_parse(const std::string& json)
+	static json_ptr_t try_parse(const std::string& json, const std::string &uri)
 	{
 		json_ptr_t root(new Json::Value());
 		try

--- a/userspace/libsinsp/mesos_state.cpp
+++ b/userspace/libsinsp/mesos_state.cpp
@@ -127,7 +127,9 @@ marathon_group::app_ptr_t mesos_state_t::add_or_replace_app(const std::string& a
 	}
 	if(!app)
 	{
-		g_logger.log("Could not find or create app [" + app_id + ']', sinsp_logger::SEV_ERROR);
+		std::string errstr = "Could not find or create app [" + app_id + ']';
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+		g_json_error_log.log(app_id, errstr, sinsp_utils::get_current_time_ns(), "add-replace-app");
 		return 0;
 	}
 
@@ -158,12 +160,16 @@ void mesos_state_t::add_task_to_app(marathon_group::app_ptr_t app, const std::st
 		}
 		else
 		{
-			g_logger.log("Task [" + task_id + "] can not be obtained (null). Task not added to app [" + app->get_id() + ']', sinsp_logger::SEV_ERROR);
+			std::string errstr =  "Task [" + task_id + "] can not be obtained (null). Task not added to app [" + app->get_id() + ']';
+			g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+			g_json_error_log.log(task_id, errstr, sinsp_utils::get_current_time_ns(), "add-task-to-app");
 		}
 	}
 	else
 	{
-		g_logger.log("Attempt to add task [" + task_id + "] to non-existing (null) app.", sinsp_logger::SEV_ERROR);
+		std::string errstr = "Attempt to add task [" + task_id + "] to non-existing (null) app.";
+		g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+		g_json_error_log.log(task_id, errstr, sinsp_utils::get_current_time_ns(), "add-task-to-app");
 	}
 }
 
@@ -435,8 +441,10 @@ marathon_group::ptr_t mesos_state_t::add_group(const Json::Value& group, maratho
 						}
 						else
 						{
-							g_logger.log("An error occurred adding app [" + app_id.asString() +
-										"] to group [" + id + ']', sinsp_logger::SEV_ERROR);
+							std::string errstr = "An error occurred adding app [" + app_id.asString() +
+								"] to group [" + id + ']';
+							g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+							g_json_error_log.log(app_id.asString(), errstr, sinsp_utils::get_current_time_ns(), "add-group");
 						}
 					}
 				}
@@ -538,12 +546,16 @@ marathon_app::ptr_t mesos_state_t::add_app(const Json::Value& app, const std::st
 			}
 			else
 			{
-				g_logger.log("NOT added app [" + id + "] to Marathon group: [" + group_id + ']', sinsp_logger::SEV_ERROR);
+				std::string errstr = "NOT added app [" + id + "] to Marathon group: [" + group_id + ']';
+				g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+				g_json_error_log.log(id, errstr, sinsp_utils::get_current_time_ns(), "add-app");
 			}
 		}
 		else
 		{
-			g_logger.log("Could not determine group ID for app: " + id, sinsp_logger::SEV_ERROR);
+			std::string errstr = "Could not determine group ID for app: " + id;
+			g_logger.log(errstr, sinsp_logger::SEV_ERROR);
+			g_json_error_log.log(id, errstr, sinsp_utils::get_current_time_ns(), "add-app");
 		}
 	}
 	return p_app;

--- a/userspace/libsinsp/mesos_state.cpp
+++ b/userspace/libsinsp/mesos_state.cpp
@@ -538,7 +538,9 @@ marathon_app::ptr_t mesos_state_t::add_app(const Json::Value& app, const std::st
 							}
 							else
 							{
-								g_logger.log("Marathon task not found in mesos state: " + tid, sinsp_logger::SEV_WARNING);
+								std::string errstr = "Marathon task not found in mesos state: " + tid;
+								g_logger.log(errstr, sinsp_logger::SEV_WARNING);
+								g_json_error_log.log(tid, errstr, sinsp_utils::get_current_time_ns(), "add-app");
 							}
 						}
 					}

--- a/userspace/libsinsp/mesos_state.h
+++ b/userspace/libsinsp/mesos_state.h
@@ -11,6 +11,7 @@
 #include "json/json.h"
 #include "sinsp.h"
 #include "sinsp_int.h"
+#include "json_error_log.h"
 #include <vector>
 #include <map>
 #include <unordered_map>
@@ -317,14 +318,18 @@ inline void mesos_state_t::remove_task(mesos_framework& framework, const std::st
 			{
 				if(!group->remove_task(uid))
 				{
-					g_logger.log("Task [" + uid + "] not found in Marathon app [" + app_id + ']',
-							 sinsp_logger::SEV_ERROR);
+					std::string errstr = "Task [" + uid + "] not found in Marathon app [" + app_id + ']';
+					g_logger.log(errstr,
+						     sinsp_logger::SEV_ERROR);
+					g_json_error_log.log(uid, errstr, sinsp_utils::get_current_time_ns(), "remove-task");
 				}
 			}
 			else
 			{
-				g_logger.log("Group not found for Marathon app [" + app_id + "] while trying to remove task [" + uid + ']',
-							 sinsp_logger::SEV_ERROR);
+				std::string errstr = "Group not found for Marathon app [" + app_id + "] while trying to remove task [" + uid + ']';
+				g_logger.log(errstr,
+					     sinsp_logger::SEV_ERROR);
+				g_json_error_log.log(app_id, errstr, sinsp_utils::get_current_time_ns(), "remove-task");
 			}
 		}
 		else

--- a/userspace/libsinsp/token_bucket.cpp
+++ b/userspace/libsinsp/token_bucket.cpp
@@ -1,0 +1,91 @@
+/*
+Copyright (C) 2016 Draios inc.
+
+This file is part of falco.
+
+falco is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+falco is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with falco.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <cstddef>
+#include <sys/time.h>
+
+#include "utils.h"
+#include "token_bucket.h"
+
+token_bucket::token_bucket()
+{
+	init(1, 1);
+}
+
+token_bucket::~token_bucket()
+{
+}
+
+void token_bucket::init(double rate, double max_tokens, uint64_t now)
+{
+	m_rate = rate;
+	m_max_tokens = max_tokens;
+	m_tokens = max_tokens;
+
+	if(now == 0)
+	{
+		now = sinsp_utils::get_current_time_ns();
+	}
+
+	m_last_seen = now;
+}
+
+bool token_bucket::claim()
+{
+	uint64_t now = sinsp_utils::get_current_time_ns();
+
+	return claim(1, now);
+}
+
+bool token_bucket::claim(double tokens, uint64_t now)
+{
+	double tokens_gained = m_rate * ((now - m_last_seen) / (1000000000.0));
+	m_last_seen = now;
+
+	m_tokens += tokens_gained;
+
+	//
+	// Cap at max_tokens
+	//
+	if(m_tokens > m_max_tokens)
+	{
+		m_tokens = m_max_tokens;
+	}
+
+	//
+	// If m_tokens is < tokens, can't claim.
+	//
+	if(m_tokens < tokens)
+	{
+		return false;
+	}
+
+	m_tokens -= tokens;
+
+	return true;
+}
+
+double token_bucket::get_tokens()
+{
+	return m_tokens;
+}
+
+uint64_t token_bucket::get_last_seen()
+{
+	return m_last_seen;
+}

--- a/userspace/libsinsp/token_bucket.h
+++ b/userspace/libsinsp/token_bucket.h
@@ -1,0 +1,77 @@
+/*
+Copyright (C) 2016 Draios inc.
+
+This file is part of falco.
+
+falco is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+falco is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with falco.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+// A simple token bucket that accumulates tokens at a fixed rate and allows
+// for limited bursting in the form of "banked" tokens.
+
+class token_bucket
+{
+public:
+	token_bucket();
+	virtual ~token_bucket();
+
+	//
+	// Initialize the token bucket and start accumulating tokens
+	//
+	void init(double rate, double max_tokens, uint64_t now = 0);
+
+	//
+	// Try to claim tokens tokens from the token bucket, using a
+	// timestamp of now. Returns true if the tokens could be
+	// claimed. Also updates internal metrics.
+	//
+	bool claim(double tokens, uint64_t now);
+
+	// Simpler version of claim that claims a single token and
+	// uses the current time for now
+	bool claim();
+
+	// Return the current number of tokens available
+	double get_tokens();
+
+	// Return the last time someone tried to claim a token.
+	uint64_t get_last_seen();
+
+private:
+
+	//
+	// The number of tokens generated per second.
+	//
+	double m_rate;
+
+	//
+	// The maximum number of tokens that can be banked for future
+	// claim()s.
+	//
+	double m_max_tokens;
+
+	//
+	// The current number of tokens
+	//
+	double m_tokens;
+
+	//
+	// The last time claim() was called (or the object was created).
+	// Nanoseconds since the epoch.
+	//
+	uint64_t m_last_seen;
+};


### PR DESCRIPTION
Modify the json parse error logger to also emit custom user events. See commits for more specific changes.

The last commit that also emits all mesos-related error logs as user events by passing them through the json error logger is somewhat optional. I wanted to try to be as comprehensive as possible to collect as much potential error information. Would definitely like feedback on that.