### PR TITLE
Support logging elapsed time on tracers

### DIFF
--- a/userspace/libsinsp/tracer_emitter.cpp
+++ b/userspace/libsinsp/tracer_emitter.cpp
@@ -116,8 +116,10 @@ void tracer_writer::close_fd()
 	}
 }
 
-tracer_emitter::tracer_emitter(std::string tag)
+tracer_emitter::tracer_emitter(std::string tag, uint64_t timeout_ns)
 	: m_tag(std::move(tag))
+	, m_start_ns(sinsp_utils::get_current_time_ns())
+	, m_timeout_ns(timeout_ns)
 {
 	start();
 }
@@ -126,10 +128,11 @@ bool tracer_emitter::m_enabled = false;
 
 // XXX find/write a constexpr-compatible string class
 // for compile time concatenation
-tracer_emitter::tracer_emitter(std::string tag, const tracer_emitter &parent)
-	: m_tag(parent.tag() + '.' + std::move(tag))
+tracer_emitter::tracer_emitter(std::string tag, const tracer_emitter &parent, uint64_t timeout_ns)
+	: tracer_emitter::tracer_emitter(
+		parent.tag() + '.' + std::move(tag),
+		std::min(timeout_ns, parent.m_timeout_ns))
 {
-	start();
 }
 
 tracer_emitter::~tracer_emitter()
@@ -137,6 +140,7 @@ tracer_emitter::~tracer_emitter()
 	if (!m_exit_written)
 	{
 		write_tracer(false);
+		elapsed_time(); // just for the side effect of logging if needed
 	}
 }
 
@@ -145,13 +149,14 @@ void tracer_emitter::start()
 	write_tracer(true);
 }
 
-void tracer_emitter::stop()
+uint64_t tracer_emitter::stop()
 {
 	ASSERT(!m_exit_written);
 	if (!m_exit_written)
 	{
 		write_tracer(false);
 	}
+	return elapsed_time();
 }
 
 void tracer_emitter::write_tracer(const bool enter)
@@ -176,4 +181,14 @@ void tracer_emitter::write_tracer(const bool enter)
 	{
 		m_exit_written = true;
 	}
+}
+
+uint64_t tracer_emitter::elapsed_time() const
+{
+	auto elapsed = sinsp_utils::get_current_time_ns() - m_start_ns;
+	if (elapsed > m_timeout_ns)
+	{
+		g_logger.format(sinsp_logger::SEV_INFO, "Tracer %s elapsed time %llu ns", m_tag.c_str(), elapsed);
+	}
+	return elapsed;
 }

--- a/userspace/libsinsp/tracer_emitter.h
+++ b/userspace/libsinsp/tracer_emitter.h
@@ -6,8 +6,10 @@
 class tracer_emitter
 {
 public:
-	tracer_emitter(std::string tag);
-	tracer_emitter(std::string tag, const tracer_emitter &parent);
+	static const uint64_t no_timeout = ~0ULL;
+
+	tracer_emitter(std::string tag, uint64_t timeout_ns=no_timeout);
+	tracer_emitter(std::string tag, const tracer_emitter &parent, uint64_t timeout_ns=no_timeout);
 	~tracer_emitter();
 
 	tracer_emitter() = delete;
@@ -17,15 +19,18 @@ public:
 	// Stop is only needed if you want the exit
 	// event before the instance gets destructed,
 	// i.e. goes out of scope
-	void stop();
+	uint64_t stop();
 	static void set_enabled(bool enabled) { m_enabled = enabled; }
 
 private:
 	void start();
 	void write_tracer(const bool enter);
 	const std::string& tag() const { return m_tag; }
+	uint64_t elapsed_time() const;
 
 	const std::string m_tag;
+	const uint64_t m_start_ns = 0;
+	const uint64_t m_timeout_ns = 0;
 	bool m_exit_written = false;
 	static bool m_enabled;
 };


### PR DESCRIPTION
Apart from having the tracers in the first place, allow setting
a timeout, after which we log a message to bring our attention
to the problem in the first place.