### PR TITLE
[SMAGENT-989] containerizing fedora atomic build in sequential pre-compile script

### DIFF
--- a/scripts/Dockerfiles/Dockerfile.fedora
+++ b/scripts/Dockerfiles/Dockerfile.fedora
@@ -1,0 +1,27 @@
+FROM fedora:28
+
+RUN dnf -y update && dnf -y install \
+    wget \
+    git \
+    gcc \
+    gcc-c++ \
+    autoconf \
+    make \
+    cmake \
+    python-lxml \
+    cpio \
+    elfutils-libelf-devel \
+    findutils \
+    kmod \
+&& dnf clean all
+
+WORKDIR /build
+
+# Use the same directory structure as the jenkins worker
+RUN mkdir -p sysdig/scripts
+ADD kernel-crawler.py sysdig/scripts/
+ADD build-probe-binaries sysdig/scripts/
+
+WORKDIR probe
+
+ENTRYPOINT [ "../sysdig/scripts/build-probe-binaries" ]

--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -15,14 +15,14 @@ set -euo pipefail
 PROBE_NAME=$1
 PROBE_VERSION=$2
 REPOSITORY_NAME=$3
-KERNEL_TYPE=
+EXTRA_BUILD_INSTRU=
 BASEDIR=$(pwd)
 ARCH=$(uname -m)
 URL_TIMEOUT=300
 RETRY=10
 
 if [ $# -eq 4 ]; then
-	KERNEL_TYPE=$4
+	EXTRA_BUILD_INSTRU=$4
 fi
 
 if [ ! -d $BASEDIR/output ]; then
@@ -38,14 +38,14 @@ fi
 function update_code_for {
 	repo=$1
 	if [ ! -d $repo ]; then
-		git clone git@github.com:draios/$repo.git
+		git clone https://github.com/draios/$repo.git
 	fi
 
 	cd $repo
 	git checkout master
 	# The UEK builder container doesn't have git credentials
 	# It relies on the non-UEK builds doing the pull earlier
-	if [[ ! "$KERNEL_TYPE" =~ "UEK" ]]; then
+	if [[ ! "$EXTRA_BUILD_INSTRU" =~ "UEK" ]]; then
 		git pull
 	fi
 
@@ -104,6 +104,13 @@ function build_probe {
 	fi
 
 	cd $BASEDIR
+}
+
+function build_for_fedoro_atomic_in_container {
+	echo "Creating Fedora-Atomic builder"
+	docker build -t fedora-builder:latest -f ../sysdig/scripts/Dockerfiles/Dockerfile.fedora --pull ../sysdig/scripts
+	docker run -i --rm --name fedora-atomic-build -v $BASEDIR:/build/probe fedora-builder $PROBE_NAME $PROBE_VERSION $REPOSITORY_NAME Fedora-Atomic
+	echo "Done with building Fedora Atomic modules ($PROBE_NAME $PROBE_VERSION $REPOSITORY_NAME) in container"
 }
 
 function coreos_build_old {
@@ -444,7 +451,7 @@ function debian_build {
 	cd ${BASEDIR}
 }
 
-if [ -z "$KERNEL_TYPE" ]; then
+if [ -z "$EXTRA_BUILD_INSTRU" ]; then
 	#
 	# Ubuntu build
 	#
@@ -483,6 +490,12 @@ if [ -z "$KERNEL_TYPE" ]; then
 	do
 		rhel_build $URL
 	done
+
+	#
+	# Fedora Atomic build
+	#
+	echo "Building Fedora Atomic in container"
+	build_for_fedoro_atomic_in_container
 
 	#
 	# CoreOS build
@@ -607,8 +620,18 @@ if [ -z "$KERNEL_TYPE" ]; then
 	#fi
 
 	echo "Success."
+elif [ "CONTAINER-Fedora-Atomic" = "$EXTRA_BUILD_INSTRU" ]; then
+	build_for_fedoro_atomic_in_container
+elif [ "Fedora-Atomic" = "$EXTRA_BUILD_INSTRU" ]; then
+	echo Building Fedora Atomic kernel modules in container
+	DIR=$(dirname $(readlink -f $0))
+	URLS="$($DIR/kernel-crawler.py Fedora-Atomic)"
 
-elif [ "OL6-UEK" = "$KERNEL_TYPE" ]; then
+	for URL in $URLS
+	do
+		rhel_build $URL
+	done
+elif [ "OL6-UEK" = "$EXTRA_BUILD_INSTRU" ]; then
 	# This should only run in the ol6-builder container context
 	echo Building Oracle Linux 6 UEK
 	DIR=$(dirname $(readlink -f $0))
@@ -618,7 +641,7 @@ elif [ "OL6-UEK" = "$KERNEL_TYPE" ]; then
 	do
 		rhel_build $URL
 	done
-elif [ "OL7-UEK" = "$KERNEL_TYPE" ]; then
+elif [ "OL7-UEK" = "$EXTRA_BUILD_INSTRU" ]; then
 	# This should only run in the ol7-builder container context
 	echo Building Oracle Linux 7 UEK
 	DIR=$(dirname $(readlink -f $0))

--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -15,14 +15,19 @@ set -euo pipefail
 PROBE_NAME=$1
 PROBE_VERSION=$2
 REPOSITORY_NAME=$3
-EXTRA_BUILD_INSTRU=
+KERNEL_TYPE=
+BUILD_TYPE="process"
 BASEDIR=$(pwd)
 ARCH=$(uname -m)
 URL_TIMEOUT=300
 RETRY=10
 
-if [ $# -eq 4 ]; then
-	EXTRA_BUILD_INSTRU=$4
+if [ $# -ge 4 ]; then
+	KERNEL_TYPE=$4
+fi
+
+if [ $# -ge 5 ]; then
+	BUILD_TYPE=$5
 fi
 
 if [ ! -d $BASEDIR/output ]; then
@@ -45,7 +50,7 @@ function update_code_for {
 	git checkout master
 	# The UEK builder container doesn't have git credentials
 	# It relies on the non-UEK builds doing the pull earlier
-	if [[ ! "$EXTRA_BUILD_INSTRU" =~ "UEK" ]]; then
+	if [[ ! "$KERNEL_TYPE" =~ "UEK" ]]; then
 		git pull
 	fi
 
@@ -451,7 +456,7 @@ function debian_build {
 	cd ${BASEDIR}
 }
 
-if [ -z "$EXTRA_BUILD_INSTRU" ]; then
+if [ -z "$KERNEL_TYPE" ]; then
 	#
 	# Ubuntu build
 	#
@@ -619,18 +624,20 @@ if [ -z "$EXTRA_BUILD_INSTRU" ]; then
 	#fi
 
 	echo "Success."
-elif [ "CONTAINER-Fedora-Atomic" = "$EXTRA_BUILD_INSTRU" ]; then
-	build_for_fedoro_atomic_in_container
-elif [ "Fedora-Atomic" = "$EXTRA_BUILD_INSTRU" ]; then
-	echo Building Fedora Atomic kernel modules in container
-	DIR=$(dirname $(readlink -f $0))
-	URLS="$($DIR/kernel-crawler.py Fedora-Atomic)"
+elif [ "Fedora-Atomic" = "$KERNEL_TYPE" ]; then
+	if [ "container" = "$BUILD_TYPE" ]; then
+		build_for_fedoro_atomic_in_container
+	else
+		echo Building Fedora Atomic kernel modules in container
+		DIR=$(dirname $(readlink -f $0))
+		URLS="$($DIR/kernel-crawler.py Fedora-Atomic)"
 
-	for URL in $URLS
-	do
-		rhel_build $URL
-	done
-elif [ "OL6-UEK" = "$EXTRA_BUILD_INSTRU" ]; then
+		for URL in $URLS
+		do
+			rhel_build $URL
+		done
+	fi
+elif [ "OL6-UEK" = "$KERNEL_TYPE" ]; then
 	# This should only run in the ol6-builder container context
 	echo Building Oracle Linux 6 UEK
 	DIR=$(dirname $(readlink -f $0))
@@ -640,7 +647,7 @@ elif [ "OL6-UEK" = "$EXTRA_BUILD_INSTRU" ]; then
 	do
 		rhel_build $URL
 	done
-elif [ "OL7-UEK" = "$EXTRA_BUILD_INSTRU" ]; then
+elif [ "OL7-UEK" = "$KERNEL_TYPE" ]; then
 	# This should only run in the ol7-builder container context
 	echo Building Oracle Linux 7 UEK
 	DIR=$(dirname $(readlink -f $0))

--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -494,7 +494,6 @@ if [ -z "$EXTRA_BUILD_INSTRU" ]; then
 	#
 	# Fedora Atomic build
 	#
-	echo "Building Fedora Atomic in container"
 	build_for_fedoro_atomic_in_container
 
 	#


### PR DESCRIPTION
# features
* dockerfile of module builder for fedora distrio (including fedora atomic)
* build script builds fedora atomic modules in sequential fashion along w/ others
# how to verify w/o jenkins job
to test fedora-atomic modules containerized only.  
The FULL pre-builds test may not be able to run for lack of  dependencies, which should be tested on jenkins host.
```
// make a folder (say xxx) along side of sysdig source folder
$ cd xxx/
$ ../sysdig/scripts/build-probe-binaries sysdig-probe 0.22.0 test Fedora-Atomic container
$ cd output/
$ ls
...
sysdig-probe-0.22.0-x86_64-4.17.0-200.fc28.x86_64-5d308e9816127feb2edfd42c571c8fcf.ko
...
```