### PR TITLE
Domain name filterchecks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,37 @@ else()
 endif()
 
 #
+# Intel tbb
+#
+if(NOT WIN32 AND NOT APPLE)
+	option(USE_BUNDLED_TBB "Enable building of the bundled tbb" ${USE_BUNDLED_DEPS})
+	if(NOT USE_BUNDLED_TBB)
+		find_path(TBB_INCLUDE tbb.h PATH_SUFFIXES tbb)
+		find_library(TBB_LIB NAMES tbb)
+		if(TBB_INCLUDE AND TBB_LIB)
+			message(STATUS "Found tbb: include: ${TBB_INCLUDE}, lib: ${TBB_LIB}")
+		else()
+			message(FATAL_ERROR "Couldn't find system tbb")
+		endif()
+	else()
+		set(TBB_SRC "${PROJECT_BINARY_DIR}/tbb-prefix/src/tbb")
+
+		message(STATUS "Using bundled tbb in '${TBB_SRC}'")
+
+		set(TBB_INCLUDE "${TBB_SRC}/include/")
+		set(TBB_LIB "${TBB_SRC}/build/lib_release/libtbb.a")
+		ExternalProject_Add(tbb
+			URL "https://github.com/01org/tbb/archive/2018_U5.tar.gz" # FIXME
+			URL_MD5 "ff3ae09f8c23892fbc3008c39f78288f"
+			CONFIGURE_COMMAND ""
+			BUILD_COMMAND ${CMD_MAKE} tbb_build_dir=${TBB_SRC}/build tbb_build_prefix=lib extra_inc=big_iron.inc
+			BUILD_IN_SOURCE 1
+			BUILD_BYPRODUCTS ${TBB_LIB}
+			INSTALL_COMMAND "")
+	endif()
+endif()
+
+#
 # jq
 #
 if(NOT WIN32 AND NOT APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,7 @@ if(NOT WIN32 AND NOT APPLE)
 		set(TBB_INCLUDE "${TBB_SRC}/include/")
 		set(TBB_LIB "${TBB_SRC}/build/lib_release/libtbb.a")
 		ExternalProject_Add(tbb
-			URL "https://github.com/01org/tbb/archive/2018_U5.tar.gz" # FIXME
+			URL "http://s3.amazonaws.com/download.draios.com/dependencies/tbb-2018_U5.tar.gz"
 			URL_MD5 "ff3ae09f8c23892fbc3008c39f78288f"
 			CONFIGURE_COMMAND ""
 			BUILD_COMMAND ${CMD_MAKE} tbb_build_dir=${TBB_SRC}/build tbb_build_prefix=lib extra_inc=big_iron.inc

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -10,6 +10,7 @@ if(NOT WIN32 AND NOT APPLE)
 	include_directories("${CURSES_INCLUDE_DIR}")
 	include_directories("${JQ_INCLUDE}")
 	include_directories("${OPENSSL_INCLUDE_DIR}")
+	include_directories("${TBB_INCLUDE}")
 endif()
 
 add_library(sinsp STATIC
@@ -102,12 +103,16 @@ if(NOT WIN32)
 	if(USE_BUNDLED_CURL)
 		add_dependencies(sinsp curl)
 	endif()
+	if(USE_BUNDLED_TBB)
+		add_dependencies(sinsp tbb)
+	endif()
 
 	if(NOT APPLE)
 		target_link_libraries(sinsp
 			"${JQ_LIB}"
 			"${B64_LIB}"
 			"${CURL_LIBRARIES}"
+			"${TBB_LIB}"
 			rt
 			anl)
 	endif()

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(sinsp STATIC
 	cursesui.cpp
 	event.cpp
 	eventformatter.cpp
+	dns_manager.cpp
 	docker.cpp
 	dumper.cpp
 	fdinfo.cpp

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -149,7 +149,7 @@ bool sinsp_dns_manager::match(const char *name, int af, void *addr, uint64_t ts)
 	return false;
 }
 
-string sinsp_dns_manager::name_of(int af, void *addr)
+string sinsp_dns_manager::name_of(int af, void *addr, uint64_t ts)
 {
 	string ret;
 
@@ -169,12 +169,14 @@ string sinsp_dns_manager::name_of(int af, void *addr)
 				memcpy(v6.m_b, addr, sizeof(ipv6addr));
 				if (info.m_v6_addrs.find(v6) != info.m_v6_addrs.end())
 				{
+					info.m_last_used_ts = ts;
 					ret = name;
 					break;
 				}
 			}
 			else if(af == AF_INET && info.m_v4_addrs.find(*(uint32_t *)addr) != info.m_v4_addrs.end())
 			{
+				info.m_last_used_ts = ts;
 				ret = name;
 				break;
 			}

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -47,6 +47,9 @@ void sinsp_dns_resolver::refresh(uint64_t erase_timeout, uint64_t base_refresh_t
 					refreshed_info.m_timeout = base_refresh_timeout;
 					refreshed_info.m_last_resolve_ts = info.m_last_resolve_ts = ts;
 
+					// dns_info::operator!= will check if some
+					// v4 or v6 addresses are changed from the
+					// last resolution
 					if(refreshed_info != info)
 					{
 						info = refreshed_info;

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -44,8 +44,8 @@ void sinsp_dns_resolver::refresh(uint64_t erase_timeout, uint64_t base_refresh_t
 				else if(ts > (info.m_last_resolve_ts + info.m_timeout))
 				{
 					sinsp_dns_manager::dns_info refreshed_info = manager.resolve(name, ts);
-					info.m_timeout = base_refresh_timeout;
-					info.m_last_resolve_ts = ts;
+					refreshed_info.m_timeout = base_refresh_timeout;
+					refreshed_info.m_last_resolve_ts = info.m_last_resolve_ts = ts;
 
 					if(refreshed_info != info)
 					{

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -99,9 +99,9 @@ inline sinsp_dns_manager::dns_info sinsp_dns_manager::resolve(const std::string 
 			}
 			else // AF_INET6
 			{
-				std::array<uint32_t, 4> v6_ip;
-				memcpy(v6_ip.data(), ((struct sockaddr_in6*)rp->ai_addr)->sin6_addr.s6_addr, 16);
-				dinfo.m_v6_addrs.insert(v6_ip);
+				ipv6addr v6;
+				memcpy(v6.m_b, ((struct sockaddr_in6*)rp->ai_addr)->sin6_addr.s6_addr, sizeof(ipv6addr));
+				dinfo.m_v6_addrs.insert(v6);
 			}
 		}
 		freeaddrinfo(result);
@@ -137,9 +137,9 @@ bool sinsp_dns_manager::match(const char *name, uint32_t *addr, uint64_t ts, boo
 
 	if(is_v6)
 	{
-		std::array<uint32_t, 4> v6_ip;
-		memcpy(v6_ip.data(), addr, 16);
-		return dinfo.m_v6_addrs.find(v6_ip) != dinfo.m_v6_addrs.end();
+		ipv6addr v6;
+		memcpy(v6.m_b, addr, sizeof(ipv6addr));
+		return dinfo.m_v6_addrs.find(v6) != dinfo.m_v6_addrs.end();
 	}
 	else
 	{
@@ -165,9 +165,9 @@ string sinsp_dns_manager::name_of(uint32_t *addr, bool is_v6)
 
 			if(is_v6)
 			{
-				std::array<uint32_t, 4> v6_ip;
-				memcpy(v6_ip.data(), addr, 16);
-				if (info.m_v6_addrs.find(v6_ip) != info.m_v6_addrs.end())
+				ipv6addr v6;
+				memcpy(v6.m_b, addr, sizeof(ipv6addr));
+				if (info.m_v6_addrs.find(v6) != info.m_v6_addrs.end())
 				{
 					ret = name;
 					break;

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -197,5 +197,6 @@ void sinsp_dns_manager::cleanup()
 		m_exit_signal.set_value();
 		m_resolver->join();
 		m_resolver = NULL;
+		m_exit_signal = std::promise<void>();
 	}
 }

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -1,0 +1,195 @@
+/*
+Copyright (C) 2013-2018 Draios inc.
+
+This file is part of sysdig.
+
+sysdig is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+sysdig is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "dns_manager.h"
+
+void sinsp_dns_resolver::refresh(uint64_t erase_timeout, uint64_t base_refresh_timeout, uint64_t max_refresh_timeout, std::future<void> f_exit)
+{
+#ifdef HAS_CAPTURE
+	sinsp_dns_manager &manager = sinsp_dns_manager::get();
+	while(true)
+	{
+		if(!manager.m_cache.empty())
+		{
+			std::list<std::string> to_delete;
+
+			uint64_t ts = sinsp_utils::get_current_time_ns();
+
+			for(auto &it: manager.m_cache)
+			{
+				const std::string &name = it.first;
+				sinsp_dns_manager::dns_info &info = it.second;
+
+				if((ts > info.m_last_used_ts) &&
+				   (ts - info.m_last_used_ts) > erase_timeout)
+				{
+					// remove the entry if it's hasn't been used for a whole hour
+					to_delete.push_back(name);
+				}
+				else if(ts > (info.m_last_resolve_ts + info.m_timeout))
+				{
+					sinsp_dns_manager::dns_info refreshed_info = manager.resolve(name, ts);
+					info.m_timeout = base_refresh_timeout;
+					info.m_last_resolve_ts = ts;
+
+					if(refreshed_info != info)
+					{
+						info = refreshed_info;
+					}
+					else if(info.m_timeout < max_refresh_timeout)
+					{
+						// double the timeout until 320 secs
+						info.m_timeout <<= 1;
+					}
+				}
+			}
+			if(!to_delete.empty())
+			{
+				manager.m_erase_mutex.lock();
+				for(const auto &name : to_delete)
+				{
+					manager.m_cache.unsafe_erase(name);
+				}
+				manager.m_erase_mutex.unlock();
+			}
+		}
+
+		if(f_exit.wait_for(std::chrono::nanoseconds(base_refresh_timeout)) == std::future_status::ready)
+		{
+			break;
+		}
+	}
+#endif
+}
+
+#ifdef HAS_CAPTURE
+inline sinsp_dns_manager::dns_info sinsp_dns_manager::resolve(const std::string &name, uint64_t ts)
+{
+	dns_info dinfo;
+
+	struct addrinfo hints, *result, *rp;
+	memset(&hints, 0, sizeof(struct addrinfo));
+
+	// Allow IPv4 or IPv6, all socket types, all protocols
+	hints.ai_family = AF_UNSPEC;
+
+	int s = getaddrinfo(name.c_str(), NULL, &hints, &result);
+	if (!s && result)
+	{
+		for (rp = result; rp != NULL; rp = rp->ai_next)
+		{
+			if(rp->ai_family == AF_INET)
+			{
+				dinfo.m_v4_addrs.insert(((struct sockaddr_in*)rp->ai_addr)->sin_addr.s_addr);
+			}
+			else // AF_INET6
+			{
+				std::array<uint32_t, 4> v6_ip;
+				memcpy(v6_ip.data(), ((struct sockaddr_in6*)rp->ai_addr)->sin6_addr.s6_addr, 16);
+				dinfo.m_v6_addrs.insert(v6_ip);
+			}
+		}
+		freeaddrinfo(result);
+	}
+	return dinfo;
+}
+#endif
+
+bool sinsp_dns_manager::match(const char *name, uint32_t *addr, uint64_t ts, bool is_v6)
+{
+#ifdef HAS_CAPTURE
+	if(!m_resolver)
+	{
+		m_resolver = new thread(sinsp_dns_resolver::refresh, m_erase_timeout, m_base_refresh_timeout, m_max_refresh_timeout, m_exit_signal.get_future());
+	}
+
+	string sname = string(name);
+
+	m_erase_mutex.lock();
+
+	if(m_cache.find(sname) == m_cache.end())
+	{
+		dns_info dinfo = resolve(sname, ts);
+		dinfo.m_timeout = m_base_refresh_timeout;
+		dinfo.m_last_resolve_ts = ts;
+		m_cache[sname] = dinfo;
+	}
+
+	m_cache[sname].m_last_used_ts = ts;
+	dns_info &dinfo = m_cache[sname];
+
+	m_erase_mutex.unlock();
+
+	if(is_v6)
+	{
+		std::array<uint32_t, 4> v6_ip;
+		memcpy(v6_ip.data(), addr, 16);
+		return dinfo.m_v6_addrs.find(v6_ip) != dinfo.m_v6_addrs.end();
+	}
+	else
+	{
+		return dinfo.m_v4_addrs.find(*addr) != dinfo.m_v4_addrs.end();
+	}
+#endif
+	return false;
+}
+
+string sinsp_dns_manager::name_of(uint32_t *addr, bool is_v6)
+{
+	string ret;
+
+#ifdef HAS_CAPTURE
+
+	if(!m_cache.empty())
+	{
+		m_erase_mutex.lock();
+		for(auto &it: m_cache)
+		{
+			const std::string &name = it.first;
+			sinsp_dns_manager::dns_info &info = it.second;
+
+			if(is_v6)
+			{
+				std::array<uint32_t, 4> v6_ip;
+				memcpy(v6_ip.data(), addr, 16);
+				if (info.m_v6_addrs.find(v6_ip) != info.m_v6_addrs.end())
+				{
+					ret = name;
+					break;
+				}
+			}
+			else if(info.m_v4_addrs.find(*addr) != info.m_v4_addrs.end())
+			{
+				ret = name;
+				break;
+			}
+		}
+		m_erase_mutex.unlock();
+	}
+#endif
+	return ret;
+}
+
+void sinsp_dns_manager::cleanup()
+{
+	if(m_resolver)
+	{
+		m_exit_signal.set_value();
+		m_resolver->join();
+	}
+}

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -196,5 +196,6 @@ void sinsp_dns_manager::cleanup()
 	{
 		m_exit_signal.set_value();
 		m_resolver->join();
+		m_resolver = NULL;
 	}
 }

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -110,7 +110,7 @@ inline sinsp_dns_manager::dns_info sinsp_dns_manager::resolve(const std::string 
 }
 #endif
 
-bool sinsp_dns_manager::match(const char *name, uint32_t *addr, uint64_t ts, bool is_v6)
+bool sinsp_dns_manager::match(const char *name, int af, void *addr, uint64_t ts)
 {
 #ifdef HAS_CAPTURE
 	if(!m_resolver)
@@ -135,21 +135,21 @@ bool sinsp_dns_manager::match(const char *name, uint32_t *addr, uint64_t ts, boo
 
 	m_erase_mutex.unlock();
 
-	if(is_v6)
+	if(af == AF_INET6)
 	{
 		ipv6addr v6;
 		memcpy(v6.m_b, addr, sizeof(ipv6addr));
 		return dinfo.m_v6_addrs.find(v6) != dinfo.m_v6_addrs.end();
 	}
-	else
+	else if(af == AF_INET)
 	{
-		return dinfo.m_v4_addrs.find(*addr) != dinfo.m_v4_addrs.end();
+		return dinfo.m_v4_addrs.find(*(uint32_t *)addr) != dinfo.m_v4_addrs.end();
 	}
 #endif
 	return false;
 }
 
-string sinsp_dns_manager::name_of(uint32_t *addr, bool is_v6)
+string sinsp_dns_manager::name_of(int af, void *addr)
 {
 	string ret;
 
@@ -163,7 +163,7 @@ string sinsp_dns_manager::name_of(uint32_t *addr, bool is_v6)
 			const std::string &name = it.first;
 			sinsp_dns_manager::dns_info &info = it.second;
 
-			if(is_v6)
+			if(af == AF_INET6)
 			{
 				ipv6addr v6;
 				memcpy(v6.m_b, addr, sizeof(ipv6addr));
@@ -173,7 +173,7 @@ string sinsp_dns_manager::name_of(uint32_t *addr, bool is_v6)
 					break;
 				}
 			}
-			else if(info.m_v4_addrs.find(*addr) != info.m_v4_addrs.end())
+			else if(af == AF_INET && info.m_v4_addrs.find(*(uint32_t *)addr) != info.m_v4_addrs.end())
 			{
 				ret = name;
 				break;

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -1,0 +1,125 @@
+/*
+Copyright (C) 2013-2018 Draios inc.
+
+This file is part of sysdig.
+
+sysdig is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+sysdig is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <future>
+#include <mutex>
+#ifdef HAS_CAPTURE
+#include "tbb/concurrent_unordered_map.h"
+#endif
+#include "sinsp.h"
+
+
+struct sinsp_dns_resolver
+{
+	static void refresh(uint64_t erase_timeout, uint64_t base_refresh_timeout, uint64_t max_refresh_timeout, std::future<void> f_exit);
+};
+
+class sinsp_dns_manager
+{
+public:
+
+	bool match(const char *name, uint32_t *addr, uint64_t ts, bool is_v6);
+	string name_of(uint32_t *addr, bool is_v6);
+
+	void cleanup();
+
+        static sinsp_dns_manager& get()
+        {
+            static sinsp_dns_manager instance;
+            return instance;
+        };
+
+	void set_erase_timeout(uint64_t ns)
+	{
+		m_erase_timeout = ns;
+	};
+	void set_base_refresh_timeout(uint64_t ns)
+	{
+		m_base_refresh_timeout = ns;
+	};
+	void set_max_refresh_timeout(uint64_t ns)
+	{
+		m_max_refresh_timeout = ns;
+	};
+
+	size_t size()
+	{
+#ifdef HAS_CAPTURE
+		return m_cache.size();
+#else
+		return 0;
+#endif
+	};
+
+private:
+
+	sinsp_dns_manager() :
+		m_erase_timeout(3600 * ONE_SECOND_IN_NS),
+		m_base_refresh_timeout(10 * ONE_SECOND_IN_NS),
+		m_max_refresh_timeout(320 * ONE_SECOND_IN_NS)
+	{};
+        sinsp_dns_manager(sinsp_dns_manager const&) = delete;
+        void operator=(sinsp_dns_manager const&) = delete;
+
+#ifdef HAS_CAPTURE
+	struct dns_info
+	{
+		bool operator==(const dns_info &other) const
+		{
+			return m_v4_addrs == other.m_v4_addrs && m_v6_addrs == other.m_v6_addrs;
+		};
+		bool operator!=(const dns_info &other) const
+		{
+			return !operator==(other);
+		};
+
+		uint64_t m_timeout;
+		uint64_t m_last_resolve_ts;
+		uint64_t m_last_used_ts;
+		std::set<uint32_t> m_v4_addrs;
+		std::set<std::array<uint32_t, 4>> m_v6_addrs;
+	};
+
+	static inline dns_info resolve(const std::string &name, uint64_t ts);
+
+	typedef tbb::concurrent_unordered_map<std::string, dns_info> c_dns_table;
+	c_dns_table m_cache;
+#endif
+
+	// tbb concurrent unordered map is not thread-safe for deletions,
+	// so we still need a mutex, but the chances of waiting are really
+	// low, since we will almost never do an erase.
+	std::mutex m_erase_mutex;
+
+	// used to let m_resolver when to terminate
+	std::promise<void> m_exit_signal;
+
+	std::thread *m_resolver;
+
+	uint64_t m_erase_timeout;
+	uint64_t m_base_refresh_timeout;
+	uint64_t m_max_refresh_timeout;
+
+	friend sinsp_dns_resolver;
+};

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -112,7 +112,7 @@ private:
 	// low, since we will almost never do an erase.
 	std::mutex m_erase_mutex;
 
-	// used to let m_resolver when to terminate
+	// used to let m_resolver know when to terminate
 	std::promise<void> m_exit_signal;
 
 	std::thread *m_resolver;

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -98,7 +98,7 @@ private:
 		uint64_t m_last_resolve_ts;
 		uint64_t m_last_used_ts;
 		std::set<uint32_t> m_v4_addrs;
-		std::set<std::array<uint32_t, 4>> m_v6_addrs;
+		std::set<ipv6addr> m_v6_addrs;
 	};
 
 	static inline dns_info resolve(const std::string &name, uint64_t ts);

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -39,8 +39,8 @@ class sinsp_dns_manager
 {
 public:
 
-	bool match(const char *name, uint32_t *addr, uint64_t ts, bool is_v6);
-	string name_of(uint32_t *addr, bool is_v6);
+	bool match(const char *name, int af, void *addr, uint64_t ts);
+	string name_of(int af, void *addr);
 
 	void cleanup();
 

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -40,7 +40,7 @@ class sinsp_dns_manager
 public:
 
 	bool match(const char *name, int af, void *addr, uint64_t ts);
-	string name_of(int af, void *addr);
+	string name_of(int af, void *addr, uint64_t ts);
 
 	void cleanup();
 

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -637,17 +637,21 @@ uint8_t* sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT uint32_t* len, bool 
 				return NULL;
 			}
 
+			m_tstr.clear();
 			scap_fd_type evt_type = m_fdinfo->m_type;
 			if(evt_type == SCAP_FD_IPV4_SOCK)
 			{
-				m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip);
+				m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, evt->get_ts());
 			}
 			else if (evt_type == SCAP_FD_IPV6_SOCK)
 			{
-				m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip.m_b[0]);
+				m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip.m_b[0], evt->get_ts());
 			}
 
-			RETURN_EXTRACT_STRING(m_tstr);
+			if(!m_tstr.empty())
+			{
+				RETURN_EXTRACT_STRING(m_tstr);
+			}
 		}
 
 		break;
@@ -696,24 +700,29 @@ uint8_t* sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT uint32_t* len, bool 
 				return NULL;
 			}
 
+			m_tstr.clear();
 			scap_fd_type evt_type = m_fdinfo->m_type;
 			if(evt_type == SCAP_FD_IPV4_SOCK)
 			{
-				m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip);
+				m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, evt->get_ts());
 			}
 			else if(evt_type == SCAP_FD_IPV4_SERVSOCK)
 			{
-				m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4serverinfo.m_ip);
+				m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4serverinfo.m_ip, evt->get_ts());
 			}
 			else if (evt_type == SCAP_FD_IPV6_SOCK)
 			{
-				m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip.m_b[0]);
+				m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip.m_b[0], evt->get_ts());
 			}
 			else if(evt_type == SCAP_FD_IPV6_SERVSOCK)
 			{
-				m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6serverinfo.m_ip.m_b[0]);
+				m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6serverinfo.m_ip.m_b[0], evt->get_ts());
 			}
-			RETURN_EXTRACT_STRING(m_tstr);
+
+			if(!m_tstr.empty())
+			{
+				RETURN_EXTRACT_STRING(m_tstr);
+			}
 		}
 
 		break;
@@ -807,28 +816,29 @@ uint8_t* sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT uint32_t* len, bool 
 			}
 			else
 			{
+				m_tstr.clear();
 				if(is_local)
 				{
 					if(m_field_id == TYPE_LIP_NAME)
 					{
 						if(evt_type == SCAP_FD_IPV4_SOCK)
 						{
-							m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip);
+							m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, evt->get_ts());
 						}
 						else
 						{
-							m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip.m_b[0]);
+							m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip.m_b[0], evt->get_ts());
 						}
 					}
 					else
 					{
 						if(evt_type == SCAP_FD_IPV4_SOCK)
 						{
-							m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip);
+							m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, evt->get_ts());
 						}
 						else
 						{
-							m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip.m_b[0]);
+							m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip.m_b[0], evt->get_ts());
 						}
 					}
 				}
@@ -838,26 +848,30 @@ uint8_t* sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT uint32_t* len, bool 
 					{
 						if(evt_type == SCAP_FD_IPV4_SOCK)
 						{
-							m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip);
+							m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, evt->get_ts());
 						}
 						else
 						{
-							m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip.m_b[0]);
+							m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip.m_b[0], evt->get_ts());
 						}
 					}
 					else
 					{
 						if(evt_type == SCAP_FD_IPV4_SOCK)
 						{
-							m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip);
+							m_tstr = sinsp_dns_manager::get().name_of(AF_INET, &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, evt->get_ts());
 						}
 						else
 						{
-							m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip.m_b[0]);
+							m_tstr = sinsp_dns_manager::get().name_of(AF_INET6, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip.m_b[0], evt->get_ts());
 						}
 					}
 				}
-				RETURN_EXTRACT_STRING(m_tstr);
+
+				if(!m_tstr.empty())
+				{
+					RETURN_EXTRACT_STRING(m_tstr);
+				}
 			}
 		}
 
@@ -1741,22 +1755,17 @@ bool sinsp_filter_check_fd::compare(sinsp_evt *evt)
 	//
 	// Some fields are filter only and therefore get a special treatment
 	//
-	switch(m_field_id)
+	if(m_field_id == TYPE_IP)
 	{
-	case TYPE_IP:
 		return compare_ip(evt);
-	case TYPE_PORT:
-	case TYPE_PROTO:
+	}
+	else if(m_field_id == TYPE_PORT || m_field_id == TYPE_PROTO)
+	{
 		return compare_port(evt);
-	case TYPE_NET:
+	}
+	else if(m_field_id == TYPE_NET)
+	{
 		return compare_net(evt);
-	case TYPE_CLIENTIP_NAME:
-	case TYPE_SERVERIP_NAME:
-	case TYPE_LIP_NAME:
-	case TYPE_RIP_NAME:
-		return compare_domain(evt);
-	default:
-		break;
 	}
 
 	//
@@ -1768,6 +1777,17 @@ bool sinsp_filter_check_fd::compare(sinsp_evt *evt)
 
 	if(extracted_val == NULL)
 	{
+		// optimization for *_NAME fields
+		// the first time we will call compare_domain, the next ones
+		// we will the able to extract and use flt_compare
+		if(m_field_id == TYPE_CLIENTIP_NAME ||
+		   m_field_id == TYPE_SERVERIP_NAME ||
+		   m_field_id == TYPE_LIP_NAME ||
+		   m_field_id == TYPE_RIP_NAME)
+		{
+			return compare_domain(evt);
+		}
+
 		return false;
 	}
 

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -288,6 +288,10 @@ public:
 		TYPE_RNET = 31,
 		TYPE_IS_CONNECTED = 32,
 		TYPE_NAME_CHANGED = 33,
+		TYPE_CLIENTIP_NAME = 34,
+		TYPE_SERVERIP_NAME = 35,
+		TYPE_LIP_NAME = 36,
+		TYPE_RIP_NAME = 37
 	};
 
 	enum fd_type
@@ -312,6 +316,7 @@ public:
 	bool compare_ip(sinsp_evt *evt);
 	bool compare_net(sinsp_evt *evt);
 	bool compare_port(sinsp_evt *evt);
+	bool compare_domain(sinsp_evt *evt);
 	bool compare(sinsp_evt *evt);
 
 	sinsp_threadinfo* m_tinfo;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -35,6 +35,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include "chisel.h"
 #include "cyclewriter.h"
 #include "protodecoder.h"
+#include "dns_manager.h"
 
 #ifndef CYGWING_AGENT
 #include "k8s_api_handler.h"
@@ -215,6 +216,7 @@ sinsp::~sinsp()
 	delete m_mesos_client;
 #ifdef HAS_CAPTURE
 	curl_global_cleanup();
+	sinsp_dns_manager::get().cleanup();
 #endif
 #endif
 }

--- a/userspace/libsinsp/tuples.cpp
+++ b/userspace/libsinsp/tuples.cpp
@@ -20,7 +20,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 
 ipv6addr ipv6addr::empty_address = {0x00000000, 0x00000000, 0x00000000, 0x00000000};
 
-bool ipv6addr::operator==(const ipv6addr &other)
+bool ipv6addr::operator==(const ipv6addr &other) const
 {
 	return (m_b[0] == other.m_b[0] &&
 		m_b[1] == other.m_b[1] &&
@@ -28,12 +28,22 @@ bool ipv6addr::operator==(const ipv6addr &other)
 		m_b[3] == other.m_b[3]);
 }
 
-bool ipv6addr::operator!=(const ipv6addr &other)
+bool ipv6addr::operator!=(const ipv6addr &other) const
 {
 	return !operator==(other);
 }
 
-bool ipv6addr::in_subnet(const ipv6addr &other)
+bool ipv6addr::operator<(const ipv6addr &other) const
+{
+	for(int i = 0; i < 4; i++)
+	{
+		if(m_b[i] < other.m_b[i]) return true;
+		else if(other.m_b[i] < m_b[i]) return false;
+	}
+	return false;
+}
+
+bool ipv6addr::in_subnet(const ipv6addr &other) const
 {
 	// They're in the same subnet if the first 64 bits match
 	// (Assumes convention of first 48 bits for network, next 16

--- a/userspace/libsinsp/tuples.h
+++ b/userspace/libsinsp/tuples.h
@@ -53,9 +53,10 @@ typedef struct _ipv6addr
 {
 	uint32_t m_b[4];
 
-	bool operator==(const _ipv6addr &other);
-	bool operator!=(const _ipv6addr &other);
-	bool in_subnet(const _ipv6addr &other);
+	bool operator==(const _ipv6addr &other) const;
+	bool operator!=(const _ipv6addr &other) const;
+	bool operator<(const _ipv6addr &other) const;
+	bool in_subnet(const _ipv6addr &other) const;
 
 	static struct _ipv6addr empty_address;
 }ipv6addr;


### PR DESCRIPTION
Add support for a new set of filterchecks, in the form of `fd.*ip.name`, that allows to match the related IP address with a domain name, and to display a previously matched one.

Domain name resolutions are handled in a separate thread spawned the first time the new filterchecks are resolved. It's in charge of keep the resolutions in sync over time.

A new dependency for the Intel TBB library has been added. It's used for its high-performance concurrent maps.

Once the PR is approved, the TBB download URL has to be changed to point under `download.draios.com`.