### PR TITLE
Async framework base

### DIFF
--- a/userspace/async/async_key_value_source.h
+++ b/userspace/async/async_key_value_source.h
@@ -1,0 +1,280 @@
+/*
+Copyright (C) 2019 Sysdig, Inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <list>
+#include <map>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <stdint.h>
+
+namespace sysdig
+{
+
+/**
+ * Base class for classes that need to collect values asynchronously from some
+ * value source.  Subclasses will override the the run_impl() method and
+ * implement the concrete value lookup behavior.  In that method, subclasses
+ * will use use dequeue_next_key() method to get the key that it will use to
+ * collect the value(s), collect the appropriate value(s), and call the
+ * store_value() method to save the value.  The run_impl() method should
+ * continue to dequeue and process values while the dequeue_next_key() method
+ * returns true.
+ *
+ * The constructor for this class accepts a maximum wait time; this specifies
+ * how long client code is willing to wait for a synchronous response (i.e.,
+ * how long the lookup() method will block waiting for the requested value).
+ * If the async_key_value_source is able to collect the requested value
+ * within that time period, then the lookup() method will return them.
+ *
+ * If the lookup() method is unable to collect the requested value within
+ * the requested time period, then one of two things will happen.
+ *
+ * <ol>
+ * <li>If the client supplied a callback handler in the call to lookup(), then
+ *     that callback handler will be invoked by the async_key_value_source once
+ *     the value has been collected.  Note that the callback handler will be
+ *     invoked in the context of the asynchronous thread associated with the
+ *     async_key_value_source.</li>
+ * <li>If the client did not supply a handler, then the value will be stored,
+ *     and the next call to the lookup() method with the same key will return
+ *     the previously collected value.  If lookup() is not called with the
+ *     specified ttl time, then this compoment will prune the stored value.</li>
+ * </ol>
+ *
+ * @tparam key_type   The type of the keys for which concrete subclasses will
+ *                    query.  This type must have a valid operator==().
+ * @tparam value_type The type of value that concrete subclasses will
+ *                    receive from a query.  This type must have a valid
+ *                    operator=().
+ */
+template<typename key_type, typename value_type>
+class async_key_value_source
+{
+public:
+	/**
+	 * If provided to the constructor as max_wait_ms, then lookup will
+	 * not wait for a response.
+	 */
+	const static uint64_t NO_WAIT_LOOKUP = 0;
+
+	/**
+	 * A callback handler will take a key and a output reference to the
+	 * value.
+	 */
+        typedef std::function<void(const key_type& key,
+			           const value_type& value)> callback_handler;
+
+	/**
+	 * Initialize this new async_key_value_source, which will block
+	 * synchronously for the given max_wait_ms for value collection.
+	 *
+	 * @param[in] max_wait_ms The maximum amount of time that client code
+	 *                        is willing to wait for lookup() to collect
+	 *                        a value before falling back to an async
+	 *                        return.
+	 * @param[in] ttl_ms      The time, in milliseconds, that a cached
+	 *                        value will live before being considered
+	 *                        "too old" and being pruned.
+	 */
+	async_key_value_source(uint64_t max_wait_ms, uint64_t ttl_ms);
+
+	async_key_value_source(const async_key_value_source&) = delete;
+	async_key_value_source(async_key_value_source&&) = delete;
+	async_key_value_source& operator=(const async_key_value_source&) = delete;
+
+	virtual ~async_key_value_source();
+
+	/**
+	 * Returns the maximum amount of time, in milliseconds, that a call to
+	 * lookup() will block synchronously before returning.
+	 */
+	uint64_t get_max_wait() const;
+
+	/**
+	 * Returns the maximum amount of time, in milliseconds, that a cached
+	 * value will live before being pruned.
+	 */
+	uint64_t get_ttl() const;
+
+	/**
+	 * Lookup value(s) based on the given key.  This method will block
+	 * the caller for up the max_wait_ms time specified at construction
+	 * for the desired value(s) to be available.
+	 *
+	 * @param[in] key       The key to the value for which the client
+	 *                      wishs to query.
+	 * @param[out] value    If this method is able to fetch the desired
+	 *                      value within the max_wait_ms specified at
+	 *                      construction time, then this output parameter
+	 *                      will contain the collected value.  The value
+	 *                      of this parameter is defined only if this method
+	 *                      returns true.
+	 * @param[in] handler   If this method is unable to collect the requested
+	 *                      value(s) before the timeout, and if this parameter
+	 *                      is a valid, non-empty, function, then this class
+	 *                      will invoke the given handler from the async
+	 *                      thread immediately after the collected values
+	 *                      are available.  If this handler is empty, then
+	 *                      this async_key_value_source will store the
+	 *                      values until either the next call to lookup()
+	 *                      or until its ttl expires, whichever comes first.
+	 *                      The handler is responsible for any thread-safety
+	 *                      guarantees.
+	 *
+	 * @returns true if this method was able to lookup and return the
+	 *          value synchronously; false otherwise.
+	 */
+	bool lookup(const key_type& key,
+                    value_type& value,
+                    const callback_handler& handler = callback_handler());
+
+	/**
+	 * Determines if the async thread assocaited with this
+	 * async_key_value_source is running.
+	 *
+	 * <b>Note:</b> This API is for information only.  Clients should
+	 * not use this to implement any sort of complex behavior.  Such
+	 * use will lead to race conditions.  For example, is_running() and
+	 * lookup() could potentially race, causing is_running() to return
+	 * false after lookup() has started the thread.
+	 *
+	 * @returns true if the async thread is running, false otherwise.
+	 */
+	bool is_running() const;
+
+protected:
+	/**
+	 * Stops the thread assocaited with this async_key_value_source, if
+	 * it is running; otherwise, does nothing.  The only use for this is
+	 * in a destructor to ensure that the async thread stops when the
+	 * object is destroyed.
+	 */
+	void stop();
+
+	/**
+	 * Dequeues an entry from the request queue and returns it in the given
+	 * key.  Concrete subclasses will call this method to get the next key
+	 * for which to collect values.
+	 *
+	 * @returns true if there was a key to dequeue, false otherwise.
+	 */
+	bool dequeue_next_key(key_type& key);
+
+	/**
+	 * Get the (potentially partial) value for the given key.
+	 *
+	 * @param[in] key The key whose value is needed.
+	 *
+	 * @returns the value associated with the given key.
+	 */
+	value_type get_value(const key_type& key);
+
+	/**
+	 * Stores a value for the given key.  Concrete subclasses will call
+	 * this method from their run_impl() method to save (or otherwise
+	 * notifiy the client about) an available value.
+	 *
+	 * @param[in] key   The key for which the client asked for the value.
+	 * @param[in] value The collected value.
+	 */
+	void store_value(const key_type& key, const value_type& value);
+
+	/**
+	 * Concrete subclasses must override this method to perform the
+	 * asynchronous value lookup.  The implementation should:
+	 *
+	 * <ul>
+	 * <li>Loop while dequeue_next_key() is true.</li>
+	 * <li>Get any existing value for that key using get_value()</li>
+	 * <li>Do whatever work is necessary to lookup the value associated
+	 *     with that key.</li>
+	 * <li>Call store_value to store the updated value, and to
+	 *     notify any client code waiting on that data.</li>
+	 * </ul>
+	 */
+	virtual void run_impl() = 0;
+
+private:
+	/**
+	 * Holds information associated with a single lookup() request.
+	 */
+	struct lookup_request
+	{
+		lookup_request():
+			m_available(false),
+			m_value(),
+			m_available_condition(),
+			m_callback(),
+			m_start_time(std::chrono::steady_clock::now())
+		{ }
+
+		/** Is the value here available? */
+		bool m_available;
+
+		/** The value for a key. */
+		value_type m_value;
+
+		/** Block in lookup() waiting for a sync response. */
+		std::condition_variable m_available_condition;
+
+		/**
+		 * A optional client-specified callback handler for async
+		 * response notification.
+		 */
+		callback_handler m_callback;
+
+		/** The time at which this request was made. */
+		std::chrono::time_point<std::chrono::steady_clock> m_start_time;
+	};
+
+	typedef std::map<key_type, lookup_request> value_map;
+
+	/**
+	 * The entry point of the async thread, which blocks waiting for work
+	 * and dispatches work to run_impl().
+	 */
+	void run();
+
+	/**
+	 * Remove any entries that are older than the time-to-live.
+	 */
+	void prune_stale_requests();
+
+	uint64_t m_max_wait_ms;
+	uint64_t m_ttl_ms;
+	std::thread m_thread;
+	bool m_running;
+	bool m_terminate;
+	mutable std::mutex m_mutex;
+	std::condition_variable m_start_condition;
+	std::condition_variable m_queue_not_empty_condition;
+	std::list<key_type> m_request_queue;
+	std::set<key_type> m_request_set;
+	value_map m_value_map;
+};
+
+
+} // end namespace sysdig
+
+#include "async_key_value_source.tpp"

