### PR TITLE
Properly initialize default settings for tracers

### DIFF
--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -1222,6 +1222,7 @@ static int32_t set_default_settings(scap_t *handle)
 	settings.page_faults = false;
 	settings.dropping_mode = false;
 	settings.is_dropping = false;
+	settings.tracers_enabled = false;
 	settings.fullcapture_port_range_start = 0;
 	settings.fullcapture_port_range_end = 0;
 


### PR DESCRIPTION
One more and then I'm done for the day with trivial PRs (today was valgrind day against my SSL work, so a few of these things came out).

valgrind reports:

```
==75769== Syscall param bpf(attr->value) points to uninitialised byte(s)
==75769==    at 0x4CA62A9: syscall (syscall.S:38)
==75769==    by 0xC36BD8: sys_bpf (misc.h:38)
==75769==    by 0xC36CC7: bpf_map_update_elem (scap_bpf.c:95)
==75769==    by 0xC39D3E: set_default_settings (scap_bpf.c:1230)
==75769==    by 0xC3A2C1: scap_bpf_load (scap_bpf.c:1371)
==75769==    by 0xC2120D: scap_open_live_int (scap.c:294)
==75769==    by 0xC2231C: scap_open (scap.c:720)
==75769==    by 0xA64BF2: sinsp::open(unsigned int) (sinsp.cpp:475)
==75769==    by 0xA6580A: sinsp::open(std::string) (sinsp.cpp:683)
==75769==    by 0x90D9B8: sysdig_init(int, char**) (sysdig.cpp:1454)
==75769==    by 0x90EF6C: main (sysdig.cpp:1692)
==75769==  Address 0x1ffeffeaed is on thread 1's stack
==75769==  in frame #3, created by set_default_settings (scap_bpf.c:1209)
==75769==
```