### PR TITLE
Handle events for unknown threads after scap start [SMAGENT-1082]

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -62,6 +62,7 @@ void on_new_entry_from_proc(void* context, scap_t* handle, int64_t tid, scap_thr
 // sinsp implementation
 ///////////////////////////////////////////////////////////////////////////////
 sinsp::sinsp() :
+	m_check_bump_max_n_proc_lookups(true),
 	m_evt(this),
 	m_container_manager(this)
 {
@@ -1020,6 +1021,60 @@ void sinsp::restart_capture_at_filepos(uint64_t filepos)
 	}
 }
 
+int32_t sinsp::get_max_n_proc_lookups()
+{
+	uint32_t boost = 0;
+
+	// if m_max_n_proc_lookups has been set to a negative value,
+	// the proc scan has been disabled, so skip everything
+	if(m_max_n_proc_lookups >= 0)
+	{
+		static const uint64_t startup = sinsp_utils::get_current_time_sec();
+
+		if(m_check_bump_max_n_proc_lookups)
+		{
+			auto now = sinsp_utils::get_current_time_sec();
+			m_check_bump_max_n_proc_lookups = ((now - startup) < BUMP_MAX_N_PROC_LOOKUPS_DURATION_IN_SEC);
+			uint32_t boost = 0;
+                        /*		
+			 	 ^
+			 	 |
+			 	 |\
+			 	 | \
+			       K +--+
+			 	 |  |\
+			 	 |  | \
+			 	 |  |  \
+			 	 |  |   \
+			       N +--+----+
+			 	 |  | 	 |\
+			 	 |  | 	 | \
+			       R +--+----+--+
+			 	 |  |    |  |\
+			 	 +--+-------+--------------------------->
+			 	    S	 x  T+S
+			
+						
+			 T = BUMP_MAX_N_PROC_LOOKUPS_DURATION_IN_SEC
+			 S = startup		
+			 K = STARTUP_MAX_N_PROC_LOOKUPS
+					
+						
+			             K - R      
+			    boost = ------- * (T - (x - S))
+			               T 
+		        */
+			if(m_check_bump_max_n_proc_lookups)
+			{
+				boost = (STARTUP_MAX_N_PROC_LOOKUPS - m_max_n_proc_lookups)*(BUMP_MAX_N_PROC_LOOKUPS_DURATION_IN_SEC- (now - startup ))/(BUMP_MAX_N_PROC_LOOKUPS_DURATION_IN_SEC);
+				g_logger.format(sinsp_logger::SEV_TRACE, "Bumping max_n_proc_lookups to %d", m_max_n_proc_lookups + boost);
+
+			}
+		}
+	}
+	return m_max_n_proc_lookups + boost;
+}
+
 int32_t sinsp::next(OUT sinsp_evt **puevt)
 {
 	sinsp_evt* evt;
@@ -1458,14 +1513,15 @@ threadinfo_map_t::ptr_t sinsp::get_thread_ref(int64_t tid, bool query_os_if_not_
 
 		m_n_proc_lookups++;
 
-		if(m_n_proc_lookups == m_max_n_proc_lookups)
+		auto current_n_proc_lookups = get_max_n_proc_lookups();
+		if(m_n_proc_lookups == current_n_proc_lookups)
 		{
 			g_logger.format(sinsp_logger::SEV_INFO, "Reached max process lookup number, duration=%" PRIu64 "ms",
 				m_n_proc_lookups_duration_ns / 1000000);
 		}
 
-		if(m_max_n_proc_lookups < 0 ||
-		   m_n_proc_lookups <= m_max_n_proc_lookups)
+		if(current_n_proc_lookups < 0 ||
+		   m_n_proc_lookups <= current_n_proc_lookups)
 		{
 #ifdef HAS_ANALYZER
 			tracer_emitter("sinsp_proc_lookup");

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -980,6 +980,10 @@ private:
 
 	void add_suppressed_comms(scap_open_args &oargs);
 
+	int32_t get_max_n_proc_lookups();
+	static const int STARTUP_MAX_N_PROC_LOOKUPS = 100;
+	static const int BUMP_MAX_N_PROC_LOOKUPS_DURATION_IN_SEC = 60;
+	bool m_check_bump_max_n_proc_lookups;
 	scap_t* m_h;
 	uint32_t m_nevts;
 	int64_t m_filesize;

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -760,6 +760,11 @@ uint64_t sinsp_utils::get_current_time_ns()
     return tv.tv_sec * (uint64_t) 1000000000 + tv.tv_usec * 1000;
 }
 
+uint64_t sinsp_utils::get_current_time_sec()
+{
+	return get_current_time_ns() / 1e+9;
+}
+
 bool sinsp_utils::glob_match(const char *pattern, const char *string)
 {
 #ifdef _WIN32

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -102,6 +102,8 @@ public:
 
 	static uint64_t get_current_time_ns();
 
+	static uint64_t get_current_time_sec();
+
 	static bool glob_match(const char *pattern, const char *string);
 
 #ifndef _WIN32


### PR DESCRIPTION
During startup, a process's thread creation event may be missed (if it
happens in between /proc scan and scap_start_capture). In some cases,
this can result in misbehaving, namely, in mistaking the thread as a
process. To overcome the issue, during a short interval after startup,
if agent gets an event for a non-scanned thread, it performs a second
scan
 