### PR TITLE
Async docker daemon communication [SMAGENT-979]

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -635,11 +635,10 @@ bool sinsp_container_engine_docker::resolve(sinsp_container_manager* manager, si
 		return false;
 
 	tinfo->m_container_id = container_info.m_id;
-	if (!manager->container_exists(container_info.m_id) &&
-	    m_pending_requests.find(container_info.m_id) == m_pending_requests.end())
+	if (!manager->container_exists(container_info.m_id))
 	{
-#ifndef _WIN32
-		if (query_os_for_missing_info)
+#if !defined(_WIN32) && defined(HAS_CAPTURE)
+		if (query_os_for_missing_info && m_pending_requests.find(container_info.m_id) == m_pending_requests.end())
 		{
 			m_pending_requests[container_info.m_id].url = "http://localhost" + m_api_version + "/containers/" + container_info.m_id + "/json";
 			m_pending_requests[container_info.m_id].query_images_endpoint = false;
@@ -654,7 +653,7 @@ bool sinsp_container_engine_docker::resolve(sinsp_container_manager* manager, si
 #endif
 			manager->add_container(container_info, tinfo);
 			manager->notify_new_container(container_info);
-#ifndef _WIN32
+#if !defined(_WIN32) && defined(HAS_CAPTURE)
 		}
 #endif
 	}

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -30,6 +30,8 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include "dragent_win_hal_public.h"
 #endif
 
+#define MAX_CONCURRENT_DOCKER_REQUESTS 256
+
 void sinsp_container_info::parse_json_mounts(const Json::Value &mnt_obj, vector<sinsp_container_info::container_mount_info> &mounts)
 {
 	if(!mnt_obj.isNull() && mnt_obj.isArray())
@@ -668,6 +670,10 @@ bool sinsp_container_engine_docker::resolve(sinsp_container_manager* manager, si
 		{
 			if(m_pending_requests.find(container_info.m_id) == m_pending_requests.end())
 			{
+				if(m_pending_requests.size() > MAX_CONCURRENT_DOCKER_REQUESTS)
+				{
+					return false;
+				}
 				m_pending_requests[container_info.m_id].stage = REQ_S_CONTAINERS;
 				m_pending_requests[container_info.m_id].c_id = container_info.m_id;
 				m_pending_requests[container_info.m_id].container_info = container_info;

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -1259,7 +1259,8 @@ bool sinsp_container_engine_rkt::parse_rkt(sinsp_container_info *container, cons
 
 sinsp_container_manager::sinsp_container_manager(sinsp* inspector) :
 	m_inspector(inspector),
-	m_last_flush_time_ns(0)
+	m_last_flush_time_ns(0),
+	m_refresh_interval(1000000) // 1 ms
 {
 }
 
@@ -1517,9 +1518,11 @@ void sinsp_container_manager::cleanup()
 	sinsp_container_engine_docker::cleanup();
 }
 
-void sinsp_container_manager::refresh()
+void sinsp_container_manager::refresh(uint64_t ts)
 {
-	sinsp_container_engine_docker::refresh();
+	m_refresh_interval.run([this]() {
+		sinsp_container_engine_docker::refresh();
+	}, ts);
 }
 
 void sinsp_container_manager::set_query_docker_image_info(bool query_image_info)

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -189,12 +189,11 @@ public:
 protected:
 #if !defined(CYGWING_AGENT) && defined(HAS_CAPTURE)
 	static size_t curl_write_callback(const char* ptr, size_t size, size_t nmemb, string* json);
-
-	static bool start_docker_request(docker_request_info *req);
 #endif
 #ifdef CYGWING_AGENT
 	static sinsp_docker_response get_docker(const sinsp_container_manager* manager, const string& url, string &json);
 #endif
+	static bool start_docker_request(docker_request_info *req);
 	static bool parse_docker(sinsp_container_manager* manager, sinsp_container_info *container, sinsp_threadinfo* tinfo,
 				 Json::Value &root, bool &query_images_endpoint, string &id_to_query_for_ip);
 	static bool parse_docker_image(sinsp_container_manager* manager, sinsp_container_info *container, Json::Value &root);

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -190,7 +190,7 @@ public:
 		string buf;
 		request_stage stage;
 		sinsp_container_info container_info;
-		sinsp_threadinfo *tinfo;
+		uint64_t pid;
 		sinsp_container_manager *manager;
 	};
 protected:
@@ -281,12 +281,13 @@ public:
 	void refresh();
 
 	void set_query_docker_image_info(bool query_image_info);
+
+	sinsp* m_inspector;
 private:
 	string container_to_json(const sinsp_container_info& container_info);
 	bool container_to_sinsp_event(const string& json, sinsp_evt* evt);
 	string get_docker_env(const Json::Value &env_vars, const string &mti);
 
-	sinsp* m_inspector;
 	unordered_map<string, sinsp_container_info> m_containers;
 	uint64_t m_last_flush_time_ns;
 	list<new_container_cb> m_new_callbacks;

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -174,14 +174,21 @@ public:
 	static void refresh();
 	static void set_query_image_info(bool query_image_info);
 
+	enum request_stage
+	{
+		REQ_S_CONTAINERS = 0,
+		REQ_S_IMAGES_NETPARENT,
+		REQ_S_IMAGES,
+		REQ_S_NETPARENT_CONTAINER,
+		REQ_S_DONE
+	};
+
 	struct docker_request_info
 	{
-		string url;
+		string c_id;
+		string i_id;
 		string buf;
-		Json::Value c_root;
-		Json::Value i_root;
-		bool query_images_endpoint;
-		string id_to_query_for_ip;
+		request_stage stage;
 		sinsp_container_info container_info;
 		sinsp_threadinfo *tinfo;
 		sinsp_container_manager *manager;

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -261,7 +261,7 @@ public:
 	bool remove_inactive_containers();
 	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread);
 	sinsp_container_info * get_container(const string &id);
-	void notify_new_container(const sinsp_container_info& container_info);
+	void notify_new_container(const sinsp_container_info& container_info, sinsp_threadinfo *tinfo);
 	template<typename E> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	template<typename E1, typename E2, typename... Args> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	bool resolve_container(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
@@ -285,7 +285,7 @@ public:
 	sinsp* m_inspector;
 private:
 	string container_to_json(const sinsp_container_info& container_info);
-	bool container_to_sinsp_event(const string& json, sinsp_evt* evt);
+	bool container_to_sinsp_event(const string& json, sinsp_threadinfo *tinfo, sinsp_evt* evt);
 	string get_docker_env(const Json::Value &env_vars, const string &mti);
 
 	unordered_map<string, sinsp_container_info> m_containers;

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -24,6 +24,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include <curl/curl.h>
 #include <curl/easy.h>
 #include <curl/multi.h>
+#include "utils.h"
 #endif
 
 enum sinsp_container_type
@@ -278,7 +279,7 @@ public:
 	void subscribe_on_remove_container(remove_container_cb callback);
 
 	void cleanup();
-	void refresh();
+	void refresh(uint64_t ts);
 
 	void set_query_docker_image_info(bool query_image_info);
 
@@ -292,6 +293,7 @@ private:
 	uint64_t m_last_flush_time_ns;
 	list<new_container_cb> m_new_callbacks;
 	list<remove_container_cb> m_remove_callbacks;
+	run_on_interval m_refresh_interval;
 };
 
 template<typename E> bool sinsp_container_manager::resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info)

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -190,7 +190,7 @@ public:
 		string buf;
 		request_stage stage;
 		sinsp_container_info container_info;
-		uint64_t pid;
+		int64_t pid;
 		sinsp_container_manager *manager;
 	};
 protected:
@@ -210,8 +210,8 @@ protected:
 	static bool m_query_image_info;
 #if !defined(CYGWING_AGENT) && defined(HAS_CAPTURE)
 	static CURLM *m_curlm;
+	static int m_running_handles;
 	static unordered_map<string, docker_request_info> m_pending_requests;
-	static uint32_t m_n_polling_attempts;
 #endif
 };
 

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -136,7 +136,7 @@ sinsp_threadinfo* sinsp_evt::get_thread_info(bool query_os_if_not_found)
 		return m_tinfo;
 	}
 
-	return m_inspector->get_thread(m_pevt->tid, query_os_if_not_found, false);
+	return m_inspector->get_thread(m_pevt->tid, query_os_if_not_found, get_category() & EC_INTERNAL);
 }
 
 int64_t sinsp_evt::get_fd_num()

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1268,9 +1268,15 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 	m_parser->process_event(evt);
 #endif
 
