### PR TITLE
Allow evttype filters to work with syscalls

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -2232,7 +2232,7 @@ bool sinsp_evttype_filter::run(sinsp_evt *evt, uint16_t ruleset)
 
 	uint16_t etype = evt->m_pevt->type;
 
-	list<filter_wrapper *> *filters = m_filter_by_evttype[etype];
+	list<filter_wrapper *> *filters;
 
 	if(etype == PPME_GENERIC_E || etype == PPME_GENERIC_X)
 	{
@@ -2241,6 +2241,10 @@ bool sinsp_evttype_filter::run(sinsp_evt *evt, uint16_t ruleset)
 		uint16_t evid = *(uint16_t *)parinfo->m_val;
 
 		filters = m_filter_by_syscall[evid];
+	}
+	else
+	{
+		filters = m_filter_by_evttype[etype];
 	}
 
 	if(filters)

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -175,6 +175,7 @@ public:
 
 	void add(std::string &name,
 		 std::set<uint32_t> &evttypes,
+		 std::set<uint32_t> &syscalls,
 		 std::set<string> &tags,
 		 sinsp_filter* filter);
 
@@ -205,6 +206,12 @@ public:
 	// relates to event type 10.
 	void evttypes_for_ruleset(std::vector<bool> &evttypes, uint16_t ruleset);
 
+	// Populate the provided vector, indexed by syscall code, of the
+	// syscall codes associated with the given ruleset id. For
+	// example, syscalls[10] = true would mean that this ruleset
+	// relates to syscall code 10.
+	void syscalls_for_ruleset(std::vector<bool> &syscalls, uint16_t ruleset);
+
 private:
 
 	class filter_wrapper {
@@ -217,6 +224,9 @@ private:
 		// Indexes from event type to enabled/disabled.
 		std::vector<bool> evttypes;
 
+		// Indexes from syscall code to enabled/disabled.
+		std::vector<bool> syscalls;
+
 		// Indexes from ruleset to enabled/disabled. Unlike
 		// m_filter_by_evttype, this is managed as a vector as we're
 		// expecting ruleset ids that are small and grouped in the range
@@ -224,9 +234,9 @@ private:
 		std::vector<bool> enabled;
 	};
 
-        // Solely used for code sharing in evttypes_for_rulset
-	void check_filter_wrappers(std::vector<bool> &evttypes,
-				   uint32_t etype,
+        // Solely used for code sharing in evttypes_for_ruleset/syscalls_for_ruleset
+	void check_filter_wrappers(std::vector<bool> &evttypes_syscalls,
+				   uint32_t idx,
 				   std::list<filter_wrapper *> &filters,
 				   uint16_t ruleset);
 
@@ -234,10 +244,14 @@ private:
 	// filters per event type.
 	std::list<filter_wrapper *> *m_filter_by_evttype[PPM_EVENT_MAX];
 
+	// Maps from syscall number to filter. There can be multiple
+	// filters per syscall number
+	std::list<filter_wrapper *> *m_filter_by_syscall[PPM_SC_MAX];
+
 	// It's possible to add an event type filter with an empty
-	// list of event types, meaning it should run for all event
-	// types.
-	std::list<filter_wrapper *> m_catchall_evttype_filters;
+	// list of event types/syscall numbers, meaning it should run
+	// for all event types/syscalls.
+	std::list<filter_wrapper *> m_catchall_filters;
 
 	// Maps from tag to list of filters having that tag.
 	std::map<std::string, std::list<filter_wrapper *>> m_filter_by_tag;
@@ -246,7 +260,7 @@ private:
 	// m_filter_by_evttype/m_catchall_evttype_filters, so they can
 	// be cleaned up.
 
-	map<std::string,filter_wrapper *> m_evttype_filters;
+	map<std::string,filter_wrapper *> m_filters;
 };
 
 /*@}*/

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1570,6 +1570,7 @@ const string sinsp::get_filter()
 
 void sinsp::add_evttype_filter(string &name,
 			       set<uint32_t> &evttypes,
+			       set<uint32_t> &syscalls,
 			       set<string> &tags,
 			       sinsp_filter *filter)
 {
@@ -1579,7 +1580,7 @@ void sinsp::add_evttype_filter(string &name,
 		m_evttype_filter = new sinsp_evttype_filter();
 	}
 
-	m_evttype_filter->add(name, evttypes, tags, filter);
+	m_evttype_filter->add(name, evttypes, syscalls, tags, filter);
 }
 
 bool sinsp::run_filters_on_evt(sinsp_evt *evt)

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -391,6 +391,7 @@ public:
 
 	void add_evttype_filter(std::string &name,
 				std::set<uint32_t> &evttypes,
+				std::set<uint32_t> &syscalls,
 				std::set<std::string> &tags,
 				sinsp_filter* filter);
 


### PR DESCRIPTION
Syscalls have their own numbers but they weren't really handled by
sinsp_evttype_filter. This meant that there wasn't a way to handle
filters with evt.type=xxx clauses where xxx was a value that didn't have
a corresponding event entry (like "madvise", for examples), or where a
syscall like open could also be done indirectly via syscall(__NR_open,
...).

This fixes that by also tracking the syscall numbers for an event like
"open" or "madvise". They are passed to add() as a separate set and
there are corresponding arrays/lists that map from a syscall number to a
list of filters to run related to that syscall.

in ::run(), if the event number if PPME_GENERIC_E/X, look at the
argument to find the syscall number and index into the syscall-specific
vectors to find the right filters.