### PR TITLE
Fix Docker/CRI interaction

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -105,6 +105,7 @@ bool sinsp_container_manager::resolve_container(sinsp_threadinfo* tinfo, bool qu
 	ASSERT(tinfo);
 	bool matches = false;
 
+	tinfo->m_container_id = "";
 	if (m_inspector->m_parser->m_fd_listener)
 	{
 		matches = m_inspector->m_parser->m_fd_listener->on_resolve_container(this, tinfo, query_os_for_missing_info);
@@ -126,11 +127,6 @@ bool sinsp_container_manager::resolve_container(sinsp_threadinfo* tinfo, bool qu
 	>(tinfo, query_os_for_missing_info);
 
 #endif // CYGWING_AGENT
-
-	if (!matches)
-	{
-		tinfo->m_container_id = "";
-	}
 
 	// Also identify if this thread is part of a container healthcheck
 	identify_healthcheck(tinfo);

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -370,14 +370,6 @@ void sinsp_container_manager::set_query_docker_image_info(bool query_image_info)
 	libsinsp::container_engine::docker::set_query_image_info(query_image_info);
 }
 
-void sinsp_container_manager::set_docker_cri_mode(bool docker_then_cri)
-{
-#if defined(HAS_CAPTURE)
-	auto mode = docker_then_cri ? libsinsp::container_engine::docker::WEAK : libsinsp::container_engine::docker::DISABLED;
-	libsinsp::container_engine::docker::set_mode(mode);
-#endif
-}
-
 void sinsp_container_manager::set_cri_socket_path(const std::string &path)
 {
 #if defined(HAS_CAPTURE)

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -65,7 +65,6 @@ public:
 	void cleanup();
 
 	void set_query_docker_image_info(bool query_image_info);
-	void set_docker_cri_mode(bool docker_then_cri);
 	void set_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
 	sinsp* get_inspector() { return m_inspector; }

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -33,6 +33,7 @@ limitations under the License.
 using namespace libsinsp::cri;
 using namespace libsinsp::container_engine;
 
+namespace {
 bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container, sinsp_threadinfo *tinfo)
 {
 	if(!s_cri)
@@ -96,6 +97,7 @@ bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container
 	}
 
 	return true;
+}
 }
 
 cri::cri()

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -59,8 +59,10 @@ cri::cri()
 
 	if (!status.ok())
 	{
-		// we could disable CRI support here...
-		g_logger.format(sinsp_logger::SEV_WARNING, "CRI runtime returned an error after version check");
+		g_logger.format(sinsp_logger::SEV_NOTICE, "CRI runtime returned an error after version check at %s: %s",
+			s_cri_unix_socket_path.c_str(), status.error_message().c_str());
+		s_cri.reset(nullptr);
+		s_cri_unix_socket_path = "";
 		return;
 	}
 

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -169,7 +169,12 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 	{
 		if (query_os_for_missing_info)
 		{
-			parse_cri(manager, &container_info, tinfo);
+			if (!parse_cri(manager, &container_info, tinfo))
+			{
+				g_logger.format(sinsp_logger::SEV_DEBUG, "Failed to get CRI metadata for container %s",
+						container_info.m_id.c_str());
+				return false;
+			}
 		}
 		if (mesos::set_mesos_task_id(&container_info, tinfo))
 		{

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -33,9 +33,9 @@ limitations under the License.
 using namespace libsinsp::cri;
 using namespace libsinsp::container_engine;
 
-bool parse_cri(sinsp_container_manager* manager, sinsp_container_info *container, sinsp_threadinfo* tinfo)
+bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container, sinsp_threadinfo *tinfo)
 {
-	if (!s_cri)
+	if(!s_cri)
 	{
 		return false;
 	}
@@ -48,21 +48,22 @@ bool parse_cri(sinsp_container_manager* manager, sinsp_container_info *container
 	auto deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(s_cri_timeout);
 	context.set_deadline(deadline);
 	grpc::Status status = s_cri->ContainerStatus(&context, req, &resp);
-	if (!status.ok()) {
+	if(!status.ok())
+	{
 		return false;
 	}
 
-	if (!resp.has_status())
+	if(!resp.has_status())
 	{
 		ASSERT(false);
 		return false;
 	}
 
-	const auto& resp_container = resp.status();
+	const auto &resp_container = resp.status();
 	container->m_name = resp_container.metadata().name();
 	container->m_type = s_cri_runtime_type;
 
-	for (const auto& pair : resp_container.labels())
+	for(const auto &pair : resp_container.labels())
 	{
 		container->m_labels[pair.first] = pair.second;
 	}
@@ -70,8 +71,8 @@ bool parse_cri(sinsp_container_manager* manager, sinsp_container_info *container
 	parse_cri_image(resp_container, container);
 	parse_cri_mounts(resp_container, container);
 
-	const auto& info_it = resp.info().find("info");
-	if (info_it == resp.info().end())
+	const auto &info_it = resp.info().find("info");
+	if(info_it == resp.info().end())
 	{
 		ASSERT(false);
 		return false;

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -51,13 +51,6 @@ public:
 	static void parse_json_mounts(const Json::Value &mnt_obj, std::vector<sinsp_container_info::container_mount_info> &mounts);
 
 #if !defined(_WIN32)
-	enum engine_mode
-	{
-		DISABLED = 0,
-		ENABLED = 1,
-		WEAK = 2, // only report container when metadata is found, for Docker-then-CRI mode
-	};
-	static void set_mode(engine_mode mode);
 	static bool detect_docker(const sinsp_threadinfo* tinfo, std::string& container_id);
 #endif
 
@@ -68,9 +61,6 @@ protected:
 
 	static std::string m_api_version;
 	static bool m_query_image_info;
-#if !defined(_WIN32)
-	static engine_mode m_engine_mode;
-#endif
 };
 }
 }

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -61,6 +61,7 @@ protected:
 
 	static std::string m_api_version;
 	static bool m_query_image_info;
+	static bool m_enabled;
 };
 }
 }

--- a/userspace/libsinsp/container_engine/docker_linux.cpp
+++ b/userspace/libsinsp/container_engine/docker_linux.cpp
@@ -98,6 +98,7 @@ bool docker::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, 
 	if(detect_docker(tinfo, container_info.m_id))
 	{
 		container_info.m_type = CT_DOCKER;
+		tinfo->m_container_id = container_info.m_id;
 	}
 	else
 	{
@@ -124,7 +125,6 @@ bool docker::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, 
 		manager->add_container(container_info, tinfo);
 		manager->notify_new_container(container_info);
 	}
-	tinfo->m_container_id = container_info.m_id;
 	return true;
 }
 