-	// A side-effect of parsing this event may have generated a
-	// meta event. For example, parsing an execve or clone into a
-	// new cgroup may have created a container event.
+	if(!is_capture() && !m_meta_evt_pending)
+	{
+		m_container_manager.refresh();
+	}
+
+	// A side-effect of parsing this event (or refreshing the
+	// container manager) may have generated a meta event. For
+	// example, parsing an execve or clone into a new cgroup
+	// may have created a container event.
 	//
 	// We want that meta event to be returned/written to files
 	// *before* the original system event. So save the system

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1270,7 +1270,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 
 	if(!is_capture() && !m_meta_evt_pending)
 	{
-		m_container_manager.refresh();
+		m_container_manager.refresh(ts);
 	}
 
 	// A side-effect of parsing this event (or refreshing the

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -381,3 +381,39 @@ inline void hash_combine(std::size_t &seed, const T& val)
 {
 	seed ^= std::hash<T>()(val) + 0x9e3779b9 + (seed<<6) + (seed>>2);
 }
+
+/**
+ * Often we need to run something on an interval
+ * usually we need to store last_run_ts compare to now
+ * and run it
+ * This micro-class makes this easier
+ */
+class run_on_interval
+{
+public:
+	inline run_on_interval(uint64_t interval);
+
+	template<typename Callable>
+	inline void run(const Callable& c, uint64_t now = sinsp_utils::get_current_time_ns());
+	uint64_t interval() const { return m_interval; }
+	void interval(uint64_t i) { m_interval = i; }
+private:
+	uint64_t m_last_run_ns;
+	uint64_t m_interval;
+};
+
+run_on_interval::run_on_interval(uint64_t interval):
+		m_last_run_ns(0),
+		m_interval(interval)
+{
+}
+
+template<typename Callable>
+void run_on_interval::run(const Callable& c, uint64_t now)
+{
+	if(now - m_last_run_ns > m_interval)
+	{
+		c();
+		m_last_run_ns = now;
+	}
+}


### PR DESCRIPTION
Instead of using libcurl in a blocking manner, queue the requests to the local docker daemon in a multi handle and poll it from inspector::next().
Add and notify the new container only when all the metadata have been successfully retrieved.

Verified that events are no longer dropped even if multiple containers are started simultaneously.