### PR TITLE
Load .ko.xz module on hosts using xz compression

### DIFF
--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -69,12 +69,19 @@ load_kernel_probe() {
 			if insmod "/var/lib/dkms/${PACKAGE_NAME}/${SYSDIG_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.ko" > /dev/null 2>&1; then
 				echo "${PROBE_NAME} found and loaded in dkms"
 				exit 0
+			elif insmod "/var/lib/dkms/${PACKAGE_NAME}/${SYSDIG_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.ko.xz" > /dev/null 2>&1; then
+				echo "${PROBE_NAME} found and loaded in dkms (xz)"
+				exit 0
+			else
+				echo "* Unable to insmod"
 			fi
 		else
 			DKMS_LOG="/var/lib/dkms/${PACKAGE_NAME}/${SYSDIG_VERSION}/build/make.log"
 			if [ -f "${DKMS_LOG}" ]; then
 				echo "* Running dkms build failed, dumping ${DKMS_LOG}"
 				cat "${DKMS_LOG}"
+			else
+				echo "* Running dkms build failed, couldn't find ${DKMS_LOG}"
 			fi
 		fi
 	fi


### PR DESCRIPTION
Newer centos/rhel versions use xz compression for the kernel modules, so the probe loader will attempt to load the `.ko.xz` module if we can't find `.ko`.

Also add some extra output in error conditions