### PR TITLE
Downgrade binutils in docker image

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -55,6 +55,15 @@ RUN curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public |
 RUN rm -df /lib/modules \
  && ln -s $SYSDIG_HOST_ROOT/lib/modules /lib/modules
 
+# debian:unstable head contains binutils 2.31, which generates
+# binaries that are incompatible with kernels < 4.16. So manually
+# forcibly install binutils 2.30-22 instead.
+RUN curl -s -o binutils_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/binutils_2.30-22_amd64.deb \
+ && curl -s -o libbinutils_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/libbinutils_2.30-22_amd64.deb \
+ && curl -s -o binutils-x86-64-linux-gnu_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.30-22_amd64.deb \
+ && curl -s -o binutils-common_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/binutils-common_2.30-22_amd64.deb \
+ && dpkg -i *binutils*.deb
+
 COPY ./docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -52,6 +52,15 @@ RUN rm -df /lib/modules \
 ADD sysdig-${SYSDIG_VERSION}-x86_64.deb /
 RUN dpkg -i /sysdig-${SYSDIG_VERSION}-x86_64.deb
 
+# debian:unstable head contains binutils 2.31, which generates
+# binaries that are incompatible with kernels < 4.16. So manually
+# forcibly install binutils 2.30-22 instead.
+RUN curl -s -o binutils_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/binutils_2.30-22_amd64.deb \
+ && curl -s -o libbinutils_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/libbinutils_2.30-22_amd64.deb \
+ && curl -s -o binutils-x86-64-linux-gnu_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.30-22_amd64.deb \
+ && curl -s -o binutils-common_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/binutils-common_2.30-22_amd64.deb \
+ && dpkg -i *binutils*.deb
+
 COPY ./docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -55,6 +55,15 @@ RUN curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public |
 RUN rm -df /lib/modules \
  && ln -s $SYSDIG_HOST_ROOT/lib/modules /lib/modules
 
+# debian:unstable head contains binutils 2.31, which generates
+# binaries that are incompatible with kernels < 4.16. So manually
+# forcibly install binutils 2.30-22 instead.
+RUN curl -s -o binutils_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/binutils_2.30-22_amd64.deb \
+ && curl -s -o libbinutils_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/libbinutils_2.30-22_amd64.deb \
+ && curl -s -o binutils-x86-64-linux-gnu_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.30-22_amd64.deb \
+ && curl -s -o binutils-common_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/binutils-common_2.30-22_amd64.deb \
+ && dpkg -i *binutils*.deb
+
 COPY ./docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
debian:unstable head contains binutils 2.31, which generates binaries
that are incompatible with kernels < 4.16.

To fix this, after installing everything, downgrade binutils to
2.30-22. This has to be done as the last step as it introduces conflicts
in other dependencies of the various gcc versions and some of the
packages already in the image.