### PR TITLE
Allow proc lookups to be disabled

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -91,8 +91,6 @@ sinsp::sinsp() :
 #endif
 	m_n_proc_lookups = 0;
 	m_n_proc_lookups_duration_ns = 0;
-	m_max_n_proc_lookups = 0;
-	m_max_n_proc_socket_lookups = 0;
 	m_snaplen = DEFAULT_SNAPLEN;
 	m_buffer_format = sinsp_evt::PF_NORMAL;
 	m_input_fd = 0;
@@ -1391,13 +1389,13 @@ sinsp_threadinfo* sinsp::get_thread(int64_t tid, bool query_os_if_not_found, boo
 				m_n_proc_lookups_duration_ns / 1000000);
 		}
 
-		if(m_max_n_proc_lookups == 0 || (m_max_n_proc_lookups != 0 &&
-			(m_n_proc_lookups <= m_max_n_proc_lookups)))
+		if(m_max_n_proc_lookups < 0 ||
+		   m_n_proc_lookups <= m_max_n_proc_lookups)
 		{
 			bool scan_sockets = false;
 
-			if(m_max_n_proc_socket_lookups == 0 || (m_max_n_proc_socket_lookups != 0 &&
-				(m_n_proc_lookups <= m_max_n_proc_socket_lookups)))
+			if(m_max_n_proc_socket_lookups < 0 ||
+			   m_n_proc_lookups <= m_max_n_proc_socket_lookups)
 			{
 				scan_sockets = true;
 				if(m_n_proc_lookups == m_max_n_proc_socket_lookups)

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1032,10 +1032,10 @@ public:
 #ifdef GATHER_INTERNAL_STATS
 	sinsp_stats m_stats;
 #endif
-	uint32_t m_n_proc_lookups;
+	int32_t m_n_proc_lookups;
 	uint64_t m_n_proc_lookups_duration_ns;
-	uint32_t m_max_n_proc_lookups;
-	uint32_t m_max_n_proc_socket_lookups;
+	int32_t m_max_n_proc_lookups = -1;
+	int32_t m_max_n_proc_socket_lookups = -1;
 #ifdef HAS_ANALYZER
 	vector<uint64_t> m_tid_collisions;
 #endif

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -446,7 +446,6 @@ private:
 	sinsp_threadinfo* m_last_tinfo;
 	uint64_t m_last_flush_time_ns;
 	uint32_t m_n_drops;
-	uint32_t m_n_proc_lookups;
 
 	sinsp_threadtable_listener* m_listener;
 


### PR DESCRIPTION
N==-1 - always do a proc lookup (sysdig default)
N==0  - never do a proc lookup
N>0   - do a max of N proc lookups