### PR TITLE
Use gcc 5 by default to compile properly on Ubuntu Xenial, remove gcc…

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -14,8 +14,7 @@ RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
 ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 
-RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list \
- && apt-get update \
+RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
@@ -24,7 +23,6 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources
 	ca-certificates \
 	gcc \
 	gcc-5 \
-	gcc-4.9 \
 	libc6-dev \
 	libelf-dev \
 	libelf1 \
@@ -32,16 +30,9 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources
 	procps \
  && rm -rf /var/lib/apt/lists/*
 
-# Since our base Debian image ships with GCC 5.0 which breaks older kernels, revert the
-# default to gcc-4.9. Also, since some customers use some very old distributions whose kernel
-# makefile is hardcoded for gcc-4.6 or so (e.g. Debian Wheezy), we pretend to have gcc 4.6/4.7
-# by symlinking it to 4.9
-
-RUN rm -rf /usr/bin/gcc \
- && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc \
- && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.8 \
- && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.7 \
- && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.6
+# Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
+# default to gcc-5.
+RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-5 /usr/bin/gcc
 
 RUN curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public | apt-key add - \
  && curl -s -o /etc/apt/sources.list.d/draios.list http://download.draios.com/$SYSDIG_REPOSITORY/deb/draios.list \

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -14,8 +14,7 @@ RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
 ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 
-RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list \
- && apt-get update \
+RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
@@ -25,7 +24,6 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources
 	ca-certificates \
 	gcc \
 	gcc-5 \
-	gcc-4.9 \
 	libc6-dev \
 	libelf-dev \
 	libelf1 \
@@ -33,16 +31,9 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources
 	procps \
  && rm -rf /var/lib/apt/lists/*
 
-# Since our base Debian image ships with GCC 5.0 which breaks older kernels, revert the
-# default to gcc-4.9. Also, since some customers use some very old distributions whose kernel
-# makefile is hardcoded for gcc-4.6 or so (e.g. Debian Wheezy), we pretend to have gcc 4.6/4.7
-# by symlinking it to 4.9
-
-RUN rm -rf /usr/bin/gcc \
- && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc \
- && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.8 \
- && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.7 \
- && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.6
+# Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
+# default to gcc-5.
+RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-5 /usr/bin/gcc
 
 RUN ln -s $SYSDIG_HOST_ROOT/lib/modules /lib/modules
 

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -14,8 +14,7 @@ RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
 ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 
-RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list \
- && apt-get update \
+RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
@@ -24,7 +23,6 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources
 	ca-certificates \
 	gcc \
 	gcc-5 \
-	gcc-4.9 \
 	libc6-dev \
 	libelf-dev \
 	libelf1 \
@@ -32,16 +30,9 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources
 	procps \
  && rm -rf /var/lib/apt/lists/*
 
-# Since our base Debian image ships with GCC 5.0 which breaks older kernels, revert the
-# default to gcc-4.9. Also, since some customers use some very old distributions whose kernel
-# makefile is hardcoded for gcc-4.6 or so (e.g. Debian Wheezy), we pretend to have gcc 4.6/4.7
-# by symlinking it to 4.9
-
-RUN rm -rf /usr/bin/gcc \
- && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc \
- && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.8 \
- && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.7 \
- && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.6
+# Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
+# default to gcc-5.
+RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-5 /usr/bin/gcc
 
 RUN curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public | apt-key add - \
  && curl -s -o /etc/apt/sources.list.d/draios.list http://download.draios.com/$SYSDIG_REPOSITORY/deb/draios.list \


### PR DESCRIPTION
… 4.9 since CentOS does not work anyway due to glibc