### PR TITLE
Return default of false for _bpf_enabled()

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1973,6 +1973,8 @@ bool scap_get_bpf_enabled(scap_t *handle)
 	{
 		return handle->m_bpf;
 	}
+
+	return false;
 }
 
 int32_t scap_suppress_events_comm(scap_t *handle, const char *comm)

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -2432,6 +2432,8 @@ bool sinsp::is_bpf_enabled()
 	{
 		return scap_get_bpf_enabled(m_h);
 	}
+
+	return false;
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
If the scap handle doesn't exist, return false from _bpf_enabled()
methods.