### PR TITLE
Redefine asm_volatile_goto, needed for 5.0 kernels

### DIFF
--- a/driver/bpf/quirks.h
+++ b/driver/bpf/quirks.h
@@ -28,4 +28,13 @@ or GPL2.txt for full copies of the license.
 #define BPF_SUPPORTS_RAW_TRACEPOINTS
 #endif
 
+/* Redefine asm_volatile_goto to work around clang not supporting it
+ */
+#include <linux/types.h>
+
+#ifdef asm_volatile_goto
+#undef asm_volatile_goto
+#define asm_volatile_goto(...) asm volatile("invalid use of asm_volatile_goto")
+#endif
+
 #endif


### PR DESCRIPTION
This is inspired by an old fix I did [1] that never resulted necessary [2]
since it was fixed on the kernel side prior to making a sysdig release.

It seems like the kernel now converged towards my same hack [3], so
reintroduce it here as well.

I'm also not filtering for specific LINUX_VERSION_CODE since some of this
new asm_volatile_goto usages might be backported into some stable releases,
and it really doesn't hurt having it unconditionally enabled.

[1] https://github.com/draios/sysdig/commit/2958eb1d52e047f4b93d1238be803e7c405bdec2
[2] https://github.com/draios/sysdig/commit/9436cf2826a780ec03d9185eb23955e6967df13c
[3] https://github.com/torvalds/linux/commit/6bf3bbe1f4d4cf405e3c2bf07bbdff56d3223ec8