--- a/userspace/async/async_key_value_source.h
+++ b/userspace/async/async_key_value_source.h
@@ -266,8 +266,18 @@ private:
 	std::thread m_thread;
 	bool m_running;
 	bool m_terminate;
+
+	/**
+	 * Protects the state of instances of this class.  This protected does
+	 * not extend to subclasses (i.e., this mutex should not be held when
+	 * dispatching to overridden methbods).
+	 */
 	mutable std::mutex m_mutex;
-	std::condition_variable m_start_condition;
+
+	/**
+	 * Enables run() to block waiting for the m_request_queue to become
+	 * non-empty.
+	 */
 	std::condition_variable m_queue_not_empty_condition;
 	std::list<key_type> m_request_queue;
 	std::set<key_type> m_request_set;

--- a/userspace/async/async_key_value_source.tpp
+++ b/userspace/async/async_key_value_source.tpp
@@ -251,7 +251,7 @@ void async_key_value_source<key_type, value_type>::store_value(
 }
 
 /**
- * Prune any "old" outstanding requests.  This method expect that the caller
+ * Prune any "old" outstanding requests.  This method expects that the caller
  * is holding m_mutex.
  */
 template<typename key_type, typename value_type>

--- a/userspace/async/async_key_value_source.tpp
+++ b/userspace/async/async_key_value_source.tpp
@@ -102,7 +102,7 @@ template<typename key_type, typename value_type>
 bool async_key_value_source<key_type, value_type>::is_running() const
 {
 	// Since this is for information only and it's ok to race, we
-	// expliclty do not lock here.
+	// explicitly do not lock here.
 
 	return m_running;
 }

