### PR TITLE
Add eventformatter method to resolve all the tokens

### DIFF
--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -320,7 +320,7 @@ sinsp_evt_formatter_cache::~sinsp_evt_formatter_cache()
 {
 }
 
-bool sinsp_evt_formatter_cache::tostring(sinsp_evt *evt, string &format, OUT string *res)
+std::shared_ptr<sinsp_evt_formatter>& sinsp_evt_formatter_cache::get_cached_formatter(string &format)
 {
 	auto it = m_formatter_cache.lower_bound(format);
 
@@ -331,5 +331,15 @@ bool sinsp_evt_formatter_cache::tostring(sinsp_evt *evt, string &format, OUT str
 						    std::make_pair(format, make_shared<sinsp_evt_formatter>(m_inspector, format)));
 	}
 
-	return it->second->tostring(evt, res);
+	return it->second;
+}
+
+bool sinsp_evt_formatter_cache::resolve_tokens(sinsp_evt *evt, string &format, map<string,string>& values)
+{
+	return get_cached_formatter(format)->resolve_tokens(evt, values);
+}
+
+bool sinsp_evt_formatter_cache::tostring(sinsp_evt *evt, string &format, OUT string *res)
+{
+	return get_cached_formatter(format)->tostring(evt, res);
 }

--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -163,6 +163,42 @@ bool sinsp_evt_formatter::on_capture_end(OUT string* res)
 	return res->size() > 0;
 }
 
+bool sinsp_evt_formatter::resolve_tokens(sinsp_evt *evt, map<string,string>& values)
+{
+	bool retval = true;
+	const filtercheck_field_info* fi;
+	uint32_t j = 0;
+
+	ASSERT(m_tokenlens.size() == m_tokens.size());
+
+	for(j = 0; j < m_tokens.size(); j++)
+	{
+		char* str = m_tokens[j]->tostring(evt);
+
+		if(str == NULL)
+		{
+			if(m_require_all_values)
+			{
+				retval = false;
+				break;
+			}
+			else
+			{
+				str = (char*)"<NA>";
+			}
+		}
+
+		fi = m_tokens[j]->get_field_info();
+		if(fi)
+		{
+			values[fi->m_name] = string(str);
+		}
+	}
+
+	return retval;
+}
+
+
 bool sinsp_evt_formatter::tostring(sinsp_evt* evt, OUT string* res)
 {
 	bool retval = true;
@@ -264,10 +300,14 @@ void sinsp_evt_formatter::set_format(const string& fmt)
 	throw sinsp_exception("sinsp_evt_formatter unvavailable because it was not compiled in the library");
 }
 
+bool sinsp_evt_formatter::resolve_tokens(sinsp_evt *evt, map<string,string>& values)
+{
+	throw sinsp_exception("sinsp_evt_formatter unvavailable because it was not compiled in the library");
+}
+
 bool sinsp_evt_formatter::tostring(sinsp_evt* evt, OUT string* res)
 {
 	throw sinsp_exception("sinsp_evt_formatter unvavailable because it was not compiled in the library");
-	return false;
 }
 #endif // HAS_FILTERING
 

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -47,6 +47,18 @@ public:
 	~sinsp_evt_formatter();
 
 	/*!
+	  \brief Resolve all the formatted tokens and return them in a key/value
+	  map.
+
+	  \param evt Pointer to the event to be converted into string.
+	  \param res Reference to the map that will be filled with the result.
+
+	  \return true if all the tokens can be retrieved successfully, false
+	  otherwise.
+	*/
+	bool resolve_tokens(sinsp_evt *evt, map<string,string>& values);
+
+	/*!
 	  \brief Fills res with the string rendering of the event.
 
 	  \param evt Pointer to the event to be converted into string.

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -102,12 +102,21 @@ public:
 	sinsp_evt_formatter_cache(sinsp *inspector);
 	virtual ~sinsp_evt_formatter_cache();
 
+	// Resolve the tokens inside format and return them as a key/value map.
+	// Creates a new sinsp_evt_formatter object if necessary.
+	bool resolve_tokens(sinsp_evt *evt, std::string &format, map<string,string>& values);
+
 	// Fills in res with the event formatted according to
 	// format. Creates a new sinsp_evt_formatter object if
 	// necessary.
 	bool tostring(sinsp_evt *evt, std::string &format, OUT std::string *res);
 
 private:
+
+	// Get the formatter for this format string. Creates a new
+	// sinsp_evt_formatter object if necessary.
+	std::shared_ptr<sinsp_evt_formatter>& get_cached_formatter(string &format);
+
 	std::map<std::string,std::shared_ptr<sinsp_evt_formatter>> m_formatter_cache;
 	sinsp *m_inspector;
 };


### PR DESCRIPTION
Add a `resolve_tokens` method to the event formatter that returns a key/value map of all the resolved format parameters.