### PR TITLE
Changes to eliminate warnings with gcc 5.4

### DIFF
--- a/userspace/libsinsp/third-party/jsoncpp/jsoncpp.cpp
+++ b/userspace/libsinsp/third-party/jsoncpp/jsoncpp.cpp
@@ -230,7 +230,7 @@ static int       stackDepth_g = 0;  // see readValue()
 
 namespace Json {
 
-#if __GNUC__ >= 6
+#if __cplusplus >= 201103L
 typedef std::unique_ptr<CharReader> const  CharReaderPtr;
 #else
 typedef std::auto_ptr<CharReader>          CharReaderPtr;
@@ -3799,7 +3799,7 @@ Value& Path::make(Value& root) const {
 
 namespace Json {
 
-#if __GNUC__ >= 6
+#if __cplusplus >= 201103L
 typedef std::unique_ptr<StreamWriter> const  StreamWriterPtr;
 #else
 typedef std::auto_ptr<StreamWriter>          StreamWriterPtr;


### PR DESCRIPTION
Especially important when we consider all warnings errors.