### PR TITLE
Add -Wextra -Werror to agent build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,11 @@ if(NOT WIN32)
 
 	set(SYSDIG_DEBUG_FLAGS "-D_DEBUG")
 
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -ggdb")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -ggdb --std=c++0x")
+    set(CMAKE_SUPPRESSED_WARNINGS "-Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare -Wno-type-limits -Wno-implicit-fallthrough -Wno-format-truncation")
+    set(CMAKE_COMMON_FLAGS "-Wall -Wextra -Werror ${CMAKE_SUPPRESSED_WARNINGS} -ggdb")
+
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_COMMON_FLAGS}")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_COMMON_FLAGS} -std=c++0x")
 
 	set(CMAKE_C_FLAGS_DEBUG "${SYSDIG_DEBUG_FLAGS}")
 	set(CMAKE_CXX_FLAGS_DEBUG "${SYSDIG_DEBUG_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,12 +54,17 @@ set(PACKAGE_NAME "sysdig")
 add_definitions(-DPLATFORM_NAME="${CMAKE_SYSTEM_NAME}")
 add_definitions(-DK8S_DISABLE_THREAD)
 
+option(BUILD_WARNINGS_AS_ERRORS "Enable building with -Wextra -Werror flags")
+
 if(NOT WIN32)
 
 	set(SYSDIG_DEBUG_FLAGS "-D_DEBUG")
+	set(CMAKE_COMMON_FLAGS "-Wall -ggdb")
 
-    set(CMAKE_SUPPRESSED_WARNINGS "-Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare -Wno-type-limits -Wno-implicit-fallthrough -Wno-format-truncation")
-    set(CMAKE_COMMON_FLAGS "-Wall -Wextra -Werror ${CMAKE_SUPPRESSED_WARNINGS} -ggdb")
+	if (BUILD_WARNINGS_AS_ERRORS)
+		set(CMAKE_SUPPRESSED_WARNINGS "-Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare -Wno-type-limits -Wno-implicit-fallthrough -Wno-format-truncation")
+		set(CMAKE_COMMON_FLAGS "${CMAKE_COMMON_FLAGS} -Wextra -Werror ${CMAKE_SUPPRESSED_WARNINGS}")
+	endif()
 
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_COMMON_FLAGS}")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_COMMON_FLAGS} -std=c++0x")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if(NOT WIN32)
 	set(SYSDIG_DEBUG_FLAGS "-D_DEBUG")
 	set(CMAKE_COMMON_FLAGS "-Wall -ggdb")
 
-	if (BUILD_WARNINGS_AS_ERRORS)
+	if(BUILD_WARNINGS_AS_ERRORS)
 		set(CMAKE_SUPPRESSED_WARNINGS "-Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare -Wno-type-limits -Wno-implicit-fallthrough -Wno-format-truncation")
 		set(CMAKE_COMMON_FLAGS "${CMAKE_COMMON_FLAGS} -Wextra -Werror ${CMAKE_SUPPRESSED_WARNINGS}")
 	endif()

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -324,7 +324,6 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 #ifdef __NR_utime
 	[__NR_utime - SYSCALL_TABLE_ID0] = PPM_SC_UTIME,
 #endif
-	//[__NR_access - SYSCALL_TABLE_ID0] = PPM_SC_ACCESS,
 	[__NR_sync - SYSCALL_TABLE_ID0] = PPM_SC_SYNC,
 	[__NR_kill - SYSCALL_TABLE_ID0] = PPM_SC_KILL,
 	[__NR_rename - SYSCALL_TABLE_ID0] = PPM_SC_RENAME,
@@ -396,7 +395,6 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_mprotect - SYSCALL_TABLE_ID0] = PPM_SC_MPROTECT,
 	[__NR_init_module - SYSCALL_TABLE_ID0] = PPM_SC_INIT_MODULE,
 	[__NR_delete_module - SYSCALL_TABLE_ID0] = PPM_SC_DELETE_MODULE,
-	//[__NR_quotactl - SYSCALL_TABLE_ID0] = PPM_SC_QUOTACTL,
 	[__NR_getpgid - SYSCALL_TABLE_ID0] = PPM_SC_GETPGID,
 	[__NR_fchdir - SYSCALL_TABLE_ID0] = PPM_SC_FCHDIR,
 	[__NR_sysfs - SYSCALL_TABLE_ID0] = PPM_SC_SYSFS,

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -324,7 +324,7 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 #ifdef __NR_utime
 	[__NR_utime - SYSCALL_TABLE_ID0] = PPM_SC_UTIME,
 #endif
-	[__NR_access - SYSCALL_TABLE_ID0] = PPM_SC_ACCESS,
+	//[__NR_access - SYSCALL_TABLE_ID0] = PPM_SC_ACCESS,
 	[__NR_sync - SYSCALL_TABLE_ID0] = PPM_SC_SYNC,
 	[__NR_kill - SYSCALL_TABLE_ID0] = PPM_SC_KILL,
 	[__NR_rename - SYSCALL_TABLE_ID0] = PPM_SC_RENAME,
@@ -396,7 +396,7 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_mprotect - SYSCALL_TABLE_ID0] = PPM_SC_MPROTECT,
 	[__NR_init_module - SYSCALL_TABLE_ID0] = PPM_SC_INIT_MODULE,
 	[__NR_delete_module - SYSCALL_TABLE_ID0] = PPM_SC_DELETE_MODULE,
