### PR TITLE
Download dependencies over http, not https

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,7 +435,7 @@ if(NOT WIN32 AND NOT APPLE)
 		set(CARES_INCLUDE "${CARES_SRC}/target/include")
 		set(CARES_LIB "${CARES_SRC}/target/lib/libcares.a")
 		ExternalProject_Add(c-ares
-		URL "https://download.sysdig.com/dependencies/c-ares-1.13.0.tar.gz"
+		URL "http://download.sysdig.com/dependencies/c-ares-1.13.0.tar.gz"
 		URL_MD5 "d2e010b43537794d8bedfb562ae6bba2"
 		CONFIGURE_COMMAND ./configure --prefix=${CARES_SRC}/target
 		BUILD_COMMAND ${CMD_MAKE}
@@ -462,7 +462,7 @@ if(NOT WIN32 AND NOT APPLE)
 		set(PROTOBUF_LIB "${PROTOBUF_SRC}/target/lib/libprotobuf.a")
 		ExternalProject_Add(protobuf
 		DEPENDS openssl zlib
-		URL "https://github.com/google/protobuf/releases/download/v3.5.0/protobuf-cpp-3.5.0.tar.gz"
+		URL "http://github.com/google/protobuf/releases/download/v3.5.0/protobuf-cpp-3.5.0.tar.gz"
 		URL_MD5 "e4ba8284a407712168593e79e6555eb2"
 		# TODO what if using system zlib?
 		CONFIGURE_COMMAND /usr/bin/env CPPFLAGS=-I${ZLIB_INCLUDE} LDFLAGS=-L${ZLIB_SRC} ./configure --with-zlib --prefix=${PROTOBUF_SRC}/target


### PR DESCRIPTION
libcurl bundled with cmake doesn't support https. To enable building sysdig without libcurl installed system wide, we need to replace the https URLs with http.

The files still have their checksums verified.