### PR TITLE
Fix bpf ptrace filler

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -3874,8 +3874,8 @@ FILLER(sys_ptrace_x, true)
 			return res;
 
 		res = bpf_val_to_ring_dyn(data, 0, PT_UINT64, 0);
-		if (res != PPM_SUCCESS)
-			return res;
+
+		return res;
 	}
 
 	val = bpf_syscall_get_argument(data, 0);


### PR DESCRIPTION
Noticed when ptrace returns an error, we fill more arguments than expected,
so the event gets refused with:

"corrupted filler for event type 169 (added 5 args, should have added 3)"