### PR TITLE
Infer fd info for sendto system call [SMAGENT-1282]

### DIFF
--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -132,7 +132,7 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_pause - SYSCALL_TABLE_ID0] =                      {UF_USED | UF_ALWAYS_DROP, PPME_GENERIC_E, PPME_GENERIC_X},
 
 #ifndef __NR_socketcall
-	[__NR_socket - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_NEVER_DROP | UF_SIMPLEDRIVER_KEEP, PPME_SOCKET_SOCKET_E, PPME_SOCKET_SOCKET_X},
+	[__NR_socket - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_SIMPLEDRIVER_KEEP, PPME_SOCKET_SOCKET_E, PPME_SOCKET_SOCKET_X},
 	[__NR_bind - SYSCALL_TABLE_ID0] =                       {UF_USED | UF_NEVER_DROP, PPME_SOCKET_BIND_E,  PPME_SOCKET_BIND_X},
 	[__NR_connect - SYSCALL_TABLE_ID0] =                    {UF_USED | UF_SIMPLEDRIVER_KEEP, PPME_SOCKET_CONNECT_E, PPME_SOCKET_CONNECT_X},
 	[__NR_listen - SYSCALL_TABLE_ID0] =                     {UF_USED, PPME_SOCKET_LISTEN_E, PPME_SOCKET_LISTEN_X},

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -132,7 +132,7 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_pause - SYSCALL_TABLE_ID0] =                      {UF_USED | UF_ALWAYS_DROP, PPME_GENERIC_E, PPME_GENERIC_X},
 
 #ifndef __NR_socketcall
