### PR TITLE
Add glob as a lua visible operator

### DIFF
--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -65,6 +65,10 @@ cmpop string_to_cmpop(const char* str)
 	{
 		return CO_EXISTS;
 	}
+	else if(strcmp(str, "glob") == 0)
+	{
+		return CO_GLOB;
+	}
 	else
 	{
 		throw sinsp_exception("filter error: invalid comparison operator: " + string(str));


### PR DESCRIPTION
string_to_cmpop is used in the lua api callbacks for parsing filters,
which in turn is used by falco.

This fixes #1152.