### PR TITLE
Change sinsp_container_manager::get_container to return a ptr

### DIFF
--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -79,7 +79,7 @@ public:
 			}
 		}
 
-		std::string to_string()
+		std::string to_string() const
 		{
 			return m_source + ":" +
 				m_dest + ":" +
@@ -118,9 +118,9 @@ public:
 
 	const vector<string>& get_env() const { return m_env; }
 
-	container_mount_info *mount_by_idx(uint32_t idx);
-	container_mount_info *mount_by_source(std::string &source);
-	container_mount_info *mount_by_dest(std::string &dest);
+	const container_mount_info *mount_by_idx(uint32_t idx) const;
+	const container_mount_info *mount_by_source(std::string &source) const;
+	const container_mount_info *mount_by_dest(std::string &dest) const;
 
 	string m_id;
 	sinsp_container_type m_type;
@@ -152,7 +152,7 @@ public:
 	const unordered_map<string, sinsp_container_info>* get_containers();
 	bool remove_inactive_containers();
 	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread);
-	bool get_container(const string& id, sinsp_container_info* container_info) const;
+	const sinsp_container_info* get_container(const string& id) const;
 	bool resolve_container(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	void dump_containers(scap_dumper_t* dumper);
 	string get_container_name(sinsp_threadinfo* tinfo);
@@ -167,7 +167,6 @@ private:
 	bool parse_docker(sinsp_container_info* container);
 	string get_docker_env(const Json::Value &env_vars, const string &mti);
 	bool parse_rkt(sinsp_container_info* container, const string& podid, const string& appname);
-	sinsp_container_info* get_container(const string& id);
 
 	sinsp* m_inspector;
 	unordered_map<string, sinsp_container_info> m_containers;

--- a/userspace/libsinsp/cursesui.cpp
+++ b/userspace/libsinsp/cursesui.cpp
@@ -145,13 +145,13 @@ void json_spy_renderer::process_event_spy(sinsp_evt* evt, int32_t next_res)
 
 		if(!tinfo->m_container_id.empty())
 		{
-			sinsp_container_info container_info;
-			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
-			if(found)
+			const sinsp_container_info *container_info =
+				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
+			if(container_info)
 			{
-				if(!container_info.m_name.empty())
+				if(!container_info->m_name.empty())
 				{
-					line["c"] = container_info.m_name;
+					line["c"] = container_info->m_name;
 				}
 			}
 		}

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -5599,19 +5599,19 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			sinsp_container_info container_info;
-			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
-			if(!found)
+			const sinsp_container_info *container_info =
+				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
+			if(!container_info)
 			{
 				return NULL;
 			}
 
-			if(container_info.m_name.empty())
+			if(container_info->m_name.empty())
 			{
 				return NULL;
 			}
 
-			m_tstr = container_info.m_name;
+			m_tstr = container_info->m_name;
 		}
 
 		RETURN_EXTRACT_STRING(m_tstr);
@@ -5622,19 +5622,19 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			sinsp_container_info container_info;
-			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
-			if(!found)
+			const sinsp_container_info *container_info =
+				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
+			if(!container_info)
 			{
 				return NULL;
 			}
 
-			if(container_info.m_image.empty())
+			if(container_info->m_image.empty())
 			{
 				return NULL;
 			}
 
-			m_tstr = container_info.m_image;
+			m_tstr = container_info->m_image;
 		}
 
 		RETURN_EXTRACT_STRING(m_tstr);
@@ -5645,19 +5645,19 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			sinsp_container_info container_info;
-			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
-			if(!found)
+			const sinsp_container_info *container_info =
+				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
+			if(!container_info)
 			{
 				return NULL;
 			}
 
-			if(container_info.m_imageid.empty())
+			if(container_info->m_imageid.empty())
 			{
 				return NULL;
 			}
 
-			m_tstr = container_info.m_imageid;
+			m_tstr = container_info->m_imageid;
 		}
 
 		RETURN_EXTRACT_STRING(m_tstr);
@@ -5668,13 +5668,13 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			sinsp_container_info container_info;
-			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
-			if(!found)
+			const sinsp_container_info *container_info =
+				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
+			if(!container_info)
 			{
 				return NULL;
 			}
