### PR TITLE
Add stream event details in csysdig output

### DIFF
--- a/userspace/libsinsp/cursesui.cpp
+++ b/userspace/libsinsp/cursesui.cpp
@@ -113,8 +113,8 @@ void json_spy_renderer::process_event_spy(sinsp_evt* evt, int32_t next_res)
 		m_linecnt++;
 
 		uint64_t ts = evt->get_ts(); 
-		line["ta"] = ts;
-		line["td"] = ts - m_inspector->m_firstevent_ts;
+		line["ta"] = to_string(ts);
+		line["td"] = to_string(ts - m_inspector->m_firstevent_ts);
 
 		ppm_event_flags eflags = evt->get_info_flags();
 		if(eflags & EF_READS_FROM_FD)
@@ -134,7 +134,7 @@ void json_spy_renderer::process_event_spy(sinsp_evt* evt, int32_t next_res)
 		tc.push_back(evt->get_fd_info()->get_typechar());
 		int64_t fdnum = evt->get_fd_num();
 
-		line["fd"] = fdnum;
+		line["fd"] = to_string(fdnum);
 		line["ft"] = string(tc);
 
 		if(fdname != "")

--- a/userspace/libsinsp/cursesui.cpp
+++ b/userspace/libsinsp/cursesui.cpp
@@ -128,15 +128,20 @@ void json_spy_renderer::process_event_spy(sinsp_evt* evt, int32_t next_res)
 
 		line["v"] = argstr;
 		line["l"] = to_string(len);
+
 		string fdname = evt->get_fd_info()->m_name;
 		string tc;
 		tc.push_back(evt->get_fd_info()->get_typechar());
 		int64_t fdnum = evt->get_fd_num();
 
+		line["fd"] = fdnum;
+		line["ft"] = string(tc);
+
 		if(fdname != "")
 		{
 			sanitize_string(fdname);
 			line["f"] = to_string(fdnum) + "(<" + string(tc) + ">" + fdname + ")";
+			line["fn"] = fdname;
 		}
 		else
 		{

--- a/userspace/libsinsp/cursesui.cpp
+++ b/userspace/libsinsp/cursesui.cpp
@@ -112,6 +112,10 @@ void json_spy_renderer::process_event_spy(sinsp_evt* evt, int32_t next_res)
 		Json::Value line;
 		m_linecnt++;
 
+		uint64_t ts = evt->get_ts(); 
+		line["ta"] = ts;
+		line["td"] = ts - m_inspector->m_firstevent_ts;
+
 		ppm_event_flags eflags = evt->get_info_flags();
 		if(eflags & EF_READS_FROM_FD)
 		{


### PR DESCRIPTION
Add the following details to each stream event:

1. event timestamp:
  a. absolute: `ta`
  b. relative `td`
2. split file descriptor details; Note that information is still available as single value `f` for backwards compatibility:
  a. number `fd`
  b. type `ft`
  c. name `fn`

Only the JSON output is affected, csysdig UI is not.

Changes will be used in Sysdig Inspect to improve the stream view.