### PR TITLE
Disable reading environment from /proc by default

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -126,6 +126,7 @@ sinsp::sinsp() :
 	m_file_start_offset = 0;
 	m_flush_memory_dump = false;
 	m_next_stats_print_time_ns = 0;
+	m_large_envs_enabled = false;
 
 	// Unless the cmd line arg "-pc" or "-pcontainer" is supplied this is false
 	m_print_container_data = false;
@@ -1899,6 +1900,11 @@ void sinsp::set_drop_event_flags(ppm_event_flags flags)
 sinsp_evt::param_fmt sinsp::get_buffer_format()
 {
 	return m_buffer_format;
+}
+
+void sinsp::set_large_envs(bool enable)
+{
+	m_large_envs_enabled = enable;
 }
 
 void sinsp::set_debug_mode(bool enable_debug)

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -640,6 +640,23 @@ public:
 	}
 
 	/*!
+	  \brief Returns true if truncated environments should be loaded from /proc
+	*/
+	inline bool large_envs_enabled()
+	{
+		return is_live() && m_large_envs_enabled;
+	}
+
+	/*!
+	  \brief Enable/disable large environment support
+
+	  \param enable when it is true and the current capture is live
+	  environments larger than SCAP_MAX_ENV_SIZE will be loaded
+	  from /proc/<pid>/environ (if possible)
+	*/
+	void set_large_envs(bool enable);
+
+	/*!
 	  \brief Set the debugging mode of the inspector.
 
 	  \param enable_debug when it is true and the current capture is live
@@ -1002,6 +1019,7 @@ private:
 	// restart in the middle of the file.
 	uint64_t m_file_start_offset;
 	bool m_flush_memory_dump;
+	bool m_large_envs_enabled;
 
 	sinsp_network_interfaces* m_network_interfaces;
 public:

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -519,7 +519,7 @@ void sinsp_threadinfo::set_args(const char* args, size_t len)
 
 void sinsp_threadinfo::set_env(const char* env, size_t len)
 {
-	if (len == SCAP_MAX_ENV_SIZE && m_inspector->is_live())
+	if (len == SCAP_MAX_ENV_SIZE && m_inspector->large_envs_enabled())
 	{
 		// the environment is possibly truncated, try to read from /proc
 		// this may fail for short-lived processes

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -112,6 +112,12 @@ static void usage()
 "                    ':' or '#' characters in the file name.\n"
 "                    Option can also be provided via the environment variable SYSDIG_K8S_API_CERT.\n"
 " -l, --list         List all the fields that can be used in views.\n"
+" --large-environment\n"
+"                    Support environments larger than 4KiB\n"
+"                    When the environment is larger than 4KiB, load the whole\n"
+"                    environment from /proc instead of truncating to the first 4KiB\n"
+"                    This may fail for short-lived processes and in that case\n"
+"                    the truncated environment is used instead.\n"
 " --logfile=<file>\n"
 "                    Print program logs into the given file.\n"
 " -n <num>, --numevents=<num>\n"
@@ -334,6 +340,7 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 		{"k8s-api-cert", required_argument, 0, 'K' },
 		{"json", no_argument, 0, 'j' },
 		{"interactive", optional_argument, 0, 0 },
+		{"large-environment", no_argument, 0, 0 },
 		{"list", optional_argument, 0, 'l' },
 		{"list-views", no_argument, 0, 0},
 		{"mesos-api", required_argument, 0, 'm'},
@@ -507,6 +514,10 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 					{
 						is_interactive = true;
 						output_type = sinsp_table::OT_JSON;
+					}
+					else if(optname == "large-environment")
+					{
+						inspector->set_large_envs(true);
 					}
 					else if(optname == "logfile")
 					{

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -166,6 +166,12 @@ static void usage()
 " -l, --list         List the fields that can be used for filtering and output\n"
 "                    formatting. Use -lv to get additional information for each\n"
 "                    field.\n"
+" --large-environment\n"
+"                    Support environments larger than 4KiB\n"
+"                    When the environment is larger than 4KiB, load the whole\n"
+"                    environment from /proc instead of truncating to the first 4KiB\n"
+"                    This may fail for short-lived processes and in that case\n"
+"                    the truncated environment is used instead.\n"
 " --list-markdown    like -l, but produces markdown output\n"
 " -m <url[,marathon_url]>, --mesos-api=<url[,marathon_url]>\n"
 "                    Enable Mesos support by connecting to the API server\n"
@@ -800,6 +806,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 		{"json", no_argument, 0, 'j' },
 		{"k8s-api", required_argument, 0, 'k'},
 		{"k8s-api-cert", required_argument, 0, 'K' },
+		{"large-environment", no_argument, 0, 0 },
 		{"list", no_argument, 0, 'l' },
 		{"list-events", no_argument, 0, 'L' },
 		{"list-markdown", no_argument, 0, 0 },
@@ -1205,6 +1212,11 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 			if(string(long_options[long_index].name) == "filter-proclist")
 			{
 				filter_proclist_flag = true;
+			}
+
+			if(string(long_options[long_index].name) == "large-environment")
+			{
+				inspector->set_large_envs(true);
 			}
 
 			if(string(long_options[long_index].name) == "list-markdown")


### PR DESCRIPTION
It introduces overhead that is justified only in limited cases.

Add [c]sysdig command line option --large-environment to reenable it.