### PR TITLE
Support BPM container type

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -128,6 +128,7 @@ list(APPEND SINSP_SOURCES
 	container_engine/lxc.cpp
 	container_engine/mesos.cpp
 	container_engine/rkt.cpp
+	container_engine/bpm.cpp
 	runc.cpp)
 endif()
 

--- a/userspace/libsinsp/chisel_api.cpp
+++ b/userspace/libsinsp/chisel_api.cpp
@@ -919,7 +919,7 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 		//
 		lua_pushstring(ls, "fdtable");
 		lua_newtable(ls);
-		
+
 		if(include_fds)
 		{
 			for(fdit = fdtable->m_table.begin(); fdit != fdtable->m_table.end(); ++fdit)
@@ -1196,6 +1196,10 @@ int lua_cbacks::get_container_table(lua_State *ls)
 		else if(it->second.m_type == CT_CRIO)
 		{
 			lua_pushstring(ls, "cri-o");
+		}
+		else if(it->second.m_type == CT_BPM)
+		{
+			lua_pushstring(ls, "bpm");
 		}
 		else
 		{

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include "container_engine/libvirt_lxc.h"
 #include "container_engine/lxc.h"
 #include "container_engine/mesos.h"
+#include "container_engine/bpm.h"
 
 #include "sinsp.h"
 #include "sinsp_int.h"
@@ -445,6 +446,7 @@ void sinsp_container_manager::create_engines()
 	m_container_engines.emplace_back(new container_engine::libvirt_lxc());
 	m_container_engines.emplace_back(new container_engine::mesos());
 	m_container_engines.emplace_back(new container_engine::rkt());
+	m_container_engines.emplace_back(new container_engine::bpm());
 #endif
 }
 

--- a/userspace/libsinsp/container_engine/bpm.cpp
+++ b/userspace/libsinsp/container_engine/bpm.cpp
@@ -1,0 +1,61 @@
+/*
+Copyright (C) 2013-2019 Draios Inc dba Sysdig.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "container_engine/bpm.h"
+#include "sinsp.h"
+
+using namespace libsinsp::container_engine;
+
+bool bpm::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
+{
+	sinsp_container_info container_info;
+	bool matches = false;
+
+	for(auto it = tinfo->m_cgroups.begin(); it != tinfo->m_cgroups.end(); ++it)
+	{
+		string cgroup = it->second;
+		size_t pos;
+
+		//
+		// Non-systemd and systemd BPM
+		//
+		pos = cgroup.find("bpm-");
+		if(pos != string::npos)
+		{
+			auto id_start = pos + sizeof("bpm-") - 1;
+			auto id_end = cgroup.find(".scope", id_start);
+			container_info.m_type = CT_BPM;
+			container_info.m_id = cgroup.substr(id_start, id_end - id_start);
+			matches = true;
+			break;
+		}
+	}
+
+	if (!matches)
+		return false;
+
+	tinfo->m_container_id = container_info.m_id;
+	if (!manager->container_exists(container_info.m_id))
+	{
+		container_info.m_name = container_info.m_id;
+		manager->add_container(container_info, tinfo);
+		manager->notify_new_container(container_info);
+	}
+	return true;
+}

--- a/userspace/libsinsp/container_engine/bpm.cpp
+++ b/userspace/libsinsp/container_engine/bpm.cpp
@@ -16,9 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
-
-#include <regex>
-
 #include "container_engine/bpm.h"
 #include "sinsp.h"
 
@@ -46,8 +43,7 @@ bool bpm::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 
 			// As of BPM v1.0.3, the container ID is only allowed to contain the following chars
 			// see https://github.com/cloudfoundry-incubator/bpm-release/blob/v1.0.3/src/bpm/jobid/encoding.go
-			regex re("[a-zA-Z0-9._-]+");
-			if (regex_match(id, re))
+			if (!id.empty() && strspn(id.c_str(), "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-") == id.size())
 			{
 				container_info.m_type = CT_BPM;
 				container_info.m_id = id;

--- a/userspace/libsinsp/container_engine/bpm.cpp
+++ b/userspace/libsinsp/container_engine/bpm.cpp
@@ -48,7 +48,9 @@ bool bpm::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 	}
 
 	if (!matches)
+        {
 		return false;
+        }
 
 	tinfo->m_container_id = container_info.m_id;
 	if (!manager->container_exists(container_info.m_id))

--- a/userspace/libsinsp/container_engine/bpm.h
+++ b/userspace/libsinsp/container_engine/bpm.h
@@ -1,0 +1,36 @@
+/*
+Copyright (C) 2013-2019 Draios Inc dba Sysdig.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+class sinsp_container_manager;
+class sinsp_container_info;
+class sinsp_threadinfo;
+
+#include "container_engine/container_engine.h"
+
+namespace libsinsp {
+namespace container_engine {
+class bpm : public resolver
+{
+public:
+	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;
+};
+}
+}

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -41,6 +41,7 @@ enum sinsp_container_type
 	CT_CRI = 6,
 	CT_CONTAINERD = 7,
 	CT_CRIO = 8,
+	CT_BPM = 9,
 };
 
 // Docker and CRI-compatible runtimes are very similar

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -6205,6 +6205,9 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 			case sinsp_container_type::CT_RKT:
 				m_tstr = "rkt";
 				break;
+			case sinsp_container_type::CT_BPM:
+				m_tstr = "bpm";
+				break;
 			default:
 				ASSERT(false);
 				break;


### PR DESCRIPTION
Identify BPM containers by "bpm-" prefix in cgroup-path.

See also https://github.com/cloudfoundry-incubator/bpm-release/issues/109 and https://github.com/cloudfoundry-incubator/bpm-release/commit/ea7fef1baaba90b00eb68985d3e51260a3d59503.


This PR makes it possible to monitor BPM containers on BOSH director and BOSH deployed VMs.

I tested this change by co-deploying https://github.com/ansd/sysdig-boshrelease on the BOSH director.
```
/var/vcap/packages/sysdig/bin/csysdig -pc container.type=bpm
```
is then identifying processes belonging to BPM containers.

Also, I validated on the director that selecting the Containers View in `csysdig` is showing the containers corresponding to the output of `bpm list`.