### PR TITLE
eBPF support for RHEL 7.6

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -283,7 +283,11 @@ static __always_inline u32 bpf_compute_snaplen(struct filler_data *data,
 		}
 	} else if (data->state->tail_ctx.evt_type == PPME_SOCKET_SENDMSG_X) {
 		struct sockaddr *usrsockaddr;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)
 		struct user_msghdr mh;
+#else
+		struct msghdr mh;
+#endif
 		unsigned long val;
 		int addrlen;
 
@@ -907,7 +911,11 @@ static __always_inline bool bpf_in_ia32_syscall()
 
 	task = (struct task_struct *)bpf_get_current_task();
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 18)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0)
+	struct thread_info *thread_info = _READ(task->stack);
+
+	status = _READ(thread_info->status);
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 18)
 	status = _READ(task->thread.status);
 #elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 	status = _READ(task->thread_info.status);

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1341,14 +1341,15 @@ static __always_inline int bpf_ppm_get_tty(struct task_struct *task)
 	return tty_nr;
 }
 
-static __always_inline struct pid *bpf_task_pid(struct task_struct *task)
-{
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0)
-	return _READ(task->pids[PIDTYPE_PID].pid);
-#else
-	return _READ(task->thread_pid);
-#endif
-}
+/* PID helpers. There's some mild duplication for the benefit of keeping
+ * ifdefs inside the functions to a minimum.
+ */
+
+static __always_inline struct pid *bpf_task_pid(struct task_struct *task);
+
+static __always_inline pid_t bpf_task_pid_nr_ns(struct task_struct *task,
+						enum pid_type type,
+						struct pid_namespace *ns);
 
 static __always_inline struct pid_namespace *bpf_ns_of_pid(struct pid *pid)
 {
@@ -1380,15 +1381,22 @@ static __always_inline pid_t bpf_pid_nr_ns(struct pid *pid,
 	return nr;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
-static __always_inline struct pid **bpf_task_pid_ptr(struct task_struct *task,
-						     enum pid_type type)
+static __always_inline pid_t bpf_pid_vnr(struct pid *pid)
 {
-	return (type == PIDTYPE_PID) ?
-		&task->thread_pid :
-		&_READ(task->signal)->pids[type];
+	return bpf_pid_nr_ns(pid, bpf_ns_of_pid(pid));
 }
-#endif
+
+static __always_inline pid_t bpf_task_pid_vnr(struct task_struct *task)
+{
+	return bpf_task_pid_nr_ns(task, PIDTYPE_PID, NULL);
+}
+
+static __always_inline pid_t bpf_task_pgrp_vnr(struct task_struct *task)
+{
+	return bpf_task_pid_nr_ns(task, PIDTYPE_PGID, NULL);
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
 
 static __always_inline pid_t bpf_task_pid_nr_ns(struct task_struct *task,
 						enum pid_type type,
@@ -1399,7 +1407,43 @@ static __always_inline pid_t bpf_task_pid_nr_ns(struct task_struct *task,
 	if (!ns)
 		ns = bpf_task_active_pid_ns(task);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0)
+	if (type != PIDTYPE_PID)
+		task = _READ(task->group_leader);
+
+	nr = bpf_pid_nr_ns(_READ(task->pids[type].pid), ns);
+
+	return nr;
+}
+
+static __always_inline struct pid *bpf_task_tgid(struct task_struct *task)
+{
+	struct task_struct *leader;
+
+	leader = _READ(task->group_leader);
+	return _READ(leader->pids[PIDTYPE_PID].pid);
+}
+
+static __always_inline struct pid *bpf_task_pid(struct task_struct *task)
+{
+	return _READ(task->pids[PIDTYPE_PID].pid);
+}
+
+static __always_inline pid_t bpf_task_tgid_vnr(struct task_struct *task)
+{
+	return bpf_pid_vnr(bpf_task_tgid(task));
+}
+
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0)
+
+static __always_inline pid_t bpf_task_pid_nr_ns(struct task_struct *task,
+						enum pid_type type,
+						struct pid_namespace *ns)
+{
+	pid_t nr = 0;
+
+	if (!ns)
+		ns = bpf_task_active_pid_ns(task);
+
 	if (type != PIDTYPE_PID) {
 		if (type == __PIDTYPE_TGID)
 			type = PIDTYPE_PID;
@@ -1408,46 +1452,72 @@ static __always_inline pid_t bpf_task_pid_nr_ns(struct task_struct *task,
 	}
 
 	nr = bpf_pid_nr_ns(_READ(task->pids[type].pid), ns);
-#else
-	nr = bpf_pid_nr_ns(_READ(*bpf_task_pid_ptr(task, type)), ns);
-#endif
 
 	return nr;
 }
 
-static __always_inline pid_t bpf_task_pid_vnr(struct task_struct *task)
+static __always_inline struct pid *bpf_task_pid(struct task_struct *task)
 {
-	return bpf_task_pid_nr_ns(task, PIDTYPE_PID, NULL);
+	return _READ(task->pids[PIDTYPE_PID].pid);
 }
 
 static __always_inline pid_t bpf_task_tgid_vnr(struct task_struct *task)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0)
 	return bpf_task_pid_nr_ns(task, __PIDTYPE_TGID, NULL);
-#else
-	return bpf_task_pid_nr_ns(task, PIDTYPE_TGID, NULL);
-#endif
 }
 
-static __always_inline pid_t bpf_task_pgrp_vnr(struct task_struct *task)
+#else /* LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) */
+
+static __always_inline struct pid *bpf_task_pid(struct task_struct *task)
 {
-	return bpf_task_pid_nr_ns(task, PIDTYPE_PGID, NULL);
+	return _READ(task->thread_pid);
 }
+
+static __always_inline struct pid **bpf_task_pid_ptr(struct task_struct *task,
+						     enum pid_type type)
+{
+	return (type == PIDTYPE_PID) ?
+		&task->thread_pid :
+		&_READ(task->signal)->pids[type];
+}
+
+static __always_inline pid_t bpf_task_pid_nr_ns(struct task_struct *task,
+						enum pid_type type,
+						struct pid_namespace *ns)
+{
+	pid_t nr = 0;
+
+	if (!ns)
+		ns = bpf_task_active_pid_ns(task);
+
+	nr = bpf_pid_nr_ns(_READ(*bpf_task_pid_ptr(task, type)), ns);
+
+	return nr;
+}
+
+static __always_inline pid_t bpf_task_tgid_vnr(struct task_struct *task)
+{
+	return bpf_task_pid_nr_ns(task, PIDTYPE_TGID, NULL);
+}
+
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) */
 
 #define MAX_CGROUP_PATHS 6
 
 static __always_inline int __bpf_append_cgroup(struct css_set *cgroups,
 					       int subsys_id,
+					       const char *subsys_name,
 					       char *buf,
 					       int *len)
 {
 	struct cgroup_subsys_state *css = _READ(cgroups->subsys[subsys_id]);
-	struct cgroup_subsys *ss = _READ(css->ss);
-	char *subsys_name = (char *)_READ(ss->name);
 	struct cgroup *cgroup = _READ(css->cgroup);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0)
 	struct kernfs_node *kn = _READ(cgroup->kn);
