### PR TITLE
Support 4.14.0 - 4.14.3 kernels in eBPF.

### DIFF
--- a/driver/bpf/quirks.h
+++ b/driver/bpf/quirks.h
@@ -7,7 +7,7 @@
 #error Kernel version must be >= 4.14 with eBPF enabled
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 4)
 #define randomized_struct_fields_start  struct {
 #define randomized_struct_fields_end    };
 #endif


### PR DESCRIPTION
While testing COS, I noticed that we don't properly support kernels in the
4.14.0 - 4.14.3 range (included), since they don't include the backport
patch done in https://github.com/torvalds/linux/commit/4ca59b14e588f873795a11cdc77a25c686a29d23,
which was backported starting from 4.14.4.