### PR TITLE
Skip proc scan in sinsp_dumper w/ threads_from_sinsp=true

### DIFF
--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -660,7 +660,7 @@ int64_t scap_get_readfile_offset(scap_t* handle);
 
   \return Dump handle that can be used to identify this specific dump instance.
 */
-scap_dumper_t* scap_dump_open(scap_t *handle, const char *fname, compression_mode compress);
+scap_dumper_t* scap_dump_open(scap_t *handle, const char *fname, compression_mode compress, bool skip_proc_scan);
 
 /*!
   \brief Open a trace file for writing, using the provided fd.

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -851,7 +851,7 @@ static scap_dumper_t *scap_dump_open_gzfile(scap_t *handle, gzFile gzfile, const
 //
 // Open a "savefile" for writing.
 //
-scap_dumper_t *scap_dump_open(scap_t *handle, const char *fname, compression_mode compress)
+scap_dumper_t *scap_dump_open(scap_t *handle, const char *fname, compression_mode compress, bool skip_proc_scan)
 {
 	gzFile f = NULL;
 	int fd = -1;
@@ -902,7 +902,7 @@ scap_dumper_t *scap_dump_open(scap_t *handle, const char *fname, compression_mod
 		return NULL;
 	}
 
-	return scap_dump_open_gzfile(handle, f, fname, false);
+	return scap_dump_open_gzfile(handle, f, fname, skip_proc_scan);
 }
 
 //

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -61,11 +61,11 @@ void sinsp_dumper::open(const string& filename, bool compress, bool threads_from
 	{
 		if(compress)
 		{
-			m_dumper = scap_dump_open(m_inspector->m_h, filename.c_str(), SCAP_COMPRESSION_GZIP);
+			m_dumper = scap_dump_open(m_inspector->m_h, filename.c_str(), SCAP_COMPRESSION_GZIP, threads_from_sinsp);
 		}
 		else
 		{
-			m_dumper = scap_dump_open(m_inspector->m_h, filename.c_str(), SCAP_COMPRESSION_NONE);
+			m_dumper = scap_dump_open(m_inspector->m_h, filename.c_str(), SCAP_COMPRESSION_NONE, threads_from_sinsp);
 		}
 	}
 
@@ -93,11 +93,11 @@ void sinsp_dumper::fdopen(int fd, bool compress, bool threads_from_sinsp)
 
 	if(compress)
 	{
-		m_dumper = scap_dump_open_fd(m_inspector->m_h, fd, SCAP_COMPRESSION_GZIP, true);
+		m_dumper = scap_dump_open_fd(m_inspector->m_h, fd, SCAP_COMPRESSION_GZIP, threads_from_sinsp);
 	}
 	else
 	{
-		m_dumper = scap_dump_open_fd(m_inspector->m_h, fd, SCAP_COMPRESSION_NONE, true);
+		m_dumper = scap_dump_open_fd(m_inspector->m_h, fd, SCAP_COMPRESSION_NONE, threads_from_sinsp);
 	}
 
 	if(m_dumper == NULL)

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -741,11 +741,11 @@ void sinsp::autodump_start(const string& dump_filename, bool compress)
 
 	if(compress)
 	{
-		m_dumper = scap_dump_open(m_h, dump_filename.c_str(), SCAP_COMPRESSION_GZIP);
+		m_dumper = scap_dump_open(m_h, dump_filename.c_str(), SCAP_COMPRESSION_GZIP, false);
 	}
 	else
 	{
-		m_dumper = scap_dump_open(m_h, dump_filename.c_str(), SCAP_COMPRESSION_NONE);
+		m_dumper = scap_dump_open(m_h, dump_filename.c_str(), SCAP_COMPRESSION_NONE, false);
 	}
 
 	m_is_dumping = true;


### PR DESCRIPTION
The way sinsp_dumper::open() and ::fdopen() behaved was slightly
inconsistent. fdopen() would unconditionally call scap_dump_open with
skip_proc_scan=true, and open() would unconditionally call
scap_dump_open with skip_proc_scan=false, regardless of the value of
threads_from_sinsp.

threads_from_sinsp=true is a strong indicator that scap_dump_open
should *not* scan /proc for processes, as sinsp is going to write the
threads list to the dump file immediately after opening.

So tie threads_from_sinsp to whether or not to skip the proc
scan--threads_from_sinsp=true implies skip_proc_scan.

For fdopen(), this is a change from unconditional to honoring
threads_from_sinsp. For open(), it requires adding a skip_proc_scan
argument to scap_dump_open, setting it to false in other calls to
scap_dump_open outside of sinsp_dumper::open(), and tying it to
threads_from_sinsp in sinsp_dumper::open().