+#else
+	struct cgroup_name *cn = _READ(cgroup->name);
+#endif
 	char *cgroup_path[MAX_CGROUP_PATHS];
-	bool prev_empty = false;
 	int off = *len;
 
 	if (off > SCRATCH_SIZE_HALF)
@@ -1469,9 +1539,16 @@ static __always_inline int __bpf_append_cgroup(struct css_set *cgroups,
 
 	#pragma unroll MAX_CGROUP_PATHS
 	for (int k = 0; k < MAX_CGROUP_PATHS; ++k) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0)
 		if (kn) {
 			cgroup_path[k] = (char *)_READ(kn->name);
 			kn = _READ(kn->parent);
+#else
+		if (cn) {
+			cgroup_path[k] = cn->name;
+			cgroup = _READ(cgroup->parent);
+			cn = _READ(cgroup->name);
+#endif
 		} else {
 			cgroup_path[k] = NULL;
 		}
@@ -1479,29 +1556,35 @@ static __always_inline int __bpf_append_cgroup(struct css_set *cgroups,
 
 	#pragma unroll MAX_CGROUP_PATHS
 	for (int k = MAX_CGROUP_PATHS - 1; k >= 0 ; --k) {
-		if (cgroup_path[k]) {
-			if (!prev_empty) {
-				if (off > SCRATCH_SIZE_HALF)
-					return PPM_FAILURE_BUFFER_FULL;
+		if (!cgroup_path[k])
+			continue;
 
-				buf[off & SCRATCH_SIZE_HALF] = '/';
-				++off;
-			}
+		/* Some nodes can either be "" or "/", so make sure we
+		 * never report a double "//" when concatenating the path
+		 */
 
-			prev_empty = false;
-
+		if (buf[(off - 1) & SCRATCH_SIZE_HALF] != '/') {
 			if (off > SCRATCH_SIZE_HALF)
 				return PPM_FAILURE_BUFFER_FULL;
 
-			res = bpf_probe_read_str(&buf[off & SCRATCH_SIZE_HALF],
-						 SCRATCH_SIZE_HALF,
-						 cgroup_path[k]);
-			if (res > 1)
-				off += res - 1;
-			else if (res == 1)
-				prev_empty = true;
-			else
-				return PPM_FAILURE_INVALID_USER_MEMORY;
+			buf[off & SCRATCH_SIZE_HALF] = '/';
+			++off;
+		}
+
+		if (off > SCRATCH_SIZE_HALF)
+			return PPM_FAILURE_BUFFER_FULL;
+
+		res = bpf_probe_read_str(&buf[off & SCRATCH_SIZE_HALF],
+						SCRATCH_SIZE_HALF,
+						cgroup_path[k]);
+		if (res < 0)
+			return PPM_FAILURE_INVALID_USER_MEMORY;
+
+		if (res > 1) {
+			if (res == 2 && buf[off & SCRATCH_SIZE_HALF] == '/')
+				--res;
+
+			off += res - 1;
 		}
 	}
 
@@ -1515,6 +1598,20 @@ static __always_inline int __bpf_append_cgroup(struct css_set *cgroups,
 	return PPM_SUCCESS;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0)
+#define SUBSYS_ID(id) id ## _cgrp_id
+#else
+#define SUBSYS_ID(id) id ## _subsys_id
+#endif
+
+#define APPEND_CGROUP(id)								\
+do {											\
+	char subsys_name[sizeof(#id)] = #id;						\
+	res = __bpf_append_cgroup(cgroups, SUBSYS_ID(id), subsys_name, buf, len);	\
+	if (res != PPM_SUCCESS)								\
+		return res;								\
+} while (0)
+
 static __always_inline int bpf_append_cgroup(struct task_struct *task,
 					     char *buf,
 					     int *len)
@@ -1523,33 +1620,27 @@ static __always_inline int bpf_append_cgroup(struct task_struct *task,
 	int res;
 
 #if IS_ENABLED(CONFIG_CPUSETS)
-	res = __bpf_append_cgroup(cgroups, cpuset_cgrp_id, buf, len);
-	if (res != PPM_SUCCESS)
-		return res;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0)
+	APPEND_CGROUP(cpu);
+#else
+	APPEND_CGROUP(cpu_cgroup);
 #endif
-
-#if IS_ENABLED(CONFIG_CGROUP_SCHED)
-	res = __bpf_append_cgroup(cgroups, cpu_cgrp_id, buf, len);
-	if (res != PPM_SUCCESS)
-		return res;
-#endif
-
-#if IS_ENABLED(CONFIG_CGROUP_CPUACCT)
-	res = __bpf_append_cgroup(cgroups, cpuacct_cgrp_id, buf, len);
-	if (res != PPM_SUCCESS)
-		return res;
 #endif
 
 #if IS_ENABLED(CONFIG_BLK_CGROUP)
-	res = __bpf_append_cgroup(cgroups, io_cgrp_id, buf, len);
-	if (res != PPM_SUCCESS)
-		return res;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0)
+	APPEND_CGROUP(io);
+#else
+	APPEND_CGROUP(blkio);
+#endif
 #endif
 
 #if IS_ENABLED(CONFIG_MEMCG)
-	res = __bpf_append_cgroup(cgroups, memory_cgrp_id, buf, len);
-	if (res != PPM_SUCCESS)
-		return res;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0)
+	APPEND_CGROUP(memory);
+#else
+	APPEND_CGROUP(mem_cgroup);
+#endif
 #endif
 
 	return PPM_SUCCESS;
@@ -2636,7 +2727,11 @@ FILLER(sys_shutdown_e, true)
 FILLER(sys_recvmsg_x, true)
 {
 	const struct iovec *iov;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)
 	struct user_msghdr mh;
+#else
+	struct msghdr mh;
+#endif
 	unsigned long iovcnt;
 	unsigned long val;
 	long retval;
@@ -2675,7 +2770,11 @@ FILLER(sys_recvmsg_x, true)
 FILLER(sys_recvmsg_x_2, true)
 {
 	struct sockaddr *usrsockaddr;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)
 	struct user_msghdr mh;
+#else
+	struct msghdr mh;
+#endif
 	unsigned long val;
 	u16 size = 0;
 	long retval;
@@ -2737,7 +2836,11 @@ FILLER(sys_sendmsg_e, true)
 {
 	struct sockaddr *usrsockaddr;
 	const struct iovec *iov;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)
 	struct user_msghdr mh;
+#else
+	struct msghdr mh;
+#endif
 	unsigned long iovcnt;
 	unsigned long val;
 	u16 size = 0;
@@ -2809,7 +2912,11 @@ FILLER(sys_sendmsg_e, true)
 FILLER(sys_sendmsg_x, true)
 {
 	const struct iovec *iov;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)
 	struct user_msghdr mh;
+#else
+	struct msghdr mh;
+#endif
 	unsigned long iovcnt;
 	unsigned long val;
 	long retval;

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1581,7 +1581,8 @@ static __always_inline int __bpf_append_cgroup(struct css_set *cgroups,
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 
 		if (res > 1) {
-			if (res == 2 && buf[off & SCRATCH_SIZE_HALF] == '/')
+			if (res == sizeof("/") &&
+			    buf[off & SCRATCH_SIZE_HALF] == '/')
 				--res;
 
 			off += res - 1;
@@ -1606,7 +1607,7 @@ static __always_inline int __bpf_append_cgroup(struct css_set *cgroups,
 
 #define APPEND_CGROUP(id)								\
 do {											\
-	char subsys_name[sizeof(#id)] = #id;						\
+	char subsys_name[] = #id;							\
 	res = __bpf_append_cgroup(cgroups, SUBSYS_ID(id), subsys_name, buf, len);	\
 	if (res != PPM_SUCCESS)								\
 		return res;								\

--- a/driver/bpf/quirks.h
+++ b/driver/bpf/quirks.h
@@ -11,6 +11,21 @@ or GPL2.txt for full copies of the license.
 
 #include <linux/version.h>
 
+#ifdef RHEL_RELEASE_CODE
+
+#if RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7, 6)
+#error RHEL version must be >= 7.6
+#endif
+
+/* RHEL has its own backported eBPF version, so the other defines in
+ * quirks don't quite apply. In particular, as of 7.6:
+ * - BPF_FORBIDS_ZERO_ACCESS is not necessary
+ * - BPF_SUPPORTS_RAW_TRACEPOINTS is defined in the uapi but not actually
+ *   implemented in the kernel
+ */
+
+#else /* RHEL_RELEASE_CODE */
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
 #error Kernel version must be >= 4.14 with eBPF enabled
 #endif
@@ -27,5 +42,7 @@ or GPL2.txt for full copies of the license.
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 #define BPF_SUPPORTS_RAW_TRACEPOINTS
 #endif
+
+#endif /* RHEL_RELEASE_CODE */
 
 #endif

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -1128,56 +1128,49 @@ static int32_t set_runtime_params(scap_t *handle)
 		return SCAP_FAILURE;
 	}
 
+	//
+	// Not every kernel has BPF_JIT enabled or all the flags we'd like
+	// to tweak (e.g. earlier COS versions or RHEL 7).
+	//
+
 	FILE *f = fopen("/proc/sys/net/core/bpf_jit_enable", "w");
-	if(!f)
+	if(f)
 	{
-		// snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Can't open /proc/sys/net/core/bpf_jit_enable");
-		// return SCAP_FAILURE;
+		if(fprintf(f, "1") != 1)
+		{
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Can't write to /proc/sys/net/core/bpf_jit_enable");
+			fclose(f);
+			return SCAP_FAILURE;
+		}
 
-		// Not every kernel has BPF_JIT enabled. Fix this after COS changes.
-		return SCAP_SUCCESS;
-	}
-
-	if(fprintf(f, "1") != 1)
-	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Can't write to /proc/sys/net/core/bpf_jit_enable");
 		fclose(f);
-		return SCAP_FAILURE;
 	}
-
-	fclose(f);
 
 	f = fopen("/proc/sys/net/core/bpf_jit_harden", "w");
-	if(!f)
+	if(f)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Can't open /proc/sys/net/core/bpf_jit_harden");
-		return SCAP_FAILURE;
-	}
+		if(fprintf(f, "0") != 1)
+		{
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Can't write to /proc/sys/net/core/bpf_jit_harden");
+			fclose(f);
+			return SCAP_FAILURE;
+		}
 
-	if(fprintf(f, "0") != 1)
-	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Can't write to /proc/sys/net/core/bpf_jit_harden");
 		fclose(f);
-		return SCAP_FAILURE;
 	}
-
-	fclose(f);
 
 	f = fopen("/proc/sys/net/core/bpf_jit_kallsyms", "w");
-	if(!f)
+	if(f)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Can't open /proc/sys/net/core/bpf_jit_kallsyms");
-		return SCAP_FAILURE;
-	}
+		if(fprintf(f, "1") != 1)
+		{
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Can't write to /proc/sys/net/core/bpf_jit_kallsyms");
+			fclose(f);
+			return SCAP_FAILURE;
+		}
 
-	if(fprintf(f, "1") != 1)
-	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Can't write to /proc/sys/net/core/bpf_jit_kallsyms");
 		fclose(f);
-		return SCAP_FAILURE;
 	}
-
-	fclose(f);
 
 	return SCAP_SUCCESS;
 }


### PR DESCRIPTION
The only unfortunate casualty was switching to populating the cgroup
subsystem name at compile time rather than runtime, which makes the eBPF
state increase significantly. So I removed two more cgroups from the
supported list. It can potentially be reworked to account that, but as long
as we grab one relevant we should be fully able to do the container
detection. It'll probably be worth adding all of them at some point.