### PR TITLE
[SMAGENT-914] Perf improvements to calculating the program hash

### DIFF
--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -357,3 +357,14 @@ struct ci_compare
 bool set_socket_blocking(int sock, bool block);
 
 unsigned int read_num_possible_cpus(void);
+
+///////////////////////////////////////////////////////////////////////////////
+// hashing helpers
+///////////////////////////////////////////////////////////////////////////////
+
+// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3876.pdf
+template <typename T>
+inline void hash_combine(std::size_t &seed, const T& val)
+{
+	seed ^= std::hash<T>()(val) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+}


### PR DESCRIPTION
Use a rolling hash to avoid doing repeated string copies and
limit the hash to the first 1024 bytes