### PR TITLE
Fix libelf compilation failure

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -24,6 +24,8 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources
 	gcc \
 	gcc-5 \
 	gcc-4.9 \
+	libc6-dev \
+	libelf-dev \
 	libelf1 \
 	less \
 	procps \

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -25,6 +25,8 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources
 	gcc \
 	gcc-5 \
 	gcc-4.9 \
+	libc6-dev \
+	libelf-dev \
 	libelf1 \
 	less \
 	procps \

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -24,6 +24,8 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources
 	gcc \
 	gcc-5 \
 	gcc-4.9 \
+	libc6-dev \
+	libelf-dev \
 	libelf1 \
 	less \
 	procps \


### PR DESCRIPTION
When the kernel is compiled with `CONFIG_STACK_VALIDATION` or `CONFIG_ORC_UNWINDER`, the kernel Makefile tries to compile a test program using `libelf`. This fails for two reasons:

1) `libelf-dev` is not installed

2) Since we use `--no-install-recommends`, the installation of `gcc` doesn't pull `libc6-dev`, making it unable to compile some stuff.
