### PR TITLE
Fix cmake not being able to use https

### DIFF
--- a/.travis-scripts/linux/build.sh
+++ b/.travis-scripts/linux/build.sh
@@ -22,7 +22,7 @@ export CXX="g++-4.8"
 wget https://s3.amazonaws.com/download.draios.com/dependencies/cmake-3.3.2.tar.gz
 tar -xzf cmake-3.3.2.tar.gz
 cd cmake-3.3.2
-./bootstrap --prefix=/usr
+./bootstrap --prefix=/usr --system-curl
 make
 sudo make install
 cd ..

--- a/.travis-scripts/linux/install.sh
+++ b/.travis-scripts/linux/install.sh
@@ -17,5 +17,5 @@
 # limitations under the License.
 #
 sudo apt-get --force-yes install g++-4.8
-sudo apt-get install rpm linux-headers-$(uname -r) libelf-dev
+sudo apt-get install rpm linux-headers-$(uname -r) libelf-dev libcurl4-openssl-dev
 sudo apt-get purge cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,7 @@ if(NOT WIN32 AND NOT APPLE)
 		set(TBB_INCLUDE_DIR "${TBB_SRC}/include/")
 		set(TBB_LIB "${TBB_SRC}/build/lib_release/libtbb.a")
 		ExternalProject_Add(tbb
-			URL "http://s3.amazonaws.com/download.draios.com/dependencies/tbb-2018_U5.tar.gz"
+			URL "https://s3.amazonaws.com/download.draios.com/dependencies/tbb-2018_U5.tar.gz"
 			URL_MD5 "ff3ae09f8c23892fbc3008c39f78288f"
 			CONFIGURE_COMMAND ""
 			BUILD_COMMAND ${CMD_MAKE} tbb_build_dir=${TBB_SRC}/build tbb_build_prefix=lib extra_inc=big_iron.inc


### PR DESCRIPTION
Since we build our own version of cmake for consistency reasons, we need to enable the ability to use ssl. The prescribed way of doing this is to add `--system-curl` option to the `bootstrap` program of cmake. This requires installing `libcurl4-openssl-dev` via the travis `install.sh` script. 

I enabled `https` for the TBB cmake dependency as a test.