### PR TITLE
Adding thread_local to curl global variables

### DIFF
--- a/userspace/libsinsp/container_engine/docker_linux.cpp
+++ b/userspace/libsinsp/container_engine/docker_linux.cpp
@@ -30,8 +30,8 @@ using namespace libsinsp::runc;
 namespace {
 std::string s_docker_unix_socket_path = "/var/run/docker.sock";
 #if defined(HAS_CAPTURE)
-CURLM *s_curlm = NULL;
-CURL *s_curl = NULL;
+thread_local CURLM *s_curlm = NULL;
+thread_local CURL *s_curl = NULL;
 
 size_t docker_curl_write_callback(const char* ptr, size_t size, size_t nmemb, string* json)
 {


### PR DESCRIPTION
These variables are accessed concurrently by the main sinsp inspector
and the baseliner.

This fix https://sysdig.atlassian.net/browse/SMAGENT-1456