-			switch(container_info.m_type)
+			switch(container_info->m_type)
 			{
 			case sinsp_container_type::CT_DOCKER:
 				m_tstr = "docker";
@@ -5704,9 +5704,9 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			sinsp_container_info container_info;
-			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
-			if(!found)
+			const sinsp_container_info *container_info =
+				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
+			if(!container_info)
 			{
 				return NULL;
 			}
@@ -5714,12 +5714,12 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 			// Only return a true/false value for
 			// container types where we really know the
 			// privileged status.
-			if (container_info.m_type != sinsp_container_type::CT_DOCKER)
+			if (container_info->m_type != sinsp_container_type::CT_DOCKER)
 			{
 				return NULL;
 			}
 
-			m_u32val = (container_info.m_privileged ? 1 : 0);
+			m_u32val = (container_info->m_privileged ? 1 : 0);
 		}
 
 		RETURN_EXTRACT_VAR(m_u32val);
@@ -5731,16 +5731,16 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			sinsp_container_info container_info;
-			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
-			if(!found)
+			const sinsp_container_info *container_info =
+				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
+			if(!container_info)
 			{
 				return NULL;
 			}
 
 			m_tstr = "";
 			bool first = true;
-			for(auto &mntinfo : container_info.m_mounts)
+			for(auto &mntinfo : container_info->m_mounts)
 			{
 				if(first)
 				{
@@ -5766,22 +5766,22 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		else
 		{
 
-			sinsp_container_info container_info;
-			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
-			if(!found)
+			const sinsp_container_info *container_info =
+				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
+			if(!container_info)
 			{
 				return NULL;
 			}
 
-			sinsp_container_info::container_mount_info *mntinfo;
+			const sinsp_container_info::container_mount_info *mntinfo;
 
 			if(m_argid != -1)
 			{
-				mntinfo = container_info.mount_by_idx(m_argid);
+				mntinfo = container_info->mount_by_idx(m_argid);
 			}
 			else
 			{
-				mntinfo = container_info.mount_by_source(m_argstr);
+				mntinfo = container_info->mount_by_source(m_argstr);
 			}
 
 			if(!mntinfo)
@@ -5809,28 +5809,28 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		else
 		{
 
-			sinsp_container_info container_info;
-			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
-			if(!found)
+			const sinsp_container_info *container_info =
+				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
+			if(!container_info)
 			{
 				return NULL;
 			}
 
-			sinsp_container_info::container_mount_info *mntinfo;
+			const sinsp_container_info::container_mount_info *mntinfo;
 
 			if(m_argid != -1)
 			{
-				mntinfo = container_info.mount_by_idx(m_argid);
+				mntinfo = container_info->mount_by_idx(m_argid);
 			}
 			else
 			{
 				if (m_field_id == TYPE_CONTAINER_MOUNT_SOURCE)
 				{
-					mntinfo = container_info.mount_by_dest(m_argstr);
+					mntinfo = container_info->mount_by_dest(m_argstr);
 				}
 				else
 				{
-					mntinfo = container_info.mount_by_source(m_argstr);
+					mntinfo = container_info->mount_by_source(m_argstr);
 				}
 			}
 
@@ -7138,14 +7138,14 @@ mesos_task::ptr_t sinsp_filter_check_mesos::find_task_for_thread(const sinsp_thr
 
 		if(m_inspector && m_inspector->m_mesos_client)
 		{
-			sinsp_container_info container_info;
-			bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
-			if(!found || container_info.m_mesos_task_id.empty())
+			const sinsp_container_info *container_info =
+				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
+			if(!container_info || container_info->m_mesos_task_id.empty())
 			{
 				return NULL;
 			}
 			const mesos_state_t& mesos_state = m_inspector->m_mesos_client->get_state();
-			return mesos_state.get_task(container_info.m_mesos_task_id);
+			return mesos_state.get_task(container_info->m_mesos_task_id);
 		}
 	}
 

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -170,21 +170,21 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 {
 	if(!tinfo->m_container_id.empty())
 	{
-		sinsp_container_info container_info;
-		bool found = m_inspector->m_container_manager.get_container(tinfo->m_container_id, &container_info);
+		const sinsp_container_info * container_info =
+			m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 
 		//
 		// Note: if we don't have container info, any pick we make is arbitrary.
 		// To at least achieve consistency across client and server, we just match the host interface addresses. 
 		//
-		if(found)
+		if(container_info)
 		{
-			if(container_info.m_container_ip != 0)
+			if(container_info->m_container_ip != 0)
 			{
 				//
 				// We have a container info with a valid container IP. Let's use it.
 				//
-				if(addr == htonl(container_info.m_container_ip))
+				if(addr == htonl(container_info->m_container_ip))
 				{
 					return true;
 				}


### PR DESCRIPTION
Change sinsp_container_manager::get_container() to return a pointer
instead of filling in an object. There was a private version already
that did this, so modify it slightly to return a const ptr.

We found that this could affect performance when running lots and lots
of events against container-based filters.

This required lots of related changes whenever get_container() was
called, and some follow-on changes to enforce const-ness.