### PR TITLE
Fix potential memory leak in libelf

### DIFF
--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -551,7 +551,7 @@ static int32_t load_bpf_file(scap_t *handle, const char *path)
 		return SCAP_FAILURE;
 	}
 
-	Elf *elf = elf_begin(program_fd, ELF_C_READ, NULL);
+	Elf *elf = elf_begin(program_fd, ELF_C_READ_MMAP_PRIVATE, NULL);
 	if(!elf)
 	{
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't read ELF format");


### PR DESCRIPTION
Some old versions of libelf (such as the one used in CentOS 6) are prone to
memory leaks when elf_strptr() is called, under some circumstances the
memory is not freed even upon correct invocation of elf_end().

Eventually we should ship our own updated version of libelf, but since
people are currently welcome to build without using our bundled
dependencies, it's worth fixing anyway.

The fix consists in opening the file via mmap rather than reading it via
allocated buffers, which is something I honestly thought libelf was already
doing by default, so it was my intention to begin with.

The fix went upstream in:

```
2016-08-07  Mark Wielaard  <mjw@redhat.com>

	* elf_compress.c (__libelf_reset_rawdata): Check scn->flags and
	free rawdata_base when malloced. Set ELF_F_MALLOCED for scn->flags.
	* elf_end.c (elf_end): Check scn->flags and free rawdata_base if
	malloced.
	* libelfP.h (struct Elf_Scn): Document flags ELF_F_MALLOCED usage.
```

valgrind memory leak:

```
==44437== 213,655 bytes in 2 blocks are definitely lost in loss record 3 of 3
==44437==    at 0x483577F: malloc (vg_replace_malloc.c:299)
==44437==    by 0x403812: __libelf_set_rawdata_wrlock (elf_getdata.c:262)
==44437==    by 0x40355E: elf_strptr (elf_strptr.c:128)
```