### PR TITLE
Capture versioning

### DIFF
--- a/userspace/libscap/examples/01-open/test.c
+++ b/userspace/libscap/examples/01-open/test.c
@@ -41,10 +41,10 @@ int main(int argc, char** argv)
 		return -1;
 	}
 
-	scap_t* h = scap_open_live(error);
+	scap_t* h = scap_open_live(error, &res);
 	if(h == NULL)
 	{
-		fprintf(stderr, "%s\n", error);
+		fprintf(stderr, "%s (%d)\n", error, res);
 		return -1;
 	}
 	

--- a/userspace/libscap/examples/02-validatebuffer/test.c
+++ b/userspace/libscap/examples/02-validatebuffer/test.c
@@ -168,11 +168,11 @@ int main()
 			&new_mask);
 	*/
 
-	scap_t* h = scap_open_live(error);
+	scap_t* h = scap_open_live(error, &ret);
 	if(h == NULL)
 	{
-		fprintf(stderr, "%s\n", error);
-		return -1;
+		fprintf(stderr, "%s (%d)\n", error, ret);
+		return ret;
 	}
 
 	ndevs = scap_get_ndevs(h);

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -70,6 +70,7 @@ typedef struct ppm_evt_hdr scap_evt;
 #define SCAP_INPUT_TOO_SMALL 5
 #define SCAP_EOF 6
 #define SCAP_UNEXPECTED_BLOCK 7
+#define SCAP_VERSION_MISMATCH 8
 
 //
 // Last error string size for scap_open_live()

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -71,6 +71,7 @@ typedef struct ppm_evt_hdr scap_evt;
 #define SCAP_EOF 6
 #define SCAP_UNEXPECTED_BLOCK 7
 #define SCAP_VERSION_MISMATCH 8
+#define SCAP_NOT_SUPPORTED 9
 
 //
 // Last error string size for scap_open_live()
