### PR TITLE
CRI-O container support

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -121,7 +121,8 @@ list(APPEND SINSP_SOURCES
 	container_engine/libvirt_lxc.cpp
 	container_engine/lxc.cpp
 	container_engine/mesos.cpp
-	container_engine/rkt.cpp)
+	container_engine/rkt.cpp
+	runc.cpp)
 endif()
 
 if(NOT WIN32 AND NOT APPLE)

--- a/userspace/libsinsp/chisel_api.cpp
+++ b/userspace/libsinsp/chisel_api.cpp
@@ -1193,6 +1193,10 @@ int lua_cbacks::get_container_table(lua_State *ls)
 		{
 			lua_pushstring(ls, "containerd");
 		}
+		else if(it->second.m_type == CT_CRIO)
+		{
+			lua_pushstring(ls, "cri-o");
+		}
 		else
 		{
 			ASSERT(false);

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -366,6 +366,13 @@ void sinsp_container_manager::set_query_docker_image_info(bool query_image_info)
 	libsinsp::container_engine::docker::set_query_image_info(query_image_info);
 }
 
+void sinsp_container_manager::set_cri_extra_queries(bool extra_queries)
+{
+#if defined(HAS_CAPTURE)
+	libsinsp::container_engine::cri::set_extra_queries(extra_queries);
+#endif
+}
+
 void sinsp_container_manager::set_cri_socket_path(const std::string &path)
 {
 #if defined(HAS_CAPTURE)

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -65,6 +65,7 @@ public:
 	void cleanup();
 
 	void set_query_docker_image_info(bool query_image_info);
+	void set_cri_extra_queries(bool extra_queries);
 	void set_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
 	sinsp* get_inspector() { return m_inspector; }

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -114,8 +114,11 @@ bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container
 		return true;
 	}
 
-	container->m_container_ip = get_container_ip(container->m_id);
-	container->m_imageid = get_container_image_id(resp_container.image_ref());
+	if(s_cri_extra_queries)
+	{
+		container->m_container_ip = get_container_ip(container->m_id);
+		container->m_imageid = get_container_image_id(resp_container.image_ref());
+	}
 
 	return true;
 }
@@ -171,6 +174,7 @@ void cri::cleanup()
 {
 	s_cri.reset(nullptr);
 	s_cri_image.reset(nullptr);
+	s_cri_extra_queries = true;
 }
 
 void cri::set_cri_socket_path(const std::string& path)
@@ -181,6 +185,10 @@ void cri::set_cri_socket_path(const std::string& path)
 void cri::set_cri_timeout(int64_t timeout_ms)
 {
 	s_cri_timeout = timeout_ms;
+}
+
+void cri::set_extra_queries(bool extra_queries) {
+	s_cri_extra_queries = extra_queries;
 }
 
 bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -99,7 +99,6 @@ bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container
 
 	const auto &resp_container = resp.status();
 	container->m_name = resp_container.metadata().name();
-	container->m_type = s_cri_runtime_type;
 
 	for(const auto &pair : resp_container.labels())
 	{

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -37,6 +37,7 @@ public:
 	static void cleanup();
 	static void set_cri_socket_path(const std::string& path);
 	static void set_cri_timeout(int64_t timeout_ms);
+	static void set_extra_queries(bool extra_queries);
 };
 }
 }

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -50,10 +50,6 @@ public:
 	static void set_query_image_info(bool query_image_info);
 	static void parse_json_mounts(const Json::Value &mnt_obj, std::vector<sinsp_container_info::container_mount_info> &mounts);
 
-#if !defined(_WIN32)
-	static bool detect_docker(const sinsp_threadinfo* tinfo, std::string& container_id);
-#endif
-
 protected:
 	docker_response get_docker(sinsp_container_manager* manager, const std::string& url, std::string &json);
 	std::string build_request(const std::string& url);

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -36,6 +36,7 @@ enum sinsp_container_type
 	CT_CUSTOM = 5,
 	CT_CRI = 6,
 	CT_CONTAINERD = 7,
