### PR TITLE
handle PPM_AT_FDCWD in `render_fd`

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -593,6 +593,13 @@ int sinsp_evt::render_fd_json(Json::Value *ret, int64_t fd, const char** resolve
 			(*ret)["name"] = sanitized_str;
 		}
 	}
+	else if(fd == PPM_AT_FDCWD)
+	{
+		//
+		// `fd` can be AT_FDCWD on all *at syscalls
+		//
+		(*ret)["name"] = "AT_FDCWD";
+	}
 	else
 	{
 		//

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -703,6 +703,15 @@ char* sinsp_evt::render_fd(int64_t fd, const char** resolved_str, sinsp_evt::par
 */
 		}
 	}
+	else if(fd == PPM_AT_FDCWD)
+	{
+		//
+		// `fd` can be AT_FDCWD on all *at syscalls
+		//
+		snprintf(&m_resolved_paramstr_storage[0],
+				 m_resolved_paramstr_storage.size(),
+				 "AT_FDCWD");
+	}
 	else
 	{
 		//


### PR DESCRIPTION
When using `*at` syscalls (like `unlinkat`) the `fd` can be `AT_FDCWD` to indicate that the path will be resolved relative to the `CWD`.

Currently, if this value is used then sysdig list it as an error `ENETDOWN`:
```
26517 09:30:53.165264496 0 tests (37730) > unlinkat dirfd=-100(ENETDOWN) name=/tmp/amir 
```

This fix will handle this case and list it as `AT_FDCWD`
```
299125 16:28:12.444322286 3 tests (46526) > unlinkat dirfd=-100(AT_FDCWD) name=/tmp/amir 
```