### PR TITLE
Allow capture files with versions < software

### DIFF
--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -2210,8 +2210,9 @@ int32_t scap_read_init(scap_t *handle, gzFile f)
 		return SCAP_FAILURE;
 	}
 
-	if(sh.major_version != CURRENT_MAJOR_VERSION ||
-	   sh.minor_version != CURRENT_MINOR_VERSION)
+	if(sh.major_version > CURRENT_MAJOR_VERSION ||
+	   (sh.major_version == CURRENT_MAJOR_VERSION &&
+	    sh.minor_version > CURRENT_MINOR_VERSION))
 	{
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE,
 			 "capture created with a newer version of sysdig");


### PR DESCRIPTION
The test between capture file version and software version was doing a
strict comparison--the capture would only be read if the two versions
were equal. This prevents newer versions of sysdig from reading older
capture files.

To fix this, change the test to only refuse to read a capture if its
major number is greater or major numbers are the same but minor number
is greater.
