### PR TITLE
Fix invalid access to task->loginuid

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1567,7 +1567,6 @@ FILLER(proc_startupdate_3, true)
 		kgid_t egid;
 		pid_t vtid;
 		pid_t vpid;
-        kuid_t loginuid;
 
 		/*
 		 * flags
@@ -1628,6 +1627,7 @@ FILLER(proc_startupdate_3, true)
 		 * execve-only parameters
 		 */
 		long env_len = 0;
+		kuid_t loginuid;
 		int tty;
 
 		/*
@@ -1696,7 +1696,8 @@ FILLER(proc_startupdate_3, true)
 		 * loginuid
 		 */
 		/* TODO: implement user namespace support */
-		res = bpf_val_to_ring_type(data, task->loginuid.val, PT_INT32);
+		loginuid = _READ(task->loginuid);
+		res = bpf_val_to_ring_type(data, loginuid.val, PT_INT32);
 		if (res != PPM_SUCCESS)
 			return res;
 	}


### PR DESCRIPTION
Merging this since it seems like the patch in PR https://github.com/draios/sysdig/pull/1189 was never tested with BPF, because the kernel refuses to load the BPF program after it, since we can't just dereference random memory without going through the probe_read helper.

cc @mstemm @arossert
