### PR TITLE
Mandate type and source getters for generic events

### DIFF
--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -326,6 +326,11 @@ public:
 
 	bool falco_consider();
 
+	inline uint16_t get_source()
+	{
+		return ESRC_SINSP;
+	}
+
 // Doxygen doesn't understand VISIBILITY_PRIVATE
 #ifdef _DOXYGEN
 private:

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -53,6 +53,14 @@ enum boolop
 	BO_ANDNOT = 5,
 };
 
+enum evt_src
+{
+	ESRC_NONE = 0,
+	ESRC_SINSP = 1,
+	ESRC_K8S_AUDIT = 2,
+	ESRC_MAX = 3,
+};
+
 class gen_event
 {
 public:
@@ -71,6 +79,16 @@ public:
 
 	// Every event must expose a timestamp
 	virtual uint64_t get_ts() = 0;
+
+	/*!
+	  \brief Get the source of the event.
+	*/
+	virtual uint16_t get_source() = 0;
+
+	/*!
+	  \brief Get the type of the event.
+	*/
+	virtual uint16_t get_type() = 0;
 
 private:
 	int32_t m_check_id = 0;


### PR DESCRIPTION
Currently the generic event class serves as base class for sinsp_evt
and json_event (i.e. the k8s audit events infrastructure leverages
this class).

It would be convenient to easily determine where an event is from, and
what is its type, therefore two virtual methods are introduced:
 - get_source()
 - get_type()

Note that get_type is already implemented by the sinsp_evt class.