### PR TITLE
[SMAGENT-981] calculate HASH of fedora atomic kernel config

### DIFF
--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -22,6 +22,8 @@ get_kernel_config() {
 		echo "Found kernel config at ${SYSDIG_HOST_ROOT}/usr/lib/ostree-boot/config-${KERNEL_RELEASE}"
 		HASH=$(md5sum "${SYSDIG_HOST_ROOT}/usr/lib/ostree-boot/config-${KERNEL_RELEASE}" | cut -d' ' -f1)
 	elif [ -f /lib/modules/${KERNEL_RELEASE}/config ]; then
+		# this code works both for native host and agent container assuming that
+		# Dockerfile sets up the desired symlink /lib/modules -> $SYSDIG_HOST_ROOT/lib/modules
 		echo "Found kernel config at /lib/modules/${KERNEL_RELEASE}/config"
 		HASH=$(md5sum "/lib/modules/${KERNEL_RELEASE}/config" | cut -d' ' -f1)
 	fi

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -21,9 +21,9 @@ get_kernel_config() {
 	elif [ ! -z "${SYSDIG_HOST_ROOT}" ] && [ -f "${SYSDIG_HOST_ROOT}/usr/lib/ostree-boot/config-${KERNEL_RELEASE}" ]; then
 		echo "Found kernel config at ${SYSDIG_HOST_ROOT}/usr/lib/ostree-boot/config-${KERNEL_RELEASE}"
 		HASH=$(md5sum "${SYSDIG_HOST_ROOT}/usr/lib/ostree-boot/config-${KERNEL_RELEASE}" | cut -d' ' -f1)
-	elif [ -f /usr/lib/modules/${KERNEL_RELEASE}/config ]; then
-		echo "Found kernel config at /usr/lib/modules/${KERNEL_RELEASE}/config"
-		HASH=$(md5sum "/usr/lib/modules/${KERNEL_RELEASE}/config" | cut -d' ' -f1)
+	elif [ -f /lib/modules/${KERNEL_RELEASE}/config ]; then
+		echo "Found kernel config at /lib/modules/${KERNEL_RELEASE}/config"
+		HASH=$(md5sum "/lib/modules/${KERNEL_RELEASE}/config" | cut -d' ' -f1)
 	fi
 
 	if [ -z "${HASH}" ]; then

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -21,6 +21,9 @@ get_kernel_config() {
 	elif [ ! -z "${SYSDIG_HOST_ROOT}" ] && [ -f "${SYSDIG_HOST_ROOT}/usr/lib/ostree-boot/config-${KERNEL_RELEASE}" ]; then
 		echo "Found kernel config at ${SYSDIG_HOST_ROOT}/usr/lib/ostree-boot/config-${KERNEL_RELEASE}"
 		HASH=$(md5sum "${SYSDIG_HOST_ROOT}/usr/lib/ostree-boot/config-${KERNEL_RELEASE}" | cut -d' ' -f1)
+	elif [ -f /usr/lib/modules/${KERNEL_RELEASE}/config ]; then
+		echo "Found kernel config at /usr/lib/modules/${KERNEL_RELEASE}/config"
+		HASH=$(md5sum "/usr/lib/modules/${KERNEL_RELEASE}/config" | cut -d' ' -f1)
 	fi
 
 	if [ -z "${HASH}" ]; then


### PR DESCRIPTION
# feature
added HASH calculation for fedora atomic linux
# how to verify
in AWS start an atomic instance, and start sysdig/agent container in interactive bash session, run /opt/draios/bin/sysdigcloud-probe-loader (or sysdigcloud-probe-loader which contains the added code piece), verified the hash was calculated by having similar output:
```
* Trying to download precompiled module from https://s3.amazonaws.com/download.draios.com/stable/sysdig-probe-binaries/sysdigcloud-probe--x86_64-4.17.2-200.fc28.x86_64-991367a4c601fb9c7cc8e75487e2b5e6.ko
```