### PR TITLE
Probe builder fixes

### DIFF
--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -105,8 +105,7 @@ repos = {
             "subdirs" : [
                 "Everything/x86_64/os/Packages/k/"
             ],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^kernel-(core|devel)-[0-9].*\.rpm$')]/@href",
-            "exclude_patterns": ["4.17."]
+            "page_pattern" : "/html/body//a[regex:test(@href, '^kernel-(core|devel)-[0-9].*\.rpm$')]/@href"
         },
 
         {
@@ -115,8 +114,7 @@ repos = {
             "subdirs" : [
                 "x86_64/Packages/k/"
             ],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^kernel-(core|devel)-[0-9].*\.rpm$')]/@href",
-            "exclude_patterns": ["4.17."]
+            "page_pattern" : "/html/body//a[regex:test(@href, '^kernel-(core|devel)-[0-9].*\.rpm$')]/@href"
         },
 
         {
@@ -125,8 +123,7 @@ repos = {
             "subdirs" : [
                 "Everything/x86_64/Packages/k/"
             ],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^kernel-(core|devel)-[0-9].*\.rpm$')]/@href",
-            "exclude_patterns": ["4.17."]
+            "page_pattern" : "/html/body//a[regex:test(@href, '^kernel-(core|devel)-[0-9].*\.rpm$')]/@href"
         },
 
         # {
@@ -135,8 +132,7 @@ repos = {
         # 	"subdirs" : [
         # 		"x86_64/os/Packages/k/"
         # 	],
-        # 	"page_pattern" : "/html/body//a[regex:test(@href, '^kernel-(core|devel)-[0-9].*\.rpm$')]/@href",
-        # 	"exclude_patterns": ["4.17."]
+        # 	"page_pattern" : "/html/body//a[regex:test(@href, '^kernel-(core|devel)-[0-9].*\.rpm$')]/@href"
         # }
     ],
 

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -4,6 +4,7 @@
 # Date: August 17th, 2015
 
 import bz2
+import re
 import sqlite3
 import sys
 import tempfile
@@ -143,7 +144,8 @@ repos = {
             "subdirs" : [
                 ""
             ],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^[5-9][0-9][0-9]|current|[1][0-9]{3}')]/@href"
+            "page_pattern" : "/html/body//a[regex:test(@href, '^[5-9][0-9][0-9]|current|[1][0-9]{3}')]/@href",
+            "exclude_patterns": ["^15\d\d\."]
         },
 
         {
@@ -220,7 +222,7 @@ repos['AmazonLinux2'] = amazon_linux2
 
 def exclude_patterns(repo, packages, base_url, urls):
     for rpm in packages:
-        if "exclude_patterns" in repo and any(x in rpm for x in repo["exclude_patterns"]):
+        if "exclude_patterns" in repo and any(re.search(x, rpm) for x in repo["exclude_patterns"]):
             continue
         else:
             urls.add(base_url + str(urllib2.unquote(rpm)))

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -73,7 +73,7 @@ repos = {
             "root" : "https://mirrors.kernel.org/ubuntu/pool/main/l/",
             "discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
             "subdirs" : [""],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-[3-9].*-generic.*amd64.deb$')]/@href",
+            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-[3-9].*-generic.*amd64.deb$')]/@href"
             "exclude_patterns": ["4.15.0-14"]
         },
 
@@ -81,7 +81,7 @@ repos = {
             "root" : "https://mirrors.kernel.org/ubuntu/pool/main/l/",
             "discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
             "subdirs" : [""],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-headers-[3-9].*_all.deb$')]/@href",
+            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-headers-[3-9].*_all.deb$')]/@href"
             "exclude_patterns": ["4.15.0-14"]
         },
 
@@ -89,7 +89,7 @@ repos = {
             "root" : "http://security.ubuntu.com/ubuntu/pool/main/l/",
             "discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
             "subdirs" : [""],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-[3-9].*-generic.*amd64.deb$')]/@href",
+            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-[3-9].*-generic.*amd64.deb$')]/@href"
             "exclude_patterns": ["4.15.0-14"]
         },
 
@@ -97,7 +97,7 @@ repos = {
             "root" : "http://security.ubuntu.com/ubuntu/pool/main/l/",
             "discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
             "subdirs" : [""],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-headers-[3-9].*_all.deb$')]/@href",
+            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-headers-[3-9].*_all.deb$')]/@href"
             "exclude_patterns": ["4.15.0-14"]
         }
     ],

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -74,7 +74,6 @@ repos = {
             "discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
             "subdirs" : [""],
             "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-[3-9].*-generic.*amd64.deb$')]/@href"
-            "exclude_patterns": ["4.15.0-14"]
         },
 
         {
@@ -82,7 +81,6 @@ repos = {
             "discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
             "subdirs" : [""],
             "page_pattern" : "/html/body//a[regex:test(@href, '^linux-headers-[3-9].*_all.deb$')]/@href"
-            "exclude_patterns": ["4.15.0-14"]
         },
 
         {
@@ -90,7 +88,6 @@ repos = {
             "discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
             "subdirs" : [""],
             "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-[3-9].*-generic.*amd64.deb$')]/@href"
-            "exclude_patterns": ["4.15.0-14"]
         },
 
         {
@@ -98,7 +95,6 @@ repos = {
             "discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
             "subdirs" : [""],
             "page_pattern" : "/html/body//a[regex:test(@href, '^linux-headers-[3-9].*_all.deb$')]/@href"
-            "exclude_patterns": ["4.15.0-14"]
         }
     ],
 


### PR DESCRIPTION
Re-enable some temporarily disabled builds. Coreos alpha was re-enabled in https://github.com/draios/sysdig/commit/4508106ac4698e8884891da65b60ac54f7ff952b, but some of the 15xx alpha builds were broken, so skip them.