### PR TITLE
Fix in netmasks

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -341,6 +341,7 @@ bool flt_compare_ipv4net(cmpop op, uint64_t operand1, ipv4net* operand2)
 	switch(op)
 	{
 	case CO_EQ:
+	case CO_IN:
 	{
 		return ((operand1 & operand2->m_netmask) == (operand2->m_ip & operand2->m_netmask));
 	}

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1108,7 +1108,7 @@ bool sinsp_filter_check_fd::compare_net(sinsp_evt *evt)
 
 		if(evt_type == SCAP_FD_IPV4_SOCK)
 		{
-			if(m_cmpop == CO_EQ)
+			if(m_cmpop == CO_EQ || m_cmpop == CO_IN)
 			{
 				if(flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, (ipv4net*)filter_value_p()) ||
 				   flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, (ipv4net*)filter_value_p()))


### PR DESCRIPTION
Previously, if an expression had an xxx in (a, b, c, ...) check, the
values a, b, c would be put in a set and xxx would do a set membership
test to see if it's in the set.

For almost all filtercheck types, this is preferred, but for some types
like PT_IPV4NET, you can't actually do set membership tests, as the
notion of equals isn't a simple == operator.

So for PT_IPV4NET and any type that trivially returns false from
::flt_compare(), instead of doing the set membership test, compare the
filtercheck values individually and return true as soon as you find one
that is equal.

This fixes draios/falco#339.