### PR TITLE
Allow "in" operator to work with non-string values

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -2581,17 +2581,20 @@ int32_t sinsp_filter_check_event::parse_field_name(const char* str, bool alloc_s
 	return res;
 }
 
-void sinsp_filter_check_event::parse_filter_value(const char* str, uint32_t len, uint8_t *storage, uint32_t storage_len)
+size_t sinsp_filter_check_event::parse_filter_value(const char* str, uint32_t len, uint8_t *storage, uint32_t storage_len)
 {
+	size_t parsed_len;
 	if(m_field_id == sinsp_filter_check_event::TYPE_ARGRAW)
 	{
 		ASSERT(m_arginfo != NULL);
-		sinsp_filter_value_parser::string_to_rawval(str, len, filter_value_p(), filter_value().size(), m_arginfo->type);
+		parsed_len = sinsp_filter_value_parser::string_to_rawval(str, len, filter_value_p(), filter_value().size(), m_arginfo->type);
 	}
 	else
 	{
-		sinsp_filter_check::parse_filter_value(str, len, storage, storage_len);
+		parsed_len = sinsp_filter_check::parse_filter_value(str, len, storage, storage_len);
 	}
+
+	return parsed_len;
 }
 
 

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -85,7 +85,7 @@ public:
 	// Doesn't return the field length because the filtering engine can calculate it.
 	//
 	void add_filter_value(const char* str, uint32_t len, uint32_t i = 0 );
-	virtual void parse_filter_value(const char* str, uint32_t len, uint8_t *storage, uint32_t storage_len);
+	virtual size_t parse_filter_value(const char* str, uint32_t len, uint8_t *storage, uint32_t storage_len);
 
 	//
 	// Called after parsing for optional validation of the filter value
@@ -480,7 +480,7 @@ public:
 	~sinsp_filter_check_event();
 	sinsp_filter_check* allocate_new();
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering);
-	void parse_filter_value(const char* str, uint32_t len, uint8_t *storage, uint32_t storage_len);
+	size_t parse_filter_value(const char* str, uint32_t len, uint8_t *storage, uint32_t storage_len);
 	void validate_filter_value(const char* str, uint32_t len);
 	const filtercheck_field_info* get_field_info();
 	uint8_t* extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings = true);

--- a/userspace/libsinsp/value_parser.h
+++ b/userspace/libsinsp/value_parser.h
@@ -25,5 +25,5 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 class sinsp_filter_value_parser
 {
  public:
-	static void string_to_rawval(const char* str, uint32_t len, uint8_t *storage, string::size_type max_len, ppm_param_type ptype);
+	static size_t string_to_rawval(const char* str, uint32_t len, uint8_t *storage, string::size_type max_len, ppm_param_type ptype);
 };


### PR DESCRIPTION
When used by falco, an expression like "xxx in (a, b, c)" is stored with
an operator CO_IN and the values a, b, c, etc as values added via calls
to add_filter_value. (In sysdig, it's a bit more nuanced, with the
treatment dependent on what the type of xxx is).

When checking, a the values a, b, c are stored in a set and a set
membership test tells you if a given test value matches one of a, b, c.

For non-string values, The values a, b, c, etc are parsed into raw
values, converting things like numeric strings to 16 bit values, booleans
to 0/1, etc.

This had a bug, though, as the value being stored in the set has its
length set to the length of the original value (e.g. the string
representing the port), and not the parsed raw value (2 bytes).

This fixes that bug by storing the parsed raw length instead of the unparsed
length. In turn, that required some other changes to return the parsed
length from functions like sinsp_filter_check::parse_filter_value and
sinsp_filter_value_parser::string_to_rawval.

This fixes https://github.com/draios/falco/issues/308.