### PR TITLE
Upgrade packages on container image build

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -16,6 +16,7 @@ ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 
 RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list \
  && apt-get update \
+ && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
 	curl \

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -16,6 +16,7 @@ ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 
 RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list \
  && apt-get update \
+ && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
 	curl \

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -16,6 +16,7 @@ ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 
 RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list \
  && apt-get update \
+ && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
 	curl \


### PR DESCRIPTION
Even the latest debian:unstable image can be vulnerable
so do a full upgrade when building the images.