### PR TITLE
Change license apache2

### DIFF
--- a/.travis-scripts/linux/before_install.sh
+++ b/.travis-scripts/linux/before_install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/.travis-scripts/linux/before_install.sh
+++ b/.travis-scripts/linux/before_install.sh
@@ -1,3 +1,21 @@
 #!/bin/bash
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get update

--- a/.travis-scripts/linux/before_install.sh
+++ b/.travis-scripts/linux/before_install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/.travis-scripts/linux/build.sh
+++ b/.travis-scripts/linux/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/.travis-scripts/linux/build.sh
+++ b/.travis-scripts/linux/build.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 set -e
 export CC="gcc-4.8"
 export CXX="g++-4.8"

--- a/.travis-scripts/linux/build.sh
+++ b/.travis-scripts/linux/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/.travis-scripts/linux/install.sh
+++ b/.travis-scripts/linux/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/.travis-scripts/linux/install.sh
+++ b/.travis-scripts/linux/install.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 sudo apt-get --force-yes install g++-4.8
 sudo apt-get install rpm linux-headers-$(uname -r) libelf-dev
 sudo apt-get purge cmake

--- a/.travis-scripts/linux/install.sh
+++ b/.travis-scripts/linux/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/.travis-scripts/osx/before_install.sh
+++ b/.travis-scripts/osx/before_install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/.travis-scripts/osx/before_install.sh
+++ b/.travis-scripts/osx/before_install.sh
@@ -1,2 +1,19 @@
 #!/bin/bash
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 brew update

--- a/.travis-scripts/osx/before_install.sh
+++ b/.travis-scripts/osx/before_install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/.travis-scripts/osx/build.sh
+++ b/.travis-scripts/osx/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/.travis-scripts/osx/build.sh
+++ b/.travis-scripts/osx/build.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 set -e
 mkdir build
 cd build

--- a/.travis-scripts/osx/build.sh
+++ b/.travis-scripts/osx/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/.travis-scripts/osx/install.sh
+++ b/.travis-scripts/osx/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/.travis-scripts/osx/install.sh
+++ b/.travis-scripts/osx/install.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 function install_if_not_present(){
 	brew ls | grep ${1}
 	if [[ ${?} -ne 0 ]]; then

--- a/.travis-scripts/osx/install.sh
+++ b/.travis-scripts/osx/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 language: c
 os:
     - linux

--- a/CMakeCPackOptions.cmake
+++ b/CMakeCPackOptions.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/CMakeCPackOptions.cmake
+++ b/CMakeCPackOptions.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/CMakeCPackOptions.cmake
+++ b/CMakeCPackOptions.cmake
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 if(CPACK_GENERATOR MATCHES "TGZ")
 	set(CPACK_SET_DESTDIR "ON")
 	set(CPACK_STRIP_FILES "OFF")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # Prior to doing anything, we make sure that we aren't trying to
 # run cmake in-tree. (see Issue 71: https://github.com/draios/sysdig/issues/71)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,7 +407,7 @@ set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "http://www.sysdig.org")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "dkms (>= 2.1.0.0)")
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_BINARY_DIR}/scripts/debian/postinst;${CMAKE_BINARY_DIR}/scripts/debian/prerm")
 
-set(CPACK_RPM_PACKAGE_LICENSE "GPLv2")
+set(CPACK_RPM_PACKAGE_LICENSE "Apache v2.0")
 set(CPACK_RPM_PACKAGE_URL "http://www.sysdig.org")
 set(CPACK_RPM_PACKAGE_REQUIRES "dkms, gcc, make, kernel-devel, perl")
 set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${PROJECT_SOURCE_DIR}/scripts/rpm/postinstall")

--- a/COPYING
+++ b/COPYING
@@ -1,339 +1,203 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 2, June 1991
+The contents of the driver/ subdirectory are licensed separately--see COPYING.driver.
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-                            Preamble
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-  The licenses for most software are designed to take away your
-freedom to share and change it.  By contrast, the GNU General Public
-License is intended to guarantee your freedom to share and change free
-software--to make sure the software is free for all its users.  This
-General Public License applies to most of the Free Software
-Foundation's software and to any other program whose authors commit to
-using it.  (Some other Free Software Foundation software is covered by
-the GNU Lesser General Public License instead.)  You can apply it to
-your programs, too.
+   1. Definitions.
 
-  When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-this service if you wish), that you receive source code or can get it
-if you want it, that you can change the software or use pieces of it
-in new free programs; and that you know you can do these things.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-  To protect your rights, we need to make restrictions that forbid
-anyone to deny you these rights or to ask you to surrender the rights.
-These restrictions translate to certain responsibilities for you if you
-distribute copies of the software, or if you modify it.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must give the recipients all the rights that
-you have.  You must make sure that they, too, receive or can get the
-source code.  And you must show them these terms so they know their
-rights.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-  We protect your rights with two steps: (1) copyright the software, and
-(2) offer you this license which gives you legal permission to copy,
-distribute and/or modify the software.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-  Also, for each author's protection and ours, we want to make certain
-that everyone understands that there is no warranty for this free
-software.  If the software is modified by someone else and passed on, we
-want its recipients to know that what they have is not the original, so
-that any problems introduced by others will not reflect on the original
-authors' reputations.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-  Finally, any free program is threatened constantly by software
-patents.  We wish to avoid the danger that redistributors of a free
-program will individually obtain patent licenses, in effect making the
-program proprietary.  To prevent this, we have made it clear that any
-patent must be licensed for everyone's free use or not licensed at all.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-  The precise terms and conditions for copying, distribution and
-modification follow.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-                    GNU GENERAL PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-  0. This License applies to any program or other work which contains
-a notice placed by the copyright holder saying it may be distributed
-under the terms of this General Public License.  The "Program", below,
-refers to any such program or work, and a "work based on the Program"
-means either the Program or any derivative work under copyright law:
-that is to say, a work containing the Program or a portion of it,
-either verbatim or with modifications and/or translated into another
-language.  (Hereinafter, translation is included without limitation in
-the term "modification".)  Each licensee is addressed as "you".
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope.  The act of
-running the Program is not restricted, and the output from the Program
-is covered only if its contents constitute a work based on the
-Program (independent of having been made by running the Program).
-Whether that is true depends on what the Program does.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-  1. You may copy and distribute verbatim copies of the Program's
-source code as you receive it, in any medium, provided that you
-conspicuously and appropriately publish on each copy an appropriate
-copyright notice and disclaimer of warranty; keep intact all the
-notices that refer to this License and to the absence of any warranty;
-and give any other recipients of the Program a copy of this License
-along with the Program.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-You may charge a fee for the physical act of transferring a copy, and
-you may at your option offer warranty protection in exchange for a fee.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-  2. You may modify your copy or copies of the Program or any portion
-of it, thus forming a work based on the Program, and copy and
-distribute such modifications or work under the terms of Section 1
-above, provided that you also meet all of these conditions:
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-    a) You must cause the modified files to carry prominent notices
-    stating that you changed the files and the date of any change.
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-    b) You must cause any work that you distribute or publish, that in
-    whole or in part contains or is derived from the Program or any
-    part thereof, to be licensed as a whole at no charge to all third
-    parties under the terms of this License.
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-    c) If the modified program normally reads commands interactively
-    when run, you must cause it, when started running for such
-    interactive use in the most ordinary way, to print or display an
-    announcement including an appropriate copyright notice and a
-    notice that there is no warranty (or else, saying that you provide
-    a warranty) and that users may redistribute the program under
-    these conditions, and telling the user how to view a copy of this
-    License.  (Exception: if the Program itself is interactive but
-    does not normally print such an announcement, your work based on
-    the Program is not required to print an announcement.)
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-These requirements apply to the modified work as a whole.  If
-identifiable sections of that work are not derived from the Program,
-and can be reasonably considered independent and separate works in
-themselves, then this License, and its terms, do not apply to those
-sections when you distribute them as separate works.  But when you
-distribute the same sections as part of a whole which is a work based
-on the Program, the distribution of the whole must be on the terms of
-this License, whose permissions for other licensees extend to the
-entire whole, and thus to each and every part regardless of who wrote it.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-Thus, it is not the intent of this section to claim rights or contest
-your rights to work written entirely by you; rather, the intent is to
-exercise the right to control the distribution of derivative or
-collective works based on the Program.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-In addition, mere aggregation of another work not based on the Program
-with the Program (or with a work based on the Program) on a volume of
-a storage or distribution medium does not bring the other work under
-the scope of this License.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-  3. You may copy and distribute the Program (or a work based on it,
-under Section 2) in object code or executable form under the terms of
-Sections 1 and 2 above provided that you also do one of the following:
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-    a) Accompany it with the complete corresponding machine-readable
-    source code, which must be distributed under the terms of Sections
-    1 and 2 above on a medium customarily used for software interchange; or,
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-    b) Accompany it with a written offer, valid for at least three
-    years, to give any third party, for a charge no more than your
-    cost of physically performing source distribution, a complete
-    machine-readable copy of the corresponding source code, to be
-    distributed under the terms of Sections 1 and 2 above on a medium
-    customarily used for software interchange; or,
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-    c) Accompany it with the information you received as to the offer
-    to distribute corresponding source code.  (This alternative is
-    allowed only for noncommercial distribution and only if you
-    received the program in object code or executable form with such
-    an offer, in accord with Subsection b above.)
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-The source code for a work means the preferred form of the work for
-making modifications to it.  For an executable work, complete source
-code means all the source code for all modules it contains, plus any
-associated interface definition files, plus the scripts used to
-control compilation and installation of the executable.  However, as a
-special exception, the source code distributed need not include
-anything that is normally distributed (in either source or binary
-form) with the major components (compiler, kernel, and so on) of the
-operating system on which the executable runs, unless that component
-itself accompanies the executable.
+   END OF TERMS AND CONDITIONS
 
-If distribution of executable or object code is made by offering
-access to copy from a designated place, then offering equivalent
-access to copy the source code from the same place counts as
-distribution of the source code, even though third parties are not
-compelled to copy the source along with the object code.
+   APPENDIX: How to apply the Apache License to your work.
 
-  4. You may not copy, modify, sublicense, or distribute the Program
-except as expressly provided under this License.  Any attempt
-otherwise to copy, modify, sublicense or distribute the Program is
-void, and will automatically terminate your rights under this License.
-However, parties who have received copies, or rights, from you under
-this License will not have their licenses terminated so long as such
-parties remain in full compliance.
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-  5. You are not required to accept this License, since you have not
-signed it.  However, nothing else grants you permission to modify or
-distribute the Program or its derivative works.  These actions are
-prohibited by law if you do not accept this License.  Therefore, by
-modifying or distributing the Program (or any work based on the
-Program), you indicate your acceptance of this License to do so, and
-all its terms and conditions for copying, distributing or modifying
-the Program or works based on it.
+   Copyright [yyyy] [name of copyright owner]
 
