### PR TITLE
Allow fd.port to be used with in.

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1224,6 +1224,20 @@ bool sinsp_filter_check_fd::compare_port(sinsp_evt *evt)
 				return true;
 			}
 			break;
+
+		case CO_IN:
+			if(flt_compare(m_cmpop,
+				       PT_PORT,
+				       sport,
+				       sizeof(*sport)) ||
+			   flt_compare(m_cmpop,
+				       PT_PORT,
+				       dport,
+				       sizeof(*dport)))
+			{
+				return true;
+			}
+			break;
 		default:
 			throw sinsp_exception("filter error: unsupported port comparison operator");
 		}


### PR DESCRIPTION
When the filtercheck is fd.port, it's handled by
sinsp_filter_check_fd::compare_port, which checks both the source and
destination port. This didn't accept an operator of CO_IN.

Change this to do flt_compare() using the source and destination port,
whichh in turn uses set membership tests.

Related to changes in https://github.com/draios/falco/pull/320.