### PR TITLE
parsing MODULE_URL as an argument passed and env. variable

### DIFF
--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -126,7 +126,7 @@ fi
 
 if [ ! -z $SYSDIG_PROBE_URL ]; then
 	URL=$SYSDIG_PROBE_URL/$SYSDIG_PROBE_FILENAME
-	echo "* Trying to downlod a precompiled module from a custom $URL"
+	echo "* Trying to downlod a precompiled module from a custom URL $URL"
 else 
 	URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
 	echo "* Trying to download a precompiled module from $URL"

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -126,7 +126,7 @@ fi
 
 if [ ! -z $SYSDIG_PROBE_URL ]; then
 	URL=$SYSDIG_PROBE_URL/$SYSDIG_PROBE_FILENAME
-	echo "* Trying to downlod a precompiled module from a custom location $URL"
+	echo "* Trying to downlod a precompiled module from a custom $URL"
 else 
 	URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
 	echo "* Trying to download a precompiled module from $URL"

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -128,8 +128,8 @@ if [ ! -z $SYSDIG_PROBE_URL ]; then
 	URL=$SYSDIG_PROBE_URL/$SYSDIG_PROBE_FILENAME
 	echo "* Trying to downlod precompiled module from custom location $URL"
 else 
-    URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
-    echo "* Trying to download precompiled module from $URL"
+	URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
+	echo "* Trying to download precompiled module from $URL"
 fi
 
 if curl --create-dirs -f -s -o ~/.sysdig/$SYSDIG_PROBE_FILENAME $URL; then

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -126,10 +126,10 @@ fi
 
 if [ ! -z $SYSDIG_PROBE_URL ]; then
 	URL=$SYSDIG_PROBE_URL/$SYSDIG_PROBE_FILENAME
-	echo "* Trying to downlod precompiled module from custom location $URL"
+	echo "* Trying to downlod a precompiled module from a custom location $URL"
 else 
 	URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
-	echo "* Trying to download precompiled module from $URL"
+	echo "* Trying to download a precompiled module from $URL"
 fi
 
 if curl --create-dirs -f -s -o ~/.sysdig/$SYSDIG_PROBE_FILENAME $URL; then

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -124,13 +124,17 @@ if [ -f ~/.sysdig/$SYSDIG_PROBE_FILENAME ]; then
 	exit $?
 fi
 
-if [ ! -z "$1" ]; then
-    echo "Found kernel module custom URL $1, will use it"
-    URL=$1
-else 
-    URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
+if [ ! -z $SYSDIG_PROBE_URL ]; then
+	URL=$SYSDIG_PROBE_URL/$SYSDIG_PROBE_FILENAME
+	echo "* Trying to downlod precompiled module from custom location $URL"
+	if curl --create-dirs -f -s -o ~/.sysdig/$SYSDIG_PROBE_FILENAME $URL; then
+		echo "Download succeeded, loading module"
+		insmod ~/.sysdig/$SYSDIG_PROBE_FILENAME
+		exit $?
+	fi
 fi
 
+URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
 echo "* Trying to download precompiled module from $URL"
 if curl --create-dirs -f -s -o ~/.sysdig/$SYSDIG_PROBE_FILENAME $URL; then
 	echo "Download succeeded, loading module"

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -127,15 +127,11 @@ fi
 if [ ! -z $SYSDIG_PROBE_URL ]; then
 	URL=$SYSDIG_PROBE_URL/$SYSDIG_PROBE_FILENAME
 	echo "* Trying to downlod precompiled module from custom location $URL"
-	if curl --create-dirs -f -s -o ~/.sysdig/$SYSDIG_PROBE_FILENAME $URL; then
-		echo "Download succeeded, loading module"
-		insmod ~/.sysdig/$SYSDIG_PROBE_FILENAME
-		exit $?
-	fi
+else 
+        URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
+        echo "* Trying to download precompiled module from $URL"
 fi
 
-URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
-echo "* Trying to download precompiled module from $URL"
 if curl --create-dirs -f -s -o ~/.sysdig/$SYSDIG_PROBE_FILENAME $URL; then
 	echo "Download succeeded, loading module"
 	insmod ~/.sysdig/$SYSDIG_PROBE_FILENAME

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -126,12 +126,16 @@ fi
 
 if [ ! -z $SYSDIG_PROBE_URL ]; then
 	URL=$SYSDIG_PROBE_URL/$SYSDIG_PROBE_FILENAME
-	echo "* Trying to downlod a precompiled module from a custom URL $URL"
-else 
-	URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
-	echo "* Trying to download a precompiled module from $URL"
+	echo "* Trying to downlod precompiled module from custom location $URL"
+	if curl --create-dirs -f -s -o ~/.sysdig/$SYSDIG_PROBE_FILENAME $URL; then
+		echo "Download succeeded, loading module"
+		insmod ~/.sysdig/$SYSDIG_PROBE_FILENAME
+		exit $?
+	fi
 fi
 
+URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
+echo "* Trying to download precompiled module from $URL"
 if curl --create-dirs -f -s -o ~/.sysdig/$SYSDIG_PROBE_FILENAME $URL; then
 	echo "Download succeeded, loading module"
 	insmod ~/.sysdig/$SYSDIG_PROBE_FILENAME

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -124,7 +124,12 @@ if [ -f ~/.sysdig/$SYSDIG_PROBE_FILENAME ]; then
 	exit $?
 fi
 
-URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
+if [ ! -z "$1" ]; then
+    echo "Found kernel module custom URL $1, will use it"
+    URL=$1
+else 
+    URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
+fi
 
 echo "* Trying to download precompiled module from $URL"
 if curl --create-dirs -f -s -o ~/.sysdig/$SYSDIG_PROBE_FILENAME $URL; then

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -128,8 +128,8 @@ if [ ! -z $SYSDIG_PROBE_URL ]; then
 	URL=$SYSDIG_PROBE_URL/$SYSDIG_PROBE_FILENAME
 	echo "* Trying to downlod precompiled module from custom location $URL"
 else 
-        URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
-        echo "* Trying to download precompiled module from $URL"
+    URL=$(echo https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY/sysdig-probe-binaries/$SYSDIG_PROBE_FILENAME | sed s/+/%2B/g)
+    echo "* Trying to download precompiled module from $URL"
 fi
 
 if curl --create-dirs -f -s -o ~/.sysdig/$SYSDIG_PROBE_FILENAME $URL; then

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -126,7 +126,7 @@ fi
 
 if [ ! -z $SYSDIG_PROBE_URL ]; then
 	URL=$SYSDIG_PROBE_URL/$SYSDIG_PROBE_FILENAME
-	echo "* Trying to downlod precompiled module from custom location $URL"
+	echo "* Trying to downlod a precompiled module from a custom URL $URL"
 	if curl --create-dirs -f -s -o ~/.sysdig/$SYSDIG_PROBE_FILENAME $URL; then
 		echo "Download succeeded, loading module"
 		insmod ~/.sysdig/$SYSDIG_PROBE_FILENAME


### PR DESCRIPTION
Parsing an argument passed to thesysdig-probe-loader as a custom URL for the kernel module
like -e MODULE_URL=http://54.183.253.176:52354 . Has to go together with a same branch in the agent


for example

docker run --rm --name sysdig-agent  --privileged --net host --pid host -e MODULE_URL=http://54.183.253.176:52354/  -e ACCESS_KEY=xxxxx-0984-44ef-b23e-ed19dc819a14 -e TAGS=example_tag:example_value -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --shm-size=350m 40bb05a065d5