### PR TITLE
support new amazon linux 2 distro

### DIFF
--- a/scripts/install-sysdig.in
+++ b/scripts/install-sysdig.in
@@ -153,6 +153,10 @@ if [ -f /etc/debian_version ]; then
 
 elif [ -f /etc/system-release-cpe ]; then
 	DISTRO=$(cat /etc/system-release-cpe | cut -d':' -f3)
+	# New Amazon Linux 2 distro
+	if [[ "${DISTRO}" == "o" ]]; then
+		DISTRO=$(cat /etc/system-release-cpe | cut -d':' -f4)
+	fi
 	VERSION=$(cat /etc/system-release-cpe | cut -d':' -f5 | cut -d'.' -f1 | sed 's/[^0-9]*//g')
 
 	case "$DISTRO" in


### PR DESCRIPTION
add support to new aws linux 2 ami.

In the old aws linux OS the content of `/etc/system-release-cpe` is:
```
cpe:/o:amazon:linux:2017.03:ga
```
for the new linux 2 ami is:
```
cpe:2.3:o:amazon:amazon_linux:2.0
```
With this change, I'm trying to keep the detention function simple without implementing any other more complicated method.