### PR TITLE
Fix off-by-one error with loginuid extract

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1746,13 +1746,13 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	// to identify the version of the event.
 	// For example:
 	//
-	// if(evt->get_num_params() > 17)
+	// if(evt->get_num_params() > 18)
 	// {
 	//   ...
 	// }
 
 	// Get the loginuid
-	if(evt->get_num_params() > 17)
+	if(evt->get_num_params() > 18)
 	{
 		parinfo = evt->get_param(18);
 		ASSERT(parinfo->m_len == sizeof(uint32_t));


### PR DESCRIPTION
The number of params for the execve event is 19 with the loginuid being
the last param, so the check should be > 18. Extracting param 18 (which
is 0-based indexing into the array of params) is still correct.

An example of a trace file that crashes sysdig/falco without this fix is `system-binaries-network-activity.scap` in the [traces-positive](https://s3.amazonaws.com/download.draios.com/falco-tests/traces-positive.zip) tarball for falco.

@mattpag can you take a look? 