### PR TITLE
Add ability to subscribe to container addition/removal

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -122,9 +122,9 @@ bool sinsp_container_manager::remove_inactive_containers()
 		{
 			if(containers_in_use.find(it->first) == containers_in_use.end())
 			{
-				if(m_inspector->m_parser->m_fd_listener)
+				for(const auto &remove_cb : m_remove_callbacks)
 				{
-					m_inspector->m_parser->m_fd_listener->on_remove_container(m_containers[it->first]);
+					remove_cb(m_containers[it->first]);
 				}
 				m_containers.erase(it++);
 			}
@@ -976,9 +976,9 @@ void sinsp_container_manager::add_container(const sinsp_container_info& containe
 {
 	m_containers[container_info.m_id] = container_info;
 
-	if(m_inspector->m_parser->m_fd_listener)
+	for(const auto &new_cb : m_new_callbacks)
 	{
-		m_inspector->m_parser->m_fd_listener->on_new_container(container_info, thread_info);
+		new_cb(m_containers[container_info.m_id], thread_info);
 	}
 }
 
@@ -1024,4 +1024,14 @@ string sinsp_container_manager::get_container_name(sinsp_threadinfo* tinfo)
 	}
 
 	return res;
+}
+
+void sinsp_container_manager::subscribe_on_new_container(new_container_cb callback)
+{
+	m_new_callbacks.emplace_back(callback);
+}
+
+void sinsp_container_manager::subscribe_on_remove_container(remove_container_cb callback)
+{
+	m_remove_callbacks.emplace_back(callback);
 }

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -160,6 +160,11 @@ public:
 	bool set_mesos_task_id(sinsp_container_info* container, sinsp_threadinfo* tinfo);
 	string get_mesos_task_id(const string& container_id);
 
+	typedef std::function<void(const sinsp_container_info&, sinsp_threadinfo *)> new_container_cb;
+	typedef std::function<void(const sinsp_container_info&)> remove_container_cb;
+	void subscribe_on_new_container(new_container_cb callback);
+	void subscribe_on_remove_container(remove_container_cb callback);
+
 private:
 	string container_to_json(const sinsp_container_info& container_info);
 	bool container_to_sinsp_event(const string& json, sinsp_evt* evt);
@@ -171,4 +176,6 @@ private:
 	sinsp* m_inspector;
 	unordered_map<string, sinsp_container_info> m_containers;
 	uint64_t m_last_flush_time_ns;
+	list<new_container_cb> m_new_callbacks;
+	list<remove_container_cb> m_remove_callbacks;
 };

--- a/userspace/libsinsp/sinsp_int.h
+++ b/userspace/libsinsp/sinsp_int.h
@@ -136,6 +136,4 @@ public:
 	virtual void on_execve(sinsp_evt* evt) = 0;
 	virtual void on_clone(sinsp_evt* evt, sinsp_threadinfo* newtinfo) = 0;
 	virtual void on_bind(sinsp_evt* evt) = 0;
-	virtual void on_new_container(const sinsp_container_info& container_info, sinsp_threadinfo *tinfo) = 0;
-	virtual void on_remove_container(const sinsp_container_info& container_info) = 0;
 };


### PR DESCRIPTION
The container_manager can now receive callbacks to call when a new container is detected or an inactive one is removed.