### PR TITLE
Clean up error return values

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -183,7 +183,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 	if(handle->m_ncpus == -1)
 	{
 		scap_close(handle);
-		snprintf(error, SCAP_LASTERR_SIZE, "_SC_NPROCESSORS_CONF: %s", strerror(errno));
+		snprintf(error, SCAP_LASTERR_SIZE, "_SC_NPROCESSORS_CONF: %s", scap_strerror(handle, errno));
 		*rc = SCAP_FAILURE;
 		return NULL;
 	}
@@ -195,7 +195,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 	if(ndevs == -1)
 	{
 		scap_close(handle);
-		snprintf(error, SCAP_LASTERR_SIZE, "_SC_NPROCESSORS_ONLN: %s", strerror(errno));
+		snprintf(error, SCAP_LASTERR_SIZE, "_SC_NPROCESSORS_ONLN: %s", scap_strerror(handle, errno));
 		*rc = SCAP_FAILURE;
 		return NULL;
 	}
@@ -340,7 +340,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 
 			// Set close-on-exec for the fd
 			if (fcntl(handle->m_devs[j].m_fd, F_SETFD, FD_CLOEXEC) == -1) {
-				snprintf(error, SCAP_LASTERR_SIZE, "Can not set close-on-exec flag for fd for device %s (%s)", filename, strerror(errno));
+				snprintf(error, SCAP_LASTERR_SIZE, "Can not set close-on-exec flag for fd for device %s (%s)", filename, scap_strerror(handle, errno));
 				scap_close(handle);
 				*rc = SCAP_FAILURE;
 				return NULL;
@@ -1368,7 +1368,7 @@ static int32_t scap_set_dropping_mode(scap_t* handle, int request, uint32_t samp
 		if(ioctl(handle->m_devs[0].m_fd, request, sampling_ratio))
 		{
 			snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "%s, request %d for sampling ratio %u: %s",
-					__FUNCTION__, request, sampling_ratio, strerror(errno));
+					__FUNCTION__, request, sampling_ratio, scap_strerror(handle, errno));
 			ASSERT(false);
 			return SCAP_FAILURE;
 		}
@@ -1942,7 +1942,7 @@ int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret)
 			}
 			else
 			{
-				snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_get_n_tracepoint_hit failed (%s)", strerror(errno));
+				snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_get_n_tracepoint_hit failed (%s)", scap_strerror(handle, errno));
 			}
 
 			ASSERT(false);

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -980,7 +980,7 @@ int32_t scap_enable_tracers_capture(scap_t* handle);
 int32_t scap_enable_page_faults(scap_t *handle);
 uint64_t scap_get_unexpected_block_readsize(scap_t* handle);
 int32_t scap_proc_add(scap_t* handle, uint64_t tid, scap_threadinfo* tinfo);
-int32_t scap_fd_add(scap_threadinfo* tinfo, uint64_t fd, scap_fdinfo* fdinfo);
+int32_t scap_fd_add(scap_t *handle, scap_threadinfo* tinfo, uint64_t fd, scap_fdinfo* fdinfo);
 scap_dumper_t *scap_memory_dump_open(scap_t *handle, uint8_t* targetbuf, uint64_t targetbufsize);
 int32_t compr(uint8_t* dest, uint64_t* destlen, const uint8_t* source, uint64_t sourcelen, int level);
 uint8_t* scap_get_memorydumper_curpos(scap_dumper_t *d);

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -280,7 +280,7 @@ static int32_t load_maps(scap_t *handle, struct bpf_map_data *maps, int nr_maps)
 
 		if(handle->m_bpf_map_fds[j] < 0)
 		{
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't create map: %s", strerror(errno));
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't create map: %s", scap_strerror(handle, errno));
 			return SCAP_FAILURE;
 		}
 
@@ -440,7 +440,7 @@ static int32_t load_tracepoint(scap_t* handle, const char *event, struct bpf_ins
 		efd = bpf_raw_tracepoint_open(event, fd);
 		if(efd < 0)
 		{
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "BPF_RAW_TRACEPOINT_OPEN: event %s: %s", event, strerror(errno));
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "BPF_RAW_TRACEPOINT_OPEN: event %s: %s", event, scap_strerror(handle, errno));
 			return SCAP_FAILURE;
 		}
 	}
@@ -467,7 +467,7 @@ static int32_t load_tracepoint(scap_t* handle, const char *event, struct bpf_ins
 		if(err < 0 || err >= sizeof(buf))
 		{
 			close(efd);
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "read from '%s' failed '%s'", event, strerror(errno));
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "read from '%s' failed '%s'", event, scap_strerror(handle, errno));
 			return SCAP_FAILURE;
 		}
 
