### PR TITLE
Fixed a compile issue when trying to make the project using VS2017 on…

### DIFF
--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -18,6 +18,13 @@ limitations under the License.
 */
 
 
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "scap.h"
+#include "scap-int.h"
+#include "scap_savefile.h"
+
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/uio.h>
@@ -27,13 +34,6 @@ struct iovec {
 	size_t iov_len;     /* Number of bytes to transfer */
 };
 #endif
-
-#include <stdio.h>
-#include <stdlib.h>
-
-#include "scap.h"
-#include "scap-int.h"
-#include "scap_savefile.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -21,10 +21,6 @@ limitations under the License.
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "scap.h"
-#include "scap-int.h"
-#include "scap_savefile.h"
-
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/uio.h>
@@ -34,6 +30,10 @@ struct iovec {
 	size_t iov_len;     /* Number of bytes to transfer */
 };
 #endif
+
+#include "scap.h"
+#include "scap-int.h"
+#include "scap_savefile.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
… Win10 (x64).

`size_t` type must come after `#include <stdio.h>`. I felt it prudent to just put the conditional include after the unconditional ones. However, I also like to keep system includes before the non-system includes.