### PR TITLE
Fix AT_FDCWD 32-bit syscall decoding

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -3170,7 +3170,7 @@ static int f_sys_openat_e(struct event_filler_arguments *args)
 	 */
 	syscall_get_arguments(current, args->regs, 0, 1, &val);
 
-	if (val == AT_FDCWD)
+	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
 	res = val_to_ring(args, val, 0, false, 0);
@@ -4539,7 +4539,7 @@ static int f_sys_renameat_x(struct event_filler_arguments *args)
 	 */
 	syscall_get_arguments(current, args->regs, 0, 1, &val);
 
-	if (val == AT_FDCWD)
+	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
 	res = val_to_ring(args, val, 0, false, 0);
@@ -4559,7 +4559,7 @@ static int f_sys_renameat_x(struct event_filler_arguments *args)
 	 */
 	syscall_get_arguments(current, args->regs, 2, 1, &val);
 
-	if (val == AT_FDCWD)
+	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
 	res = val_to_ring(args, val, 0, false, 0);
@@ -4601,7 +4601,7 @@ static int f_sys_symlinkat_x(struct event_filler_arguments *args)
 	 */
 	syscall_get_arguments(current, args->regs, 1, 1, &val);
 
-	if (val == AT_FDCWD)
+	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
 	res = val_to_ring(args, val, 0, false, 0);


### PR DESCRIPTION
AT_FDCWD is equal to -100. In the 64-bit version of the syscall, its
value as unsigned long is 18446744073709551516 (1<<64 - 100). However,
when the 32-bit syscall version is used, the value is truncated to 32
bits and AT_FDCWD is passed as 4294967196 (1<<32 - 100).

Cast the value to int to drop the high 32 bits (the dirfd argument is
defined to be an int anyway) and then compare the signed 32-bit values.