-	[__NR_socket - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_SIMPLEDRIVER_KEEP, PPME_SOCKET_SOCKET_E, PPME_SOCKET_SOCKET_X},
+	[__NR_socket - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_NEVER_DROP | UF_SIMPLEDRIVER_KEEP, PPME_SOCKET_SOCKET_E, PPME_SOCKET_SOCKET_X},
 	[__NR_bind - SYSCALL_TABLE_ID0] =                       {UF_USED | UF_NEVER_DROP, PPME_SOCKET_BIND_E,  PPME_SOCKET_BIND_X},
 	[__NR_connect - SYSCALL_TABLE_ID0] =                    {UF_USED | UF_SIMPLEDRIVER_KEEP, PPME_SOCKET_CONNECT_E, PPME_SOCKET_CONNECT_X},
 	[__NR_listen - SYSCALL_TABLE_ID0] =                     {UF_USED, PPME_SOCKET_LISTEN_E, PPME_SOCKET_LISTEN_X},

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -258,6 +258,13 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 	//
 	switch(etype)
 	{
+	case PPME_SOCKET_SENDTO_E:
+		if(evt->m_fdinfo == nullptr)
+		{
+			infer_sendto_fdinfo(evt);
+		}
+
+		// FALLTHRU
 	case PPME_SYSCALL_OPEN_E:
 	case PPME_SOCKET_SOCKET_E:
 	case PPME_SYSCALL_EVENTFD_E:
@@ -269,7 +276,6 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 	case PPME_SYSCALL_GETRLIMIT_E:
 	case PPME_SYSCALL_SETRLIMIT_E:
 	case PPME_SYSCALL_PRLIMIT_E:
-	case PPME_SOCKET_SENDTO_E:
 	case PPME_SOCKET_SENDMSG_E:
 	case PPME_SYSCALL_SENDFILE_E:
 	case PPME_SYSCALL_SETRESUID_E:
@@ -2245,6 +2251,44 @@ inline void sinsp_parser::add_socket(sinsp_evt *evt, int64_t fd, uint32_t domain
 	// Add the fd to the table.
 	//
 	evt->m_fdinfo = evt->m_tinfo->add_fd(fd, &fdi);
+}
+
+/**
+ * If we receive a call to 'sendto()' and the event's m_fdinfo is nullptr,
+ * then we likely missed the call to 'socket()' that created the file
+ * descriptor.  In that case, we'll guess that it's a SOCK_DGRAM/UDP socket
+ * and create the fdinfo based on that.
+ *
+ * Precondition: evt->m_fdinfo == nullptr
+ */
+inline void sinsp_parser::infer_sendto_fdinfo(sinsp_evt* const evt)
+{
+	ASSERT(evt->m_fdinfo == nullptr);
+
+	const uint32_t FILE_DESCRIPTOR_PARAM = 0;
+	const uint32_t SOCKET_TUPLE_PARAM = 2;
+
+	sinsp_evt_param* parinfo = nullptr;
+
+	parinfo = evt->get_param(FILE_DESCRIPTOR_PARAM);
+	ASSERT(parinfo->m_len == sizeof(int64_t));
+	ASSERT(parinfo->get_param_info(FILE_DESCRIPTOR_PARAM)->type == PT_FD);
+	const int64_t fd = *((int64_t*) parinfo->m_val);
+
+	parinfo = evt->get_param(SOCKET_TUPLE_PARAM);
+	const char addr_family = *((char*) parinfo->m_val);
+
+	if((addr_family == AF_INET) || (addr_family == AF_INET6))
+	{
+		const uint32_t domain = (addr_family == AF_INET)
+		                        ? PPM_AF_INET
+		                        : PPM_AF_INET6;
+
+		// Here we're assuming sendto() means SOCK_DGRAM/UDP, but it
+		// can be used with TCP.  We have no way to know for sure at
+		// this point.
+		add_socket(evt, fd, domain, SOCK_DGRAM, IPPROTO_UDP);
+	}
 }
 
 void sinsp_parser::parse_socket_exit(sinsp_evt *evt)

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2259,12 +2259,18 @@ inline void sinsp_parser::add_socket(sinsp_evt *evt, int64_t fd, uint32_t domain
  * descriptor.  In that case, we'll guess that it's a SOCK_DGRAM/UDP socket
  * and create the fdinfo based on that.
  *
- * Precondition: evt->m_fdinfo == nullptr
+ * Preconditions: evt->m_fdinfo == nullptr and
+ *                evt->m_tinfo != nullptr
+ * 
  */
 inline void sinsp_parser::infer_sendto_fdinfo(sinsp_evt* const evt)
 {
-	ASSERT(evt->m_fdinfo == nullptr);
-	ASSERT(evt->m_tinfo != nullptr);
+	if((evt->m_fdinfo == nullptr) || (evt->m_tinfo != nullptr))
+	{
+		ASSERT(evt->m_fdinfo == nullptr);
+		ASSERT(evt->m_tinfo != nullptr);
+		return;
+	}
 
 	const uint32_t FILE_DESCRIPTOR_PARAM = 0;
 	const uint32_t SOCKET_TUPLE_PARAM = 2;
@@ -2273,7 +2279,7 @@ inline void sinsp_parser::infer_sendto_fdinfo(sinsp_evt* const evt)
 
 	parinfo = evt->get_param(FILE_DESCRIPTOR_PARAM);
 	ASSERT(parinfo->m_len == sizeof(int64_t));
-	ASSERT(parinfo->get_param_info(FILE_DESCRIPTOR_PARAM)->type == PT_FD);
+	ASSERT(evt->get_param_info(FILE_DESCRIPTOR_PARAM)->type == PT_FD);
 	const int64_t fd = *((int64_t*) parinfo->m_val);
 
 	if(fd < 0)

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2265,7 +2265,7 @@ inline void sinsp_parser::add_socket(sinsp_evt *evt, int64_t fd, uint32_t domain
  */
 inline void sinsp_parser::infer_sendto_fdinfo(sinsp_evt* const evt)
 {
-	if((evt->m_fdinfo == nullptr) || (evt->m_tinfo != nullptr))
+	if((evt->m_fdinfo != nullptr) || (evt->m_tinfo == nullptr))
 	{
 		ASSERT(evt->m_fdinfo == nullptr);
 		ASSERT(evt->m_tinfo != nullptr);
@@ -2299,10 +2299,13 @@ inline void sinsp_parser::infer_sendto_fdinfo(sinsp_evt* const evt)
 
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 		                "Call to sendto() with fd=%d; missing socket() "
-		                "data. Adding socket %s/SOCK_DGRAM/IPPROTO_UDP",
+		                "data. Adding socket %s/SOCK_DGRAM/IPPROTO_UDP "
+				"for command '%s', pid %d",
 		                fd,
 		                (domain == PPM_AF_INET)
-		                        ? "PPM_AF_INET" : "PPM_AF_INET6");
+		                        ? "PPM_AF_INET" : "PPM_AF_INET6",
+			        evt->m_tinfo->get_comm().c_str(),
+			        evt->m_tinfo->m_pid);
 
 		// Here we're assuming sendto() means SOCK_DGRAM/UDP, but it
 		// can be used with TCP.  We have no way to know for sure at

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -146,6 +146,7 @@ private:
 	void parse_getsockopt_exit(sinsp_evt *evt);
 
 	inline void add_socket(sinsp_evt* evt, int64_t fd, uint32_t domain, uint32_t type, uint32_t protocol);
+	inline void infer_sendto_fdinfo(sinsp_evt* evt);
 	inline void add_pipe(sinsp_evt *evt, int64_t tid, int64_t fd, uint64_t ino);
 	// Return false if the update didn't happen (for example because the tuple is NULL)
 	bool update_fd(sinsp_evt *evt, sinsp_evt_param* parinfo);

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -146,7 +146,7 @@ private:
 	void parse_getsockopt_exit(sinsp_evt *evt);
 
 	inline void add_socket(sinsp_evt* evt, int64_t fd, uint32_t domain, uint32_t type, uint32_t protocol);
-	inline void infer_sendto_fdinfo(sinsp_evt* evt);
+	inline void infer_sendto_fdinfo(sinsp_evt *evt);
 	inline void add_pipe(sinsp_evt *evt, int64_t tid, int64_t fd, uint64_t ino);
 	// Return false if the update didn't happen (for example because the tuple is NULL)
 	bool update_fd(sinsp_evt *evt, sinsp_evt_param* parinfo);


### PR DESCRIPTION
If we don't have file descriptor information when processing the sendto
system call, then we can't analyze the data associated with the system
call.

This change introduces code to try to infer the file descriptor
information.  We know that the sendto system call will be used with a
network socket, and that it will almost always be used with a UDP
socket.  If the information is missing, we inject that information into
the SENDTO_E event.