### PR TITLE
Only check out sysdig for initial invocation

### DIFF
--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -466,12 +466,12 @@ function debian_build {
 	cd ${BASEDIR}
 }
 
-checkout_sysdig
-
 if [ -z "$KERNEL_TYPE" ]; then
 	#
 	# Ubuntu build
 	#
+
+        checkout_sysdig
 
 	echo Building Ubuntu
 	DIR=$(dirname $(readlink -f $0))


### PR DESCRIPTION
Only check out the sysdig repo when KERNEL_TYPE is not defined e.g. not
when build-probe-binaries is being run from inside a olx-builder container.