--- a/userspace/async/async_key_value_source.tpp
+++ b/userspace/async/async_key_value_source.tpp
@@ -1,0 +1,288 @@
+/*
+Copyright (C) 2019 Sysdig, Inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+#include "logger.h"
+
+#include <assert.h>
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <list>
+#include <string>
+
+namespace sysdig
+{
+
+template<typename key_type, typename value_type>
+async_key_value_source<key_type, value_type>::async_key_value_source(
+		const uint64_t max_wait_ms,
+		const uint64_t ttl_ms):
+	m_max_wait_ms(max_wait_ms),
+	m_ttl_ms(ttl_ms),
+	m_thread(),
+	m_running(false),
+	m_terminate(false),
+	m_mutex(),
+	m_queue_not_empty_condition(),
+	m_value_map()
+{ }
+
+template<typename key_type, typename value_type>
+async_key_value_source<key_type, value_type>::~async_key_value_source()
+{
+	try
+	{
+		stop();
+	}
+	catch(...)
+	{
+		g_logger.log(std::string(__FUNCTION__) +
+		             ": Exception in destructor",
+		             sinsp_logger::SEV_ERROR);
+	}
+}
+
+template<typename key_type, typename value_type>
+uint64_t async_key_value_source<key_type, value_type>::get_max_wait() const
+{
+	return m_max_wait_ms;
+}
+
+template<typename key_type, typename value_type>
+uint64_t async_key_value_source<key_type, value_type>::get_ttl() const
+{
+	return m_ttl_ms;
+}
+
+template<typename key_type, typename value_type>
+void async_key_value_source<key_type, value_type>::stop()
+{
+	bool join_needed = false;
+
+	{
+		std::unique_lock<std::mutex> guard(m_mutex);
+
+		if(m_running)
+		{
+			m_terminate = true;
+			join_needed = true;
+
+			// The async thread might be waiting for new events
+			// so wake it up
+			m_queue_not_empty_condition.notify_one();
+		}
+	} // Drop the mutex before join()
+
+	if (join_needed)
+	{
+		m_thread.join();
+
+		// Remove any pointers from the thread to this object
+		// (just to be safe)
+		m_thread = std::thread();
+	}
+}
+
+template<typename key_type, typename value_type>
+bool async_key_value_source<key_type, value_type>::is_running() const
+{
+	// Since this is for information only and it's ok to race, we
+	// expliclty do not lock here.
+
+	return m_running;
+}
+
+template<typename key_type, typename value_type>
+void async_key_value_source<key_type, value_type>::run()
+{
+	m_running = true;
+
+	while(!m_terminate)
+	{
+		{
+			std::unique_lock<std::mutex> guard(m_mutex);
+
+			while(!m_terminate && m_request_queue.empty())
+			{
+				// Wait for something to show up on the queue
+				m_queue_not_empty_condition.wait(guard);
+			}
+
+			prune_stale_requests();
+		}
+
+		if(!m_terminate)
+		{
+			run_impl();
+		}
+	}
+
+	m_running = false;
+}
+
+template<typename key_type, typename value_type>
+bool async_key_value_source<key_type, value_type>::lookup(
+		const key_type& key,
+		value_type& value,
+		const callback_handler& callback)
+{
+	std::unique_lock<std::mutex> guard(m_mutex);
+
+	if(!m_running && !m_thread.joinable())
+	{
+		m_thread = std::thread(&async_key_value_source::run, this);
+	}
+
+	typename value_map::const_iterator itr = m_value_map.find(key);
+	bool request_complete = (itr != m_value_map.end()) && itr->second.m_available;
+
+	if(!request_complete)
+	{
+		// Haven't made the request yet
+		if (itr == m_value_map.end())
+		{
+			m_value_map[key].m_available = false;
+			m_value_map[key].m_value = value;
+		}
+
+		// Make request to API and let the async thread know about it
+		if (std::find(m_request_set.begin(),
+		              m_request_set.end(),
+		              key) == m_request_set.end())
+		{
+			m_request_queue.push_back(key);
+			m_request_set.insert(key);
+			m_queue_not_empty_condition.notify_one();
+		}
+
+		//
+		// If the client code is willing to wait a short amount of time
+		// to satisfy the request, then wait for the async thread to
+		// pick up the newly-added request and execute it.  If
+		// processing that request takes too much time, then we'll
+		// not be able to return the value information on this call,
+		// and the async thread will continue handling the request so
+		// that it'll be available on the next call.
+		//
+		if (m_max_wait_ms > 0)
+		{
+			m_value_map[key].m_available_condition.wait_for(
+					guard,
+					std::chrono::milliseconds(m_max_wait_ms));
+
+			itr = m_value_map.find(key);
+			request_complete = (itr != m_value_map.end()) && itr->second.m_available;
+		}
+	}
+
+	if(request_complete)
+	{
+		value = itr->second.m_value;
+		m_value_map.erase(key);
+	}
+	else
+	{
+		m_value_map[key].m_callback = callback;
+	}
+
+	return request_complete;
+}
+
+template<typename key_type, typename value_type>
+bool async_key_value_source<key_type, value_type>::dequeue_next_key(key_type& key)
+{
+	std::lock_guard<std::mutex> guard(m_mutex);
+	bool key_found = false;
+
+	if(m_request_queue.size() > 0)
+	{
+		key_found = true;
+
+		key = m_request_queue.front();
+		m_request_queue.pop_front();
+		m_request_set.erase(key);
+	}
+
+	return key_found;
+}
+
+template<typename key_type, typename value_type>
+value_type async_key_value_source<key_type, value_type>::get_value(
+		const key_type& key)
+{
+	std::lock_guard<std::mutex> guard(m_mutex);
+
+	return m_value_map[key].m_value;
+}
+
+template<typename key_type, typename value_type>
+void async_key_value_source<key_type, value_type>::store_value(
+		const key_type& key,
+		const value_type& value)
+{
+	std::lock_guard<std::mutex> guard(m_mutex);
+
+	if (m_value_map[key].m_callback)
+	{
+		m_value_map[key].m_callback(key, value);
+		m_value_map.erase(key);
+	}
+	else
+	{
+		m_value_map[key].m_value = value;
+		m_value_map[key].m_available = true;
+		m_value_map[key].m_available_condition.notify_one();
+	}
+}
+
+/**
+ * Prune any "old" outstanding requests.  This method expect that the caller
+ * is holding m_mutex.
+ */
+template<typename key_type, typename value_type>
+void async_key_value_source<key_type, value_type>::prune_stale_requests()
+{
+	// Avoid both iterating over and modifying the map by saving a list
+	// of keys to prune.
+	std::vector<key_type> keys_to_prune;
+
+	for(auto i = m_value_map.begin();
+	    !m_terminate && (i != m_value_map.end());
+	    ++i)
+	{
+		const auto now = std::chrono::steady_clock::now();
+
+		const auto age_ms =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+					now - i->second.m_start_time).count();
+
+		if(age_ms > m_ttl_ms)
+		{
+			keys_to_prune.push_back(i->first);
+		}
+	}
+
+	for(auto i = keys_to_prune.begin();
+	    !m_terminate && (i != keys_to_prune.end());
+	    ++i)
+	{
+		m_value_map.erase(*i);
+	}
+}
+
+} // end namespace sysdig

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -24,6 +24,7 @@ limitations under the License.
 #define VISIBILITY_PRIVATE private:
 #endif
 
