### PR TITLE
Properly interrupt loop when we get a SCAP_FAILURE

### DIFF
--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -262,7 +262,6 @@ captureinfo do_inspect(sinsp* inspector,
 			{
 				ui->set_truncated_input(true);
 				res = SCAP_EOF;
-				continue;
 			}
 		}
 


### PR DESCRIPTION
When csysdig is used with a truncated file, we end up in an infinite loop because we set `res` to `SCAP_EOF` but then we continue the loop, resetting `res` again to `SCAP_FAILURE`, and csysdig never exits.

This problem emerged with Inspect users on the Sysdig Monitor backend.

@ldegio can you confirm this logic? Asking since you were the original committer for this. 