-  6. Each time you redistribute the Program (or any work based on the
-Program), the recipient automatically receives a license from the
-original licensor to copy, distribute or modify the Program subject to
-these terms and conditions.  You may not impose any further
-restrictions on the recipients' exercise of the rights granted herein.
-You are not responsible for enforcing compliance by third parties to
-this License.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-  7. If, as a consequence of a court judgment or allegation of patent
-infringement or for any other reason (not limited to patent issues),
-conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot
-distribute so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you
-may not distribute the Program at all.  For example, if a patent
-license would not permit royalty-free redistribution of the Program by
-all those who receive copies directly or indirectly through you, then
-the only way you could satisfy both it and this License would be to
-refrain entirely from distribution of the Program.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-If any portion of this section is held invalid or unenforceable under
-any particular circumstance, the balance of the section is intended to
-apply and the section as a whole is intended to apply in other
-circumstances.
-
-It is not the purpose of this section to induce you to infringe any
-patents or other property right claims or to contest validity of any
-such claims; this section has the sole purpose of protecting the
-integrity of the free software distribution system, which is
-implemented by public license practices.  Many people have made
-generous contributions to the wide range of software distributed
-through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
-to distribute software through any other system and a licensee cannot
-impose that choice.
-
-This section is intended to make thoroughly clear what is believed to
-be a consequence of the rest of this License.
-
-  8. If the distribution and/or use of the Program is restricted in
-certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Program under this License
-may add an explicit geographical distribution limitation excluding
-those countries, so that distribution is permitted only in or among
-countries not thus excluded.  In such case, this License incorporates
-the limitation as if written in the body of this License.
-
-  9. The Free Software Foundation may publish revised and/or new versions
-of the General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
-
-Each version is given a distinguishing version number.  If the Program
-specifies a version number of this License which applies to it and "any
-later version", you have the option of following the terms and conditions
-either of that version or of any later version published by the Free
-Software Foundation.  If the Program does not specify a version number of
-this License, you may choose any version ever published by the Free Software
-Foundation.
-
-  10. If you wish to incorporate parts of the Program into other free
-programs whose distribution conditions are different, write to the author
-to ask for permission.  For software which is copyrighted by the Free
-Software Foundation, write to the Free Software Foundation; we sometimes
-make exceptions for this.  Our decision will be guided by the two goals
-of preserving the free status of all derivatives of our free software and
-of promoting the sharing and reuse of software generally.
-
-                            NO WARRANTY
-
-  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
-FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
-OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
-PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
-OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
-TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
-PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
-REPAIR OR CORRECTION.
-
-  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
-REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
-INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
-OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
-TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
-YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
-PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES.
-
-                     END OF TERMS AND CONDITIONS
-
-            How to Apply These Terms to Your New Programs
-
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-convey the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
-Also add information on how to contact you by electronic and paper mail.
-
-If the program is interactive, make it output a short notice like this
-when it starts in an interactive mode:
-
-    Gnomovision version 69, Copyright (C) year name of author
-    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, the commands you use may
-be called something other than `show w' and `show c'; they could even be
-mouse-clicks or menu items--whatever suits your program.
-
-You should also get your employer (if you work as a programmer) or your
-school, if any, to sign a "copyright disclaimer" for the program, if
-necessary.  Here is a sample; alter the names:
-
-  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
-  `Gnomovision' (which makes passes at compilers) written by James Hacker.
-
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
-
-This General Public License does not permit incorporating your program into
-proprietary programs.  If your program is a subroutine library, you may
-consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -44,11 +44,9 @@ Join the Community
 
 License Terms
 ---
-Sysdig is licensed to you under the [GPL 2.0](https://github.com/draios/sysdig/blob/dev/COPYING) open source license.
+The sysdig userspace programs and supporting code are licensed to you under the [Apache 2.0](./COPYING) open source license.
 
-In addition, as a special exception, the copyright holders give permission to link the code of portions of this program with the OpenSSL library under certain conditions as described in each individual source file, and distribute linked combinations including the two.
-
-You must obey the GNU General Public License in all respects for all of the code used other than OpenSSL.  If you modify file(s) with this exception, you may extend this exception to your version of the file(s), but you are not obligated to do so.  If you do not wish to do so, delete this exception statement from your version.
+The sysdig kernel module, which is in the `driver` subdirectory, is licensed to you under both the [MIT](https://github.com/draios/sysdig/blob/dev/driver/MIT.txt) and [GPLv2](https://github.com/draios/sysdig/blob/dev/driver/GPL2.txt) open source licenses.
 
 Contributor License Agreements
 ---

--- a/docker/dev/docker-entrypoint.sh
+++ b/docker/dev/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/docker/dev/docker-entrypoint.sh
+++ b/docker/dev/docker-entrypoint.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 #set -e
 
 echo "* Setting up /usr/src links from host"

--- a/docker/dev/docker-entrypoint.sh
+++ b/docker/dev/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/docker/local/docker-entrypoint.sh
+++ b/docker/local/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/docker/local/docker-entrypoint.sh
+++ b/docker/local/docker-entrypoint.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 #set -e
 
 echo "* Setting up /usr/src links from host"

--- a/docker/local/docker-entrypoint.sh
+++ b/docker/local/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/docker/stable/docker-entrypoint.sh
+++ b/docker/stable/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/docker/stable/docker-entrypoint.sh
+++ b/docker/stable/docker-entrypoint.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 #set -e
 
 echo "* Setting up /usr/src links from host"

--- a/docker/stable/docker-entrypoint.sh
+++ b/docker/stable/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+#
+# This file is dual licensed under either the MIT or GPL 2. See
+# MIT.txt or GPL.txt for full copies of the license.
+#
+
 option(BUILD_DRIVER "Build the driver on Linux" ON)
 option(ENABLE_DKMS "Enable DKMS on Linux" ON)
 

--- a/driver/GPL2.txt
+++ b/driver/GPL2.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/driver/MIT.txt
+++ b/driver/MIT.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/driver/Makefile.in
+++ b/driver/Makefile.in
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+#
+# This file is dual licensed under either the MIT or GPL 2. See
+# MIT.txt or GPL.txt for full copies of the license.
+#
+
 @PROBE_NAME@-y += main.o dynamic_params_table.o fillers_table.o flags_table.o ppm_events.o ppm_fillers.o event_table.o syscall_table.o ppm_cputime.o
 obj-m += @PROBE_NAME@.o
 ccflags-y := @KBUILD_FLAGS@

--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+#
+# This file is dual licensed under either the MIT or GPL 2. See
+# MIT.txt or GPL.txt for full copies of the license.
+#
+
 option(BUILD_BPF "Build the BPF driver on Linux" OFF)
 
 if(BUILD_BPF)

--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+#
+# This file is dual licensed under either the MIT or GPL 2. See
+# MIT.txt or GPL.txt for full copies of the license.
+#
+
 always += probe.o
 
 LLC ?= llc

--- a/driver/bpf/bpf_helpers.h
+++ b/driver/bpf/bpf_helpers.h
@@ -1,3 +1,11 @@
+/*
+
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
 #ifndef __BPF_HELPERS_H
 #define __BPF_HELPERS_H
 

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -1,3 +1,11 @@
+/*
+
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
 #ifndef __SYSDIGBPF_HELPERS_H
 #define __SYSDIGBPF_HELPERS_H
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1,3 +1,11 @@
+/*
+
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
 #ifndef __FILLERS_H
 #define __FILLERS_H
 

--- a/driver/bpf/maps.h
+++ b/driver/bpf/maps.h
@@ -1,3 +1,11 @@
+/*
+
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
 #ifndef __MAPS_H
 #define __MAPS_H
 

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -1,3 +1,11 @@
+/*
+
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
 #ifndef __PLUMBING_HELPERS_H
 #define __PLUMBING_HELPERS_H
 

--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -1,3 +1,11 @@
+/*
+
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
 #include "quirks.h"
 
 #include <generated/utsrelease.h>

--- a/driver/bpf/quirks.h
+++ b/driver/bpf/quirks.h
@@ -1,3 +1,11 @@
+/*
+
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
 #ifndef __QUIRKS_H
 #define __QUIRKS_H
 

--- a/driver/bpf/ring_helpers.h
+++ b/driver/bpf/ring_helpers.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #ifndef __RING_HELPERS_H
 #define __RING_HELPERS_H
 

--- a/driver/bpf/ring_helpers.h
+++ b/driver/bpf/ring_helpers.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/driver/bpf/ring_helpers.h
+++ b/driver/bpf/ring_helpers.h
@@ -1,19 +1,9 @@
 /*
-Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
 */
 #ifndef __RING_HELPERS_H

--- a/driver/bpf/ring_helpers.h
+++ b/driver/bpf/ring_helpers.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -1,3 +1,11 @@
+/*
+
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
 #ifndef __TYPES_H
 #define __TYPES_H
 

--- a/driver/driver_config.h.in
+++ b/driver/driver_config.h.in
@@ -1,3 +1,11 @@
+/*
+
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
 #pragma once
 
 #define PROBE_VERSION "${PROBE_VERSION}"

--- a/driver/dynamic_params_table.c
+++ b/driver/dynamic_params_table.c
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "ppm_events_public.h"

--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "ppm_events_public.h"

--- a/driver/fillers_table.c
+++ b/driver/fillers_table.c
@@ -1,3 +1,11 @@
+/*
+
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
 #include "ppm_events_public.h"
 
 #ifdef __KERNEL__

--- a/driver/flags_table.c
+++ b/driver/flags_table.c
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "ppm_events_public.h"

--- a/driver/main.c
+++ b/driver/main.c
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #define pr_fmt(fmt)	KBUILD_MODNAME ": " fmt

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifndef PPM_H_

--- a/driver/ppm_cputime.c
+++ b/driver/ppm_cputime.c
@@ -1,3 +1,11 @@
+/*
+
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
 #include <linux/version.h>
 
 // These function are taken from the linux kernel and are used only

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #define pr_fmt(fmt)	KBUILD_MODNAME ": " fmt

--- a/driver/ppm_events.h
+++ b/driver/ppm_events.h
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifndef EVENTS_H_

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifndef EVENTS_PUBLIC_H_

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #define pr_fmt(fmt)	KBUILD_MODNAME ": " fmt

--- a/driver/ppm_fillers.h
+++ b/driver/ppm_fillers.h
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifndef PPM_FILLERS_H_

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifndef PPM_FLAG_HELPERS_H_

--- a/driver/ppm_ringbuffer.h
+++ b/driver/ppm_ringbuffer.h
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifndef PPM_RINGBUFFER_H_

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -1,19 +1,10 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
 
-This file is part of sysdig.
+Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifdef __KERNEL__

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 configure_file(debian/postinst.in debian/postinst)
 configure_file(debian/prerm.in debian/prerm)
 

--- a/scripts/boot2docker-kernel-crawler.py
+++ b/scripts/boot2docker-kernel-crawler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/scripts/boot2docker-kernel-crawler.py
+++ b/scripts/boot2docker-kernel-crawler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/scripts/boot2docker-kernel-crawler.py
+++ b/scripts/boot2docker-kernel-crawler.py
@@ -1,4 +1,22 @@
 #!/usr/bin/python
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 
 # Author: Ethan Sutin
 

--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -1,5 +1,23 @@
 #!/bin/bash
 #
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
 # This script builds a precompiled version of sysdig-probe for a bunch of kernels
 # The precompiled binary is then obtained at runtime by sysdig-probe-loader
 # Ideally, the community should expand this stuff with better support

--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/scripts/compile-linux-tree.sh
+++ b/scripts/compile-linux-tree.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/scripts/compile-linux-tree.sh
+++ b/scripts/compile-linux-tree.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 #
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
 # This script tries to compile the sysdig probes against all the stable kernel
 # releases that match a specific pattern.
 #

--- a/scripts/compile-linux-tree.sh
+++ b/scripts/compile-linux-tree.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/scripts/debian/postinst.in
+++ b/scripts/debian/postinst.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/scripts/debian/postinst.in
+++ b/scripts/debian/postinst.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/scripts/debian/postinst.in
+++ b/scripts/debian/postinst.in
@@ -1,4 +1,22 @@
 #!/bin/sh
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 set -e
 
 DKMS_PACKAGE_NAME="@PACKAGE_NAME@"

--- a/scripts/debian/prerm.in
+++ b/scripts/debian/prerm.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/scripts/debian/prerm.in
+++ b/scripts/debian/prerm.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/scripts/debian/prerm.in
+++ b/scripts/debian/prerm.in
@@ -1,4 +1,21 @@
 #!/bin/sh
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 set -e
 
 DKMS_PACKAGE_NAME="@PACKAGE_NAME@"

--- a/scripts/install-sysdig.in
+++ b/scripts/install-sysdig.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of _COMPONENT_ .
 #

--- a/scripts/install-sysdig.in
+++ b/scripts/install-sysdig.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of _COMPONENT_ .
 #

--- a/scripts/install-sysdig.in
+++ b/scripts/install-sysdig.in
@@ -1,20 +1,20 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2014 Draios inc.
+# Copyright (C) 2018 Draios Inc.
 #
-# This file is part of _COMPONENT_.
+# This file is part of _COMPONENT_ .
 #
-# _COMPONENT_ is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# _COMPONENT_ is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU General Public License
-# along with _COMPONENT_.  If not, see <http://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 set -e
 

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # Author: Samuele Pilleri
 # Date: August 17th, 2015
@@ -251,7 +268,7 @@ def process_al_distro(al_distro_name, current_repo):
         elif al_distro_name == "AmazonLinux2":
             base_mirror_url = get_url.replace('\n','') + '/'
             db_path = "repodata/primary.sqlite.gz"
-        
+
         response = urllib2.urlopen(base_mirror_url + db_path)
 
         if al_distro_name == "AmazonLinux":

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/scripts/oracle-kernel-crawler.py
+++ b/scripts/oracle-kernel-crawler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/scripts/oracle-kernel-crawler.py
+++ b/scripts/oracle-kernel-crawler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/scripts/oracle-kernel-crawler.py
+++ b/scripts/oracle-kernel-crawler.py
@@ -1,4 +1,21 @@
 #!/usr/bin/python
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 import sys
 import urllib2

--- a/scripts/rpm/postinstall
+++ b/scripts/rpm/postinstall
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/scripts/rpm/postinstall
+++ b/scripts/rpm/postinstall
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 dkms add -m sysdig -v %{version} --rpm_safe_upgrade
 if [ `uname -r | grep -c "BOOT"` -eq 0 ] && [ -e /lib/modules/`uname -r`/build/include ]; then
 	dkms build -m sysdig -v %{version}

--- a/scripts/rpm/postinstall
+++ b/scripts/rpm/postinstall
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/scripts/rpm/preuninstall
+++ b/scripts/rpm/preuninstall
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/scripts/rpm/preuninstall
+++ b/scripts/rpm/preuninstall
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/scripts/rpm/preuninstall
+++ b/scripts/rpm/preuninstall
@@ -1,1 +1,18 @@
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 dkms remove -m sysdig -v %{version} --all --rpm_safe_upgrade

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -1,5 +1,22 @@
 #!/bin/bash
 #
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 # Simple script that desperately tries to load sysdig-probe looking
 # for it in a bunch of ways. Convenient when running sysdig inside
 # a container or in other weird environments.

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/test/csysdig_trace_regression.sh
+++ b/test/csysdig_trace_regression.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/test/csysdig_trace_regression.sh
+++ b/test/csysdig_trace_regression.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 #set -eu
 
 BASEDIR=.

--- a/test/csysdig_trace_regression.sh
+++ b/test/csysdig_trace_regression.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/test/sysdig_batch_parser.sh
+++ b/test/sysdig_batch_parser.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 #
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 # This script runs sysdig on all the trace files (i.e. all the files with scap 
 # extension) in the current directory, and compares the result with the one of 
 # a previous run.

--- a/test/sysdig_batch_parser.sh
+++ b/test/sysdig_batch_parser.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/test/sysdig_batch_parser.sh
+++ b/test/sysdig_batch_parser.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/test/sysdig_trace_regression.sh
+++ b/test/sysdig_trace_regression.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/test/sysdig_trace_regression.sh
+++ b/test/sysdig_trace_regression.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 set -exu
 
 unamestr=`uname`

--- a/test/sysdig_trace_regression.sh
+++ b/test/sysdig_trace_regression.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/userspace/common/sysdig_types.h
+++ b/userspace/common/sysdig_types.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifdef _WIN32

--- a/userspace/common/sysdig_types.h
+++ b/userspace/common/sysdig_types.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/common/sysdig_types.h
+++ b/userspace/common/sysdig_types.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 include_directories("${PROJECT_SOURCE_DIR}/common")
 include_directories("${ZLIB_INCLUDE}")
 if(CYGWIN)

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/userspace/libscap/compat/misc.h
+++ b/userspace/libscap/compat/misc.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #ifndef __COMPAT_MISC_H
 #define __COMPAT_MISC_H
 

--- a/userspace/libscap/compat/misc.h
+++ b/userspace/libscap/compat/misc.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/compat/misc.h
+++ b/userspace/libscap/compat/misc.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/examples/01-open/test.c
+++ b/userspace/libscap/examples/01-open/test.c
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <stdio.h>

--- a/userspace/libscap/examples/01-open/test.c
+++ b/userspace/libscap/examples/01-open/test.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/examples/01-open/test.c
+++ b/userspace/libscap/examples/01-open/test.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/examples/02-validatebuffer/test.c
+++ b/userspace/libscap/examples/02-validatebuffer/test.c
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <stdio.h>

--- a/userspace/libscap/examples/02-validatebuffer/test.c
+++ b/userspace/libscap/examples/02-validatebuffer/test.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/examples/02-validatebuffer/test.c
+++ b/userspace/libscap/examples/02-validatebuffer/test.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 ////////////////////////////////////////////////////////////////////////////

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <stdio.h>

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/mman.h>

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_bpf.h
+++ b/userspace/libscap/scap_bpf.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_bpf.h
+++ b/userspace/libscap/scap_bpf.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_bpf.h
+++ b/userspace/libscap/scap_bpf.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #ifndef _SCAP_BPF_H
 #define _SCAP_BPF_H
 

--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <stdio.h>

--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <stdio.h>

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_iflist.c
+++ b/userspace/libscap/scap_iflist.c
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <stdio.h>

--- a/userspace/libscap/scap_iflist.c
+++ b/userspace/libscap/scap_iflist.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_iflist.c
+++ b/userspace/libscap/scap_iflist.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <errno.h>

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1,20 +1,22 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
+
 
 #ifndef _WIN32
 #include <unistd.h>

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_savefile.h
+++ b/userspace/libscap/scap_savefile.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 // Force struct alignment

--- a/userspace/libscap/scap_savefile.h
+++ b/userspace/libscap/scap_savefile.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_savefile.h
+++ b/userspace/libscap/scap_savefile.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_userlist.c
+++ b/userspace/libscap/scap_userlist.c
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <stdio.h>

--- a/userspace/libscap/scap_userlist.c
+++ b/userspace/libscap/scap_userlist.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/scap_userlist.c
+++ b/userspace/libscap/scap_userlist.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/settings.h
+++ b/userspace/libscap/settings.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/settings.h
+++ b/userspace/libscap/settings.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/settings.h
+++ b/userspace/libscap/settings.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // This flag can be used to include unsupported or unrecognized sockets
 // in the fd tables. It's useful to debug close() leaks

--- a/userspace/libscap/syscall_info_table.c
+++ b/userspace/libscap/syscall_info_table.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/syscall_info_table.c
+++ b/userspace/libscap/syscall_info_table.c
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include "../common/sysdig_types.h"

--- a/userspace/libscap/syscall_info_table.c
+++ b/userspace/libscap/syscall_info_table.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/windows_hal.c
+++ b/userspace/libscap/windows_hal.c
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #include <windows.h>
 #include <stdio.h>
 #include <tlhelp32.h>

--- a/userspace/libscap/windows_hal.c
+++ b/userspace/libscap/windows_hal.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/windows_hal.c
+++ b/userspace/libscap/windows_hal.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/windows_hal.h
+++ b/userspace/libscap/windows_hal.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #pragma once
 
 int32_t scap_proc_scan_proc_dir_windows(scap_t* handle, struct scap_threadinfo** procinfo, char *error);

--- a/userspace/libscap/windows_hal.h
+++ b/userspace/libscap/windows_hal.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libscap/windows_hal.h
+++ b/userspace/libscap/windows_hal.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 include_directories(./)
 include_directories(../../common)
 include_directories(../libscap)

--- a/userspace/libsinsp/chisel.cpp
+++ b/userspace/libsinsp/chisel.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <iostream>

--- a/userspace/libsinsp/chisel.cpp
+++ b/userspace/libsinsp/chisel.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/chisel.cpp
+++ b/userspace/libsinsp/chisel.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/chisel.h
+++ b/userspace/libsinsp/chisel.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/chisel.h
+++ b/userspace/libsinsp/chisel.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/chisel.h
+++ b/userspace/libsinsp/chisel.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/chisel_api.cpp
+++ b/userspace/libsinsp/chisel_api.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <iostream>

--- a/userspace/libsinsp/chisel_api.cpp
+++ b/userspace/libsinsp/chisel_api.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/chisel_api.cpp
+++ b/userspace/libsinsp/chisel_api.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/chisel_api.h
+++ b/userspace/libsinsp/chisel_api.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/chisel_api.h
+++ b/userspace/libsinsp/chisel_api.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/chisel_api.h
+++ b/userspace/libsinsp/chisel_api.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifndef _WIN32

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/ctext.cpp
+++ b/userspace/libsinsp/ctext.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/ctext.cpp
+++ b/userspace/libsinsp/ctext.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/ctext.cpp
+++ b/userspace/libsinsp/ctext.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2015 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifndef _WIN32

--- a/userspace/libsinsp/ctext.h
+++ b/userspace/libsinsp/ctext.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/ctext.h
+++ b/userspace/libsinsp/ctext.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/ctext.h
+++ b/userspace/libsinsp/ctext.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2015 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifndef _WIN32

--- a/userspace/libsinsp/cursescomponents.cpp
+++ b/userspace/libsinsp/cursescomponents.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2015 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <stdlib.h>

--- a/userspace/libsinsp/cursescomponents.cpp
+++ b/userspace/libsinsp/cursescomponents.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursescomponents.cpp
+++ b/userspace/libsinsp/cursescomponents.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursescomponents.h
+++ b/userspace/libsinsp/cursescomponents.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursescomponents.h
+++ b/userspace/libsinsp/cursescomponents.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 class search_caller_interface

--- a/userspace/libsinsp/cursescomponents.h
+++ b/userspace/libsinsp/cursescomponents.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursesspectro.cpp
+++ b/userspace/libsinsp/cursesspectro.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <stdlib.h>

--- a/userspace/libsinsp/cursesspectro.cpp
+++ b/userspace/libsinsp/cursesspectro.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursesspectro.cpp
+++ b/userspace/libsinsp/cursesspectro.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursesspectro.h
+++ b/userspace/libsinsp/cursesspectro.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifdef CSYSDIG

--- a/userspace/libsinsp/cursesspectro.h
+++ b/userspace/libsinsp/cursesspectro.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursesspectro.h
+++ b/userspace/libsinsp/cursesspectro.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursestable.cpp
+++ b/userspace/libsinsp/cursestable.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <stdlib.h>

--- a/userspace/libsinsp/cursestable.cpp
+++ b/userspace/libsinsp/cursestable.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursestable.cpp
+++ b/userspace/libsinsp/cursestable.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursestable.h
+++ b/userspace/libsinsp/cursestable.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifdef CSYSDIG

--- a/userspace/libsinsp/cursestable.h
+++ b/userspace/libsinsp/cursestable.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursestable.h
+++ b/userspace/libsinsp/cursestable.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursesui.cpp
+++ b/userspace/libsinsp/cursesui.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursesui.cpp
+++ b/userspace/libsinsp/cursesui.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2015 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <iostream>

--- a/userspace/libsinsp/cursesui.cpp
+++ b/userspace/libsinsp/cursesui.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursesui.h
+++ b/userspace/libsinsp/cursesui.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifdef CSYSDIG

--- a/userspace/libsinsp/cursesui.h
+++ b/userspace/libsinsp/cursesui.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cursesui.h
+++ b/userspace/libsinsp/cursesui.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cyclewriter.cpp
+++ b/userspace/libsinsp/cyclewriter.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #include "sinsp.h"
 #include "sinsp_int.h"
 #include "cyclewriter.h"

--- a/userspace/libsinsp/cyclewriter.cpp
+++ b/userspace/libsinsp/cyclewriter.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cyclewriter.cpp
+++ b/userspace/libsinsp/cyclewriter.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cyclewriter.h
+++ b/userspace/libsinsp/cyclewriter.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/cyclewriter.h
+++ b/userspace/libsinsp/cyclewriter.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #include <string>
 #include <stdlib.h>
 #include <stddef.h>

--- a/userspace/libsinsp/cyclewriter.h
+++ b/userspace/libsinsp/cyclewriter.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include "dns_manager.h"

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <sys/types.h>

--- a/userspace/libsinsp/docker.cpp
+++ b/userspace/libsinsp/docker.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // docker.cpp
 //

--- a/userspace/libsinsp/docker.cpp
+++ b/userspace/libsinsp/docker.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/docker.cpp
+++ b/userspace/libsinsp/docker.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/docker.h
+++ b/userspace/libsinsp/docker.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/docker.h
+++ b/userspace/libsinsp/docker.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // docker.h
 //

--- a/userspace/libsinsp/docker.h
+++ b/userspace/libsinsp/docker.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include "sinsp.h"

--- a/userspace/libsinsp/dumper.h
+++ b/userspace/libsinsp/dumper.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/dumper.h
+++ b/userspace/libsinsp/dumper.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/dumper.h
+++ b/userspace/libsinsp/dumper.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifndef _WIN32

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include "sinsp.h"

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifndef _WIN32

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 //

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/filter_value.h
+++ b/userspace/libsinsp/filter_value.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/filter_value.h
+++ b/userspace/libsinsp/filter_value.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2016 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/filter_value.h
+++ b/userspace/libsinsp/filter_value.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <time.h>

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/http_reason.cpp
+++ b/userspace/libsinsp/http_reason.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include "http_reason.h"

--- a/userspace/libsinsp/http_reason.cpp
+++ b/userspace/libsinsp/http_reason.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/http_reason.cpp
+++ b/userspace/libsinsp/http_reason.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/http_reason.h
+++ b/userspace/libsinsp/http_reason.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/http_reason.h
+++ b/userspace/libsinsp/http_reason.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/http_reason.h
+++ b/userspace/libsinsp/http_reason.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include "sinsp.h"

--- a/userspace/libsinsp/ifinfo.h
+++ b/userspace/libsinsp/ifinfo.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/ifinfo.h
+++ b/userspace/libsinsp/ifinfo.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/ifinfo.h
+++ b/userspace/libsinsp/ifinfo.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/ifinfo_test.cpp
+++ b/userspace/libsinsp/ifinfo_test.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <gtest.h>

--- a/userspace/libsinsp/ifinfo_test.cpp
+++ b/userspace/libsinsp/ifinfo_test.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/ifinfo_test.cpp
+++ b/userspace/libsinsp/ifinfo_test.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/internal_metrics.cpp
+++ b/userspace/libsinsp/internal_metrics.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/internal_metrics.cpp
+++ b/userspace/libsinsp/internal_metrics.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/internal_metrics.cpp
+++ b/userspace/libsinsp/internal_metrics.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include "sinsp.h"

--- a/userspace/libsinsp/internal_metrics.h
+++ b/userspace/libsinsp/internal_metrics.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/internal_metrics.h
+++ b/userspace/libsinsp/internal_metrics.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/internal_metrics.h
+++ b/userspace/libsinsp/internal_metrics.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/json_error_log.cpp
+++ b/userspace/libsinsp/json_error_log.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/json_error_log.cpp
+++ b/userspace/libsinsp/json_error_log.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #include <fstream>
 
 #include <sinsp.h>

--- a/userspace/libsinsp/json_error_log.cpp
+++ b/userspace/libsinsp/json_error_log.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/json_error_log.h
+++ b/userspace/libsinsp/json_error_log.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/json_error_log.h
+++ b/userspace/libsinsp/json_error_log.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/json_error_log.h
+++ b/userspace/libsinsp/json_error_log.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #pragma once
 
 #include <string>

--- a/userspace/libsinsp/json_query.cpp
+++ b/userspace/libsinsp/json_query.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // json_parser.h
 //

--- a/userspace/libsinsp/json_query.cpp
+++ b/userspace/libsinsp/json_query.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/json_query.cpp
+++ b/userspace/libsinsp/json_query.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/json_query.h
+++ b/userspace/libsinsp/json_query.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/json_query.h
+++ b/userspace/libsinsp/json_query.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/json_query.h
+++ b/userspace/libsinsp/json_query.h
@@ -1,4 +1,22 @@
-//
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 // json_parser.h
 //
 // jq wrapper

--- a/userspace/libsinsp/k8s.cpp
+++ b/userspace/libsinsp/k8s.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s.cpp
+++ b/userspace/libsinsp/k8s.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s.cpp
 //

--- a/userspace/libsinsp/k8s.cpp
+++ b/userspace/libsinsp/k8s.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s.h
+++ b/userspace/libsinsp/k8s.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s.h
 //

--- a/userspace/libsinsp/k8s.h
+++ b/userspace/libsinsp/k8s.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s.h
+++ b/userspace/libsinsp/k8s.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_api_error.cpp
+++ b/userspace/libsinsp/k8s_api_error.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_api_error.cpp
+++ b/userspace/libsinsp/k8s_api_error.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_api_error.cpp
 //

--- a/userspace/libsinsp/k8s_api_error.cpp
+++ b/userspace/libsinsp/k8s_api_error.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_api_error.h
+++ b/userspace/libsinsp/k8s_api_error.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_api_error.h
 //

--- a/userspace/libsinsp/k8s_api_error.h
+++ b/userspace/libsinsp/k8s_api_error.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_api_error.h
+++ b/userspace/libsinsp/k8s_api_error.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_api_handler.cpp
+++ b/userspace/libsinsp/k8s_api_handler.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_api_handler.cpp
 //

--- a/userspace/libsinsp/k8s_api_handler.cpp
+++ b/userspace/libsinsp/k8s_api_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_api_handler.cpp
+++ b/userspace/libsinsp/k8s_api_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_api_handler.h
+++ b/userspace/libsinsp/k8s_api_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_api_handler.h
+++ b/userspace/libsinsp/k8s_api_handler.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_api_handler.h
 //

--- a/userspace/libsinsp/k8s_api_handler.h
+++ b/userspace/libsinsp/k8s_api_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_component.cpp
+++ b/userspace/libsinsp/k8s_component.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_component.cpp
+++ b/userspace/libsinsp/k8s_component.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_component.cpp
 //

--- a/userspace/libsinsp/k8s_component.cpp
+++ b/userspace/libsinsp/k8s_component.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_component.h
+++ b/userspace/libsinsp/k8s_component.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_component.h
+++ b/userspace/libsinsp/k8s_component.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_component.h
 //

--- a/userspace/libsinsp/k8s_component.h
+++ b/userspace/libsinsp/k8s_component.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_daemonset_handler.cpp
+++ b/userspace/libsinsp/k8s_daemonset_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_daemonset_handler.cpp
+++ b/userspace/libsinsp/k8s_daemonset_handler.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_daemonset_handler.cpp
 //

--- a/userspace/libsinsp/k8s_daemonset_handler.cpp
+++ b/userspace/libsinsp/k8s_daemonset_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_daemonset_handler.h
+++ b/userspace/libsinsp/k8s_daemonset_handler.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_daemonset_handler.h
 //

--- a/userspace/libsinsp/k8s_daemonset_handler.h
+++ b/userspace/libsinsp/k8s_daemonset_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_daemonset_handler.h
+++ b/userspace/libsinsp/k8s_daemonset_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_deployment_handler.cpp
+++ b/userspace/libsinsp/k8s_deployment_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_deployment_handler.cpp
+++ b/userspace/libsinsp/k8s_deployment_handler.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_deployment_handler.cpp
 //

--- a/userspace/libsinsp/k8s_deployment_handler.cpp
+++ b/userspace/libsinsp/k8s_deployment_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_deployment_handler.h
+++ b/userspace/libsinsp/k8s_deployment_handler.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_deployment_handler.h
 //

--- a/userspace/libsinsp/k8s_deployment_handler.h
+++ b/userspace/libsinsp/k8s_deployment_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_deployment_handler.h
+++ b/userspace/libsinsp/k8s_deployment_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_dispatcher.cpp
+++ b/userspace/libsinsp/k8s_dispatcher.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_dispatcher.cpp
+++ b/userspace/libsinsp/k8s_dispatcher.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_dispatcher.cpp
 //

--- a/userspace/libsinsp/k8s_dispatcher.cpp
+++ b/userspace/libsinsp/k8s_dispatcher.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_dispatcher.h
+++ b/userspace/libsinsp/k8s_dispatcher.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_dispatcher.h
 //

--- a/userspace/libsinsp/k8s_dispatcher.h
+++ b/userspace/libsinsp/k8s_dispatcher.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_dispatcher.h
+++ b/userspace/libsinsp/k8s_dispatcher.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_event_data.cpp
+++ b/userspace/libsinsp/k8s_event_data.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_event_data.cpp
+++ b/userspace/libsinsp/k8s_event_data.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_net.cpp
 //

--- a/userspace/libsinsp/k8s_event_data.cpp
+++ b/userspace/libsinsp/k8s_event_data.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_event_data.h
+++ b/userspace/libsinsp/k8s_event_data.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_event_data.h
 //

--- a/userspace/libsinsp/k8s_event_data.h
+++ b/userspace/libsinsp/k8s_event_data.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_event_data.h
+++ b/userspace/libsinsp/k8s_event_data.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_event_handler.cpp
+++ b/userspace/libsinsp/k8s_event_handler.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_event_handler.cpp
 //

--- a/userspace/libsinsp/k8s_event_handler.cpp
+++ b/userspace/libsinsp/k8s_event_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_event_handler.cpp
+++ b/userspace/libsinsp/k8s_event_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_event_handler.h
+++ b/userspace/libsinsp/k8s_event_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_event_handler.h
+++ b/userspace/libsinsp/k8s_event_handler.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_event_handler.h
 //

--- a/userspace/libsinsp/k8s_event_handler.h
+++ b/userspace/libsinsp/k8s_event_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_handler.cpp
+++ b/userspace/libsinsp/k8s_handler.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_handler.cpp
 //

--- a/userspace/libsinsp/k8s_handler.cpp
+++ b/userspace/libsinsp/k8s_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_handler.cpp
+++ b/userspace/libsinsp/k8s_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_handler.h
+++ b/userspace/libsinsp/k8s_handler.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_handler.h
 //

--- a/userspace/libsinsp/k8s_handler.h
+++ b/userspace/libsinsp/k8s_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_handler.h
+++ b/userspace/libsinsp/k8s_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_namespace_handler.cpp
+++ b/userspace/libsinsp/k8s_namespace_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_namespace_handler.cpp
+++ b/userspace/libsinsp/k8s_namespace_handler.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_namespace_handler.cpp
 //

--- a/userspace/libsinsp/k8s_namespace_handler.cpp
+++ b/userspace/libsinsp/k8s_namespace_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_namespace_handler.h
+++ b/userspace/libsinsp/k8s_namespace_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_namespace_handler.h
+++ b/userspace/libsinsp/k8s_namespace_handler.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_namespace_handler.h
 //

--- a/userspace/libsinsp/k8s_namespace_handler.h
+++ b/userspace/libsinsp/k8s_namespace_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_net.cpp
+++ b/userspace/libsinsp/k8s_net.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_net.cpp
+++ b/userspace/libsinsp/k8s_net.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_net.cpp
 //

--- a/userspace/libsinsp/k8s_net.cpp
+++ b/userspace/libsinsp/k8s_net.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_net.h
+++ b/userspace/libsinsp/k8s_net.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_net.h
 //

--- a/userspace/libsinsp/k8s_net.h
+++ b/userspace/libsinsp/k8s_net.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_net.h
+++ b/userspace/libsinsp/k8s_net.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_node_handler.cpp
+++ b/userspace/libsinsp/k8s_node_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_node_handler.cpp
+++ b/userspace/libsinsp/k8s_node_handler.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_node_handler.cpp
 //

--- a/userspace/libsinsp/k8s_node_handler.cpp
+++ b/userspace/libsinsp/k8s_node_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_node_handler.h
+++ b/userspace/libsinsp/k8s_node_handler.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_node_handler.h
 //

--- a/userspace/libsinsp/k8s_node_handler.h
+++ b/userspace/libsinsp/k8s_node_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_node_handler.h
+++ b/userspace/libsinsp/k8s_node_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_pod_handler.cpp
+++ b/userspace/libsinsp/k8s_pod_handler.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_pod_handler.cpp
 //

--- a/userspace/libsinsp/k8s_pod_handler.cpp
+++ b/userspace/libsinsp/k8s_pod_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_pod_handler.cpp
+++ b/userspace/libsinsp/k8s_pod_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_pod_handler.h
+++ b/userspace/libsinsp/k8s_pod_handler.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_pod_handler.h
 //

--- a/userspace/libsinsp/k8s_pod_handler.h
+++ b/userspace/libsinsp/k8s_pod_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_pod_handler.h
+++ b/userspace/libsinsp/k8s_pod_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_replicaset_handler.cpp
+++ b/userspace/libsinsp/k8s_replicaset_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_replicaset_handler.cpp
+++ b/userspace/libsinsp/k8s_replicaset_handler.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_replicaset_handler.cpp
 //

--- a/userspace/libsinsp/k8s_replicaset_handler.cpp
+++ b/userspace/libsinsp/k8s_replicaset_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_replicaset_handler.h
+++ b/userspace/libsinsp/k8s_replicaset_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_replicaset_handler.h
+++ b/userspace/libsinsp/k8s_replicaset_handler.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_replicaset_handler.h
 //

--- a/userspace/libsinsp/k8s_replicaset_handler.h
+++ b/userspace/libsinsp/k8s_replicaset_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_replicationcontroller_handler.cpp
+++ b/userspace/libsinsp/k8s_replicationcontroller_handler.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_replicationcontroller_handler.cpp
 //

--- a/userspace/libsinsp/k8s_replicationcontroller_handler.cpp
+++ b/userspace/libsinsp/k8s_replicationcontroller_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_replicationcontroller_handler.cpp
+++ b/userspace/libsinsp/k8s_replicationcontroller_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_replicationcontroller_handler.h
+++ b/userspace/libsinsp/k8s_replicationcontroller_handler.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_replicationcontroller_handler.h
 //

--- a/userspace/libsinsp/k8s_replicationcontroller_handler.h
+++ b/userspace/libsinsp/k8s_replicationcontroller_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_replicationcontroller_handler.h
+++ b/userspace/libsinsp/k8s_replicationcontroller_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_service_handler.cpp
+++ b/userspace/libsinsp/k8s_service_handler.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_service_handler.cpp
 //

--- a/userspace/libsinsp/k8s_service_handler.cpp
+++ b/userspace/libsinsp/k8s_service_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_service_handler.cpp
+++ b/userspace/libsinsp/k8s_service_handler.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_service_handler.h
+++ b/userspace/libsinsp/k8s_service_handler.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_service_handler.h
 //

--- a/userspace/libsinsp/k8s_service_handler.h
+++ b/userspace/libsinsp/k8s_service_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_service_handler.h
+++ b/userspace/libsinsp/k8s_service_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_state.cpp
+++ b/userspace/libsinsp/k8s_state.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_state.cpp
 //

--- a/userspace/libsinsp/k8s_state.cpp
+++ b/userspace/libsinsp/k8s_state.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_state.cpp
+++ b/userspace/libsinsp/k8s_state.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_state.h
+++ b/userspace/libsinsp/k8s_state.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/k8s_state.h
+++ b/userspace/libsinsp/k8s_state.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_state.h
 //

--- a/userspace/libsinsp/k8s_state.h
+++ b/userspace/libsinsp/k8s_state.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/logger.cpp
+++ b/userspace/libsinsp/logger.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifndef _WIN32

--- a/userspace/libsinsp/logger.cpp
+++ b/userspace/libsinsp/logger.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/logger.cpp
+++ b/userspace/libsinsp/logger.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/logger.h
+++ b/userspace/libsinsp/logger.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/logger.h
+++ b/userspace/libsinsp/logger.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/logger.h
+++ b/userspace/libsinsp/logger.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/lua_parser.cpp
+++ b/userspace/libsinsp/lua_parser.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/lua_parser.cpp
+++ b/userspace/libsinsp/lua_parser.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #include <iostream>
 #include <fstream>
 #include "sinsp.h"

--- a/userspace/libsinsp/lua_parser.cpp
+++ b/userspace/libsinsp/lua_parser.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/lua_parser.h
+++ b/userspace/libsinsp/lua_parser.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #pragma once
 
 #include "sinsp.h"

--- a/userspace/libsinsp/lua_parser.h
+++ b/userspace/libsinsp/lua_parser.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/lua_parser.h
+++ b/userspace/libsinsp/lua_parser.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #include "sinsp.h"
 #include "sinsp_int.h"
 

--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/lua_parser_api.h
+++ b/userspace/libsinsp/lua_parser_api.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/lua_parser_api.h
+++ b/userspace/libsinsp/lua_parser_api.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/lua_parser_api.h
+++ b/userspace/libsinsp/lua_parser_api.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/marathon_component.cpp
+++ b/userspace/libsinsp/marathon_component.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // marathon_component.cpp
 //

--- a/userspace/libsinsp/marathon_component.cpp
+++ b/userspace/libsinsp/marathon_component.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/marathon_component.cpp
+++ b/userspace/libsinsp/marathon_component.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/marathon_component.h
+++ b/userspace/libsinsp/marathon_component.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // marathon_component.h
 //

--- a/userspace/libsinsp/marathon_component.h
+++ b/userspace/libsinsp/marathon_component.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/marathon_component.h
+++ b/userspace/libsinsp/marathon_component.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/marathon_http.cpp
+++ b/userspace/libsinsp/marathon_http.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/marathon_http.cpp
+++ b/userspace/libsinsp/marathon_http.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/marathon_http.cpp
+++ b/userspace/libsinsp/marathon_http.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // marathon_http.cpp
 //

--- a/userspace/libsinsp/marathon_http.h
+++ b/userspace/libsinsp/marathon_http.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/marathon_http.h
+++ b/userspace/libsinsp/marathon_http.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // marathon_http.h
 //

--- a/userspace/libsinsp/marathon_http.h
+++ b/userspace/libsinsp/marathon_http.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/memmem.cpp
+++ b/userspace/libsinsp/memmem.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/memmem.cpp
+++ b/userspace/libsinsp/memmem.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/memmem.cpp
+++ b/userspace/libsinsp/memmem.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifndef _GNU_SOURCE

--- a/userspace/libsinsp/mesos.cpp
+++ b/userspace/libsinsp/mesos.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos.cpp
+++ b/userspace/libsinsp/mesos.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // mesos.cpp
 //

--- a/userspace/libsinsp/mesos.cpp
+++ b/userspace/libsinsp/mesos.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos.h
+++ b/userspace/libsinsp/mesos.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // mesos.h
 //

--- a/userspace/libsinsp/mesos.h
+++ b/userspace/libsinsp/mesos.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos.h
+++ b/userspace/libsinsp/mesos.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_auth.cpp
+++ b/userspace/libsinsp/mesos_auth.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2016 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 //

--- a/userspace/libsinsp/mesos_auth.cpp
+++ b/userspace/libsinsp/mesos_auth.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_auth.cpp
+++ b/userspace/libsinsp/mesos_auth.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_auth.h
+++ b/userspace/libsinsp/mesos_auth.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2016 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 //

--- a/userspace/libsinsp/mesos_auth.h
+++ b/userspace/libsinsp/mesos_auth.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_auth.h
+++ b/userspace/libsinsp/mesos_auth.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_collector.cpp
+++ b/userspace/libsinsp/mesos_collector.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // mesos_collector.cpp
 //

--- a/userspace/libsinsp/mesos_collector.cpp
+++ b/userspace/libsinsp/mesos_collector.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_collector.cpp
+++ b/userspace/libsinsp/mesos_collector.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_collector.h
+++ b/userspace/libsinsp/mesos_collector.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // mesos_collector.h
 //

--- a/userspace/libsinsp/mesos_collector.h
+++ b/userspace/libsinsp/mesos_collector.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_collector.h
+++ b/userspace/libsinsp/mesos_collector.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_common.h
+++ b/userspace/libsinsp/mesos_common.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // mesos_common.h
 //

--- a/userspace/libsinsp/mesos_common.h
+++ b/userspace/libsinsp/mesos_common.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_common.h
+++ b/userspace/libsinsp/mesos_common.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_component.cpp
+++ b/userspace/libsinsp/mesos_component.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // mesos_component.cpp
 //

--- a/userspace/libsinsp/mesos_component.cpp
+++ b/userspace/libsinsp/mesos_component.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_component.cpp
+++ b/userspace/libsinsp/mesos_component.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_component.h
+++ b/userspace/libsinsp/mesos_component.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_component.h
+++ b/userspace/libsinsp/mesos_component.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // mesos_component.h
 //

--- a/userspace/libsinsp/mesos_component.h
+++ b/userspace/libsinsp/mesos_component.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_http.cpp
+++ b/userspace/libsinsp/mesos_http.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // mesos_http.cpp
 //

--- a/userspace/libsinsp/mesos_http.cpp
+++ b/userspace/libsinsp/mesos_http.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_http.cpp
+++ b/userspace/libsinsp/mesos_http.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_http.h
+++ b/userspace/libsinsp/mesos_http.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_http.h
+++ b/userspace/libsinsp/mesos_http.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // mesos_http.h
 //

--- a/userspace/libsinsp/mesos_http.h
+++ b/userspace/libsinsp/mesos_http.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_state.cpp
+++ b/userspace/libsinsp/mesos_state.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // k8s_state.cpp
 //

--- a/userspace/libsinsp/mesos_state.cpp
+++ b/userspace/libsinsp/mesos_state.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_state.cpp
+++ b/userspace/libsinsp/mesos_state.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_state.h
+++ b/userspace/libsinsp/mesos_state.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // mesos_state_t.h
 //

--- a/userspace/libsinsp/mesos_state.h
+++ b/userspace/libsinsp/mesos_state.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/mesos_state.h
+++ b/userspace/libsinsp/mesos_state.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifdef _WIN32

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 ////////////////////////////////////////////////////////////////////////////

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/prefix_search.cpp
+++ b/userspace/libsinsp/prefix_search.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2016 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <string.h>

--- a/userspace/libsinsp/prefix_search.cpp
+++ b/userspace/libsinsp/prefix_search.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/prefix_search.cpp
+++ b/userspace/libsinsp/prefix_search.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/prefix_search.h
+++ b/userspace/libsinsp/prefix_search.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/prefix_search.h
+++ b/userspace/libsinsp/prefix_search.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2016 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/prefix_search.h
+++ b/userspace/libsinsp/prefix_search.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/procinfo_test.cpp
+++ b/userspace/libsinsp/procinfo_test.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/procinfo_test.cpp
+++ b/userspace/libsinsp/procinfo_test.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/procinfo_test.cpp
+++ b/userspace/libsinsp/procinfo_test.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include "sinsp.h"

--- a/userspace/libsinsp/protodecoder.cpp
+++ b/userspace/libsinsp/protodecoder.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <time.h>

--- a/userspace/libsinsp/protodecoder.cpp
+++ b/userspace/libsinsp/protodecoder.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/protodecoder.cpp
+++ b/userspace/libsinsp/protodecoder.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/protodecoder.h
+++ b/userspace/libsinsp/protodecoder.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/protodecoder.h
+++ b/userspace/libsinsp/protodecoder.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/protodecoder.h
+++ b/userspace/libsinsp/protodecoder.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <stdio.h>

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 /*!

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_auth.cpp
+++ b/userspace/libsinsp/sinsp_auth.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // sinsp_auth.cpp
 //

--- a/userspace/libsinsp/sinsp_auth.cpp
+++ b/userspace/libsinsp/sinsp_auth.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_auth.cpp
+++ b/userspace/libsinsp/sinsp_auth.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_auth.h
+++ b/userspace/libsinsp/sinsp_auth.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // sinsp_auth.h
 //

--- a/userspace/libsinsp/sinsp_auth.h
+++ b/userspace/libsinsp/sinsp_auth.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_auth.h
+++ b/userspace/libsinsp/sinsp_auth.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_curl.cpp
+++ b/userspace/libsinsp/sinsp_curl.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_curl.cpp
+++ b/userspace/libsinsp/sinsp_curl.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // sinsp_curl.cpp
 //

--- a/userspace/libsinsp/sinsp_curl.cpp
+++ b/userspace/libsinsp/sinsp_curl.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_curl.h
+++ b/userspace/libsinsp/sinsp_curl.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // sinsp_curl.h
 //

--- a/userspace/libsinsp/sinsp_curl.h
+++ b/userspace/libsinsp/sinsp_curl.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_curl.h
+++ b/userspace/libsinsp/sinsp_curl.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_errno.h
+++ b/userspace/libsinsp/sinsp_errno.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #define SE_EPERM            1      /* Operation not permitted */

--- a/userspace/libsinsp/sinsp_errno.h
+++ b/userspace/libsinsp/sinsp_errno.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_errno.h
+++ b/userspace/libsinsp/sinsp_errno.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_int.h
+++ b/userspace/libsinsp/sinsp_int.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_int.h
+++ b/userspace/libsinsp/sinsp_int.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_int.h
+++ b/userspace/libsinsp/sinsp_int.h
@@ -1,20 +1,22 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
+
 
 ////////////////////////////////////////////////////////////////////////////
 // Public definitions for the scap library

--- a/userspace/libsinsp/sinsp_signal.h
+++ b/userspace/libsinsp/sinsp_signal.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #define SE_NSIG           64

--- a/userspace/libsinsp/sinsp_signal.h
+++ b/userspace/libsinsp/sinsp_signal.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_signal.h
+++ b/userspace/libsinsp/sinsp_signal.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_test.cpp
+++ b/userspace/libsinsp/sinsp_test.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <gtest.h>

--- a/userspace/libsinsp/sinsp_test.cpp
+++ b/userspace/libsinsp/sinsp_test.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/sinsp_test.cpp
+++ b/userspace/libsinsp/sinsp_test.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/socket_collector.h
+++ b/userspace/libsinsp/socket_collector.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // socket_collector.h
 //

--- a/userspace/libsinsp/socket_collector.h
+++ b/userspace/libsinsp/socket_collector.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/socket_collector.h
+++ b/userspace/libsinsp/socket_collector.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -1,3 +1,22 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 //
 // socket_handler.h
 //

--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/stats.cpp
+++ b/userspace/libsinsp/stats.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 ////////////////////////////////////////////////////////////////////////////

--- a/userspace/libsinsp/stats.cpp
+++ b/userspace/libsinsp/stats.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/stats.cpp
+++ b/userspace/libsinsp/stats.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/stats.h
+++ b/userspace/libsinsp/stats.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/stats.h
+++ b/userspace/libsinsp/stats.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/stats.h
+++ b/userspace/libsinsp/stats.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/stopwatch.cpp
+++ b/userspace/libsinsp/stopwatch.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/stopwatch.cpp
+++ b/userspace/libsinsp/stopwatch.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/stopwatch.cpp
+++ b/userspace/libsinsp/stopwatch.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // stopwatch.cpp
 //

--- a/userspace/libsinsp/stopwatch.h
+++ b/userspace/libsinsp/stopwatch.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/stopwatch.h
+++ b/userspace/libsinsp/stopwatch.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // stopwatch.h
 //

--- a/userspace/libsinsp/stopwatch.h
+++ b/userspace/libsinsp/stopwatch.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/table.cpp
+++ b/userspace/libsinsp/table.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/table.cpp
+++ b/userspace/libsinsp/table.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <algorithm>

--- a/userspace/libsinsp/table.cpp
+++ b/userspace/libsinsp/table.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/table.h
+++ b/userspace/libsinsp/table.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #define SINSP_TABLE_DEFAULT_REFRESH_INTERVAL_NS 1000000000

--- a/userspace/libsinsp/table.h
+++ b/userspace/libsinsp/table.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/table.h
+++ b/userspace/libsinsp/table.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifndef _WIN32

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/token_bucket.cpp
+++ b/userspace/libsinsp/token_bucket.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/token_bucket.cpp
+++ b/userspace/libsinsp/token_bucket.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2016 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This file is part of falco.
+This file is part of sysdig.
 
-falco is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-falco is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with falco.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <cstddef>

--- a/userspace/libsinsp/token_bucket.cpp
+++ b/userspace/libsinsp/token_bucket.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/token_bucket.h
+++ b/userspace/libsinsp/token_bucket.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2016 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This file is part of falco.
+This file is part of sysdig.
 
-falco is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-falco is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with falco.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/token_bucket.h
+++ b/userspace/libsinsp/token_bucket.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/token_bucket.h
+++ b/userspace/libsinsp/token_bucket.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/tracer_emitter.cpp
+++ b/userspace/libsinsp/tracer_emitter.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/tracer_emitter.cpp
+++ b/userspace/libsinsp/tracer_emitter.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #include "tracer_emitter.h"
 #include "sinsp.h"
 #include "sinsp_int.h"

--- a/userspace/libsinsp/tracer_emitter.cpp
+++ b/userspace/libsinsp/tracer_emitter.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/tracer_emitter.h
+++ b/userspace/libsinsp/tracer_emitter.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #pragma once
 #include <string>
 

--- a/userspace/libsinsp/tracer_emitter.h
+++ b/userspace/libsinsp/tracer_emitter.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/tracer_emitter.h
+++ b/userspace/libsinsp/tracer_emitter.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/tracers.cpp
+++ b/userspace/libsinsp/tracers.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <time.h>

--- a/userspace/libsinsp/tracers.cpp
+++ b/userspace/libsinsp/tracers.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/tracers.cpp
+++ b/userspace/libsinsp/tracers.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/tracers.h
+++ b/userspace/libsinsp/tracers.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #define UESTORAGE_INITIAL_BUFSIZE 256

--- a/userspace/libsinsp/tracers.h
+++ b/userspace/libsinsp/tracers.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/tracers.h
+++ b/userspace/libsinsp/tracers.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/tuples.cpp
+++ b/userspace/libsinsp/tuples.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include <tuples.h>

--- a/userspace/libsinsp/tuples.h
+++ b/userspace/libsinsp/tuples.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/tuples.h
+++ b/userspace/libsinsp/tuples.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/tuples.h
+++ b/userspace/libsinsp/tuples.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/uri.cpp
+++ b/userspace/libsinsp/uri.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/uri.cpp
+++ b/userspace/libsinsp/uri.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/uri.cpp
+++ b/userspace/libsinsp/uri.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // uri.cpp
 //

--- a/userspace/libsinsp/uri.h
+++ b/userspace/libsinsp/uri.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/uri.h
+++ b/userspace/libsinsp/uri.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/uri.h
+++ b/userspace/libsinsp/uri.h
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 //
 // uri.h
 //

--- a/userspace/libsinsp/user_event.cpp
+++ b/userspace/libsinsp/user_event.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/user_event.cpp
+++ b/userspace/libsinsp/user_event.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/user_event.cpp
+++ b/userspace/libsinsp/user_event.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #include "sinsp.h"

--- a/userspace/libsinsp/user_event.h
+++ b/userspace/libsinsp/user_event.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/user_event.h
+++ b/userspace/libsinsp/user_event.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/user_event.h
+++ b/userspace/libsinsp/user_event.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #ifndef _WIN32

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/value_parser.cpp
+++ b/userspace/libsinsp/value_parser.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/value_parser.cpp
+++ b/userspace/libsinsp/value_parser.cpp
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #include "sinsp.h"
 #include "sinsp_int.h"
 #include "value_parser.h"

--- a/userspace/libsinsp/value_parser.cpp
+++ b/userspace/libsinsp/value_parser.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/value_parser.h
+++ b/userspace/libsinsp/value_parser.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/value_parser.h
+++ b/userspace/libsinsp/value_parser.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/libsinsp/value_parser.h
+++ b/userspace/libsinsp/value_parser.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/viewinfo.cpp
+++ b/userspace/libsinsp/viewinfo.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/viewinfo.cpp
+++ b/userspace/libsinsp/viewinfo.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 #include <algorithm>
 #include "sinsp.h"

--- a/userspace/libsinsp/viewinfo.cpp
+++ b/userspace/libsinsp/viewinfo.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/viewinfo.h
+++ b/userspace/libsinsp/viewinfo.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2015 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once	

--- a/userspace/libsinsp/viewinfo.h
+++ b/userspace/libsinsp/viewinfo.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/libsinsp/viewinfo.h
+++ b/userspace/libsinsp/viewinfo.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 include_directories("${JSONCPP_INCLUDE}")
 
 if(NOT WIN32)

--- a/userspace/sysdig/chisels/COPYING
+++ b/userspace/sysdig/chisels/COPYING
@@ -1,339 +1,203 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 2, June 1991
+The contents of the driver/ subdirectory are licensed separately--see COPYING.driver.
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-                            Preamble
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-  The licenses for most software are designed to take away your
-freedom to share and change it.  By contrast, the GNU General Public
-License is intended to guarantee your freedom to share and change free
-software--to make sure the software is free for all its users.  This
-General Public License applies to most of the Free Software
-Foundation's software and to any other program whose authors commit to
-using it.  (Some other Free Software Foundation software is covered by
-the GNU Lesser General Public License instead.)  You can apply it to
-your programs, too.
+   1. Definitions.
 
-  When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-this service if you wish), that you receive source code or can get it
-if you want it, that you can change the software or use pieces of it
-in new free programs; and that you know you can do these things.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-  To protect your rights, we need to make restrictions that forbid
-anyone to deny you these rights or to ask you to surrender the rights.
-These restrictions translate to certain responsibilities for you if you
-distribute copies of the software, or if you modify it.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must give the recipients all the rights that
-you have.  You must make sure that they, too, receive or can get the
-source code.  And you must show them these terms so they know their
-rights.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-  We protect your rights with two steps: (1) copyright the software, and
-(2) offer you this license which gives you legal permission to copy,
-distribute and/or modify the software.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-  Also, for each author's protection and ours, we want to make certain
-that everyone understands that there is no warranty for this free
-software.  If the software is modified by someone else and passed on, we
-want its recipients to know that what they have is not the original, so
-that any problems introduced by others will not reflect on the original
-authors' reputations.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-  Finally, any free program is threatened constantly by software
-patents.  We wish to avoid the danger that redistributors of a free
-program will individually obtain patent licenses, in effect making the
-program proprietary.  To prevent this, we have made it clear that any
-patent must be licensed for everyone's free use or not licensed at all.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-  The precise terms and conditions for copying, distribution and
-modification follow.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-                    GNU GENERAL PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-  0. This License applies to any program or other work which contains
-a notice placed by the copyright holder saying it may be distributed
-under the terms of this General Public License.  The "Program", below,
-refers to any such program or work, and a "work based on the Program"
-means either the Program or any derivative work under copyright law:
-that is to say, a work containing the Program or a portion of it,
-either verbatim or with modifications and/or translated into another
-language.  (Hereinafter, translation is included without limitation in
-the term "modification".)  Each licensee is addressed as "you".
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope.  The act of
-running the Program is not restricted, and the output from the Program
-is covered only if its contents constitute a work based on the
-Program (independent of having been made by running the Program).
-Whether that is true depends on what the Program does.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-  1. You may copy and distribute verbatim copies of the Program's
-source code as you receive it, in any medium, provided that you
-conspicuously and appropriately publish on each copy an appropriate
-copyright notice and disclaimer of warranty; keep intact all the
-notices that refer to this License and to the absence of any warranty;
-and give any other recipients of the Program a copy of this License
-along with the Program.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-You may charge a fee for the physical act of transferring a copy, and
-you may at your option offer warranty protection in exchange for a fee.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-  2. You may modify your copy or copies of the Program or any portion
-of it, thus forming a work based on the Program, and copy and
-distribute such modifications or work under the terms of Section 1
-above, provided that you also meet all of these conditions:
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-    a) You must cause the modified files to carry prominent notices
-    stating that you changed the files and the date of any change.
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-    b) You must cause any work that you distribute or publish, that in
-    whole or in part contains or is derived from the Program or any
-    part thereof, to be licensed as a whole at no charge to all third
-    parties under the terms of this License.
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-    c) If the modified program normally reads commands interactively
-    when run, you must cause it, when started running for such
-    interactive use in the most ordinary way, to print or display an
-    announcement including an appropriate copyright notice and a
-    notice that there is no warranty (or else, saying that you provide
-    a warranty) and that users may redistribute the program under
-    these conditions, and telling the user how to view a copy of this
-    License.  (Exception: if the Program itself is interactive but
-    does not normally print such an announcement, your work based on
-    the Program is not required to print an announcement.)
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-These requirements apply to the modified work as a whole.  If
-identifiable sections of that work are not derived from the Program,
-and can be reasonably considered independent and separate works in
-themselves, then this License, and its terms, do not apply to those
-sections when you distribute them as separate works.  But when you
-distribute the same sections as part of a whole which is a work based
-on the Program, the distribution of the whole must be on the terms of
-this License, whose permissions for other licensees extend to the
-entire whole, and thus to each and every part regardless of who wrote it.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-Thus, it is not the intent of this section to claim rights or contest
-your rights to work written entirely by you; rather, the intent is to
-exercise the right to control the distribution of derivative or
-collective works based on the Program.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-In addition, mere aggregation of another work not based on the Program
-with the Program (or with a work based on the Program) on a volume of
-a storage or distribution medium does not bring the other work under
-the scope of this License.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-  3. You may copy and distribute the Program (or a work based on it,
-under Section 2) in object code or executable form under the terms of
-Sections 1 and 2 above provided that you also do one of the following:
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-    a) Accompany it with the complete corresponding machine-readable
-    source code, which must be distributed under the terms of Sections
-    1 and 2 above on a medium customarily used for software interchange; or,
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-    b) Accompany it with a written offer, valid for at least three
-    years, to give any third party, for a charge no more than your
-    cost of physically performing source distribution, a complete
-    machine-readable copy of the corresponding source code, to be
-    distributed under the terms of Sections 1 and 2 above on a medium
-    customarily used for software interchange; or,
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-    c) Accompany it with the information you received as to the offer
-    to distribute corresponding source code.  (This alternative is
-    allowed only for noncommercial distribution and only if you
-    received the program in object code or executable form with such
-    an offer, in accord with Subsection b above.)
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-The source code for a work means the preferred form of the work for
-making modifications to it.  For an executable work, complete source
-code means all the source code for all modules it contains, plus any
-associated interface definition files, plus the scripts used to
-control compilation and installation of the executable.  However, as a
-special exception, the source code distributed need not include
-anything that is normally distributed (in either source or binary
-form) with the major components (compiler, kernel, and so on) of the
-operating system on which the executable runs, unless that component
-itself accompanies the executable.
+   END OF TERMS AND CONDITIONS
 
-If distribution of executable or object code is made by offering
-access to copy from a designated place, then offering equivalent
-access to copy the source code from the same place counts as
-distribution of the source code, even though third parties are not
-compelled to copy the source along with the object code.
+   APPENDIX: How to apply the Apache License to your work.
 
-  4. You may not copy, modify, sublicense, or distribute the Program
-except as expressly provided under this License.  Any attempt
-otherwise to copy, modify, sublicense or distribute the Program is
-void, and will automatically terminate your rights under this License.
-However, parties who have received copies, or rights, from you under
-this License will not have their licenses terminated so long as such
-parties remain in full compliance.
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-  5. You are not required to accept this License, since you have not
-signed it.  However, nothing else grants you permission to modify or
-distribute the Program or its derivative works.  These actions are
-prohibited by law if you do not accept this License.  Therefore, by
-modifying or distributing the Program (or any work based on the
-Program), you indicate your acceptance of this License to do so, and
-all its terms and conditions for copying, distributing or modifying
-the Program or works based on it.
+   Copyright [yyyy] [name of copyright owner]
 
-  6. Each time you redistribute the Program (or any work based on the
-Program), the recipient automatically receives a license from the
-original licensor to copy, distribute or modify the Program subject to
-these terms and conditions.  You may not impose any further
-restrictions on the recipients' exercise of the rights granted herein.
-You are not responsible for enforcing compliance by third parties to
-this License.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-  7. If, as a consequence of a court judgment or allegation of patent
-infringement or for any other reason (not limited to patent issues),
-conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot
-distribute so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you
-may not distribute the Program at all.  For example, if a patent
-license would not permit royalty-free redistribution of the Program by
-all those who receive copies directly or indirectly through you, then
-the only way you could satisfy both it and this License would be to
-refrain entirely from distribution of the Program.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-If any portion of this section is held invalid or unenforceable under
-any particular circumstance, the balance of the section is intended to
-apply and the section as a whole is intended to apply in other
-circumstances.
-
-It is not the purpose of this section to induce you to infringe any
-patents or other property right claims or to contest validity of any
-such claims; this section has the sole purpose of protecting the
-integrity of the free software distribution system, which is
-implemented by public license practices.  Many people have made
-generous contributions to the wide range of software distributed
-through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
-to distribute software through any other system and a licensee cannot
-impose that choice.
-
-This section is intended to make thoroughly clear what is believed to
-be a consequence of the rest of this License.
-
-  8. If the distribution and/or use of the Program is restricted in
-certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Program under this License
-may add an explicit geographical distribution limitation excluding
-those countries, so that distribution is permitted only in or among
-countries not thus excluded.  In such case, this License incorporates
-the limitation as if written in the body of this License.
-
-  9. The Free Software Foundation may publish revised and/or new versions
-of the General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
-
-Each version is given a distinguishing version number.  If the Program
-specifies a version number of this License which applies to it and "any
-later version", you have the option of following the terms and conditions
-either of that version or of any later version published by the Free
-Software Foundation.  If the Program does not specify a version number of
-this License, you may choose any version ever published by the Free Software
-Foundation.
-
-  10. If you wish to incorporate parts of the Program into other free
-programs whose distribution conditions are different, write to the author
-to ask for permission.  For software which is copyrighted by the Free
-Software Foundation, write to the Free Software Foundation; we sometimes
-make exceptions for this.  Our decision will be guided by the two goals
-of preserving the free status of all derivatives of our free software and
-of promoting the sharing and reuse of software generally.
-
-                            NO WARRANTY
-
-  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
-FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
-OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
-PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
-OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
-TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
-PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
-REPAIR OR CORRECTION.
-
-  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
-REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
-INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
-OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
-TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
-YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
-PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES.
-
-                     END OF TERMS AND CONDITIONS
-
-            How to Apply These Terms to Your New Programs
-
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-convey the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
-Also add information on how to contact you by electronic and paper mail.
-
-If the program is interactive, make it output a short notice like this
-when it starts in an interactive mode:
-
-    Gnomovision version 69, Copyright (C) year name of author
-    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, the commands you use may
-be called something other than `show w' and `show c'; they could even be
-mouse-clicks or menu items--whatever suits your program.
-
-You should also get your employer (if you work as a programmer) or your
-school, if any, to sign a "copyright disclaimer" for the program, if
-necessary.  Here is a sample; alter the names:
-
-  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
-  `Gnomovision' (which makes passes at compilers) written by James Hacker.
-
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
-
-This General Public License does not permit incorporating your program into
-proprietary programs.  If your program is a subroutine library, you may
-consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/userspace/sysdig/chisels/ansiterminal.lua
+++ b/userspace/sysdig/chisels/ansiterminal.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/ansiterminal.lua
+++ b/userspace/sysdig/chisels/ansiterminal.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/ansiterminal.lua
+++ b/userspace/sysdig/chisels/ansiterminal.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 local pairs = pairs

--- a/userspace/sysdig/chisels/around.lua
+++ b/userspace/sysdig/chisels/around.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/around.lua
+++ b/userspace/sysdig/chisels/around.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/around.lua
+++ b/userspace/sysdig/chisels/around.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/bottlenecks.lua
+++ b/userspace/sysdig/chisels/bottlenecks.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/bottlenecks.lua
+++ b/userspace/sysdig/chisels/bottlenecks.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- The number of items to show

--- a/userspace/sysdig/chisels/bottlenecks.lua
+++ b/userspace/sysdig/chisels/bottlenecks.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/common.lua
+++ b/userspace/sysdig/chisels/common.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/common.lua
+++ b/userspace/sysdig/chisels/common.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 --[[

--- a/userspace/sysdig/chisels/common.lua
+++ b/userspace/sysdig/chisels/common.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/echo_fds.lua
+++ b/userspace/sysdig/chisels/echo_fds.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/echo_fds.lua
+++ b/userspace/sysdig/chisels/echo_fds.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/echo_fds.lua
+++ b/userspace/sysdig/chisels/echo_fds.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/fdbytes_by.lua
+++ b/userspace/sysdig/chisels/fdbytes_by.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/fdbytes_by.lua
+++ b/userspace/sysdig/chisels/fdbytes_by.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/fdbytes_by.lua
+++ b/userspace/sysdig/chisels/fdbytes_by.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/fdcount_by.lua
+++ b/userspace/sysdig/chisels/fdcount_by.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/fdcount_by.lua
+++ b/userspace/sysdig/chisels/fdcount_by.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/fdcount_by.lua
+++ b/userspace/sysdig/chisels/fdcount_by.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/fdtime_by.lua
+++ b/userspace/sysdig/chisels/fdtime_by.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/fdtime_by.lua
+++ b/userspace/sysdig/chisels/fdtime_by.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/fdtime_by.lua
+++ b/userspace/sysdig/chisels/fdtime_by.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/fileslower.lua
+++ b/userspace/sysdig/chisels/fileslower.lua
@@ -1,4 +1,23 @@
 --[[
+Copyright (C) 2014 Brendan Gregg.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
+--[[
 fileslower.lua - trace file I/O slower than a given threshold.
 
 USAGE: sysdig -c fileslower min_ms
@@ -15,19 +34,6 @@ chisel to change this behavior.
 Note: The file I/O traced is those matched by the sysdig filter:
 "evt.is_io=true and fd.type=file".
 
-Copyright (C) 2014 Brendan Gregg.
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/flame.lua
+++ b/userspace/sysdig/chisels/flame.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/flame.lua
+++ b/userspace/sysdig/chisels/flame.lua
@@ -1,18 +1,22 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
+
 
 -- Chisel description
 disabled_description = "Flame graph generator";

--- a/userspace/sysdig/chisels/flame.lua
+++ b/userspace/sysdig/chisels/flame.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/http.lua
+++ b/userspace/sysdig/chisels/http.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2015 Luca Marturana
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Common function used by http parsing chisels

--- a/userspace/sysdig/chisels/http.lua
+++ b/userspace/sysdig/chisels/http.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/http.lua
+++ b/userspace/sysdig/chisels/http.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/httplog.lua
+++ b/userspace/sysdig/chisels/httplog.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/httplog.lua
+++ b/userspace/sysdig/chisels/httplog.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/httplog.lua
+++ b/userspace/sysdig/chisels/httplog.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2015 Luca Marturana
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/httptop.lua
+++ b/userspace/sysdig/chisels/httptop.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/httptop.lua
+++ b/userspace/sysdig/chisels/httptop.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/httptop.lua
+++ b/userspace/sysdig/chisels/httptop.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2015 Luca Marturana
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/iobytes.lua
+++ b/userspace/sysdig/chisels/iobytes.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/iobytes.lua
+++ b/userspace/sysdig/chisels/iobytes.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/iobytes.lua
+++ b/userspace/sysdig/chisels/iobytes.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/iobytes_file.lua
+++ b/userspace/sysdig/chisels/iobytes_file.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/iobytes_file.lua
+++ b/userspace/sysdig/chisels/iobytes_file.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/iobytes_file.lua
+++ b/userspace/sysdig/chisels/iobytes_file.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/iobytes_net.lua
+++ b/userspace/sysdig/chisels/iobytes_net.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/iobytes_net.lua
+++ b/userspace/sysdig/chisels/iobytes_net.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/iobytes_net.lua
+++ b/userspace/sysdig/chisels/iobytes_net.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/list_login_shells.lua
+++ b/userspace/sysdig/chisels/list_login_shells.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/list_login_shells.lua
+++ b/userspace/sysdig/chisels/list_login_shells.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/list_login_shells.lua
+++ b/userspace/sysdig/chisels/list_login_shells.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/lscontainers.lua
+++ b/userspace/sysdig/chisels/lscontainers.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/lscontainers.lua
+++ b/userspace/sysdig/chisels/lscontainers.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/lscontainers.lua
+++ b/userspace/sysdig/chisels/lscontainers.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/lsof.lua
+++ b/userspace/sysdig/chisels/lsof.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/lsof.lua
+++ b/userspace/sysdig/chisels/lsof.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/lsof.lua
+++ b/userspace/sysdig/chisels/lsof.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/memcachelog.lua
+++ b/userspace/sysdig/chisels/memcachelog.lua
@@ -1,4 +1,24 @@
 --[[
+
+Copyright (C) 2015 Donatas Abraitis.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
+--[[
 memcachelog.lua - show most used memcached keys.
 
 USAGE: sysdig -c memcachelog <get|set>
@@ -10,20 +30,6 @@ USAGE: sysdig -c memcachelog <get|set>
   sysdig -c memcachelog 'set 1000'  # show memcached set utilization which object's size is higher than 1000
 
 By default it will print both methods.
-
-Copyright (C) 2015 Donatas Abraitis.
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/netlower.lua
+++ b/userspace/sysdig/chisels/netlower.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/netlower.lua
+++ b/userspace/sysdig/chisels/netlower.lua
@@ -1,4 +1,23 @@
 --[[
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
+--[[
 netlower.lua - trace network I/O slower than a given threshold.
 
 USAGE: sysdig -c netlower min_ms
@@ -8,20 +27,6 @@ USAGE: sysdig -c netlower min_ms
    sysdig -c netlower "1 disable_colors"	# show network I/O slower than 1 ms. w/ no colors
    sysdig -c netlower 1000				  # show network I/O slower than 1000 ms and container output
 
-Copyright (C) 2013-2014 Draios inc.
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
-
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/netlower.lua
+++ b/userspace/sysdig/chisels/netlower.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/netstat.lua
+++ b/userspace/sysdig/chisels/netstat.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/netstat.lua
+++ b/userspace/sysdig/chisels/netstat.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/netstat.lua
+++ b/userspace/sysdig/chisels/netstat.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/proc_exec_time.lua
+++ b/userspace/sysdig/chisels/proc_exec_time.lua
@@ -1,25 +1,29 @@
 --[[
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
+--[[
 USAGE: sysdig -c proc_exec_time
    eg,
 
    sysdig -c proc_exec_time				 # show processes that have finished
    sysdig -c proc_exec_time disable_colors" # show processes that have finished w/ no colors
    sysdig -pc -c proc_exec_time			 # show processes that have finished and container output
-
-Copyright (C) 2014 Draios inc.
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
-
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --]]
 
 -- Chisel description
@@ -105,7 +109,7 @@ function on_event()
 
 	if duration ~= nil then
 		local color = terminal.green
-	
+
 		if duration > THRESHOLD_RED_NS then
 			color = terminal.red
 		elseif duration > THRESHOLD_YELLOW_NS then

--- a/userspace/sysdig/chisels/proc_exec_time.lua
+++ b/userspace/sysdig/chisels/proc_exec_time.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/proc_exec_time.lua
+++ b/userspace/sysdig/chisels/proc_exec_time.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/ps.lua
+++ b/userspace/sysdig/chisels/ps.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/ps.lua
+++ b/userspace/sysdig/chisels/ps.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/ps.lua
+++ b/userspace/sysdig/chisels/ps.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/scallslower.lua
+++ b/userspace/sysdig/chisels/scallslower.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/scallslower.lua
+++ b/userspace/sysdig/chisels/scallslower.lua
@@ -1,4 +1,23 @@
 --[[
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
+--[[
 scallslower.lua - trace the syscalls slower than a given threshold.
 
 USAGE: sysdig -c scallslower min_ms
@@ -8,20 +27,6 @@ USAGE: sysdig -c scallslower min_ms
    sysdig -c scallslower "1 disable_colors" # show syscalls slower than 1 ms. w/ no colors
    sysdig -pc -c scallslower 1000		   # show syscalls slower than 1000 ms and container output
 
-Copyright (C) 2013-2014 Draios inc.
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
-
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/scallslower.lua
+++ b/userspace/sysdig/chisels/scallslower.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/shellshock_detect.lua
+++ b/userspace/sysdig/chisels/shellshock_detect.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/shellshock_detect.lua
+++ b/userspace/sysdig/chisels/shellshock_detect.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/shellshock_detect.lua
+++ b/userspace/sysdig/chisels/shellshock_detect.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spectrogram.lua
+++ b/userspace/sysdig/chisels/spectrogram.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/spectrogram.lua
+++ b/userspace/sysdig/chisels/spectrogram.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spectrogram.lua
+++ b/userspace/sysdig/chisels/spectrogram.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spy_file.lua
+++ b/userspace/sysdig/chisels/spy_file.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spy_file.lua
+++ b/userspace/sysdig/chisels/spy_file.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/spy_file.lua
+++ b/userspace/sysdig/chisels/spy_file.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spy_ip.lua
+++ b/userspace/sysdig/chisels/spy_ip.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/spy_ip.lua
+++ b/userspace/sysdig/chisels/spy_ip.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spy_ip.lua
+++ b/userspace/sysdig/chisels/spy_ip.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spy_logs.lua
+++ b/userspace/sysdig/chisels/spy_logs.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spy_logs.lua
+++ b/userspace/sysdig/chisels/spy_logs.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Edit this to change which files are watched by this chisel

--- a/userspace/sysdig/chisels/spy_logs.lua
+++ b/userspace/sysdig/chisels/spy_logs.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spy_port.lua
+++ b/userspace/sysdig/chisels/spy_port.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/spy_port.lua
+++ b/userspace/sysdig/chisels/spy_port.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spy_port.lua
+++ b/userspace/sysdig/chisels/spy_port.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spy_syslog.lua
+++ b/userspace/sysdig/chisels/spy_syslog.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spy_syslog.lua
+++ b/userspace/sysdig/chisels/spy_syslog.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/spy_syslog.lua
+++ b/userspace/sysdig/chisels/spy_syslog.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spy_users.lua
+++ b/userspace/sysdig/chisels/spy_users.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/spy_users.lua
+++ b/userspace/sysdig/chisels/spy_users.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/spy_users.lua
+++ b/userspace/sysdig/chisels/spy_users.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/statsd.lua
+++ b/userspace/sysdig/chisels/statsd.lua
@@ -1,3 +1,22 @@
+--[[
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
 -- Statsd client
 --
 -- For statsd protocol info: https://github.com/b/statsd_spec

--- a/userspace/sysdig/chisels/statsd.lua
+++ b/userspace/sysdig/chisels/statsd.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/statsd.lua
+++ b/userspace/sysdig/chisels/statsd.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/stderr.lua
+++ b/userspace/sysdig/chisels/stderr.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/stderr.lua
+++ b/userspace/sysdig/chisels/stderr.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/stderr.lua
+++ b/userspace/sysdig/chisels/stderr.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/stdin.lua
+++ b/userspace/sysdig/chisels/stdin.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/stdin.lua
+++ b/userspace/sysdig/chisels/stdin.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/stdin.lua
+++ b/userspace/sysdig/chisels/stdin.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/stdout.lua
+++ b/userspace/sysdig/chisels/stdout.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/stdout.lua
+++ b/userspace/sysdig/chisels/stdout.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/stdout.lua
+++ b/userspace/sysdig/chisels/stdout.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/subsecoffset.lua
+++ b/userspace/sysdig/chisels/subsecoffset.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 Copyright (C) 2015 Brendan Gregg.
 
 This file is part of sysdig.

--- a/userspace/sysdig/chisels/subsecoffset.lua
+++ b/userspace/sysdig/chisels/subsecoffset.lua
@@ -1,18 +1,21 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 Copyright (C) 2015 Brendan Gregg.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/table_generator.lua
+++ b/userspace/sysdig/chisels/table_generator.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/table_generator.lua
+++ b/userspace/sysdig/chisels/table_generator.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/table_generator.lua
+++ b/userspace/sysdig/chisels/table_generator.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topconns.lua
+++ b/userspace/sysdig/chisels/topconns.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topconns.lua
+++ b/userspace/sysdig/chisels/topconns.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topconns.lua
+++ b/userspace/sysdig/chisels/topconns.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topcontainers_cpu.lua
+++ b/userspace/sysdig/chisels/topcontainers_cpu.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topcontainers_cpu.lua
+++ b/userspace/sysdig/chisels/topcontainers_cpu.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topcontainers_cpu.lua
+++ b/userspace/sysdig/chisels/topcontainers_cpu.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topcontainers_error.lua
+++ b/userspace/sysdig/chisels/topcontainers_error.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topcontainers_error.lua
+++ b/userspace/sysdig/chisels/topcontainers_error.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topcontainers_error.lua
+++ b/userspace/sysdig/chisels/topcontainers_error.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topcontainers_file.lua
+++ b/userspace/sysdig/chisels/topcontainers_file.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topcontainers_file.lua
+++ b/userspace/sysdig/chisels/topcontainers_file.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topcontainers_file.lua
+++ b/userspace/sysdig/chisels/topcontainers_file.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topcontainers_net.lua
+++ b/userspace/sysdig/chisels/topcontainers_net.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topcontainers_net.lua
+++ b/userspace/sysdig/chisels/topcontainers_net.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topcontainers_net.lua
+++ b/userspace/sysdig/chisels/topcontainers_net.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topfiles_bytes.lua
+++ b/userspace/sysdig/chisels/topfiles_bytes.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topfiles_bytes.lua
+++ b/userspace/sysdig/chisels/topfiles_bytes.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topfiles_bytes.lua
+++ b/userspace/sysdig/chisels/topfiles_bytes.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topfiles_errors.lua
+++ b/userspace/sysdig/chisels/topfiles_errors.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topfiles_errors.lua
+++ b/userspace/sysdig/chisels/topfiles_errors.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topfiles_errors.lua
+++ b/userspace/sysdig/chisels/topfiles_errors.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topfiles_time.lua
+++ b/userspace/sysdig/chisels/topfiles_time.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topfiles_time.lua
+++ b/userspace/sysdig/chisels/topfiles_time.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topfiles_time.lua
+++ b/userspace/sysdig/chisels/topfiles_time.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topports_server.lua
+++ b/userspace/sysdig/chisels/topports_server.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topports_server.lua
+++ b/userspace/sysdig/chisels/topports_server.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topports_server.lua
+++ b/userspace/sysdig/chisels/topports_server.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topprocs_cpu.lua
+++ b/userspace/sysdig/chisels/topprocs_cpu.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topprocs_cpu.lua
+++ b/userspace/sysdig/chisels/topprocs_cpu.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topprocs_cpu.lua
+++ b/userspace/sysdig/chisels/topprocs_cpu.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topprocs_errors.lua
+++ b/userspace/sysdig/chisels/topprocs_errors.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topprocs_errors.lua
+++ b/userspace/sysdig/chisels/topprocs_errors.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topprocs_errors.lua
+++ b/userspace/sysdig/chisels/topprocs_errors.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topprocs_file.lua
+++ b/userspace/sysdig/chisels/topprocs_file.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topprocs_file.lua
+++ b/userspace/sysdig/chisels/topprocs_file.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topprocs_file.lua
+++ b/userspace/sysdig/chisels/topprocs_file.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topprocs_net.lua
+++ b/userspace/sysdig/chisels/topprocs_net.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topprocs_net.lua
+++ b/userspace/sysdig/chisels/topprocs_net.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topprocs_net.lua
+++ b/userspace/sysdig/chisels/topprocs_net.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/topscalls.lua
+++ b/userspace/sysdig/chisels/topscalls.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topscalls.lua
+++ b/userspace/sysdig/chisels/topscalls.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- The number of items to show

--- a/userspace/sysdig/chisels/topscalls.lua
+++ b/userspace/sysdig/chisels/topscalls.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topscalls_time.lua
+++ b/userspace/sysdig/chisels/topscalls_time.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/topscalls_time.lua
+++ b/userspace/sysdig/chisels/topscalls_time.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- The number of items to show

--- a/userspace/sysdig/chisels/topscalls_time.lua
+++ b/userspace/sysdig/chisels/topscalls_time.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/tracers_2_statsd.lua
+++ b/userspace/sysdig/chisels/tracers_2_statsd.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/tracers_2_statsd.lua
+++ b/userspace/sysdig/chisels/tracers_2_statsd.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/tracers_2_statsd.lua
+++ b/userspace/sysdig/chisels/tracers_2_statsd.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_backlog.lua
+++ b/userspace/sysdig/chisels/v_backlog.lua
@@ -1,18 +1,21 @@
 --[[
-Copyright (C) Donatas Abraitis.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2015 Donatas Abraitis.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info =

--- a/userspace/sysdig/chisels/v_connections.lua
+++ b/userspace/sysdig/chisels/v_connections.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_connections.lua
+++ b/userspace/sysdig/chisels/v_connections.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_connections.lua
+++ b/userspace/sysdig/chisels/v_connections.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_containers.lua
+++ b/userspace/sysdig/chisels/v_containers.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_containers.lua
+++ b/userspace/sysdig/chisels/v_containers.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_containers.lua
+++ b/userspace/sysdig/chisels/v_containers.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_containers_errors.lua
+++ b/userspace/sysdig/chisels/v_containers_errors.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_containers_errors.lua
+++ b/userspace/sysdig/chisels/v_containers_errors.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_containers_errors.lua
+++ b/userspace/sysdig/chisels/v_containers_errors.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_cpus.lua
+++ b/userspace/sysdig/chisels/v_cpus.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_cpus.lua
+++ b/userspace/sysdig/chisels/v_cpus.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_infoz = 

--- a/userspace/sysdig/chisels/v_cpus.lua
+++ b/userspace/sysdig/chisels/v_cpus.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_directories.lua
+++ b/userspace/sysdig/chisels/v_directories.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_directories.lua
+++ b/userspace/sysdig/chisels/v_directories.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_directories.lua
+++ b/userspace/sysdig/chisels/v_directories.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_docker_events.lua
+++ b/userspace/sysdig/chisels/v_docker_events.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_docker_events.lua
+++ b/userspace/sysdig/chisels/v_docker_events.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_docker_events.lua
+++ b/userspace/sysdig/chisels/v_docker_events.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_errors.lua
+++ b/userspace/sysdig/chisels/v_errors.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_errors.lua
+++ b/userspace/sysdig/chisels/v_errors.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_errors.lua
+++ b/userspace/sysdig/chisels/v_errors.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_file_opens.lua
+++ b/userspace/sysdig/chisels/v_file_opens.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_file_opens.lua
+++ b/userspace/sysdig/chisels/v_file_opens.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_file_opens.lua
+++ b/userspace/sysdig/chisels/v_file_opens.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_files.lua
+++ b/userspace/sysdig/chisels/v_files.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_files.lua
+++ b/userspace/sysdig/chisels/v_files.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_files.lua
+++ b/userspace/sysdig/chisels/v_files.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_incoming_connections.lua
+++ b/userspace/sysdig/chisels/v_incoming_connections.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_incoming_connections.lua
+++ b/userspace/sysdig/chisels/v_incoming_connections.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_incoming_connections.lua
+++ b/userspace/sysdig/chisels/v_incoming_connections.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_io_by_type.lua
+++ b/userspace/sysdig/chisels/v_io_by_type.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_io_by_type.lua
+++ b/userspace/sysdig/chisels/v_io_by_type.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_io_by_type.lua
+++ b/userspace/sysdig/chisels/v_io_by_type.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_kubernetes_controllers.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_controllers.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_kubernetes_controllers.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_controllers.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_kubernetes_controllers.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_controllers.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_kubernetes_deployments.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_deployments.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_kubernetes_deployments.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_deployments.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_kubernetes_deployments.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_deployments.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_kubernetes_namespaces.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_namespaces.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_kubernetes_namespaces.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_namespaces.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_kubernetes_namespaces.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_namespaces.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_kubernetes_pods.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_pods.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_kubernetes_pods.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_pods.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_kubernetes_pods.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_pods.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_kubernetes_replicasets.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_replicasets.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_kubernetes_replicasets.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_replicasets.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_kubernetes_replicasets.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_replicasets.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_kubernetes_services.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_services.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_kubernetes_services.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_services.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_kubernetes_services.lua
+++ b/userspace/sysdig/chisels/v_kubernetes_services.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_marathon_apps.lua
+++ b/userspace/sysdig/chisels/v_marathon_apps.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_marathon_apps.lua
+++ b/userspace/sysdig/chisels/v_marathon_apps.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_marathon_apps.lua
+++ b/userspace/sysdig/chisels/v_marathon_apps.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_marathon_groups.lua
+++ b/userspace/sysdig/chisels/v_marathon_groups.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_marathon_groups.lua
+++ b/userspace/sysdig/chisels/v_marathon_groups.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_marathon_groups.lua
+++ b/userspace/sysdig/chisels/v_marathon_groups.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_mesos_frameworks.lua
+++ b/userspace/sysdig/chisels/v_mesos_frameworks.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_mesos_frameworks.lua
+++ b/userspace/sysdig/chisels/v_mesos_frameworks.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_mesos_frameworks.lua
+++ b/userspace/sysdig/chisels/v_mesos_frameworks.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_mesos_tasks.lua
+++ b/userspace/sysdig/chisels/v_mesos_tasks.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_mesos_tasks.lua
+++ b/userspace/sysdig/chisels/v_mesos_tasks.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_mesos_tasks.lua
+++ b/userspace/sysdig/chisels/v_mesos_tasks.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_notifications.lua
+++ b/userspace/sysdig/chisels/v_notifications.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_notifications.lua
+++ b/userspace/sysdig/chisels/v_notifications.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_notifications.lua
+++ b/userspace/sysdig/chisels/v_notifications.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_page_faults.lua
+++ b/userspace/sysdig/chisels/v_page_faults.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_page_faults.lua
+++ b/userspace/sysdig/chisels/v_page_faults.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_page_faults.lua
+++ b/userspace/sysdig/chisels/v_page_faults.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_port_bindings.lua
+++ b/userspace/sysdig/chisels/v_port_bindings.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_port_bindings.lua
+++ b/userspace/sysdig/chisels/v_port_bindings.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_port_bindings.lua
+++ b/userspace/sysdig/chisels/v_port_bindings.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2017 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_procs.lua
+++ b/userspace/sysdig/chisels/v_procs.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_procs.lua
+++ b/userspace/sysdig/chisels/v_procs.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_procs.lua
+++ b/userspace/sysdig/chisels/v_procs.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_procs_cpu.lua
+++ b/userspace/sysdig/chisels/v_procs_cpu.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_procs_cpu.lua
+++ b/userspace/sysdig/chisels/v_procs_cpu.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_procs_cpu.lua
+++ b/userspace/sysdig/chisels/v_procs_cpu.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_procs_errors.lua
+++ b/userspace/sysdig/chisels/v_procs_errors.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_procs_errors.lua
+++ b/userspace/sysdig/chisels/v_procs_errors.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_procs_errors.lua
+++ b/userspace/sysdig/chisels/v_procs_errors.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_procs_fd_usage.lua
+++ b/userspace/sysdig/chisels/v_procs_fd_usage.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_procs_fd_usage.lua
+++ b/userspace/sysdig/chisels/v_procs_fd_usage.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_procs_fd_usage.lua
+++ b/userspace/sysdig/chisels/v_procs_fd_usage.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_slow_io.lua
+++ b/userspace/sysdig/chisels/v_slow_io.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_slow_io.lua
+++ b/userspace/sysdig/chisels/v_slow_io.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_slow_io.lua
+++ b/userspace/sysdig/chisels/v_slow_io.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2017 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_spans_list.lua
+++ b/userspace/sysdig/chisels/v_spans_list.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spans_list.lua
+++ b/userspace/sysdig/chisels/v_spans_list.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info =

--- a/userspace/sysdig/chisels/v_spans_list.lua
+++ b/userspace/sysdig/chisels/v_spans_list.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spans_summary.lua
+++ b/userspace/sysdig/chisels/v_spans_summary.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spans_summary.lua
+++ b/userspace/sysdig/chisels/v_spans_summary.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info =

--- a/userspace/sysdig/chisels/v_spans_summary.lua
+++ b/userspace/sysdig/chisels/v_spans_summary.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spectro_all.lua
+++ b/userspace/sysdig/chisels/v_spectro_all.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 view_info = 
 {

--- a/userspace/sysdig/chisels/v_spectro_all.lua
+++ b/userspace/sysdig/chisels/v_spectro_all.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spectro_all.lua
+++ b/userspace/sysdig/chisels/v_spectro_all.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spectro_file.lua
+++ b/userspace/sysdig/chisels/v_spectro_file.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 view_info = 
 {

--- a/userspace/sysdig/chisels/v_spectro_file.lua
+++ b/userspace/sysdig/chisels/v_spectro_file.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spectro_file.lua
+++ b/userspace/sysdig/chisels/v_spectro_file.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spectro_traces.lua
+++ b/userspace/sysdig/chisels/v_spectro_traces.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spectro_traces.lua
+++ b/userspace/sysdig/chisels/v_spectro_traces.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 view_info =
 {

--- a/userspace/sysdig/chisels/v_spectro_traces.lua
+++ b/userspace/sysdig/chisels/v_spectro_traces.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_sports.lua
+++ b/userspace/sysdig/chisels/v_sports.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_sports.lua
+++ b/userspace/sysdig/chisels/v_sports.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_sports.lua
+++ b/userspace/sysdig/chisels/v_sports.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spy_syslog.lua
+++ b/userspace/sysdig/chisels/v_spy_syslog.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_spy_syslog.lua
+++ b/userspace/sysdig/chisels/v_spy_syslog.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spy_syslog.lua
+++ b/userspace/sysdig/chisels/v_spy_syslog.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spy_users.lua
+++ b/userspace/sysdig/chisels/v_spy_users.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spy_users.lua
+++ b/userspace/sysdig/chisels/v_spy_users.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_spy_users.lua
+++ b/userspace/sysdig/chisels/v_spy_users.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spy_users_wsysdig.lua
+++ b/userspace/sysdig/chisels/v_spy_users_wsysdig.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_spy_users_wsysdig.lua
+++ b/userspace/sysdig/chisels/v_spy_users_wsysdig.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_spy_users_wsysdig.lua
+++ b/userspace/sysdig/chisels/v_spy_users_wsysdig.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_syscall_procs.lua
+++ b/userspace/sysdig/chisels/v_syscall_procs.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_syscall_procs.lua
+++ b/userspace/sysdig/chisels/v_syscall_procs.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_syscall_procs.lua
+++ b/userspace/sysdig/chisels/v_syscall_procs.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_syscalls.lua
+++ b/userspace/sysdig/chisels/v_syscalls.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_syscalls.lua
+++ b/userspace/sysdig/chisels/v_syscalls.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_syscalls.lua
+++ b/userspace/sysdig/chisels/v_syscalls.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_threads.lua
+++ b/userspace/sysdig/chisels/v_threads.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_threads.lua
+++ b/userspace/sysdig/chisels/v_threads.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2014 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info = 

--- a/userspace/sysdig/chisels/v_threads.lua
+++ b/userspace/sysdig/chisels/v_threads.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_traces_list.lua
+++ b/userspace/sysdig/chisels/v_traces_list.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_traces_list.lua
+++ b/userspace/sysdig/chisels/v_traces_list.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info =

--- a/userspace/sysdig/chisels/v_traces_list.lua
+++ b/userspace/sysdig/chisels/v_traces_list.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_traces_summary.lua
+++ b/userspace/sysdig/chisels/v_traces_summary.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/v_traces_summary.lua
+++ b/userspace/sysdig/chisels/v_traces_summary.lua
@@ -1,18 +1,20 @@
 --[[
-Copyright (C) 2013-2015 Draios inc.
- 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (C) 2018 Draios inc.
 
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 view_info =

--- a/userspace/sysdig/chisels/v_traces_summary.lua
+++ b/userspace/sysdig/chisels/v_traces_summary.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/wsysdig_summary.lua
+++ b/userspace/sysdig/chisels/wsysdig_summary.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/chisels/wsysdig_summary.lua
+++ b/userspace/sysdig/chisels/wsysdig_summary.lua
@@ -1,17 +1,20 @@
 --[[
-Copyright (C) 2017 Draios inc.
+Copyright (C) 2018 Draios inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+This file is part of sysdig.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 --]]
 
 -- Chisel description

--- a/userspace/sysdig/chisels/wsysdig_summary.lua
+++ b/userspace/sysdig/chisels/wsysdig_summary.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/config_sysdig.h.in
+++ b/userspace/sysdig/config_sysdig.h.in
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/config_sysdig.h.in
+++ b/userspace/sysdig/config_sysdig.h.in
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2018 Draios inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #pragma once
 
 #define SYSDIG_VERSION "${SYSDIG_VERSION}"

--- a/userspace/sysdig/config_sysdig.h.in
+++ b/userspace/sysdig/config_sysdig.h.in
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #define __STDC_FORMAT_MACROS

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/fields_info.cpp
+++ b/userspace/sysdig/fields_info.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/fields_info.cpp
+++ b/userspace/sysdig/fields_info.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 //

--- a/userspace/sysdig/fields_info.cpp
+++ b/userspace/sysdig/fields_info.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/man/CMakeLists.txt
+++ b/userspace/sysdig/man/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/userspace/sysdig/man/CMakeLists.txt
+++ b/userspace/sysdig/man/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/userspace/sysdig/man/CMakeLists.txt
+++ b/userspace/sysdig/man/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 find_program(PANDOC pandoc)
 
 if (PANDOC)

--- a/userspace/sysdig/man/build.sh
+++ b/userspace/sysdig/man/build.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc.
 #
 # This file is part of sysdig .
 #

--- a/userspace/sysdig/man/build.sh
+++ b/userspace/sysdig/man/build.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc.
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #

--- a/userspace/sysdig/man/build.sh
+++ b/userspace/sysdig/man/build.sh
@@ -1,2 +1,19 @@
+#
+# Copyright (C) 2018 Draios Inc.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 pandoc -s -f markdown_github -t man sysdig.md -o sysdig.8
 pandoc -s -f markdown_github -t man csysdig.md -o csysdig.8

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #define __STDC_FORMAT_MACROS

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/sysdig.h
+++ b/userspace/sysdig/sysdig.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018 Draios inc.
+Copyright (C) 2013-2018 Draios inc.
 
 This file is part of sysdig.
 

--- a/userspace/sysdig/sysdig.h
+++ b/userspace/sysdig/sysdig.h
@@ -1,19 +1,20 @@
 /*
-Copyright (C) 2013-2014 Draios inc.
+Copyright (C) 2018 Draios inc.
 
 This file is part of sysdig.
 
-sysdig is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-sysdig is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with sysdig.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 */
 
 #pragma once

--- a/userspace/sysdig/sysdig.h
+++ b/userspace/sysdig/sysdig.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2018 Draios inc.
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 


### PR DESCRIPTION
Change sysdig's license for userspace code from gplv2 to apache 2.

Change the driver code from gpl to dual-licensed gplv2 and mit.

These changes show allow for license compatibility with falco, which is already apache 2 licensed.