### PR TITLE
socket/bind handling

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2089,13 +2089,14 @@ inline void sinsp_parser::add_socket(sinsp_evt *evt, int64_t fd, uint32_t domain
 	{
 		fdi.m_type = (domain == PPM_AF_INET)? SCAP_FD_IPV4_SOCK : SCAP_FD_IPV6_SOCK;
 
+		uint8_t l4proto = SCAP_L4_UNKNOWN;
 		if(protocol == IPPROTO_TCP)
 		{
-			fdi.m_sockinfo.m_ipv4info.m_fields.m_l4proto = (type == SOCK_RAW)? SCAP_L4_RAW : SCAP_L4_TCP;
+			l4proto = (type == SOCK_RAW)? SCAP_L4_RAW : SCAP_L4_TCP;
 		}
 		else if(protocol == IPPROTO_UDP)
 		{
-			fdi.m_sockinfo.m_ipv4info.m_fields.m_l4proto = (type == SOCK_RAW)? SCAP_L4_RAW : SCAP_L4_UDP;
+			l4proto = (type == SOCK_RAW)? SCAP_L4_RAW : SCAP_L4_UDP;
 		}
 		else if(protocol == IPPROTO_IP)
 		{
@@ -2106,11 +2107,11 @@ inline void sinsp_parser::add_socket(sinsp_evt *evt, int64_t fd, uint32_t domain
 			//
 			if((type & 0xff) == SOCK_STREAM)
 			{
-				fdi.m_sockinfo.m_ipv4info.m_fields.m_l4proto = SCAP_L4_TCP;
+				l4proto = SCAP_L4_TCP;
 			}
 			else if((type & 0xff) == SOCK_DGRAM)
 			{
-				fdi.m_sockinfo.m_ipv4info.m_fields.m_l4proto = SCAP_L4_UDP;
+				l4proto = SCAP_L4_UDP;
 			}
 			else
 			{
@@ -2119,11 +2120,21 @@ inline void sinsp_parser::add_socket(sinsp_evt *evt, int64_t fd, uint32_t domain
 		}
 		else if(protocol == IPPROTO_ICMP)
 		{
-			fdi.m_sockinfo.m_ipv4info.m_fields.m_l4proto = (type == SOCK_RAW)? SCAP_L4_RAW : SCAP_L4_ICMP;
+			l4proto = (type == SOCK_RAW)? SCAP_L4_RAW : SCAP_L4_ICMP;
 		}
 		else if(protocol == IPPROTO_RAW)
 		{
-			fdi.m_sockinfo.m_ipv4info.m_fields.m_l4proto = SCAP_L4_RAW;
+			l4proto = SCAP_L4_RAW;
+		}
+
+		if(domain == PPM_AF_INET)
+		{
+			fdi.m_sockinfo.m_ipv4info.m_fields.m_l4proto = l4proto;
+		}
+		else
+		{
+			memset(&(fdi.m_sockinfo.m_ipv6info), 0, sizeof(fdi.m_sockinfo.m_ipv6info));
+			fdi.m_sockinfo.m_ipv6info.m_fields.m_l4proto = l4proto;
 		}
 	}
 	else if(domain == PPM_AF_NETLINK)


### PR DESCRIPTION
Minor modifications/fixes to the `socket`,`bind` parsers:
- Use the correct sockinfo when setting the fd l4 protocol
- Extract the ip address and set the role during `bind`