### PR TITLE
Fix cwd initialization from non main thread forks

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1265,7 +1265,7 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 		//
 		// Not a thread, copy cwd
 		//
-		tinfo.m_cwd = ptinfo->m_cwd;
+		tinfo.m_cwd = ptinfo->get_cwd();
 	}
 	//if((tinfo.m_flags & (PPM_CL_CLONE_FILES)))
 	//{


### PR DESCRIPTION
`m_cwd` must always be accessed via the `get_cwd()` helper, otherwise a non main thread creating a child process will mistakenly obtain an empty cwd since we just keep file information in the main thread.