### PR TITLE
Prebuild minikube kernel modules

### DIFF
--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -466,6 +466,66 @@ function debian_build {
 	cd ${BASEDIR}
 }
 
+function minikube_build {
+        VERSION=$1
+
+	MINIKUBE_BASEDIR=${BASEDIR}/minikube
+
+	if [ ! -d ${MINIKUBE_BASEDIR} ]; then
+	    mkdir -p ${MINIKUBE_BASEDIR}
+	fi
+
+	MINIKUBE_DIR=${MINIKUBE_BASEDIR}/minikube-$(echo ${VERSION} | sed 's/^v//')
+
+	if [ ! -d ${MINIKUBE_DIR} ]; then
+	    wget -P ${MINIKUBE_BASEDIR} --timeout=${URL_TIMEOUT} --tries=${RETRY} https://github.com/kubernetes/minikube/archive/${VERSION}.tar.gz
+	    tar -C ${MINIKUBE_BASEDIR} -zxf ${MINIKUBE_BASEDIR}/${VERSION}.tar.gz
+	    rm -f ${MINIKUBE_BASEDIR}/${VERSION}.tar.gz
+	fi
+
+	MINIKUBE_KERNEL_VERSION=$(cat ${MINIKUBE_DIR}/deploy/iso/minikube-iso/configs/minikube_defconfig | grep BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE | cut -d= -f 2 | sed 's/"//g')
+	TGZ_NAME=linux-${MINIKUBE_KERNEL_VERSION}.tar.xz
+	MAJOR=$(echo $MINIKUBE_KERNEL_VERSION | cut -d. -f1)
+	MINOR=$(echo $MINIKUBE_KERNEL_VERSION | cut -d. -f2)
+
+	KERNEL_CONFIG=${MINIKUBE_DIR}/deploy/iso/minikube-iso/board/coreos/minikube/linux_defconfig
+
+	# The filename used to contain the kernel version
+	if [ ! -e ${KERNEL_CONFIG} ]; then
+	    KERNEL_CONFIG=${MINIKUBE_DIR}/deploy/iso/minikube-iso/board/coreos/minikube/linux-${MAJOR}.${MINOR}_defconfig
+	fi
+
+	if [ ! -e ${KERNEL_CONFIG} ]; then
+	    echo "****ERROR: Could not find kernel config for minikube version ${VERSION}. Expected at ${KERNEL_CONFIG}"
+	    exit 1
+	fi
+
+	export KERNELDIR=${MINIKUBE_BASEDIR}/linux-${MINIKUBE_KERNEL_VERSION}
+
+	if [ ! -d ${KERNELDIR} ]; then
+	        wget -P ${MINIKUBE_BASEDIR} --timeout=${URL_TIMEOUT} --tries=${RETRY} https://www.kernel.org/pub/linux/kernel/v${MAJOR}.x/${TGZ_NAME}
+		tar -C ${MINIKUBE_BASEDIR} -xf ${MINIKUBE_BASEDIR}/${TGZ_NAME}
+		rm -f ${MINIKUBE_BASEDIR}/${TGZ_NAME}
+	fi
+
+	pushd ${KERNELDIR}
+	make distclean
+	cp ${KERNEL_CONFIG} .config
+	# Manually setting ARCH to x86_64 mirrors what buildroot does.
+	ARCH=x86_64 make olddefconfig
+	make modules_prepare
+	popd
+
+	HASH=$(md5sum ${KERNELDIR}/.config | cut -d' ' -f1)
+	HASH_ORIG=${HASH}
+
+	KERNEL_RELEASE=$(cat ${KERNELDIR}/include/config/kernel.release)
+
+	cd $BASEDIR
+
+	build_probe
+}
+
 if [ -z "$KERNEL_TYPE" ]; then
 	#
 	# Ubuntu build
@@ -637,6 +697,13 @@ if [ -z "$KERNEL_TYPE" ]; then
 	for URL in $URLS
 	do
 		rhel_build $URL
