### PR TITLE
Update fetching kernel sources for recent Debian releases

### DIFF
--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -383,7 +383,7 @@ function debian_build {
 	else
 		KERNEL_RELEASE=$(echo ${DEB} | grep -E -o "[0-9]{1}\.[0-9]+\.[0-9]+(-[0-9]+)?"| head -1)
 		KERNEL_MAJOR=$(echo ${KERNEL_RELEASE} | grep -E -o "[0-9]{1}\.[0-9]+")
-		PACKAGE=$(echo ${DEB} | grep -E -o "(common_[0-9]{1}\.[0-9]+.*amd64|amd64_[0-9]{1}\.[0-9]+.*amd64)" | sed -E 's/(common_|amd64_|_amd64)//g')
+		PACKAGE=$(echo ${DEB} | grep -E -o "(common_[0-9]{1}\.[0-9]+.*amd64|amd64_[0-9]{1}\.[0-9]+.*amd64|common_[0-9]{1}\.[0-9]+.*_all)" | sed -E 's/(common_|amd64_|_amd64|_all)//g')
 
 		if [[ ! -d ${KERNEL_RELEASE} ]]; then
 			mkdir ${KERNEL_RELEASE}

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -162,21 +162,35 @@ repos = {
             "discovery_pattern": "/html/body/pre/a[@href = 'linux/']/@href",
             "subdirs": [""],
             "page_pattern": "/html/body//a[regex:test(@href, '^linux-(image|headers)-[3-9]\.[0-9]+\.[0-9]+.*amd64.deb$')]/@href",
-            "exclude_patterns": ["-rt", "dbg", "trunk", "all", "exp", "unsigned"]
+            "exclude_patterns": ["-rt", "dbg", "trunk", "all", "exp", "unsigned", "cloud-amd64"]
+        },
+        {
+            "root": "https://mirrors.kernel.org/debian/pool/main/l/",
+            "discovery_pattern": "/html/body/pre/a[@href = 'linux/']/@href",
+            "subdirs": [""],
+            "page_pattern": "/html/body//a[regex:test(@href, '^linux-headers-[3-9]\.[0-9]+\.[0-9]+.*-common_.*_all.deb$')]/@href",
+            "exclude_patterns": ["-rt", "dbg", "trunk", "exp", "unsigned", "cloud-amd64"] # don't exclude "all" like other debian sources
         },
         {
             "root": "http://security.debian.org/pool/updates/main/l/",
             "discovery_pattern": "/html/body/table//tr/td/a[@href = 'linux/']/@href",
             "subdirs": [""],
             "page_pattern": "/html/body//a[regex:test(@href, '^linux-(image|headers)-[3-9]\.[0-9]+\.[0-9]+.*amd64.deb$')]/@href",
-            "exclude_patterns": ["-rt", "dbg", "trunk", "all", "exp", "unsigned"]
+            "exclude_patterns": ["-rt", "dbg", "trunk", "all", "exp", "unsigned", "cloud-amd64"]
+        },
+        {
+            "root": "http://security.debian.org/pool/updates/main/l/",
+            "discovery_pattern": "/html/body/table//tr/td/a[@href = 'linux/']/@href",
+            "subdirs": [""],
+            "page_pattern": "/html/body//a[regex:test(@href, '^linux-headers-[3-9]\.[0-9]+\.[0-9]+.*-common_.*_all.deb$')]/@href",
+            "exclude_patterns": ["-rt", "dbg", "trunk", "exp", "unsigned", "cloud-amd64"] # don't exclude "all" like other debian sources
         },
         {
             "root": "http://mirrors.kernel.org/debian/pool/main/l/",
-            "discovery_pattern": "/html/body/pre/a[@href = 'linux-tools/']/@href",
+            "discovery_pattern": "/html/body/pre/a[regex:test(@href, 'linux/|linux-tools/')]/@href",
             "subdirs": [""],
             "page_pattern": "/html/body//a[regex:test(@href, '^linux-kbuild-.*amd64.deb$')]/@href",
-            "exclude_patterns": ["-rt", "dbg", "trunk", "all", "exp", "unsigned"]
+            "exclude_patterns": ["-rt", "dbg", "trunk", "all", "exp", "unsigned", "cloud-amd64"]
         }
     ]
 }


### PR DESCRIPTION
This picks up some kernel versions we've been missing, and it excludes the newer `cloud-amd64` kernels. We need to manually clean up the probe builder to remove some `cloud-amd64` downloads, but there aren't many since they only came out recently.

added:
```
< http://mirrors.kernel.org/debian/pool/main/l/linux/linux-kbuild-4.13_4.13.13-1~bpo9+1_amd64.deb
< http://mirrors.kernel.org/debian/pool/main/l/linux/linux-kbuild-4.14_4.14.13-1~bpo9+1_amd64.deb
< http://mirrors.kernel.org/debian/pool/main/l/linux/linux-kbuild-4.14_4.14.17-1_amd64.deb
< http://mirrors.kernel.org/debian/pool/main/l/linux/linux-kbuild-4.15_4.15.11-1_amd64.deb
< http://mirrors.kernel.org/debian/pool/main/l/linux/linux-kbuild-4.15_4.15.4-1_amd64.deb
< http://mirrors.kernel.org/debian/pool/main/l/linux/linux-kbuild-4.9_4.9.65-3+deb9u2~bpo8+1_amd64.deb
< http://mirrors.kernel.org/debian/pool/main/l/linux/linux-kbuild-4.9_4.9.82-1+deb9u3_amd64.deb
< http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-3-common_4.9.30-2+deb9u5_all.deb
< http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-4-common_4.9.65-3+deb9u1_all.deb
< http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-5-common_4.9.65-3+deb9u2_all.deb
< http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-6-common_4.9.82-1+deb9u3_all.deb
< https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-4.13.0-0.bpo.1-common_4.13.13-1~bpo9+1_all.deb
< https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-4.14.0-0.bpo.2-common_4.14.7-1~bpo9+1_all.deb
< https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-4.14.0-0.bpo.3-common_4.14.13-1~bpo9+1_all.deb
< https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-4.14.0-3-common_4.14.13-1_all.deb
< https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-4.14.0-3-common_4.14.17-1_all.deb
< https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-4.15.0-1-common_4.15.4-1_all.deb
< https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-4.15.0-2-common_4.15.11-1_all.deb
< https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-4.9.0-0.bpo.4-common_4.9.65-3+deb9u1~bpo8+1_all.deb
< https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-4.9.0-0.bpo.5-common_4.9.65-3+deb9u2~bpo8+1_all.deb
< https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-4.9.0-6-common_4.9.82-1+deb9u3_all.deb
```

removed
``` 
> https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-4.15.0-1-cloud-amd64_4.15.4-1_amd64.deb
> https://mirrors.kernel.org/debian/pool/main/l/linux/linux-headers-4.15.0-2-cloud-amd64_4.15.11-1_amd64.deb
> https://mirrors.kernel.org/debian/pool/main/l/linux/linux-image-4.15.0-1-cloud-amd64_4.15.4-1_amd64.deb
> https://mirrors.kernel.org/debian/pool/main/l/linux/linux-image-4.15.0-2-cloud-amd64_4.15.11-1_amd64.deb
```