### PR TITLE
Page fault tracepoints can be disabled as with ubuntu-artful (see bel…

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -201,7 +201,7 @@ static struct tracepoint *tp_signal_deliver;
 static struct tracepoint *tp_page_fault_user;
 static struct tracepoint *tp_page_fault_kernel;
 static bool g_fault_tracepoint_registered;
-static bool g_fault_tracepoint_disabled = false;
+static bool g_fault_tracepoint_disabled;
 #endif
 
 #ifdef _DEBUG
@@ -1031,8 +1031,8 @@ cleanup_ioctl_procinfo:
 		ASSERT(g_tracepoint_registered);
 
 		if (g_fault_tracepoint_disabled) {
-			ret = 0;
-			pr_info("kernel page fault tracepoints are disabled\n");
+			pr_err("kernel page fault tracepoints are disabled\n");
+			ret = -EPERM;
 			goto cleanup_ioctl;
 		}
 


### PR DESCRIPTION
…ow). Ignore --page-faults if this is the case.

http://kernel.ubuntu.com/git/ubuntu/ubuntu-artful.git/commit/arch/x86/mm/fault.c?id=4ecc04d14ee2f9b46d3e252215a7622d7d47e974