### PR TITLE
[SMAGENT-1292] Probe is not built for a number of ubuntu kernels

### DIFF
--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -93,8 +93,15 @@ function clean_sysdig {
 
 function build_probe {
 
-	if [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko ] ||
-	   [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko ]; then
+    # Skip Kernel 4.15.0-29 because probe does not build against it
+    if [ $KERNEL_RELEASE-$HASH = "4.15.0-29-generic-ea0aa038a6b9bdc4bb42152682bba6ce"  ]
+    then
+	echo "Temporarily skipping " $PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
+	return
+    fi
+
+    if [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko ] ||
+	       [ ! -f $BASEDIR/output/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko ]; then
 
 		if [[ -f "${KERNELDIR}/scripts/gcc-plugins/stackleak_plugin.so" ]]; then
 			echo "Rebuilding gcc plugins for ${KERNELDIR}"
@@ -325,7 +332,7 @@ function ubuntu_build {
 
 	NUM_DEB=$(ls linux-*.deb -1 | wc -l)
 
-	if [ $NUM_DEB -eq 3 ]; then
+	if [ $NUM_DEB -eq 4 ]; then
 
 		local KERNEL_FOLDER=$KERNEL_RELEASE
 		KERNEL_RELEASE=$(ls -1 linux-image-* | grep -E -o "[0-9]{1}\.[0-9]+\.[0-9]+-[0-9]+-[a-z]+")

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -91,7 +91,7 @@ repos = {
             "root" : "https://mirrors.kernel.org/ubuntu/pool/main/l/",
             "discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
             "subdirs" : [""],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-[3-9].*-generic.*amd64.deb$')]/@href"
+            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-(unsigned-)*[3-9].*-generic.*amd64.deb$')]/@href"
         },
 
         {
@@ -105,7 +105,7 @@ repos = {
             "root" : "http://security.ubuntu.com/ubuntu/pool/main/l/",
             "discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
             "subdirs" : [""],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-[3-9].*-generic.*amd64.deb$')]/@href"
+            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|headers)-(unsigned-)*[3-9].*-generic.*amd64.deb$')]/@href"
         },
 
         {
@@ -113,6 +113,13 @@ repos = {
             "discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
             "subdirs" : [""],
             "page_pattern" : "/html/body//a[regex:test(@href, '^linux-headers-[3-9].*_all.deb$')]/@href"
+        },
+
+        {
+            "root" : "http://security.ubuntu.com/ubuntu/pool/main/l/",
+            "discovery_pattern" : "/html/body//a[@href = 'linux/']/@href",
+            "subdirs" : [""],
+            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-modules-[3-9].*-generic.*amd64.deb$')]/@href"
         }
     ],
 


### PR DESCRIPTION
Ubuntu packetization has changed:

- amd64 images packages' name have now this form: `linux-image-unsigned-4.15.0-29-lowlatency_4.15.0-29.31_amd64.deb` **(unsinged)** was not present before
- `boot/config_someversion` has been moved into `linux-module` package.

This PR reflects these changes.

That said, if you use this patch, you will see the jenkins probe builder job failing. This is for an uncorrelated issue:
the probes compilations for Ubuntu kernel version 4.15.0-29 (and only for this version!) fail with the following error
Makefile:287: scripts/Kbuild.include: No such file or directory
arch/x86/Makefile:156: CONFIG_X86_X32 enabled but no binutils support
Makefile:693: scripts/Makefile.kcov: No such file or directory
Makefile:694: scripts/Makefile.gcc-plugins: No such file or directory
Makefile:862: scripts/Makefile.extrawarn: No such file or directory
Makefile:863: scripts/Makefile.ubsan: No such file or directory
Makefile:976: "Cannot use CONFIG_STACK_VALIDATION=y, please install libelf-dev, libelf-devel or elfutils-libelf-devel"
make[5]: *** No rule to make target `scripts/Makefile.ubsan'.  Stop.
make[4]: *** [all] Error 2
make[3]: *** [driver/CMakeFiles/driver] Error 2
make[2]: *** [driver/CMakeFiles/driver.dir/all] Error 2
make[1]: *** [driver/CMakeFiles/driver.dir/rule] Error 2
make: *** [driver] Error 2



Without the patch, this kernel version is not fetched. Then the Jenkins job completes successfully.

My advice is to block this PR until the compilation error has been solved