### PR TITLE
Detect container health checks

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -83,6 +83,58 @@ const sinsp_container_info::container_mount_info *sinsp_container_info::mount_by
 	return NULL;
 }
 
+std::string sinsp_container_info::normalize_healthcheck_arg(const std::string &arg)
+{
+	std::string ret = arg;
+
+	if(ret.empty())
+	{
+		return ret;
+	}
+
+	// Remove pairs of leading/trailing " or ' chars, if present
+	while(ret.front() == '"' || ret.front() == '\'')
+	{
+		if(ret.back() == ret.front())
+		{
+			ret.pop_back();
+			ret.erase(0, 1);
+		}
+	}
+
+	return ret;
+}
+
+void sinsp_container_info::parse_healthcheck(const Json::Value &healthcheck_obj)
+{
+	if(!healthcheck_obj.isNull())
+	{
+		const Json::Value &test_obj = healthcheck_obj["Test"];
+
+		if(!test_obj.isNull() && test_obj.isArray() && test_obj.size() >= 2)
+		{
+			if(test_obj[0].asString() == "CMD")
+			{
+				m_has_healthcheck = true;
+				m_healthcheck_exe = normalize_healthcheck_arg(test_obj[1].asString());
+
+				for(uint32_t i = 2; i < test_obj.size(); i++)
+				{
+					m_healthcheck_args.push_back(normalize_healthcheck_arg(test_obj[i].asString()));
+				}
+			}
+			else if(test_obj[0].asString() == "CMD-SHELL")
+			{
+				m_has_healthcheck = true;
+				m_healthcheck_exe = "/bin/sh";
+				m_healthcheck_args.push_back("-c");
+				m_healthcheck_args.push_back(test_obj[1].asString());
+			}
+		}
+	}
+}
+
+
 #if !defined(CYGWING_AGENT) && defined(HAS_CAPTURE)
 CURLM *sinsp_container_engine_docker::m_curlm = NULL;
 CURL *sinsp_container_engine_docker::m_curl = NULL;
@@ -189,6 +241,8 @@ bool sinsp_container_engine_docker::parse_docker(sinsp_container_manager* manage
 	{
 		container->m_imageid = imgstr.substr(cpos + 1);
 	}
+
+	container->parse_healthcheck(config_obj["Healthcheck"]);
 
 	// containers can be spawned using just the imageID as image name,
 	// with or without the hash prefix (e.g. sha256:)
@@ -1147,6 +1201,10 @@ bool sinsp_container_manager::resolve_container(sinsp_threadinfo* tinfo, bool qu
 	{
 		tinfo->m_container_id = "";
 	}
+
+	// Also identify if this thread is part of a container healthcheck
+	identify_healthcheck(tinfo);
+
 	return matches;
 }
 
@@ -1291,6 +1349,67 @@ string sinsp_container_manager::get_container_name(sinsp_threadinfo* tinfo)
 	}
 
 	return res;