+	done
+
+	VERSIONS=$(curl https://api.github.com/repos/kubernetes/minikube/releases | jq -r '.[].name' | head -10)
+
+	for VERSION in $VERSIONS
+	do
+	        minikube_build $VERSION
 	done
 
 	#

--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -24,12 +24,6 @@
 #
 set -euo pipefail
 
-#
-# For continuous integration log purposes, wget prints its own output to stderr
-# so it can be convenient to redirect it to a file. This can be done directly
-# at runtime.
-#
-
 PROBE_NAME=$1
 PROBE_VERSION=$2
 REPOSITORY_NAME=$3
@@ -140,7 +134,7 @@ function coreos_build_old {
 	cd $COREOS_DIR
 
 	if [ ! -f config_orig ]; then
-		wget --timeout=${URL_TIMEOUT} --tries=${RETRY} ${VERSION_URL}coreos_developer_container.bin.bz2
+		wget -nv --timeout=${URL_TIMEOUT} --tries=${RETRY} ${VERSION_URL}coreos_developer_container.bin.bz2
 		bunzip2 coreos_developer_container.bin.bz2
 		sudo kpartx -asv coreos_developer_container.bin
 		LOOPDEV=$(sudo kpartx -asv coreos_developer_container.bin | cut -d\  -f 3)
@@ -162,7 +156,7 @@ function coreos_build_old {
 	KERNEL_URL=https://www.kernel.org/pub/linux/kernel/v${MAJOR}.x/$TGZ_NAME
 
 	if [ ! -f $TGZ_NAME ]; then
-		wget --timeout=${URL_TIMEOUT} --tries=${RETRY} $KERNEL_URL
+		wget -nv --timeout=${URL_TIMEOUT} --tries=${RETRY} $KERNEL_URL
 	fi
 
 	if [ ! -d $DIR_NAME ]; then
@@ -197,7 +191,7 @@ function coreos_build_new {
 	cd $COREOS_DIR
 
 	if [ ! -f coreos_developer_container.bin ]; then
-		wget --timeout=${URL_TIMEOUT} --tries=${RETRY} ${VERSION_URL}coreos_developer_container.bin.bz2
+		wget -nv --timeout=${URL_TIMEOUT} --tries=${RETRY} ${VERSION_URL}coreos_developer_container.bin.bz2
 		bunzip2 coreos_developer_container.bin.bz2
 	fi
 
@@ -257,7 +251,7 @@ function boot2docker_build {
 
 	if [ ! -f $TGZ_NAME ]; then
 		echo Downloading $TGZ_NAME [Boot2Docker]
-		wget --timeout=${URL_TIMEOUT} --tries=${RETRY} $KERNEL_URL
+		wget -nv --timeout=${URL_TIMEOUT} --tries=${RETRY} $KERNEL_URL
 	fi
 
 	if [ ! -d $DIR_NAME ]; then
@@ -280,7 +274,7 @@ function boot2docker_build {
 		; do \
 	        patch -p1 < "$patch"; \
 		done
-		wget --timeout=${URL_TIMEOUT} --tries=${RETRY} -O .config $KERNEL_CONFIG
+		wget -nv --timeout=${URL_TIMEOUT} --tries=${RETRY} -O .config $KERNEL_CONFIG
 		cp .config ../config-orig
 		make olddefconfig
 		make modules_prepare
@@ -319,7 +313,7 @@ function ubuntu_build {
 
 	if [ ! -f $DEB ]; then
 		echo Downloading $DEB [Ubuntu]
-		wget --timeout=${URL_TIMEOUT} --tries=${RETRY} $URL
+		wget -nv --timeout=${URL_TIMEOUT} --tries=${RETRY} $URL
 		dpkg -x $DEB ./
 	fi
 
@@ -361,7 +355,7 @@ function rhel_build {
 
 	if [ ! -f $RPM ]; then
 		echo Downloading $RPM [RHEL and CentOS]
-		wget --timeout=${URL_TIMEOUT} --tries=${RETRY} $URL
+		wget -nv --timeout=${URL_TIMEOUT} --tries=${RETRY} $URL
 		rpm2cpio $RPM | cpio -idm
 	fi
 
@@ -399,7 +393,7 @@ function debian_build {
 		fi
 		if [ ! -f ${BASEDIR}/common-dependencies/debian/kbuild/${DEB} ]; then
 			echo Downloading ${DEB} [Debian]
-			wget --timeout=${URL_TIMEOUT} --tries=${RETRY} -P ${BASEDIR}/common-dependencies/debian/kbuild ${URL}
+			wget -nv --timeout=${URL_TIMEOUT} --tries=${RETRY} -P ${BASEDIR}/common-dependencies/debian/kbuild ${URL}
 		fi
 		return
 	else
@@ -421,7 +415,7 @@ function debian_build {
 
 		if [ ! -f ${DEB} ]; then
 			echo Downloading ${DEB} [Debian]
-			wget --timeout=${URL_TIMEOUT} --tries=${RETRY} ${URL}
+			wget -nv --timeout=${URL_TIMEOUT} --tries=${RETRY} ${URL}
 			dpkg -x ${DEB} ./
 		fi
 	fi
@@ -478,7 +472,7 @@ function minikube_build {
 	MINIKUBE_DIR=${MINIKUBE_BASEDIR}/minikube-$(echo ${VERSION} | sed 's/^v//')
 
 	if [ ! -d ${MINIKUBE_DIR} ]; then
-	    wget -P ${MINIKUBE_BASEDIR} --timeout=${URL_TIMEOUT} --tries=${RETRY} https://github.com/kubernetes/minikube/archive/${VERSION}.tar.gz
+	    wget -nv -P ${MINIKUBE_BASEDIR} --timeout=${URL_TIMEOUT} --tries=${RETRY} https://github.com/kubernetes/minikube/archive/${VERSION}.tar.gz
 	    tar -C ${MINIKUBE_BASEDIR} -zxf ${MINIKUBE_BASEDIR}/${VERSION}.tar.gz
 	    rm -f ${MINIKUBE_BASEDIR}/${VERSION}.tar.gz
 	fi
@@ -503,7 +497,7 @@ function minikube_build {
 	export KERNELDIR=${MINIKUBE_BASEDIR}/linux-${MINIKUBE_KERNEL_VERSION}
 
 	if [ ! -d ${KERNELDIR} ]; then
-	        wget -P ${MINIKUBE_BASEDIR} --timeout=${URL_TIMEOUT} --tries=${RETRY} https://www.kernel.org/pub/linux/kernel/v${MAJOR}.x/${TGZ_NAME}
+	        wget -nv -P ${MINIKUBE_BASEDIR} --timeout=${URL_TIMEOUT} --tries=${RETRY} https://www.kernel.org/pub/linux/kernel/v${MAJOR}.x/${TGZ_NAME}
 		tar -C ${MINIKUBE_BASEDIR} -xf ${MINIKUBE_BASEDIR}/${TGZ_NAME}
 		rm -f ${MINIKUBE_BASEDIR}/${TGZ_NAME}
 	fi


### PR DESCRIPTION
Use the github releases page to get the last 10 minikube versions.

Download the minikube tarball to get the base kernel version and config
used by buildroot.

Download the right linux kernel, start with minikube's config, "make
olddefconfig" to get the full config, and build the kernel module using
that kernel tree and config.

@bertocci I didn't quite tackle it the way you were doing it with doing the build inside a container. It didn't seem necessary to me once I found the kernel config directly in the minikube tarball. What do you think?