### PR TITLE
Add support for docker images without name

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -181,15 +181,21 @@ bool sinsp_container_engine_docker::parse_docker(sinsp_container_manager* manage
 		container->m_imageid = imgstr.substr(cpos + 1);
 	}
 
-	string hostname, port;
-	sinsp_utils::split_container_image(container->m_image,
-					   hostname,
-					   port,
-					   container->m_imagerepo,
-					   container->m_imagetag,
-					   container->m_imagedigest,
-					   false);
-	if(container->m_imagedigest.empty() || container->m_imagetag.empty())
+	bool no_name = strncmp(container->m_image.c_str(), container->m_imageid.c_str(),
+			       MIN(container->m_image.length(), container->m_imageid.length())) == 0;
+	if(!no_name)
+	{
+		string hostname, port;
+		sinsp_utils::split_container_image(container->m_image,
+						   hostname,
+						   port,
+						   container->m_imagerepo,
+						   container->m_imagetag,
+						   container->m_imagedigest,
+						   false);
+	}
+
+	if(no_name || container->m_imagedigest.empty() || container->m_imagetag.empty())
 	{
 		string img_json;
 #ifndef CYGWING_AGENT
@@ -206,6 +212,10 @@ bool sinsp_container_engine_docker::parse_docker(sinsp_container_manager* manage
 					if(rdig.isString())
 					{
 						string repodigest = rdig.asString();
+						if(container->m_imagerepo.empty())
+						{
+							container->m_imagerepo = repodigest.substr(0, repodigest.find("@"));
+						}
 						if(repodigest.find(container->m_imagerepo) != string::npos)
 						{
 							container->m_imagedigest = repodigest.substr(repodigest.find("@")+1);
@@ -218,6 +228,10 @@ bool sinsp_container_engine_docker::parse_docker(sinsp_container_manager* manage
 					if(rtag.isString())
 					{
 						string repotag = rtag.asString();
+						if(container->m_imagerepo.empty())
+						{
+							container->m_imagerepo = repotag.substr(0, repotag.find(":"));
+						}
 						if(repotag.find(container->m_imagerepo) != string::npos)
 						{
 							container->m_imagetag = repotag.substr(repotag.find(":")+1);


### PR DESCRIPTION
It's possible to run docker images by specifying only their imageID.
In those cases, parse the image name metadata from the images endpoint.