### PR TITLE
Don't consider EF_OLD_VERSION a falco skip flag

### DIFF
--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -848,7 +848,7 @@ VISIBILITY_PRIVATE
 
         static inline ppm_event_flags falco_skip_flags()
         {
-		return (ppm_event_flags) (EF_SKIPPARSERESET | EF_UNUSED | EF_OLD_VERSION | EF_DROP_FALCO);
+		return (ppm_event_flags) (EF_SKIPPARSERESET | EF_UNUSED | EF_DROP_FALCO);
         }
 // Doxygen doesn't understand VISIBILITY_PRIVATE
 #ifdef _DOXYGEN


### PR DESCRIPTION
Falco might read a trace file containing older events. These events
shouldn't be skipped simply because a newer version of the event exists.