### PR TITLE
Fix reading scap files with PPM_ENABLE_SENTINEL enabled

### DIFF
--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1421,6 +1421,18 @@ struct ppm_evt_hdr {
 	uint16_t type; /* the event type */
 	uint32_t nparams; /* the number of parameters of the event */
 };
+
+/// Event header as stored in scap files. if PPM_ENABLE_SENTINEL is not defined,
+/// it must be identical to ppm_evt_hdr. Otherwise, it must match the *end*
+/// of ppm_evt_hdr (scap files don't have the sentinel at the beginning of the struct)
+/// see scap_next_offline() in scap_savefile.c
+struct ppm_scap_evt_hdr {
+	uint64_t ts; /* timestamp, in nanoseconds from epoch */
+	uint64_t tid; /* the tid of the thread that generated this event */
+	uint32_t len; /* the event len, including the header */
+	uint16_t type; /* the event type */
+	uint32_t nparams; /* the number of parameters of the event */
+};
 #if defined __sun
 #pragma pack()
 #else

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -2745,7 +2745,7 @@ int32_t scap_next_offline(scap_t *handle, OUT scap_evt **pevent, OUT uint16_t *p
 			return SCAP_UNEXPECTED_BLOCK;
 		}
 
-		hdr_len = sizeof(struct ppm_evt_hdr);
+		hdr_len = sizeof(struct ppm_scap_evt_hdr);
 		if(bh.block_type != EV_BLOCK_TYPE_V2 && bh.block_type != EVF_BLOCK_TYPE_V2)
 		{
 			hdr_len -= 4;
@@ -2768,7 +2768,9 @@ int32_t scap_next_offline(scap_t *handle, OUT scap_evt **pevent, OUT uint16_t *p
 			return SCAP_FAILURE;
 		}
 
-		readsize = gzread(f, handle->m_file_evt_buf, readlen);
+		// read a ppm_scap_evt_hdr struct leaving some space at the beginning of the buffer
+		// so that we can cast the whole buffer as ppm_evt_hdr
+		readsize = gzread(f, handle->m_file_evt_buf + sizeof(struct ppm_evt_hdr) - sizeof(struct ppm_scap_evt_hdr), readlen);
 		CHECK_READ_SIZE(readsize, readlen);
 
 		//


### PR DESCRIPTION
scap files don't have the sentinel stored regardless of PPM_ENABLE_SENTINEL being defined or not. This leads to scap files being loaded incorrectly when `#define PPM_ENABLE_SENTINEL`