+}
+
+void sinsp_container_manager::identify_healthcheck(sinsp_threadinfo *tinfo)
+{
+	// This thread is a part of a container healthcheck if its
+	// parent thread is part of a health check.
+	sinsp_threadinfo* ptinfo = tinfo->get_parent_thread();
+
+	if(ptinfo && ptinfo->m_is_container_healthcheck)
+	{
+		tinfo->m_is_container_healthcheck = true;
+		return;
+	}
+
+	sinsp_container_info *cinfo = get_container(tinfo->m_container_id);
+
+	if(!cinfo)
+	{
+		return;
+	}
+
+	// Otherwise, the thread is a part of a container healthcheck if:
+	//
+	// 1. the comm and args match the container's healthcheck
+	// 2. we traverse the parent state and do *not* find vpid=1,
+	//    or find a process not in a container
+	//
+	// This indicates the initial process of the healthcheck.
+
+	if(!cinfo->m_has_healthcheck ||
+	   cinfo->m_healthcheck_exe != tinfo->m_exe ||
+	   cinfo->m_healthcheck_args != tinfo->m_args)
+	{
+		return;
+	}
+
+	if(tinfo->m_vpid == 1)
+	{
+		tinfo->m_is_container_healthcheck = false;
+		return;
+	}
+	bool found_container_init = false;
+	sinsp_threadinfo::visitor_func_t visitor =
+		[&found_container_init] (sinsp_threadinfo *ptinfo)
+	{
+		if(ptinfo->m_vpid == 1 && !ptinfo->m_container_id.empty())
+		{
+			found_container_init = true;
+
+			return false;
+		}
+
+		return true;
+	};
+
+	tinfo->traverse_parent_state(visitor);
+
+	if(!found_container_init)
+	{
+		tinfo->m_is_container_healthcheck = true;
+	}
 }
 
 void sinsp_container_manager::subscribe_on_new_container(new_container_cb callback)

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -244,6 +244,9 @@ bool sinsp_container_engine_docker::parse_docker(sinsp_container_manager* manage
 
 	container->parse_healthcheck(config_obj["Healthcheck"]);
 
+	// Saving full healthcheck for container event parsing/writing
+	container->m_healthcheck_obj = config_obj["Healthcheck"];
+
 	// containers can be spawned using just the imageID as image name,
 	// with or without the hash prefix (e.g. sha256:)
 	bool no_name = !container->m_imageid.empty() &&
@@ -1238,6 +1241,11 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 	}
 
 	container["Mounts"] = mounts;
+
+	if(!container_info.m_healthcheck_obj.isNull())
+	{
+		container["Healthcheck"] = container_info.m_healthcheck_obj;
+	}
 
 	char addrbuff[100];
 	uint32_t iph = htonl(container_info.m_container_ip);

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -120,7 +120,9 @@ public:
 		m_swap_limit(0),
 		m_cpu_shares(1024),
 		m_cpu_quota(0),
-		m_cpu_period(100000)
+		m_cpu_period(100000),
+		m_has_healthcheck(false),
+		m_healthcheck_exe("")
 #ifdef HAS_ANALYZER
 		,m_metadata_deadline(0)
 #endif
@@ -128,6 +130,9 @@ public:
 	}
 
 	static void parse_json_mounts(const Json::Value &mnt_obj, vector<container_mount_info> &mounts);
+
+	std::string normalize_healthcheck_arg(const std::string &arg);
+	void parse_healthcheck(const Json::Value &config_obj);
 
 	const vector<string>& get_env() const { return m_env; }
 
@@ -155,6 +160,9 @@ public:
 	int64_t m_cpu_shares;
 	int64_t m_cpu_quota;
 	int64_t m_cpu_period;
+	bool m_has_healthcheck;
+	std::string m_healthcheck_exe;
+	std::vector<std::string> m_healthcheck_args;
 #ifdef HAS_ANALYZER
 	string m_sysdig_agent_conf;
 	uint64_t m_metadata_deadline;
@@ -241,6 +249,7 @@ public:
 	bool resolve_container(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	void dump_containers(scap_dumper_t* dumper);
 	string get_container_name(sinsp_threadinfo* tinfo);
+	void identify_healthcheck(sinsp_threadinfo *tinfo);
 
 	bool container_exists(const string& container_id) const {
 		return m_containers.find(container_id) != m_containers.end();

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -160,6 +160,7 @@ public:
 	int64_t m_cpu_shares;
 	int64_t m_cpu_quota;
 	int64_t m_cpu_period;
+	Json::Value m_healthcheck_obj;
 	bool m_has_healthcheck;
 	std::string m_healthcheck_exe;
 	std::vector<std::string> m_healthcheck_args;

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -2046,23 +2046,6 @@ uint8_t* sinsp_filter_check_thread::extract_thread_cpu(sinsp_evt *evt, OUT uint3
 	return NULL;
 }
 
-static void populate_cmdline(string &cmdline, sinsp_threadinfo *tinfo)
-{
-	cmdline = tinfo->get_comm() + " ";
-
-	uint32_t j;
-	uint32_t nargs = (uint32_t)tinfo->m_args.size();
-
-	for(j = 0; j < nargs; j++)
-	{
-		cmdline += tinfo->m_args[j];
-		if(j < nargs -1)
-		{
-			cmdline += ' ';
-		}
-	}
-}
-
 uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
@@ -2181,7 +2164,7 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 		}
 	case TYPE_CMDLINE:
 		{
-			populate_cmdline(m_tstr, tinfo);
+			sinsp_threadinfo::populate_cmdline(m_tstr, tinfo);
 			RETURN_EXTRACT_STRING(m_tstr);
 		}
 	case TYPE_EXELINE:
@@ -2299,7 +2282,7 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 
 			if(ptinfo != NULL)
 			{
-				populate_cmdline(m_tstr, ptinfo);
+				sinsp_threadinfo::populate_cmdline(m_tstr, ptinfo);
 				RETURN_EXTRACT_STRING(m_tstr);
 			}
 			else

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -338,6 +338,7 @@ public:
 		TYPE_EXEPATH = 43,
 		TYPE_NAMETID = 44,
 		TYPE_VPGID = 45,
+		TYPE_IS_CONTAINER_HEALTHCHECK = 46,
 	};
 
 	sinsp_filter_check_thread();
