### PR TITLE
Fix case where fclose could be called twice.

### DIFF
--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -527,6 +527,7 @@ int32_t scap_proc_fill_loginuid(scap_t *handle, struct scap_threadinfo* tinfo, c
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Could not read loginuid from %s (%s)",
 			 loginuid_path, scap_strerror(handle, errno));
 		fclose(f);
+		return SCAP_FAILURE;
 	}
 
 	fclose(f);


### PR DESCRIPTION
The check to see if we found the `loginuid` closes the file pointer and doesn't return. If we can't find the loginuid this could lead to `fclose` being called twice which was causing falco to segfault with the error `free(): double free detected in tcache 2` on COS.

I believe we want to function to return `SCAP_FAILURE` if we can't find the `loginuid`.

Tested on COS and this stopped the segfault. 