### PR TITLE
Fix wrong handling of UDP connections wrt connect syscall

### DIFF
--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -291,6 +291,11 @@ public:
 		return (m_flags & FLAGS_SOCKET_CONNECTED) == FLAGS_SOCKET_CONNECTED;
 	}
 
+	inline bool is_cloned()
+	{
+		return (m_flags & FLAGS_IS_CLONED) == FLAGS_IS_CLONED;
+	}
+
 	scap_fd_type m_type; ///< The fd type, e.g. file, directory, IPv4 socket...
 	uint32_t m_openflags; ///< If this FD is a file, the flags that were used when opening it. See the PPM_O_* definitions in driver/ppm_events_public.h.
 	
@@ -335,6 +340,7 @@ private:
 		FLAGS_IN_BASELINE_RW = (1 << 11),
 		FLAGS_IN_BASELINE_OTHER = (1 << 12),
 		FLAGS_SOCKET_CONNECTED = (1 << 13),
+		FLAGS_IS_CLONED = (1 << 14),
 	};
 
 	void add_filename(const char* fullpath);
@@ -419,6 +425,11 @@ private:
 	inline void set_socket_connected()
 	{
 		m_flags |= FLAGS_SOCKET_CONNECTED;
+	}
+
+	inline void set_is_cloned()
+	{
+		m_flags |= FLAGS_IS_CLONED;
 	}
 
 	T* m_usrstate;

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1240,6 +1240,14 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 		tinfo.m_fdtable = *(ptinfo->get_fd_table());
 
 		//
+		// Track down that those are cloned fds
+		//
+		for(auto fdit = tinfo.m_fdtable.m_table.begin(); fdit != tinfo.m_fdtable.m_table.end(); ++fdit)
+		{
+			fdit->second.set_is_cloned();
+		}
+
+		//
 		// It's important to reset the cache of the child thread, to prevent it from
 		// referring to an element in the parent's table.
 		//

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2266,6 +2266,7 @@ void sinsp_parser::parse_connect_exit(sinsp_evt *evt)
 	unordered_map<int64_t, sinsp_fdinfo_t>::iterator fdit;
 	const char *parstr;
 	int64_t retval;
+	bool changed;
 
 	if(evt->m_fdinfo == NULL)
 	{
@@ -2337,24 +2338,40 @@ void sinsp_parser::parse_connect_exit(sinsp_evt *evt)
 		//
 		ASSERT(evt->m_fdinfo->m_type == SCAP_FD_IPV4_SOCK || evt->m_fdinfo->m_type == SCAP_FD_IPV4_SERVSOCK);
 
-#ifndef HAS_ANALYZER
 		//
 		// Update the FD info with this tuple
 		//
 		if(family == PPM_AF_INET)
 		{
-			m_inspector->m_parser->set_ipv4_addresses_and_ports(evt->m_fdinfo, packed_data);
+			changed = m_inspector->m_parser->set_ipv4_addresses_and_ports(evt->m_fdinfo, packed_data);
 		}
 		else
 		{
-			m_inspector->m_parser->set_ipv4_mapped_ipv6_addresses_and_ports(evt->m_fdinfo, packed_data);
+			changed = m_inspector->m_parser->set_ipv4_mapped_ipv6_addresses_and_ports(evt->m_fdinfo, packed_data);
 		}
-#endif
+
+		if(changed && evt->m_fdinfo->is_role_server() && evt->m_fdinfo->is_udp_socket())
+		{
+			// connect done by a udp server, swap the addresses
+			swap_ipv4_addresses(evt->m_fdinfo);
+		}
 
 		//
 		// Add the friendly name to the fd info
 		//
-		evt->m_fdinfo->m_name = evt->get_param_as_str(1, &parstr, sinsp_evt::PF_SIMPLE);
+		if(evt->m_fdinfo->is_role_server() && evt->m_fdinfo->is_udp_socket())
+		{
+			sinsp_utils::sockinfo_to_str(&evt->m_fdinfo->m_sockinfo,
+						     evt->m_fdinfo->m_type, &evt->m_paramstr_storage[0],
+						     (uint32_t)evt->m_paramstr_storage.size(),
+						     m_inspector->m_hostname_and_port_resolution_enabled);
+
+			evt->m_fdinfo->m_name = &evt->m_paramstr_storage[0];
+		}
+		else
+		{
+			evt->m_fdinfo->m_name = evt->get_param_as_str(1, &parstr, sinsp_evt::PF_SIMPLE);
+		}
 	}
 	else
 	{
@@ -2381,10 +2398,13 @@ void sinsp_parser::parse_connect_exit(sinsp_evt *evt)
 #endif
 	}
 
-	//
-	// Mark this fd as a client
-	//
-	evt->m_fdinfo->set_role_client();
+	if(evt->m_fdinfo->is_role_none())
+	{
+		//
+		// Mark this fd as a client
+		//
+		evt->m_fdinfo->set_role_client();
+	}
 
 	//
 	// Mark this fd as a connected socket


### PR DESCRIPTION
A UDP connection can start with a recvfrom and then do a connect
to fix the packets address. When parsing a connect, if we
are in one of those cases, avoid to set a wrong client role
for the connection and if needed swap the sock_info retrieved
from the connect tuple.

Also, add a IS_CLONED flag to fdinfo to track down fds copied during a `clone`.