### PR TITLE
Add missing defns of bpf/seccomp syscalls

### DIFF
--- a/userspace/libscap/syscall_info_table.c
+++ b/userspace/libscap/syscall_info_table.c
@@ -345,6 +345,8 @@ const struct ppm_syscall_desc g_syscall_info_table[PPM_SC_MAX] = {
 	/*PPM_SC_GETRESUID32*/ { EC_IO_OTHER, (enum ppm_event_flags)(EF_NONE), "getresuid" },
 	/*PPM_SC_GETRESGID32*/ { EC_IO_OTHER, (enum ppm_event_flags)(EF_NONE), "getresgid" },
 	/*PPM_SC_FINIT_MODULE*/ { EC_SYSTEM, (enum ppm_event_flags)(EF_NONE), "finit_module" }, /* load a kernel module */
+	/*PPM_SC_BPF*/ { EC_OTHER, (enum ppm_event_flags)(EF_NONE), "bpf" },
+	/*PPM_SC_SECCOMP*/ { EC_OTHER, (enum ppm_event_flags)(EF_NONE), "seccomp" }
 };
 
 bool validate_info_table_size()


### PR DESCRIPTION
In https://github.com/draios/sysdig/pull/1031 I added bpf/seccomp
syscall numbers but forgot to add their corresponding definitions to
g_syscall_info_table. Add them.