### PR TITLE
Fix for newer versions of LXC not being detected

### DIFF
--- a/userspace/libsinsp/container_engine/lxc.cpp
+++ b/userspace/libsinsp/container_engine/lxc.cpp
@@ -43,6 +43,17 @@ bool lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 			matches = true;
 			break;
 		}
+
+		pos = cgroup.find("/lxc.payload/");
+		if(pos != std::string::npos)
+		{
+			auto id_start = pos + sizeof("/lxc.payload/") - 1;
+			auto id_end = cgroup.find('/', id_start);
+			container_info.m_type = CT_LXC;
+			container_info.m_id = cgroup.substr(id_start, id_end - id_start);
+			matches = true;
+			break;
+		}
 	}
 
 	if (!matches)


### PR DESCRIPTION
/sys/fs/cgroup/cpuset/lxc

being split to

/sys/fs/cgroup/cpuset/lxc.monitor and /sys/fs/cgroup/cpuset/lxc.payload

now additionally looks for lxc.payload

sysdig-CLA-1.0-contributing-entity: Apolloversity Inc.
sysdig-CLA-1.0-signed-off-by: Joe Mattie <joemattie@gmail.com>