### PR TITLE
eBPF: more user-friendly loading mechanism

### DIFF
--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -16,6 +16,7 @@ install(FILES
 	maps.h
 	plumbing_helpers.h
 	probe.c
+	quirks.h
 	ring_helpers.h
 	types.h
 	DESTINATION "src/${PACKAGE_NAME}-${PROBE_VERSION}/bpf"

--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -4,6 +4,7 @@
 #include <uapi/linux/bpf.h>
 #include <linux/sched.h>
 
+#include "../driver_config.h"
 #include "../ppm_events_public.h"
 #include "../ppm_fillers.h"
 #include "bpf_helpers.h"
@@ -240,4 +241,6 @@ int bpf_sched_process_fork(struct sched_process_fork_args *ctx)
 }
 #endif
 
-char release[] __bpf_section("version") = UTS_RELEASE;
+char kernel_ver[] __bpf_section("kernel_version") = UTS_RELEASE;
+
+char probe_ver[] __bpf_section("probe_version") = PROBE_VERSION;

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -235,8 +235,8 @@ if ! hash curl > /dev/null 2>&1; then
 	exit 1
 fi
 
-if [ ! -v SYSDIG_BPF_PROBE ]; then
-	load_kernel_probe
-else
+if [ -v SYSDIG_BPF_PROBE ] || [ "${1}" = "bpf" ]; then
 	load_bpf_probe
+else
+	load_kernel_probe
 fi

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -115,9 +115,15 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 	//
 	handle->m_mode = SCAP_MODE_LIVE;
 
+	//
+	// While in theory we could always rely on the scap caller to properly
+	// set a BPF probe from the environment variable, it's in practice easier
+	// to do one more check here in scap so we don't have to repeat the logic
+	// in all the possible users of the libraries (falco, sysdig, csysdig, dragent, ...)
+	//
 	if(!bpf_probe)
 	{
-		bpf_probe = scap_bpf_probe_from_env(handle);
+		bpf_probe = scap_get_bpf_probe_from_env();
 	}
 
 	char buf[SCAP_MAX_PATH_SIZE];

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -902,6 +902,8 @@ const char* scap_get_host_root();
 */
 struct ppm_proclist_info* scap_get_threadlist(scap_t* handle);
 
+const char *scap_get_bpf_probe_from_env();
+
 
 /*@}*/
 

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -43,7 +43,7 @@ static const int BUF_SIZE_PAGES = 2048;
 
 static const int BPF_LOG_SIZE = 1 << 18;
 
-static const char *BPF_PROBE_ENV = "SYSDIG_BPF_PROBE";
+static const char *SYSDIG_BPF_PROBE_ENV = "SYSDIG_BPF_PROBE";
 
 static int bpf_map_update_elem(int fd, const void *key, const void *value, uint64_t flags)
 {
@@ -620,9 +620,9 @@ cleanup:
 	return res;
 }
 
-const char *scap_bpf_probe_from_env(scap_t *handle)
+const char *scap_get_bpf_probe_from_env()
 {
-	return getenv(BPF_PROBE_ENV);
+	return getenv(SYSDIG_BPF_PROBE_ENV);
 }
 
 static void *perf_event_mmap(scap_t *handle, int fd)

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -18,6 +18,7 @@
 #include "scap.h"
 #include "scap-int.h"
 #include "scap_bpf.h"
+#include "../../driver/driver_config.h"
 #include "../../driver/bpf/types.h"
 #include "../../driver/ppm_fillers.h"
 #include "compat/misc.h"
@@ -533,11 +534,19 @@ static int32_t load_bpf_file(scap_t *handle, const char *path)
 			strtabidx = shdr.sh_link;
 			symbols = data;
 		}
-		else if(strcmp(shname, "version") == 0) {
+		else if(strcmp(shname, "kernel_version") == 0) {
 			if(strcmp(osname.release, data->d_buf))
 			{
 				snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "BPF probe is compiled for %s, but running version is %s",
 					 (char *) data->d_buf, osname.release);
+				goto cleanup;
+			}
+		}
+		else if(strcmp(shname, "probe_version") == 0) {
+			if(strcmp(PROBE_VERSION, data->d_buf))
+			{
+				snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "BPF probe version is %s, but running version is %s",
+					 (char *) data->d_buf, PROBE_VERSION);
 				goto cleanup;
 			}
 		}

--- a/userspace/libscap/scap_bpf.h
+++ b/userspace/libscap/scap_bpf.h
@@ -15,7 +15,6 @@ struct perf_lost_sample {
 	uint64_t lost;
 };
 
-const char *scap_bpf_probe_from_env(scap_t *handle);
 int32_t scap_bpf_load(scap_t *handle, const char *bpf_probe);
 int32_t scap_bpf_start_capture(scap_t *handle);
 int32_t scap_bpf_stop_capture(scap_t *handle);

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -804,7 +804,7 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 					{
 						if(bpf_probe.empty())
 						{
-							if(system("sysdig-probe-loader"))
+							if(system("sysdig-probe-loader bpf"))
 							{
 								fprintf(stderr, "Unable to load the BPF probe\n");
 							}

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -1425,7 +1425,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 					{
 						if(bpf_probe.empty())
 						{
-							if(system("sysdig-probe-loader"))
+							if(system("sysdig-probe-loader bpf"))
 							{
 								fprintf(stderr, "Unable to load the BPF probe\n");
 							}


### PR DESCRIPTION
Since merging to dev, I've been using the official build using the apt repository, and I noticed it's quite annoying to use as it requires running sysdig-probe-loader at every sysdig + kernel update. So, this PR introduces a couple improvements that automatically run sysdig-probe-loader when sysdig is started, if the BPF probe is missing or incompatible.

Now the experience should be much more aligned with dkms as long as one has clang + llvm.

Updated the documentation too: https://github.com/draios/sysdig/wiki/eBPF-(beta)#native-installation
