### PR TITLE
Fix memory leak (summary_table)

### DIFF
--- a/userspace/sysdig/sysdig.h
+++ b/userspace/sysdig/sysdig.h
@@ -74,16 +74,13 @@ public:
 class summary_table_entry
 {
 public:
-	summary_table_entry(uint16_t id, bool is_unsupported_syscall)
+	summary_table_entry(uint16_t id, bool is_unsupported_syscall) : m_ncalls(0), m_id(id), m_is_unsupported_syscall(is_unsupported_syscall)
 	{
-		m_id = id;
-		m_ncalls = 0;
-		m_is_unsupported_syscall = is_unsupported_syscall;
 	}
 
-	uint16_t m_id;
 	uint64_t m_ncalls;
-	bool m_is_unsupported_syscall;
+	uint16_t m_id;
+	bool m_is_unsupported_syscall;	
 };
 
 struct summary_table_entry_rsort_comparer


### PR DESCRIPTION
delete was never called on summary_table so it was leaking memory.

* summary_table now on stack instead of heap.

* sizeof(summary_table_entry) reduced from 24 to 16 (x86/x64) by reordering members.

sysdig-CLA-1.0-signed-off-by: Riccardo Marcangelo <ricky.65@outlook.com>