### PR TITLE
Fix fd.net comparisons with in operator

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1275,6 +1275,7 @@ bool sinsp_filter_check::flt_compare(cmpop op, ppm_param_type type, void* operan
 		{
 		case PT_IPV4NET:
 		case PT_IPV6NET:
+		case PT_IPNET:
 		case PT_SOCKADDR:
 		case PT_SOCKTUPLE:
 		case PT_FDLIST:
@@ -1285,7 +1286,9 @@ bool sinsp_filter_check::flt_compare(cmpop op, ppm_param_type type, void* operan
 				if (::flt_compare(CO_EQ,
 						  type,
 						  operand1,
-						  filter_value_p(i)))
+						  filter_value_p(i),
+						  op1_len,
+						  filter_value(i).size()))
 				{
 					return true;
 				}


### PR DESCRIPTION
When we added ipv6 support, we created a new param type PT_IPNET which
represents either an ipv4 netmask or ipv6 netmask, with the size being
used to determine the ultimate type.

That means we need to account for that type when using a CO_IN operator
and switch to checking each value in turn instead of doing a set
memberhip test.

This also means we need to call flt_compare with the correct argument
sizes so the size can be used to determine whether the netmask is ipv4
or ipv6.