### PR TITLE
Scap process blacklist

### DIFF
--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -610,6 +610,12 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, int parentt
 		fclose(f);
 	}
 
+	bool suppressed;
+	if ((res = scap_update_suppressed(handle, tinfo->comm, tid, 0, &suppressed)) != SCAP_SUCCESS)
+	{
+		return res;
+	}
+
 	//
 	// Gather the command line
 	//
@@ -1220,4 +1226,143 @@ void scap_proc_print_table(scap_t* handle)
 	}
 
 	printf("*******************************************\n");
+}
+
+
+int32_t scap_update_suppressed(scap_t *handle,
+			       const char *comm,
+			       uint64_t tid, uint64_t ptid,
+			       bool *suppressed)
+{
+	uint32_t i;
+	scap_tid *stid;
+
+	*suppressed = false;
+
+	HASH_FIND_INT64(handle->m_suppressed_tids, &ptid, stid);
+
+	if(stid != NULL)
+	{
+		*suppressed = true;
+	}
+	else
+	{
+		for(i=0; i < handle->m_num_suppressed_comms; i++)
+		{
+			if(strcmp(handle->m_suppressed_comms[i], comm) == 0)
+			{
+				*suppressed = true;
+				break;
+			}
+		}
+	}
+
+	// Also check to see if the tid is already in the set of
+	// suppressed tids.
+
+	HASH_FIND_INT64(handle->m_suppressed_tids, &tid, stid);
+
+	if(*suppressed && stid == NULL)
+	{
+		stid = (scap_tid *) malloc(sizeof(scap_tid));
+		stid->tid = tid;
+		int32_t uth_status = SCAP_SUCCESS;
+
+		HASH_ADD_INT64(handle->m_suppressed_tids, tid, stid);
+
+		if(uth_status != SCAP_SUCCESS)
+		{
+			return SCAP_FAILURE;
+		}
+		*suppressed = true;
+	}
+	else if (!*suppressed && stid != NULL)
+	{
+		HASH_DEL(handle->m_suppressed_tids, stid);
+		free(stid);
+		*suppressed = false;
+	}
+
+	return SCAP_SUCCESS;
+}
+
+int32_t scap_check_suppressed(scap_t *handle, scap_evt *pevent, bool *suppressed)
+{
+	const struct ppm_event_info* info = &(g_event_info[pevent->type]);
+	uint16_t *lens;
+	char *valptr;
+	uint32_t j;
+	int32_t res = SCAP_SUCCESS;
+	const char *comm;
+	uint64_t *ptid;
+	scap_tid *stid;
+
+	*suppressed = false;
+
+	// For events that can create a new tid (fork, vfork, clone),
+	// we need to check the comm, which might also update the set
+	// of suppressed tids.
+
+	switch(pevent->type)
+	{
+	case PPME_SYSCALL_CLONE_20_X:
+	case PPME_SYSCALL_FORK_20_X:
+	case PPME_SYSCALL_VFORK_20_X:
+	case PPME_SYSCALL_EXECVE_19_X:
+
+		lens = (uint16_t *)((char *)pevent + sizeof(struct ppm_evt_hdr));
+		valptr = (char *)lens + info->nparams * sizeof(uint16_t);
+
+		// For all of these events, the comm is argument 14,
+		// so we need to walk the list of params that far to
+		// find the comm.
+		for(j = 0; j < 13; j++)
+		{
+			if(j == 5)
+			{
+				ptid = (uint64_t *) valptr;
+			}
+
+			valptr += lens[j];
+		}
+
+		comm = valptr;
+
+		if((res = scap_update_suppressed(handle,
+						 comm,
+						 pevent->tid, *ptid,
+						 suppressed)) != SCAP_SUCCESS)
+		{
+			return res;
+		}
+
+		break;
+
+	default:
+
+		HASH_FIND_INT64(handle->m_suppressed_tids, &(pevent->tid), stid);
+
+		// When threads exit they are always removed and no longer suppressed.
+		if(pevent->type == PPME_PROCEXIT_1_E)
+		{
+			if(stid != NULL)
+			{
+				HASH_DEL(handle->m_suppressed_tids, stid);
+				free(stid);
+				*suppressed = true;
+			}
+			else
+			{
+				*suppressed = false;
+			}
+		}
+		else
+		{
+			*suppressed = (stid != NULL);
+		}
+
+		break;
+	}
+
+	return SCAP_SUCCESS;
 }

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -845,6 +845,12 @@ public:
 		return ! (flags & sinsp::falco_skip_flags());
 	}
 