+#include "sinsp_inet.h"
 #include "sinsp_public.h"
 #include "scap.h"
 #include "gen_filter.h"

--- a/userspace/libsinsp/logger.h
+++ b/userspace/libsinsp/logger.h
@@ -19,6 +19,8 @@ limitations under the License.
 
 #pragma once
 
+#include "sinsp_public.h"
+
 ///////////////////////////////////////////////////////////////////////////////
 // The logger class
 ///////////////////////////////////////////////////////////////////////////////
@@ -78,7 +80,7 @@ public:
 	void set_log_output_type(sinsp_logger::output_type log_output_type);
 	void add_stdout_log();
 	void add_stderr_log();
-	void add_file_log(string filename);
+	void add_file_log(std::string filename);
 	void add_file_log(FILE* f);
 	void add_callback_log(sinsp_logger_callback callback);
 	void remove_callback_log();
@@ -86,8 +88,8 @@ public:
 	void set_severity(severity sev);
 	severity get_severity() const;
 
-	void log(string msg, severity sev=SEV_INFO);
-	void log(string msg, event_severity sev);
+	void log(std::string msg, severity sev=SEV_INFO);
+	void log(std::string msg, event_severity sev);
 
 	// Log functions that accept printf syntax and return the formatted buffer.
 	char* format(severity sev, const char* fmt, ...);
