### PR TITLE
Don't skip name=(...) cgroups

### DIFF
--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -365,12 +365,6 @@ int32_t scap_proc_fill_cgroups(struct scap_threadinfo* tinfo, const char* procdi
 			continue;
 		}
 
-		// transient cgroup
-		if(strncmp(subsys_list, "name=", sizeof("name=") - 1) == 0)
-		{
-			continue;
-		}
-
 		// cgroup
 		cgroup = strtok_r(NULL, ":", &scratch);
 		if(cgroup == NULL)
@@ -393,7 +387,7 @@ int32_t scap_proc_fill_cgroups(struct scap_threadinfo* tinfo, const char* procdi
 				return SCAP_SUCCESS;
 			}
 
-			snprintf(tinfo->cgroups + tinfo->cgroups_len, SCAP_MAX_CGROUPS_SIZE - tinfo->cgroups_len, "%s=%s", token, cgroup);
+			snprintf(tinfo->cgroups + tinfo->cgroups_len, SCAP_MAX_CGROUPS_SIZE - tinfo->cgroups_len, "%s:%s", token, cgroup);
 			tinfo->cgroups_len += strlen(cgroup) + 1 + strlen(token) + 1;
 		}
 	}

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -593,7 +593,7 @@ void sinsp_threadinfo::set_cgroups(const char* cgroups, size_t len)
 	while(offset < len)
 	{
 		const char* str = cgroups + offset;
-		const char* sep = strchr(str, '=');
+		const char* sep = strchr(str, ':');
 		if(sep == NULL)
 		{
 			ASSERT(false);


### PR DESCRIPTION
They're useful for custom containers and apparently systemd
only sets the `name=systemd` cgroup right after reboot,
at least on CentOS 7.

Subsequent restarts set all the cgroups to the slice but that
would require restarting all services after boot.

Replace the = character we were using to separate cgroup name
from value with : (it's already used as a separator in
/proc/*/cgroup and we don't really need anything special
from this character, except for not appearing in cgroup names.