@@ -480,14 +480,14 @@ static int32_t load_tracepoint(scap_t* handle, const char *event, struct bpf_ins
 		efd = sys_perf_event_open(&attr, -1, 0, -1, 0);
 		if(efd < 0)
 		{
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "event %d fd %d err %s", id, efd, strerror(errno));
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "event %d fd %d err %s", id, efd, scap_strerror(handle, errno));
 			return SCAP_FAILURE;
 		}
 
 		if(ioctl(efd, PERF_EVENT_IOC_SET_BPF, fd))
 		{
 			close(efd);
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "PERF_EVENT_IOC_SET_BPF: %s", strerror(errno));
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "PERF_EVENT_IOC_SET_BPF: %s", scap_strerror(handle, errno));
 			return SCAP_FAILURE;
 		}
 	}
@@ -529,7 +529,7 @@ static int32_t load_bpf_file(scap_t *handle, const char *path)
 	int program_fd = open(path, O_RDONLY, 0);
 	if(program_fd < 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't open BPF probe '%s': %s", path, strerror(errno));
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't open BPF probe '%s': %s", path, scap_strerror(handle, errno));
 		return SCAP_FAILURE;
 	}
 
@@ -1259,7 +1259,7 @@ int32_t scap_bpf_load(scap_t *handle, const char *bpf_probe)
 			fp = fopen(filename, "r");
 			if(fp == NULL)
 			{
-				snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't open %s: %s", filename, strerror(errno));
+				snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't open %s: %s", filename, scap_strerror(handle, errno));
 				return SCAP_FAILURE;
 			}
 
@@ -1267,7 +1267,7 @@ int32_t scap_bpf_load(scap_t *handle, const char *bpf_probe)
 			{
 				fclose(fp);
 
-				snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't read %s: %s", filename, strerror(errno));
+				snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't read %s: %s", filename, scap_strerror(handle, errno));
 				return SCAP_FAILURE;
 			}
 
@@ -1288,7 +1288,7 @@ int32_t scap_bpf_load(scap_t *handle, const char *bpf_probe)
 		pmu_fd = sys_perf_event_open(&attr, -1, j, -1, 0);
 		if(pmu_fd < 0)
 		{
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "pmu_fd < 0: %s", strerror(errno));
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "pmu_fd < 0: %s", scap_strerror(handle, errno));
 			return SCAP_FAILURE;
 		}
 
@@ -1296,7 +1296,7 @@ int32_t scap_bpf_load(scap_t *handle, const char *bpf_probe)
 
 		if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_PERF_MAP], &j, &pmu_fd, BPF_ANY) != 0)
 		{
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_PERF_MAP bpf_map_update_elem < 0: %s", strerror(errno));
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_PERF_MAP bpf_map_update_elem < 0: %s", scap_strerror(handle, errno));
 			return SCAP_FAILURE;
 		}
 

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -33,6 +33,7 @@ along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>
+#include <errno.h>
 #else
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1604,10 +1604,10 @@ void sinsp_thread_manager::dump_threads_to_file(scap_dumper_t* dumper)
 				//
 				// Add the new fd to the scap table.
 				//
-				if(scap_fd_add(sctinfo, it->first, scfdinfo) != SCAP_SUCCESS)
+				if(scap_fd_add(m_inspector->m_h, sctinfo, it->first, scfdinfo) != SCAP_SUCCESS)
 				{
 					scap_proc_free(m_inspector->m_h, sctinfo);
-					throw sinsp_exception("error calling scap_fd_add in sinsp_thread_manager::to_scap");
+					throw sinsp_exception("error calling scap_fd_add in sinsp_thread_manager::to_scap (" + string(scap_getlasterr(m_inspector->m_h)) + ")");
 				}
 			}
 		}
@@ -1618,7 +1618,7 @@ void sinsp_thread_manager::dump_threads_to_file(scap_dumper_t* dumper)
 		if(scap_write_proc_fds(m_inspector->m_h, sctinfo, dumper) != SCAP_SUCCESS)
 		{
 			scap_proc_free(m_inspector->m_h, sctinfo);
-			throw sinsp_exception("error calling scap_proc_add in sinsp_thread_manager::to_scap");
+			throw sinsp_exception("error calling scap_proc_add in sinsp_thread_manager::to_scap (" + string(scap_getlasterr(m_inspector->m_h)) + ")");
 		}
 
 		scap_proc_free(m_inspector->m_h, sctinfo);


### PR DESCRIPTION
Several changes to improve returning errors:

1. A new function scap_strerror replaces strerror(), using a string held
in the scap handle.

2. In all cases in scap_fds/scap_procs that can return an error, either
set an error in handle->m_lasterr or properly fill in an error argument
to the function. In some cases, this involved adding an error argument
where there wasn't one.