### PR TITLE
Fix double docker request

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -206,7 +206,7 @@ bool sinsp_container_engine_docker::parse_docker(sinsp_container_manager* manage
 	{
 		string img_json;
 #ifndef CYGWING_AGENT
-		if(get_docker(manager, "http://localhost/" + m_api_version + "/images/" + container->m_imageid + "/json?digests=1", img_json) == sinsp_docker_response::RESP_OK)
+		if(get_docker(manager, "http://localhost" + m_api_version + "/images/" + container->m_imageid + "/json?digests=1", img_json) == sinsp_docker_response::RESP_OK)
 #else
 		if(get_docker(manager, "GET /v1.30/images/" + container->m_imageid + "/json?digests=1 HTTP/1.1\r\nHost: docker \r\n\r\n", img_json) == sinsp_docker_response::RESP_OK)
 #endif

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -167,7 +167,7 @@ public:
 
 	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	static void cleanup();
-
+	static void set_query_image_info(bool query_image_info);
 protected:
 #if !defined(CYGWING_AGENT) && defined(HAS_CAPTURE)
 	static size_t curl_write_callback(const char* ptr, size_t size, size_t nmemb, string* json);
@@ -177,6 +177,7 @@ protected:
 
 	string m_unix_socket_path;
 	string m_api_version;
+	static bool m_query_image_info;
 #if !defined(CYGWING_AGENT) && defined(HAS_CAPTURE)
 	static CURLM *m_curlm;
 	static CURL *m_curl;
@@ -246,6 +247,8 @@ public:
 	void subscribe_on_remove_container(remove_container_cb callback);
 
 	void cleanup();
+
+	void set_query_docker_image_info(bool query_image_info);
 private:
 	string container_to_json(const sinsp_container_info& container_info);
 	bool container_to_sinsp_event(const string& json, sinsp_evt* evt);

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1578,6 +1578,11 @@ void sinsp::add_suppressed_comms(scap_open_args &oargs)
 	oargs.suppressed_comms[i++] = NULL;
 }
 
+void sinsp::set_query_docker_image_info(bool query_image_info)
+{
+	m_container_manager.set_query_docker_image_info(query_image_info);
+}
+
 void sinsp::set_snaplen(uint32_t snaplen)
 {
 	//

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -852,6 +852,8 @@ public:
 
 	bool check_suppressed(int64_t tid);
 
+	void set_query_docker_image_info(bool query_image_info);
+
 VISIBILITY_PRIVATE
 
         static inline ppm_event_flags falco_skip_flags()


### PR DESCRIPTION
Fix a malformed URL that was causing a 301 from the docker daemon.

Also in this PR:
- sinsp clients can set a flag to turn off the additional image info parsing.
 - re-adding PR 1167 and 1168.