@@ -103,6 +105,8 @@ private:
 	severity m_sev;
 	char m_tbuf[32768];
 };
+
+extern sinsp_logger g_logger;
 
 inline bool sinsp_logger::is_callback() const
 {

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -46,6 +46,7 @@ limitations under the License.
 #pragma warning(disable: 4251 4200 4221 4190)
 #endif
 
+#include "sinsp_inet.h"
 #include "sinsp_public.h"
 
 #define __STDC_FORMAT_MACROS

--- a/userspace/libsinsp/sinsp_inet.h
+++ b/userspace/libsinsp/sinsp_inet.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2018-2019 Sysdig, Inc.
+Copyright (C) 2019 Sysdig, Inc.
 
 This file is part of sysdig.
 
@@ -18,11 +18,8 @@ limitations under the License.
 */
 #pragma once
 
-#ifdef _WIN32
-#define SINSP_PUBLIC __declspec(dllexport)
-//#include <Ws2tcpip.h>
+#if defined(_WIN32)
+#    include <Ws2tcpip.h>
 #else
-#define SINSP_PUBLIC
-//#include <arpa/inet.h>
+#    include <arpa/inet.h>
 #endif
-

--- a/userspace/libsinsp/sinsp_int.h
+++ b/userspace/libsinsp/sinsp_int.h
@@ -52,6 +52,7 @@ using namespace std;
 #include "parsers.h"
 #include "ifinfo.h"
 #include "internal_metrics.h"
+#include "sinsp_public.h"
 
 #ifndef MIN
 #define MIN(X,Y) ((X) < (Y)? (X):(Y))
@@ -80,10 +81,8 @@ using namespace std;
 // Public export macro
 //
 #ifdef _WIN32
-#define SINSP_PUBLIC __declspec(dllexport)
 #define BRK(X) {if(evt != NULL && evt->get_num() == X)__debugbreak();}
 #else
-#define SINSP_PUBLIC
 #define BRK(X)
 #endif
 

--- a/userspace/libsinsp/sinsp_public.h
+++ b/userspace/libsinsp/sinsp_public.h
@@ -20,9 +20,7 @@ limitations under the License.
 
 #ifdef _WIN32
 #define SINSP_PUBLIC __declspec(dllexport)
-//#include <Ws2tcpip.h>
 #else
 #define SINSP_PUBLIC
-//#include <arpa/inet.h>
 #endif
 


### PR DESCRIPTION
This change introduces a template class, `async_key_value_source`, that
developers will subclass to create concrete classes that can
asynchronously fetch some data and make it available for later use.

The other changes here are a result of `logger.h` not being
self-sufficient.  I pull networking headers out of `sinsp_public.h` and
added them to `sinsp_inet.h`, and included `sinsp_inet.h` in various places.