### PR TITLE
Hotfix for PR 1260

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -848,6 +848,12 @@ void sinsp::on_new_entry_from_proc(void* context,
 				delete newti;
 				return;
 			}
+
+			sinsp_tinfo = find_thread(tid, true);
+			if (!sinsp_tinfo) {
+				ASSERT(false);
+				return;
+			}
 		}
 
 		sinsp_fdinfo_t sinsp_fdinfo;


### PR DESCRIPTION
We do need the lookup after insertion (to get a smart pointer to the threadinfo, at least)