--- a/userspace/libsinsp/container_engine/docker_win.cpp
+++ b/userspace/libsinsp/container_engine/docker_win.cpp
@@ -34,14 +34,6 @@ void docker::cleanup()
 {
 }
 
-void docker::set_cri_socket_path(const std::string& path)
-{
-}
-
-void docker::set_cri_timeout(int64_t timeout_ms)
-{
-}
-
 std::string docker::build_request(const std::string &url)
 {
 	return "GET " + m_api_version + url + " HTTP/1.1\r\nHost: docker\r\n\r\n";

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1596,11 +1596,6 @@ void sinsp::set_query_docker_image_info(bool query_image_info)
 	m_container_manager.set_query_docker_image_info(query_image_info);
 }
 
-void sinsp::set_docker_cri_mode(bool docker_then_cri)
-{
-	m_container_manager.set_docker_cri_mode(docker_then_cri);
-}
-
 void sinsp::set_cri_socket_path(const std::string& path)
 {
 	m_container_manager.set_cri_socket_path(path);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -880,7 +880,6 @@ public:
 
 	void set_fullcapture_port_range(uint16_t range_start, uint16_t range_end);
 
-	void set_docker_cri_mode(bool docker_then_cri);
 	void set_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
 

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -82,19 +82,12 @@ static void usage()
 " --cri <path>       Path to CRI socket for container metadata\n"
 "                    Use the specified socket to fetch data from a CRI-compatible runtime\n"
 "\n"
-"                    Note: this disables Docker support unless --docker-then-cri\n"
-"                    is also passed.\n"
 " --cri-timeout <timeout_ms>\n"
 "                    Wait at most <timeout_ms> milliseconds for response from CRI\n"
 #endif
 " -d <period>, --delay=<period>\n"
 "                    Set the delay between updates, in milliseconds. This works\n"
 "                    similarly to the -d option in top.\n"
-#ifdef HAS_CAPTURE
-" --docker-then-cri  Enable Docker support along with CRI\n"
-"                    First, query the Docker daemon for container metadata.\n"
-"                    If that fails, query CRI.\n"
-#endif
 " -E, --exclude-users\n"
 "                    Don't create the user/group tables by querying the OS when\n"
 "                    sysdig starts. This also means that no user or group info\n"
@@ -329,7 +322,6 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 	string bpf_probe;
 #ifdef HAS_CAPTURE
 	string cri_socket_path;
-	bool docker_then_cri = false;
 #endif
 
 #ifndef _WIN32
@@ -353,7 +345,6 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 #ifdef HAS_CAPTURE
 		{"cri", required_argument, 0, 0 },
 		{"cri-timeout", required_argument, 0, 0 },
-		{"docker-then-cri", no_argument, 0, 0 },
 #endif
 		{"delay", required_argument, 0, 'd' },
 		{"exclude-users", no_argument, 0, 'E' },
@@ -551,10 +542,6 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 					{
 						inspector->set_cri_timeout(sinsp_numparser::parsed64(optarg));
 					}
-					else if(optname == "docker-then-cri")
-					{
-						docker_then_cri = true;
-					}
 #endif
 					else if(optname == "logfile")
 					{
@@ -599,7 +586,6 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 		if(!cri_socket_path.empty())
 		{
 			inspector->set_cri_socket_path(cri_socket_path);
-			inspector->set_docker_cri_mode(docker_then_cri);
 		}
 #endif
 

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -96,8 +96,6 @@ static void usage()
 " --cri <path>       Path to CRI socket for container metadata\n"
 "                    Use the specified socket to fetch data from a CRI-compatible runtime\n"
 "\n"
-"                    Note: this disables Docker support unless --docker-then-cri\n"
-"                    is also passed.\n"
 " --cri-timeout <timeout_ms>\n"
 "                    Wait at most <timeout_ms> milliseconds for response from CRI\n"
 #endif
@@ -109,11 +107,6 @@ static void usage()
 " -D, --debug        Capture events about sysdig itself, display internal events\n"
 "                    in addition to system events, and print additional\n"
 "                    logging on standard error.\n"
-#ifdef HAS_CAPTURE
-" --docker-then-cri  Enable Docker support along with CRI\n"
-"                    First, query the Docker daemon for container metadata.\n"
-"                    If that fails, query CRI.\n"
-#endif
 " -E, --exclude-users\n"
 "                    Don't create the user/group tables by querying the OS when\n"
 "                    sysdig starts. This also means that no user or group info\n"
@@ -790,7 +783,6 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 	std::set<std::string> suppress_comms;
 #ifdef HAS_CAPTURE
 	string cri_socket_path;
-	bool docker_then_cri = false;
 #endif
 
 	// These variables are for the cycle_writer engine
@@ -811,7 +803,6 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 #ifdef HAS_CAPTURE
 		{"cri", required_argument, 0, 0 },
 		{"cri-timeout", required_argument, 0, 0 },
-		{"docker-then-cri", no_argument, 0, 0 },
 #endif
 		{"displayflt", no_argument, 0, 'd' },
 		{"debug", no_argument, 0, 'D'},
@@ -1213,9 +1204,6 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 					else if (optname == "cri-timeout") {
 						inspector->set_cri_timeout(sinsp_numparser::parsed64(optarg));
 					}
-					else if (optname == "docker-then-cri") {
-						docker_then_cri = true;
-					}
 #endif
 					else if (optname == "unbuffered") {
 						unbuf_flag = true;
@@ -1253,7 +1241,6 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 		if(!cri_socket_path.empty())
 		{
 			inspector->set_cri_socket_path(cri_socket_path);
-			inspector->set_docker_cri_mode(docker_then_cri);
 		}
 #endif
 


### PR DESCRIPTION
Some Docker versions use `/run/containerd/containerd.sock` as the containerd socket which interferes with just using Docker without CRI.

Make the Docker-then-CRI mode the only supported one but also (to avoid repeated overhead) disable calling Docker API when we can't connect.