### PR TITLE
Add std:: namespace

### DIFF
--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -73,7 +73,7 @@ public:
 	//
 	// Check if string ends with another 
 	//
-	static bool endswith(const string& str, const string& ending);
+	static bool endswith(const std::string& str, const std::string& ending);
 	static bool endswith(const char *str, const char *ending, uint32_t lstr, uint32_t lend);
 
 	//


### PR DESCRIPTION
For the sysdig build, some header file already has a "using namespace
std", but other builds do not, which revealed the problem.