+	CT_CRIO = 8,
 };
 
 // Docker and CRI-compatible runtimes are very similar
@@ -43,7 +44,8 @@ static inline bool is_docker_compatible(sinsp_container_type t)
 {
 	return t == CT_DOCKER ||
 		t == CT_CRI ||
-		t == CT_CONTAINERD;
+		t == CT_CONTAINERD ||
+		t == CT_CRIO;
 }
 
 class sinsp_container_info

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -40,6 +40,7 @@ std::unique_ptr <runtime::v1alpha2::RuntimeService::Stub> s_cri = nullptr;
 std::unique_ptr <runtime::v1alpha2::ImageService::Stub> s_cri_image = nullptr;
 int64_t s_cri_timeout = 1000;
 sinsp_container_type s_cri_runtime_type = CT_CRI;
+bool s_cri_extra_queries = true;
 
 sinsp_container_type get_cri_runtime_type(const std::string &runtime_name)
 {

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -34,6 +34,9 @@ sinsp_container_type get_cri_runtime_type(const std::string &runtime_name)
 	if(runtime_name == "containerd")
 	{
 		return CT_CONTAINERD;
+	} else if(runtime_name == "cri-o")
+	{
+		return CT_CRIO;
 	} else
 	{
 		return CT_CRI;

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -31,6 +31,7 @@ namespace libsinsp {
 namespace cri {
 extern std::string s_cri_unix_socket_path;
 extern std::unique_ptr<runtime::v1alpha2::RuntimeService::Stub> s_cri;
+extern std::unique_ptr<runtime::v1alpha2::ImageService::Stub> s_cri_image;
 extern int64_t s_cri_timeout;
 extern sinsp_container_type s_cri_runtime_type;
 
@@ -49,5 +50,9 @@ bool parse_cri_runtime_spec(const Json::Value &info, sinsp_container_info *conta
 bool is_pod_sandbox(const std::string &container_id);
 
 uint32_t get_pod_sandbox_ip(const std::string &pod_sandbox_id);
+
+uint32_t get_container_ip(const std::string &container_id);
+
+std::string get_container_image_id(const std::string &image_ref);
 }
 }

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -34,6 +34,7 @@ extern std::unique_ptr<runtime::v1alpha2::RuntimeService::Stub> s_cri;
 extern std::unique_ptr<runtime::v1alpha2::ImageService::Stub> s_cri_image;
 extern int64_t s_cri_timeout;
 extern sinsp_container_type s_cri_runtime_type;
+extern bool s_cri_extra_queries;
 
 sinsp_container_type get_cri_runtime_type(const std::string &runtime_name);
 

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -6151,6 +6151,9 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 			case sinsp_container_type::CT_CONTAINERD:
 				m_tstr = "containerd";
 				break;
+			case sinsp_container_type::CT_CRIO:
+				m_tstr = "cri-o";
+				break;
 			case sinsp_container_type::CT_RKT:
 				m_tstr = "rkt";
 				break;

--- a/userspace/libsinsp/runc.cpp
+++ b/userspace/libsinsp/runc.cpp
@@ -1,0 +1,99 @@
+/*
+Copyright (C) 2013-2019 Draios Inc dba Sysdig.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "runc.h"
+
+#include <cstring>
+
+#include "sinsp.h"
+#include "sinsp_int.h"
+
+namespace {
+
+const size_t CONTAINER_ID_LENGTH = 64;
+const size_t REPORTED_CONTAINER_ID_LENGTH = 12;
+const char* CONTAINER_ID_VALID_CHARACTERS = "0123456789abcdefABCDEF";
+
+static_assert(REPORTED_CONTAINER_ID_LENGTH <= CONTAINER_ID_LENGTH, "Reported container ID length cannot be longer than actual length");
+
+// check if cgroup ends with <prefix><container_id><suffix>
+// If true, set <container_id> to a truncated version of the id and return true.
+// Otherwise return false and leave container_id unchanged
+bool match_one_container_id(const std::string &cgroup, const std::string &prefix, const std::string &suffix, std::string &container_id)
+{
+	size_t start_pos = cgroup.rfind(prefix);
+	if (start_pos == std::string::npos)
+	{
+		return false;
+	}
+	start_pos += prefix.size();
+
+	size_t end_pos = cgroup.rfind(suffix);
+	if (end_pos == std::string::npos)
+	{
+		return false;
+	}
+
+	if (end_pos - start_pos != CONTAINER_ID_LENGTH)
+	{
+		return false;
+	}
+
+	size_t invalid_ch_pos = cgroup.find_first_not_of(CONTAINER_ID_VALID_CHARACTERS, start_pos);
+	if (invalid_ch_pos < CONTAINER_ID_LENGTH)
+	{
+		return false;
+	}
+
+	container_id = cgroup.substr(start_pos, REPORTED_CONTAINER_ID_LENGTH);
+	return true;
+}
+
+bool match_container_id(const std::string &cgroup, const libsinsp::runc::cgroup_layout *layout,
+			std::string &container_id)
+{
+	for(size_t i = 0; layout[i].prefix && layout[i].suffix; ++i)
+	{
+		if(match_one_container_id(cgroup, layout[i].prefix, layout[i].suffix, container_id))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+}
+
+namespace libsinsp {
+namespace runc {
+
+bool matches_runc_cgroups(const sinsp_threadinfo *tinfo, const cgroup_layout *layout, std::string &container_id)
+{
+	for(const auto &it : tinfo->m_cgroups)
+	{
+		if(match_container_id(it.second, layout, container_id))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+}
+}

--- a/userspace/libsinsp/runc.h
+++ b/userspace/libsinsp/runc.h
@@ -1,0 +1,47 @@
+/*
+Copyright (C) 2013-2019 Draios Inc dba Sysdig.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <string>
+
+class sinsp_threadinfo;
+
+namespace libsinsp {
+namespace runc {
+
+/// runc-based runtimes (Docker, containerd, CRI-O, probably others) use the same two cgroup layouts
+/// with slight variations:
+/// - non-systemd layout uses cgroups ending with .../<prefix><container id>
+/// - systemd layout uses .../<prefix><container id>.scope
+/// where <container id> is always 64 hex digits (we report the first 12 as the container id).
+/// For non-systemd only CRI-O seems to use /crio-<container id>, while for systemd layout
+/// while all known container engines use a prefix like "docker-", "crio-" or "containerd-cri-".
+/// We can encode all these variants with a simple list of (prefix, suffix) pairs
+/// (the last one must be a pair of null pointers to mark the end of the array)
+struct cgroup_layout {
+	const char* prefix;
+	const char* suffix;
+};
+
+/// If any of the cgroups of the thread in `tinfo` matches the `layout`, set `container_id` to the found id
+/// and return true. Otherwise, return false and leave `container_id` unchanged
+bool matches_runc_cgroups(const sinsp_threadinfo *tinfo, const cgroup_layout *layout, std::string &container_id);
+}
+}

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1596,6 +1596,11 @@ void sinsp::set_query_docker_image_info(bool query_image_info)
 	m_container_manager.set_query_docker_image_info(query_image_info);
 }
 
+void sinsp::set_cri_extra_queries(bool extra_queries)
+{
+	m_container_manager.set_cri_extra_queries(extra_queries);
+}
+
 void sinsp::set_cri_socket_path(const std::string& path)
 {
 	m_container_manager.set_cri_socket_path(path);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -879,6 +879,8 @@ public:
 
 	void set_query_docker_image_info(bool query_image_info);
 
+	void set_cri_extra_queries(bool extra_queries);
+
 	void set_fullcapture_port_range(uint16_t range_start, uint16_t range_end);
 
 	void set_cri_socket_path(const std::string& path);


### PR DESCRIPTION
CRI-O uses CRI so most of the work is done already but it differs in some important ways from containerd and has to be supported explicitly.