### PR TITLE
Modified BPF probe builder

### DIFF
--- a/docker/ebpf-probe-builder/build_bpf_probe.sh
+++ b/docker/ebpf-probe-builder/build_bpf_probe.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -euo pipefail
+set -eu
 
 # Defaults
 DRIVER_DIR=/opt/draios/src/draios-agent-0.1.1dev
@@ -36,7 +36,18 @@ done
 
 mkdir -p ${HOME}/.sysdig
 
+#
+# Mapped volumes:
+#  - ${OUT_DIR}: The directory that the probe gets put in. Defaults to ~/.sysdig
+#  - ${DRIVER_DIR}: The prepared bpf driver code that gets written by the installer
+#  - ${KERNEL_DIR}: The kmod build directory for the target kernel.
+#  - /lib/modules: Unfortunately, on some distros (Debian / Ubuntu), there are
+#    additional support directories (such as a -commmon counterpart to -amd64) which
+#    need to be accessible for the makefile
+#  - /usr: As with the above, on Debian based systems the /lib/modules tree will have
+#    symlinks into /usr/lib/linux-kbuild* and these directories need to be present.
+
 docker build -t ebpf-probe-builder:latest --pull .
-docker run --rm -it -v ${OUT_DIR}:/out -v ${DRIVER_DIR}:/driver -v ${KERNEL_DIR}:/kernel -e BPF_PROBE_FILENAME=bpf_probe.o ebpf-probe-builder:latest
+docker run --rm -i -v ${OUT_DIR}:/out -v ${DRIVER_DIR}:/driver -v ${KERNEL_DIR}:/kernel -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -e BPF_PROBE_FILENAME=bpf_probe.o ebpf-probe-builder:latest
 
 echo "Probe is in ${OUT_DIR}/"

--- a/docker/ebpf-probe-builder/probe-builder-entrypoint.sh
+++ b/docker/ebpf-probe-builder/probe-builder-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
+# Copyright (C) 2013-2019 Draios Inc dba Sysdig.
 #
-# This file is part of sysdig .
+# This file is part of sysdig.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,9 +22,24 @@
 # docker container)
 #
 
-set -euo pipefail
+set -exu
 
 echo "* Building probe ${BPF_PROBE_FILENAME}"
+
+# On some distros, the modules dir links into /usr/src, so we need to make sure
+# we have that sorted so we can build properly
+for i in $(ls /host/usr/src); do
+	ln -s /host/usr/src/$i /usr/src/$i
+done
+
+# Again, on some distros, we need to populate the /lib/modules directory
+# because the kernel header info is split among several subdirs
+
+mkdir -p /lib/modules
+
+for i in $(ls /host/lib/modules); do
+	ln -s /host/lib/modules/$i /lib/modules/$i
+done
 
 cd /driver/bpf
 echo "Building bpf"


### PR DESCRIPTION
When attempting to run on Jenkins, I discovered that the probe builder
does not work  on Debian-based distributions due to the idiosyncratic
way those distros set up their kernel build directories.

These modifications unfortunately make the ebpf probe builder container
a bit less secure, but they also make it more likely to actually work.

I also modified the shell script options because the Jenkins host is not
running a shell that support -o pipefail