+	// Add comm to the list of comms for which the inspector
+	// should not return events.
+	bool suppress_events_comm(const std::string &comm);
+
+	bool check_suppressed(int64_t tid);
+
 VISIBILITY_PRIVATE
 
         static inline ppm_event_flags falco_skip_flags()
@@ -865,6 +871,7 @@ private:
 
 	void add_thread(const sinsp_threadinfo* ptinfo);
 	void remove_thread(int64_t tid, bool force);
+
 	//
 	// Note: lookup_only should be used when the query for the thread is made
 	//       not as a consequence of an event for that thread arriving, but
@@ -932,6 +939,8 @@ private:
 	{
 		scap_fseek(m_h, filepos);
 	}
+
+	void add_suppressed_comms(scap_open_args &oargs);
 
 	scap_t* m_h;
 	uint32_t m_nevts;
@@ -1126,6 +1135,10 @@ public:
 #if defined(HAS_CAPTURE)
 	int64_t m_sysdig_pid;
 #endif
+
+	// Any thread with a comm in this set will not have its events
+	// returned in sinsp::next()
+	std::set<std::string> m_suppressed_comms;
 
 	friend class sinsp_parser;
 	friend class sinsp_analyzer;

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -212,6 +212,8 @@ static void usage()
 "                    emitted by sysdig to be flushed, which generates higher CPU\n"
 "                    usage but is useful when piping sysdig's output into another\n"
 "                    process or into a script.\n"
+" -U, --suppress-comm\n"
+"                    Ignore all events from processes having the provided comm.\n"
 " -v, --verbose      Verbose output.\n"
 "                    This flag will cause the full content of text and binary\n"
 "                    buffers to be printed on screen, instead of being truncated\n"
@@ -765,6 +767,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 	bool page_faults = false;
 	bool bpf = false;
 	string bpf_probe;
+	std::set<std::string> suppress_comms;
 
 	// These variables are for the cycle_writer engine
 	int duration_seconds = 0;
@@ -809,6 +812,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 		{"readfile", required_argument, 0, 'r' },
 		{"snaplen", required_argument, 0, 's' },
 		{"summary", no_argument, 0, 'S' },
+		{"suppress-comm", required_argument, 0, 'U' },
 		{"timetype", required_argument, 0, 't' },
 		{"force-tracers-capture", required_argument, 0, 'T'},
 		{"unbuffered", no_argument, 0, 0 },
@@ -841,7 +845,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
                                         "C:"
                                         "dDEe:F"
                                         "G:"
-                                        "hi:jk:K:lLm:M:n:Pp:qRr:Ss:t:Tv"
+                                        "hi:jk:K:lLm:M:n:Pp:qRr:Ss:t:TU:v"
                                         "W:"
                                         "w:xXz", long_options, &long_index)) != -1)
 		{
@@ -1130,6 +1134,10 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 			case 'T':
 				force_tracers_capture = true;
 				break;
+
+			case 'U':
+				suppress_comms.insert(string(optarg));
+				break;
 			case 'v':
 				verbose = true;
 				break;
@@ -1366,6 +1374,21 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 			}
 #endif
 
+			// Suppress any comms specified via -U. We
+			// need to do this *before* opening the
+			// inspector, as that reads the process list.
+			for(auto &comm : suppress_comms)
+			{
+				if (!inspector->suppress_events_comm(comm.c_str()))
+				{
+					fprintf(stderr, "Could not add %s to the set of suppressed comms--did you specify more than %d values?\n",
+						comm.c_str(),
+						SCAP_MAX_SUPPRESSED_COMMS);
+					res.m_res = EXIT_FAILURE;
+					goto exit;
+				}
+			}
+
 			//
 			// Launch the capture
 			//
@@ -1560,9 +1583,10 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 
 			if(verbose)
 			{
-				fprintf(stderr, "Driver Events:%" PRIu64 "\nDriver Drops:%" PRIu64 "\n",
+				fprintf(stderr, "Driver Events:%" PRIu64 "\nDriver Drops:%" PRIu64 "\nSuppressed by Comm:%" PRIu64 "\n",
 					cstats.n_evts,
-					cstats.n_drops);
+					cstats.n_drops,
+					cstats.n_suppressed);
 
 				fprintf(stderr, "Elapsed time: %.3lf, Captured Events: %" PRIu64 ", %.2lf eps\n",
 					duration,


### PR DESCRIPTION
Add the ability to ignore events by process name (comm). At the scap level, ignoring is by tid. At the sinsp level, as threads are added/removed from the thread table the comm is checked against a set of comms and if found the tid is added to the scap-level ignore hash table.