@@ -722,6 +723,7 @@ public:
 		TYPE_CONTAINER_IMAGE_REPOSITORY,
 		TYPE_CONTAINER_IMAGE_TAG,
 		TYPE_CONTAINER_IMAGE_DIGEST,
+		TYPE_CONTAINER_HEALTHCHECK,
 	};
 
 	sinsp_filter_check_container();

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4460,6 +4460,8 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		}
 
 		sinsp_container_info::parse_json_mounts(container["Mounts"], container_info.m_mounts);
+
+		container_info.parse_healthcheck(container["Healthcheck"]);
 		const Json::Value& contip = container["ip"];
 		if(!contip.isNull() && contip.isConvertibleTo(Json::stringValue))
 		{

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -935,6 +935,19 @@ void sinsp_threadinfo::traverse_parent_state(visitor_func_t &visitor)
 	}
 }
 
+void sinsp_threadinfo::populate_cmdline(string &cmdline, sinsp_threadinfo *tinfo)
+{
+	cmdline = tinfo->get_comm();
+
+	uint32_t j;
+	uint32_t nargs = (uint32_t)tinfo->m_args.size();
+
+	for(j = 0; j < nargs; j++)
+	{
+		cmdline += " " + tinfo->m_args[j];
+	}
+}
+
 shared_ptr<sinsp_threadinfo> sinsp_threadinfo::lookup_thread()
 {
 	return m_inspector->get_thread_ref(m_pid, true, true);

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -90,6 +90,7 @@ void sinsp_threadinfo::init()
 	m_lastevent_data = NULL;
 	m_parent_loop_detected = false;
 	m_tty = 0;
+	m_is_container_healthcheck = false;
 	m_blprogram = NULL;
 	m_loginuid = 0;
 }
@@ -423,6 +424,7 @@ void sinsp_threadinfo::init(scap_threadinfo* pi)
 	m_clone_ts = pi->clone_ts;
 	m_tty = pi->tty;
 	m_loginuid = pi->loginuid;
+	m_is_container_healthcheck = false;
 
 	set_cgroups(pi->cgroups, pi->cgroups_len);
 	m_root = pi->root;

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -263,6 +263,9 @@ public:
 	int32_t m_tty;
 	int32_t m_loginuid; ///< loginuid (auid)
 
+	// If true, this thread is part of a container health check
+	bool m_is_container_healthcheck;
+
 	//
 	// State for multi-event processing
 	//

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -230,6 +230,8 @@ public:
 	typedef std::function<bool (sinsp_threadinfo *)> visitor_func_t;
 	void traverse_parent_state(visitor_func_t &visitor);
 
+	static void populate_cmdline(string &cmdline, sinsp_threadinfo *tinfo);
+
 	//
 	// Core state
 	//


### PR DESCRIPTION
Changes to track whether or not a container has a configured healthcheck and whether or not a given threadinfo is being executed as a part of a container healthcheck.