### PR TITLE
SMAGENT-1396 - Async Protobuf Serialization

### DIFF
--- a/userspace/libsinsp/capture_stats_source.h
+++ b/userspace/libsinsp/capture_stats_source.h
@@ -25,7 +25,7 @@ class scap_stats;
 /**
  * Interface to an object that can provide capture statistics.
  *
- * Note that this intention here is to apply the Interface Segregation
+ * Note that the intention here is to apply the Interface Segregation
  * Principle (ISP) to class sinsp.  Some clients of sinsp need only the
  * get_capture_stats() API, and this interface exposes only that API.  Do
  * not add additional APIs here.  If some client of sinsp needs a different

--- a/userspace/libsinsp/capture_stats_source.h
+++ b/userspace/libsinsp/capture_stats_source.h
@@ -13,11 +13,25 @@ class scap_stats;
 
 /**
  * Interface to an object that can provide capture statistics.
+ *
+ * Note that this intention here is to apply the Interface Segregation
+ * Principle (ISP) to class sinsp.  Some clients of sinsp need only the
+ * get_capture_stats() API, and this interface exposes only that API.  Do
+ * not add additional APIs here.  If some client of sinsp needs a different
+ * set of APIs, introduce a new interface.
  */
 class SINSP_PUBLIC capture_stats_source
 {
 public:
 	virtual ~capture_stats_source() = default;
 
+	/**
+	 * Fill the given structure with statistics about the currently
+	 * open capture.
+	 *
+	 * @note This may not work for a file-based capture source.
+	 *
+	 * @param[out] stats The capture statistics
+	 */
 	virtual void get_capture_stats(scap_stats* stats) = 0;
 };

--- a/userspace/libsinsp/capture_stats_source.h
+++ b/userspace/libsinsp/capture_stats_source.h
@@ -1,0 +1,23 @@
+/**
+ * @file
+ *
+ * Interface to capture_stats_source.
+ *
+ * @copyright Copyright (c) 2019 Sysdig Inc., All Rights Reserved
+ */
+#pragma once
+
+#include "sinsp_public.h"
+
+class scap_stats;
+
+/**
+ * Interface to an object that can provide capture statistics.
+ */
+class SINSP_PUBLIC capture_stats_source
+{
+public:
+	virtual ~capture_stats_source() = default;
+
+	virtual void get_capture_stats(scap_stats* stats) = 0;
+};

--- a/userspace/libsinsp/capture_stats_source.h
+++ b/userspace/libsinsp/capture_stats_source.h
@@ -1,10 +1,21 @@
-/**
- * @file
- *
- * Interface to capture_stats_source.
- *
- * @copyright Copyright (c) 2019 Sysdig Inc., All Rights Reserved
- */
+/*
+Copyright (C) 2019 Sysdig Inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #pragma once
 
 #include "sinsp_public.h"

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -42,6 +42,9 @@ limitations under the License.
 */
 
 #pragma once
+
+#include "capture_stats_source.h"
+
 #ifdef _WIN32
 #pragma warning(disable: 4251 4200 4221 4190)
 #endif
@@ -226,7 +229,7 @@ public:
   - event retrieval
   - setting capture filters
 */
-class SINSP_PUBLIC sinsp
+class SINSP_PUBLIC sinsp : public capture_stats_source
 {
 public:
 	typedef std::shared_ptr<sinsp> ptr;
@@ -542,7 +545,7 @@ public:
 
 	  \note this call won't work on file captures.
 	*/
-	virtual void get_capture_stats(scap_stats *stats);
+	void get_capture_stats(scap_stats* stats) override;
 
 	void set_max_thread_table_size(uint32_t value);
 


### PR DESCRIPTION
This change applies the Interface Segregation Principle to class `sinsp` so that clients of the `get_capture_stats()` operation can be exposed only to an interface that exposes that API instead of the full-blown interface of `sinsp`.