### PR TITLE
Ensure m_bpf is set to false for offline handles

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -468,6 +468,7 @@ scap_t* scap_open_offline_int(gzFile gzfile,
 #ifdef CYGWING_AGENT
 	handle->m_whh = NULL;
 #endif
+	handle->m_bpf = false;
 
 	handle->m_file_evt_buf = (char*)malloc(FILE_READ_BUF_SIZE);
 	if(!handle->m_file_evt_buf)


### PR DESCRIPTION
Otherwise, when calling scap_get_stats you might do an uninitialized
read of handle->m_bpf.

cc @gianlucaborello, I'll go ahead and merge after travis builds.