### PR TITLE
http_code type should be long not int

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -506,7 +506,7 @@ sinsp_docker_response sinsp_container_engine_docker::get_docker(const sinsp_cont
 		return sinsp_docker_response::RESP_ERROR;
 	}
 
-	int http_code = 0;
+	long http_code = 0;
 	if(curl_easy_getinfo(m_curl, CURLINFO_RESPONSE_CODE, &http_code) != CURLE_OK)
 	{
 		ASSERT(false);


### PR DESCRIPTION
based on [curl_easy_getinfo doc](https://curl.haxx.se/libcurl/c/curl_easy_getinfo.html), the type for code query it is expecting is long*, not int*.

changed it to long, confirmed it work fine.