-	[__NR_quotactl - SYSCALL_TABLE_ID0] = PPM_SC_QUOTACTL,
+	//[__NR_quotactl - SYSCALL_TABLE_ID0] = PPM_SC_QUOTACTL,
 	[__NR_getpgid - SYSCALL_TABLE_ID0] = PPM_SC_GETPGID,
 	[__NR_fchdir - SYSCALL_TABLE_ID0] = PPM_SC_FCHDIR,
 	[__NR_sysfs - SYSCALL_TABLE_ID0] = PPM_SC_SYSFS,
@@ -454,22 +454,12 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 #endif
 /* [__NR_mmap_pgoff - SYSCALL_TABLE_ID0] = PPM_SC_NR_MMAP_PGOFF, */
 	[__NR_lchown - SYSCALL_TABLE_ID0] = PPM_SC_LCHOWN,
-	[__NR_getuid - SYSCALL_TABLE_ID0] = PPM_SC_GETUID,
-	[__NR_getgid - SYSCALL_TABLE_ID0] = PPM_SC_GETGID,
-	[__NR_geteuid - SYSCALL_TABLE_ID0] = PPM_SC_GETEUID,
-	[__NR_getegid - SYSCALL_TABLE_ID0] = PPM_SC_GETEGID,
 	[__NR_setreuid - SYSCALL_TABLE_ID0] = PPM_SC_SETREUID,
 	[__NR_setregid - SYSCALL_TABLE_ID0] = PPM_SC_SETREGID,
 	[__NR_getgroups - SYSCALL_TABLE_ID0] = PPM_SC_GETGROUPS,
 	[__NR_setgroups - SYSCALL_TABLE_ID0] = PPM_SC_SETGROUPS,
 	[__NR_fchown - SYSCALL_TABLE_ID0] = PPM_SC_FCHOWN,
-	[__NR_setresuid - SYSCALL_TABLE_ID0] = PPM_SC_SETRESUID,
-	[__NR_getresuid - SYSCALL_TABLE_ID0] = PPM_SC_GETRESUID,
-	[__NR_setresgid - SYSCALL_TABLE_ID0] = PPM_SC_SETRESGID,
-	[__NR_getresgid - SYSCALL_TABLE_ID0] = PPM_SC_GETRESGID,
 	[__NR_chown - SYSCALL_TABLE_ID0] = PPM_SC_CHOWN,
-	[__NR_setuid - SYSCALL_TABLE_ID0] = PPM_SC_SETUID,
-	[__NR_setgid - SYSCALL_TABLE_ID0] = PPM_SC_SETGID,
 	[__NR_setfsuid - SYSCALL_TABLE_ID0] = PPM_SC_SETFSUID,
 	[__NR_setfsgid - SYSCALL_TABLE_ID0] = PPM_SC_SETFSGID,
 	[__NR_pivot_root - SYSCALL_TABLE_ID0] = PPM_SC_PIVOT_ROOT,
@@ -587,9 +577,6 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 #endif
 #ifdef __NR_syncfs
 	[__NR_syncfs - SYSCALL_TABLE_ID0] = PPM_SC_SYNCFS,
-#endif
-#ifdef __NR_setns
-	[__NR_setns - SYSCALL_TABLE_ID0] = PPM_SC_SETNS,
 #endif
 	[__NR_getdents64 - SYSCALL_TABLE_ID0] =  PPM_SC_GETDENTS64,
 #ifndef __NR_socketcall

--- a/userspace/libsinsp/chisel.cpp
+++ b/userspace/libsinsp/chisel.cpp
@@ -1104,7 +1104,7 @@ void sinsp_chisel::get_chisel_list(vector<chisel_desc>* chisel_descs)
 			continue;
 		}
 
-		tinydir_dir dir;
+		tinydir_dir dir = {};
 
 		tinydir_open(&dir, it->m_dir);
 

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -4523,7 +4523,7 @@ uint8_t* sinsp_filter_check_user::extract(sinsp_evt *evt, OUT uint32_t* len, boo
 {
 	*len = 0;
 	sinsp_threadinfo* tinfo = evt->get_thread_info();
-	scap_userinfo* uinfo;
+	scap_userinfo* uinfo = nullptr;
 
 	if(tinfo == NULL)
 	{

--- a/userspace/libsinsp/sinsp_curl.h
+++ b/userspace/libsinsp/sinsp_curl.h
@@ -117,12 +117,12 @@ public:
 	{
 		return m_response_headers;
 	}
-	
-	const long get_response_code() const
+
+	long get_response_code() const
 	{
 		return m_response_code;
 	}
-	
+
 private:
 	struct data
 	{


### PR DESCRIPTION
Currently our builds include the -Wall compiler flag, which enables
some, but not all, warnings. This change adds the -Wextra flag, which
enables some additional warnings.

This change also adds -Werror, which will cause the compiler to report
any warning as an error (so now anything that generates a warning will
break the build). This change explicitly omits some pervasive warnings
(e.g., unused parameters).

Note that the change to `syscall_table.c` removed some duplicate initializations.