### PR TITLE
Temporary workaround for COS

### DIFF
--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -176,6 +176,9 @@ load_bpf_probe() {
 			zcat /proc/config.gz > .config
 			sed -i 's/LOCALVERSION=""/LOCALVERSION="+"/' .config
 
+			sed -i '/^#define randomized_struct_fields_start	struct {$/d' include/linux/compiler-clang.h
+			sed -i '/^#define randomized_struct_fields_end	};$/d' include/linux/compiler-clang.h
+
 			echo "* Configuring kernel"
 
 			make olddefconfig > /dev/null


### PR DESCRIPTION
COS seems to have backported an upstream patch on their 4.14 kernel, which
wrongly reintroduces the anonymous struct for
`randomized_struct_fields_start` and `randomized_struct_fields_end`, leading
to all memory accesses via `struct task_struct` become meaningless.