### PR TITLE
Add dkms+xz dependencies to sysdig container

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
 	bc \
 	clang-7 \
 	curl \
+	dkms \
 	gnupg2 \
 	ca-certificates \
 	gcc \
@@ -31,6 +32,7 @@ RUN apt-get update \
 	less \
 	llvm-7 \
 	procps \
+	xz-utils \
  && rm -rf /var/lib/apt/lists/*
 
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
 	less \
 	llvm-7 \
 	procps \
+	xz-utils \
  && rm -rf /var/lib/apt/lists/*
 
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
 	bc \
 	clang-7 \
 	curl \
+	dkms \
 	gnupg2 \
 	ca-certificates \
 	gcc \
@@ -31,6 +32,7 @@ RUN apt-get update \
 	less \
 	llvm-7 \
 	procps \
+	xz-utils \
  && rm -rf /var/lib/apt/lists/*
 
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the


### PR DESCRIPTION
Followup from https://github.com/draios/sysdig/pull/1192, we need to add xz (and dkms where missing) to the container dependencies for loading the probe module on newer RHEL systems.