### PR TITLE
Prefix search path components

### DIFF
--- a/userspace/libsinsp/prefix_search.h
+++ b/userspace/libsinsp/prefix_search.h
@@ -157,6 +157,12 @@ void path_prefix_map<Value>::add_search_path(const filter_value_t &path, Value &
 
 	split_path(path, components);
 
+	// Add an initial "root" to the set of components. That
+	// ensures that a top-level path of '/' still results in a
+	// non-empty components list. For all other paths, there will
+	// be a dummy 'root' prefix at the top of every path.
+	components.emplace_front((uint8_t *) "root", 4);
+
 	return add_search_path_components(components, v);
 }
 
@@ -234,6 +240,12 @@ Value *path_prefix_map<Value>::match(const filter_value_t &path)
 	filter_components_t components;
 
 	split_path(path, components);
+
+	// Add an initial "root" to the set of components. That
+	// ensures that a top-level path of '/' still results in a
+	// non-empty components list. For all other paths, there will
+	// be a dummy 'root' prefix at the top of every path.
+	components.emplace_front((uint8_t *) "root", 4);
 
 	return match_components(components);
 }


### PR DESCRIPTION
These changes make it easier to do searches on paths that have a different structure to how they are split (say, based on docker image names, or urls, etc). You can provide the path pre-split into a set of components. When providing just paths, it splits the path internally.

Also fix handling of the special path prefix '/'.

@mattpag could you take a look to see if it will work for you? I've got updated unit tests that test this, but I'll wait for the sysdig merge first.