@@ -492,10 +493,12 @@ struct ppm_syscall_desc {
 
   \param error Pointer to a buffer that will contain the error string in case the
     function fails. The buffer must have size SCAP_LASTERR_SIZE.
+  \param rc Integer pointer that will contain the scap return code in case the
+    function fails.
 
   \return The capture instance handle in case of success. NULL in case of failure.
 */
-scap_t* scap_open_live(char *error);
+scap_t* scap_open_live(char *error, int32_t *rc);
 
 /*!
   \brief Start an event capture from file.
@@ -503,10 +506,12 @@ scap_t* scap_open_live(char *error);
   \param fname The name of the file to open.
   \param error Pointer to a buffer that will contain the error string in case the
     function fails. The buffer must have size SCAP_LASTERR_SIZE.
+  \param rc Integer pointer that will contain the scap return code in case the
+    function fails.
 
   \return The capture instance handle in case of success. NULL in case of failure.
 */
-scap_t* scap_open_offline(const char* fname, char *error);
+scap_t* scap_open_offline(const char* fname, char *error, int32_t *rc);
 
 /*!
   \brief Start an event capture from an already opened file descriptor.
@@ -514,10 +519,12 @@ scap_t* scap_open_offline(const char* fname, char *error);
   \param fd The fd to use.
   \param error Pointer to a buffer that will contain the error string in case the
     function fails. The buffer must have size SCAP_LASTERR_SIZE.
+  \param rc Integer pointer that will contain the scap return code in case the
+    function fails.
 
   \return The capture instance handle in case of success. NULL in case of failure.
 */
-scap_t* scap_open_offline_fd(int fd, char *error);
+scap_t* scap_open_offline_fd(int fd, char *error, int32_t *rc);
 
 /*!
   \brief Advanced function to start a capture.
@@ -525,10 +532,12 @@ scap_t* scap_open_offline_fd(int fd, char *error);
   \param args a \ref scap_open_args structure containing the open paraneters.
   \param error Pointer to a buffer that will contain the error string in case the
     function fails. The buffer must have size SCAP_LASTERR_SIZE.
+  \param rc Integer pointer that will contain the scap return code in case the
+    function fails.
 
   \return The capture instance handle in case of success. NULL in case of failure.
 */
-scap_t* scap_open(scap_open_args args, char *error);
+scap_t* scap_open(scap_open_args args, char *error, int32_t *rc);
 
 /*!
   \brief Close a capture handle.

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -2210,6 +2210,14 @@ int32_t scap_read_init(scap_t *handle, gzFile f)
 		return SCAP_FAILURE;
 	}
 
+	if(sh.major_version != CURRENT_MAJOR_VERSION ||
+	   sh.minor_version != CURRENT_MINOR_VERSION)
+	{
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE,
+			 "capture created with a newer version of sysdig");
+		return SCAP_VERSION_MISMATCH;
+	}
+
 	//
 	// Read the metadata blocks (processes, FDs, etc.)
 	//

--- a/userspace/libscap/scap_savefile.h
+++ b/userspace/libscap/scap_savefile.h
@@ -44,8 +44,13 @@ typedef struct _block_header
 // Used to recognize if a section is in host byte order or not.
 #define SHB_MAGIC		0x1A2B3C4D
 // Major version of the file format supported by this library.
+// Must be increased only when if the new version of the software
+// is not able anymore to read older captures
 #define CURRENT_MAJOR_VERSION	1
 // Minor version of the file format supported by this library.
+// Must be increased every time we change the capture format
+// (e.g. most of the changes in the event table, like adding
+// a syscall)
 #define CURRENT_MINOR_VERSION	0
 
 typedef struct _section_header_block

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -441,11 +441,12 @@ void sinsp::open(uint32_t timeout_ms)
 	}
 	oargs.import_users = m_import_users;
 
-	m_h = scap_open(oargs, error);
+	int32_t scap_rc;
+	m_h = scap_open(oargs, error, &scap_rc);
 
 	if(m_h == NULL)
 	{
-		throw sinsp_exception(error);
+		throw sinsp_exception(error, scap_rc);
 	}
 
 	scap_set_refresh_proc_table_when_saving(m_h, !m_filter_proc_table_when_saving);
@@ -480,11 +481,12 @@ void sinsp::open_nodriver()
 	}
 	oargs.import_users = m_import_users;
 
-	m_h = scap_open(oargs, error);
+	int32_t scap_rc;
+	m_h = scap_open(oargs, error, &scap_rc);
 
 	if(m_h == NULL)
 	{
-		throw sinsp_exception(error);
+		throw sinsp_exception(error, scap_rc);
 	}
 
 	scap_set_refresh_proc_table_when_saving(m_h, !m_filter_proc_table_when_saving);
@@ -616,11 +618,12 @@ void sinsp::open_int()
 		oargs.start_offset = 0;
 	}
 
-	m_h = scap_open(oargs, error);
+	int32_t scap_rc;
+	m_h = scap_open(oargs, error, &scap_rc);
 
 	if(m_h == NULL)
 	{
-		throw sinsp_exception(error);
+		throw sinsp_exception(error, scap_rc);
 	}
 
 	if(m_input_fd != 0)

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -177,12 +177,24 @@ struct sinsp_exception : std::exception
 		m_error_str = error_str;
 	}
 
+	sinsp_exception(string error_str, int32_t scap_rc)
+	{
+		m_error_str = error_str;
+		m_scap_rc = scap_rc;
+	}
+
 	char const* what() const throw()
 	{
 		return m_error_str.c_str();
 	}
 
+	int32_t scap_rc()
+	{
+		return m_scap_rc;
+	}
+
 	string m_error_str;
+	int32_t m_scap_rc;
 };
 
 /*!

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -898,6 +898,11 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 	catch(sinsp_capture_interrupt_exception&)
 	{
 	}
+	catch(sinsp_exception& e)
+	{
+		errorstr = e.what();
+		res.m_res = e.scap_rc();
+	}
 	catch(std::exception& e)
 	{
 		errorstr = e.what();

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -1543,7 +1543,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 	{
 		cerr << e.what() << endl;
 		handle_end_of_file(print_progress);
-		res.m_res = EXIT_FAILURE;
+		res.m_res = e.scap_rc();
 	}
 	catch(...)
 	{


### PR DESCRIPTION
- `sysdig`/`csysdig` will start refuse to read captures created by newer versions
- Instead of always returning `EXIT_FAILURE` if something goes wrong during the capture reading process, pass scap return codes back to the caller and use them as program exit codes.