### PR TITLE
Add a NOTICES file

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -1,0 +1,28 @@
+Copyright (C) 2013-2018 Draios Inc. dba Sysdig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SYSDIG SUBCOMPONENTS:
+
+-The files in <driver/> and its subdirectories are used to compile the
+ kernel module and may be injected into eBPF; these are dual licensed
+ under the MIT license or the GNU General Public License 2. Copies of
+ both licenses are available in the subdirectory.
+
+-The following files are under Apache 2.0:
+
+          userspace/sysdig/chisels/fileslower.lua, Copyright (C) 2014 Brendan Gregg
+          userspace/sysdig/chisels/memcachelog.lua, Copyright (C) 2015 Donatas Abraitis
+          userspace/sysdig/chisels/subsecoffset.lua, Copryight (C) 2013-2014 Draios Inc. dba Sysdig, Copyright (C) 2015 Brendan Gregg
+          userspace/sysdig/chisels/v_backlog.lua, Copyright (C) Donatas Abraitis
+


### PR DESCRIPTION
Add a NOTICES file that points out the different licensing for the
driver subdirectory and the files copyrighted outside of sysdig.