### PR TITLE
Sysdig fix for SMBACK-1611 for vulnerability CVE-2018-1000007

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 # Prior to doing anything, we make sure that we aren't trying to
 # run cmake in-tree. (see Issue 71: https://github.com/draios/sysdig/issues/71)
 if(EXISTS CMakeLists.txt)
@@ -343,8 +344,10 @@ if(NOT WIN32 AND NOT APPLE)
 
 		ExternalProject_Add(curl
 			DEPENDS openssl
-			URL "http://download.draios.com/dependencies/curl-7.57.0.tar.bz2"
-			URL_MD5 "dd3e22e923be17663e67f721c2aec054"
+			# START CHANGE for CVE-2018-1000007
+                        URL "http://download.draios.com/dependencies/curl-7.60.0.tar.bz2"
+			URL_MD5 "bd2aabf78ded6a9aec8a54532fd6b5d7"
+                        # END CHANGE for CVE-2018-1000007
 			CONFIGURE_COMMAND ./configure ${CURL_SSL_OPTION} --disable-threaded-resolver --disable-shared --enable-optimize --disable-curldebug --disable-rt --enable-http --disable-ftp --disable-file --disable-ldap --disable-ldaps --disable-rtsp --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-sspi --disable-ntlm-wb --disable-tls-srp --without-winssl --without-darwinssl --without-polarssl --without-cyassl --without-nss --without-axtls --without-ca-path --without-ca-bundle --without-libmetalink --without-librtmp --without-winidn --without-libidn --without-nghttp2 --without-libssh2
 			BUILD_COMMAND ${CMD_MAKE}
 			BUILD_IN_SOURCE 1


### PR DESCRIPTION
 Sysdig fix for SMBACK-1611 for vulnerability CVE-2018-1000007 : updated curl version 7.60