### PR TITLE
SMAGENT-1297: Rebuild gcc-plugins before building kernel module

### DIFF
--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -373,9 +373,11 @@ function rhel_build {
 
 		HASH_ORIG=$HASH
 
+		export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/usr/src/kernels/$KERNEL_RELEASE
+		cd "${KERNELDIR}" && make gcc-plugins || true
+
 		cd $BASEDIR
 
-		export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/usr/src/kernels/$KERNEL_RELEASE
 		build_probe
 	fi
 

--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -92,18 +92,16 @@ function clean_sysdig {
 }
 
 function build_probe {
-	local rebuild_gcc_plugins="${1:-"false"}"
 
-	if [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko ] || \
+	if [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko ] ||
 	   [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko ]; then
-		# Rebuild the gcc-plugins if requested
-		if [[ "${rebuild_gcc_plugins}" == "true" ]]; then
-			# Don't generate noise if there's no such target
-			# Keep going if this fails
-			(cd "${KERNELDIR}" && make gcc-plugins 2&>1 | grep -v "No rule to make target") || true
+
+		if [[ -d "${KERNELDIR}/scripts/gcc-plugins" ]]; then
+			echo "Rebuilding gcc plugins for ${KERNELDIR}"
+			(cd "${KERNELDIR}" && make gcc-plugins)
 		fi
 
-	        echo Building $PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko [${FUNCNAME[1]}]
+		echo Building $PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko [${FUNCNAME[1]}]
 
 		clean_sysdig
 		cd sysdig/
@@ -347,14 +345,11 @@ function ubuntu_build {
 function rhel_build {
 
 	#
-	# ${1} - the URL to fetch
-	# ${2} - should gcc plugins be rebuilt (default: false)
+	# The function just requires the rpm url
 	#
 
 	# Get all the parameters needed
 	URL=$1
-	local rebuild_gcc_plugins="${2:-"false"}"
-
 	RPM=$(echo $URL | grep -o '[^/]*$')
 	KERNEL_RELEASE=$(echo $RPM | awk 'match($0, /[^kernel\-(uek\-)?(core\-|devel\-)?].*[^(\.rpm)]/){ print substr($0, RSTART, RLENGTH) }')
 
@@ -387,7 +382,7 @@ function rhel_build {
 		cd $BASEDIR
 
 		export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/usr/src/kernels/$KERNEL_RELEASE
-		build_probe "${rebuild_gcc_plugins}"
+		build_probe
 	fi
 
 	cd $BASEDIR
@@ -570,7 +565,7 @@ if [ -z "$KERNEL_TYPE" ]; then
 
 	for URL in $URLS
 	do
-		rhel_build $URL "true"
+		rhel_build $URL
 	done
 
 	#

--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -384,10 +384,9 @@ function rhel_build {
 
 		HASH_ORIG=$HASH
 
-		export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/usr/src/kernels/$KERNEL_RELEASE
-
 		cd $BASEDIR
 
+		export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/usr/src/kernels/$KERNEL_RELEASE
 		build_probe "${rebuild_gcc_plugins}"
 	fi
 

--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -92,8 +92,16 @@ function clean_sysdig {
 }
 
 function build_probe {
+	local rebuild_gcc_plugins="${1:-"false"}"
 
-	if [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko ] || [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko ]; then
+	if [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko ] || \
+	   [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko ]; then
+		# Rebuild the gcc-plugins if requested
+		if [[ "${rebuild_gcc_plugins}" == "true" ]]; then
+			# Don't generate noise if there's no such target
+			# Keep going if this fails
+			(cd "${KERNELDIR}" && make gcc-plugins 2&>1 | grep -v "No rule to make target") || true
+		fi
 
 	        echo Building $PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko [${FUNCNAME[1]}]
 
@@ -339,11 +347,14 @@ function ubuntu_build {
 function rhel_build {
 
 	#
-	# The function just requires the rpm url
+	# ${1} - the URL to fetch
+	# ${2} - should gcc plugins be rebuilt (default: false)
 	#
 
 	# Get all the parameters needed
 	URL=$1
+	local rebuild_gcc_plugins="${2:-"false"}"
+
 	RPM=$(echo $URL | grep -o '[^/]*$')
 	KERNEL_RELEASE=$(echo $RPM | awk 'match($0, /[^kernel\-(uek\-)?(core\-|devel\-)?].*[^(\.rpm)]/){ print substr($0, RSTART, RLENGTH) }')
 
@@ -374,11 +385,10 @@ function rhel_build {
 		HASH_ORIG=$HASH
 
 		export KERNELDIR=$BASEDIR/$KERNEL_RELEASE/usr/src/kernels/$KERNEL_RELEASE
-		cd "${KERNELDIR}" && make gcc-plugins || true
 
 		cd $BASEDIR
 
-		build_probe
+		build_probe "${rebuild_gcc_plugins}"
 	fi
 
 	cd $BASEDIR
@@ -561,7 +571,7 @@ if [ -z "$KERNEL_TYPE" ]; then
 
 	for URL in $URLS
 	do
-		rhel_build $URL
+		rhel_build $URL "true"
 	done
 
 	#

--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -96,7 +96,7 @@ function build_probe {
 	if [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko ] ||
 	   [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko ]; then
 
-		if [[ -d "${KERNELDIR}/scripts/gcc-plugins" ]]; then
+		if [[ -f "${KERNELDIR}/scripts/gcc-plugins/stackleak_plugin.so" ]]; then
 			echo "Rebuilding gcc plugins for ${KERNELDIR}"
 			(cd "${KERNELDIR}" && make gcc-plugins)
 		fi


### PR DESCRIPTION
RHEL kernel sources come with a shared library, stackleak_plugin.so,
that we fail to link against because of missing symbols.  This change
triggers a rebuild of that library before we try to build the kernel
module.