### PR TITLE
Read CPU/memory limits from cgroups for CRI

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -134,11 +134,13 @@ endif()
 
 if(NOT WIN32 AND NOT APPLE)
 list(APPEND SINSP_SOURCES
-	grpc_channel_registry.cpp
+	async_cgroup.cpp
 	cri.cpp
 	container_engine/cri.cpp
 	${CMAKE_CURRENT_BINARY_DIR}/cri.grpc.pb.cc
-	${CMAKE_CURRENT_BINARY_DIR}/cri.pb.cc)
+	${CMAKE_CURRENT_BINARY_DIR}/cri.pb.cc
+	grpc_channel_registry.cpp
+)
 endif()
 
 add_library(sinsp STATIC ${SINSP_SOURCES})

--- a/userspace/libsinsp/async_cgroup.cpp
+++ b/userspace/libsinsp/async_cgroup.cpp
@@ -1,0 +1,126 @@
+#include "async_cgroup.h"
+
+#include <fstream>
+#include "sinsp.h"
+
+namespace {
+// to prevent 32-bit number of kilobytes from overflowing, ignore values larger than 4 TiB.
+// This reports extremely large values (e.g. almost-but-not-quite 9EiB as set by k8s) as unlimited.
+// Note: we use the same maximum value for cpu shares/quotas as well; the typical values are much lower
+// and so should never exceed CGROUP_VAL_MAX either
+constexpr const int64_t CGROUP_VAL_MAX = (1UL << 42u) - 1;
+
+/**
+ * \brief Read a single int64_t value from cgroupfs
+ * @param subsys path to the specific cgroup subsystem, e.g. /sys/fs/cgroup/cpu
+ * @param cgroup cgroup path within the cgroup mountpoint (like in /proc/pid/cgroup)
+ * @param filename the filename within the cgroup directory, e.g. cpu.shares
+ * @param out reference to the output value
+ * @return true if we successfully read the value and it's within reasonable range,
+ *          reasonable being [0; CGROUP_VAL_MAX)
+ */
+bool read_cgroup_val(std::shared_ptr<std::string>& subsys,
+	const std::string& cgroup, const std::string& filename, int64_t& out)
+{
+	std::string path = *subsys.get() + "/" + cgroup + "/" + filename;
+	std::ifstream cg_val(path);
+
+	int64_t val = -1;
+	cg_val >> val;
+
+	if(val <= 0 || val > CGROUP_VAL_MAX)
+	{
+		g_logger.format(sinsp_logger::SEV_DEBUG, "(async-cg) value of %s (%lld) out of range, ignoring",
+			path.c_str(), val);
+		return false;
+	}
+	out = val;
+	return true;
+}
+}
+
+namespace libsinsp {
+namespace async_cgroup {
+
+bool get_cgroup_resource_limits(const delayed_cgroup_key& key, delayed_cgroup_value& value, bool report_no_cgroup)
+{
+	bool found_all = true;
+	auto no_cg_log_level = report_no_cgroup
+		? sinsp_logger::SEV_INFO
+		: sinsp_logger::SEV_DEBUG;
+
+	std::shared_ptr<std::string> memcg_root = sinsp::lookup_cgroup_dir("memory");
+	if(key.m_mem_cgroup.find(key.m_container_id) == std::string::npos)
+	{
+		g_logger.format(no_cg_log_level, "(async-cg) mem cgroup for container [%s]: %s/%s -- no per-container memory cgroup, ignoring",
+			key.m_container_id.c_str(), memcg_root->c_str(), key.m_mem_cgroup.c_str());
+	}
+	else
+	{
+		g_logger.format(sinsp_logger::SEV_DEBUG, "(async-cg) mem cgroup for container [%s]: %s/%s",
+			key.m_container_id.c_str(), memcg_root->c_str(), key.m_mem_cgroup.c_str());
+		found_all = read_cgroup_val(memcg_root, key.m_mem_cgroup, "memory.limit_in_bytes", value.m_memory_limit) && found_all;
+	}
+
+	std::shared_ptr<std::string> cpucg_root = sinsp::lookup_cgroup_dir("cpu");
+	if(key.m_cpu_cgroup.find(key.m_container_id) == std::string::npos)
+	{
+		g_logger.format(no_cg_log_level, "(async-cg) cpu cgroup for container [%s]: %s/%s -- no per-container CPU cgroup, ignoring",
+				key.m_container_id.c_str(), cpucg_root->c_str(), key.m_cpu_cgroup.c_str());
+	}
+	else
+	{
+		g_logger.format(sinsp_logger::SEV_DEBUG, "(async-cg) cpu cgroup for container [%s]: %s/%s",
+				key.m_container_id.c_str(), cpucg_root->c_str(), key.m_cpu_cgroup.c_str());
+		found_all = read_cgroup_val(cpucg_root, key.m_cpu_cgroup, "cpu.shares", value.m_cpu_shares) && found_all;
+		found_all = read_cgroup_val(cpucg_root, key.m_cpu_cgroup, "cpu.cfs_quota_us", value.m_cpu_quota) && found_all;
+		found_all = read_cgroup_val(cpucg_root, key.m_cpu_cgroup, "cpu.cfs_period_us", value.m_cpu_period) && found_all;
+	}
+
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+		"(async-cg) Got cgroup limits for container [%s]: "
+		"mem_limit=%ld, cpu_shares=%ld cpu_quota=%ld cpu_period=%ld",
+		key.m_container_id.c_str(),
+		value.m_memory_limit, value.m_cpu_shares, value.m_cpu_quota, value.m_cpu_period);
+
+	return found_all;
+}
+
+void delayed_cgroup_lookup::run_impl()
+{
+	delayed_cgroup_key key;
+	while(dequeue_next_key(key)) {
+		delayed_cgroup_value value;
+		get_cgroup_resource_limits(key, value, false);
+		store_value(key, value);
+	}
+}
+
+void delayed_cgroup_lookup::update(sinsp_container_manager* manager, const delayed_cgroup_key& key, const delayed_cgroup_value& value)
+{
+	auto container = manager->get_container(key.m_container_id);
+	if(container)
+	{
+		g_logger.format(sinsp_logger::SEV_DEBUG,
+				"(async-cg) Storing limits for container [%s]: "
+				"mem_limit=%ld, cpu_shares=%ld, cpu_quota=%ld, cpu_period=%ld",
+				key.m_container_id.c_str(),
+				value.m_memory_limit, value.m_cpu_shares,
+				value.m_cpu_quota, value.m_cpu_period);
+		container->m_memory_limit = value.m_memory_limit;
+		container->m_cpu_shares = value.m_cpu_shares;
+		container->m_cpu_quota = value.m_cpu_quota;
+		container->m_cpu_period = value.m_cpu_period;
+	}
+	else
+	{
+		g_logger.format(sinsp_logger::SEV_NOTICE,
+				"(async-cg) Dropping limits for already gone container [%s]: "
+				"mem_limit=%ld, cpu_shares=%ld, cpu_quota=%ld, cpu_period=%ld",
+				key.m_container_id.c_str(),
+				value.m_memory_limit, value.m_cpu_shares,
+				value.m_cpu_quota, value.m_cpu_period);
+	}
+}
+}
+}

--- a/userspace/libsinsp/async_cgroup.h
+++ b/userspace/libsinsp/async_cgroup.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include <string>
+#include <utility>
+#include "async_key_value_source.h"
+
+class sinsp_container_manager;
+
+namespace {
+bool less_than(const std::string& lhs, const std::string& rhs, bool if_equal=false)
+{
+	int cmp = lhs.compare(rhs);
+	if(cmp < 0)
+	{
+		return true;
+	}
+	else if(cmp > 0)
+	{
+		return false;
+	}
+	else
+	{
+		return if_equal;
+	}
+}
+}
+
+namespace libsinsp {
+namespace async_cgroup {
+
+/**
+ * \brief The key for asynchronous cgroup value lookup
+ *
+ * It's effectively a (container_id, cpu_cgroup, mem_cgroup) tuple
+ * that can be used as a hash key.
+ */
+struct delayed_cgroup_key {
+	delayed_cgroup_key():
+		m_container_id(""),
+		m_cpu_cgroup(""),
+		m_mem_cgroup("") {}
+
+	delayed_cgroup_key(std::string container_id, std::string cpu_cgroup_dir, std::string mem_cgroup_dir):
+		m_container_id(std::move(container_id)),
+		m_cpu_cgroup(std::move(cpu_cgroup_dir)),
+		m_mem_cgroup(std::move(mem_cgroup_dir)) {}
+
+	bool operator<(const delayed_cgroup_key& rhs) const
+	{
+		return less_than(m_container_id, rhs.m_container_id,
+			less_than(m_cpu_cgroup, rhs.m_cpu_cgroup,
+				less_than(m_mem_cgroup, rhs.m_mem_cgroup)));
+	}
+
+	bool operator==(const delayed_cgroup_key& rhs) const
+	{
+		return m_container_id == rhs.m_container_id &&
+			m_cpu_cgroup == rhs.m_cpu_cgroup &&
+			m_mem_cgroup == rhs.m_mem_cgroup;
+	}
+
+	explicit operator const std::string&() const {
+		return m_container_id;
+	}
+
+	std::string m_container_id; // TODO a shared_ptr would be nice
+	std::string m_cpu_cgroup;
+	std::string m_mem_cgroup;
+};
+
+/**
+ * \brief The result of an asynchronous cgroup lookup
+ *
+ * This contains all the cgroup values we read during the asynchronous lookup
+ */
+struct delayed_cgroup_value {
+	delayed_cgroup_value():
+		m_cpu_shares(0),
+		m_cpu_quota(0),
+		m_cpu_period(0),
+		m_memory_limit(0) {}
+
+	int64_t m_cpu_shares;
+	int64_t m_cpu_quota;
+	int64_t m_cpu_period;
+	int64_t m_memory_limit;
+};
+
+/**
+ * \brief Read resource limits from cgroups
+ * @param key the container to read limits for
+ * @param value output value. when the return value is false, specific fields
+ *         may or may not have been modified
+ * @param report_no_cgroup if true, log a message when the container doesn't
+ *         use its own cgroups for mem/cpu and we ignore the values.
+ *         We want to log this only once since the cgroups will stay the same
+ *         during subsequent lookups
+ * @return true when all values have been successfully read, false otherwise
+ *
+ * Note: reading a zero/negative/very large value is considered a failure,
+ * because it might mean that resource limits haven't yet been set. Essentially,
+ * `false` means "there's real chance the limits could conceivably change
+ * in the future", while `true` means we really don't expect them to change
+ * any more.
+ */
+bool get_cgroup_resource_limits(const delayed_cgroup_key& key, delayed_cgroup_value& value, bool report_no_cgroup=true);
+
+/**
+ * \brief Asynchronous key-value source for delayed cgroup lookups
+ *
+ * Reading cgroup values immediately after we notice a new container may catch
+ * the cgroups before the limits have been set. To give the container runtime
+ * more time to set up the resource limits, we delay the cgroup query a bit.
+ *
+ */
+class delayed_cgroup_lookup : public sysdig::async_key_value_source<delayed_cgroup_key, delayed_cgroup_value> {
+public:
+	using sysdig::async_key_value_source<delayed_cgroup_key, delayed_cgroup_value>::async_key_value_source;
+
+	/**
+	 * \brief Store found values in container_manager
+	 * @param manager the container manager instance that holds
+	 * the containers we're looking up
+	 * @param key container lookup key
+	 * @param value resource limits found in cgroups
+	 *
+	 * This method copies any newly found resource limits from the lookup
+	 * results back to the container manager.
+	 */
+	static void update(sinsp_container_manager* manager, const delayed_cgroup_key& key, const delayed_cgroup_value& value);
+
+	/**
+	 * \brief Wait for all pending lookups to complete
+	 */
+	void quiesce() {
+		this->stop();
+	}
+private:
+	void run_impl() override;
+};
+}
+}
+
+namespace std {
+/**
+ * \brief Specialization of std::hash for delayed_cgroup_key
+ *
+ * It allows `delayed_cgroup_key` instances to be used as `unordered_map` keys
+ */
+template<> struct hash<libsinsp::async_cgroup::delayed_cgroup_key> {
+	std::size_t operator()(const libsinsp::async_cgroup::delayed_cgroup_key& h) const {
+		size_t h1 = ::std::hash<std::string>{}(h.m_container_id);
+		size_t h2 = ::std::hash<std::string>{}(h.m_cpu_cgroup);
+		size_t h3 = ::std::hash<std::string>{}(h.m_mem_cgroup);
+		return h1 ^ (h2 << 1u) ^ (h3 << 2u);
+	}
+};
+}

--- a/userspace/libsinsp/async_container.h
+++ b/userspace/libsinsp/async_container.h
@@ -47,7 +47,7 @@ public:
 	/**
 	 * \brief Wait for all pending lookups to complete
 	 */
-	void quiesce() {
+	virtual void quiesce() {
 		this->stop();
 	}
 };

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -42,6 +42,7 @@ limitations under the License.
 #include "k8s_api_handler.h"
 #ifdef HAS_CAPTURE
 #include <curl/curl.h>
+#include <mntent.h>
 #endif
 #endif
 
@@ -2537,3 +2538,56 @@ bool sinsp_thread_manager::remove_inactive_threads()
 
 	return res;
 }
+
+#ifdef HAS_CAPTURE
+std::shared_ptr<std::string> sinsp::lookup_cgroup_dir(const string& subsys)
+{
+	shared_ptr<string> cgroup_dir;
+	static std::unordered_map<std::string, std::shared_ptr<std::string>> cgroup_dir_cache;
+
+	const auto& it = cgroup_dir_cache.find(subsys);
+	if(it != cgroup_dir_cache.end())
+	{
+		return it->second;
+	}
+
+	// Look for mount point of cgroup filesystem
+	// It should be already mounted on the host or by
+	// our docker-entrypoint.sh script
+	if(strcmp(scap_get_host_root(), "") != 0)
+	{
+		// We are inside our container, so we should use the directory
+		// mounted by it
+		auto cgroup = std::string(scap_get_host_root()) + "/cgroup/" + subsys;
+		cgroup_dir = std::make_shared<std::string>(cgroup);
+	}
+	else
+	{
+		struct mntent mntent_buf = {};
+		char mntent_string_buf[4096];
+		FILE* fp = setmntent("/proc/mounts", "r");
+		struct mntent* entry = getmntent_r(fp, &mntent_buf,
+			mntent_string_buf, sizeof(mntent_string_buf));
+		while(entry != nullptr)
+		{
+			if(strcmp(entry->mnt_type, "cgroup") == 0 &&
+			   hasmntopt(entry, subsys.c_str()) != NULL)
+			{
+				cgroup_dir = std::make_shared<std::string>(entry->mnt_dir);
+				break;
+			}
+			entry = getmntent(fp);
+		}
+		endmntent(fp);
+	}
+	if(!cgroup_dir)
+	{
+		return std::make_shared<std::string>();
+	}
+	else
+	{
+		cgroup_dir_cache[subsys] = cgroup_dir;
+		return cgroup_dir;
+	}
+}
+#endif

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -867,6 +867,10 @@ public:
 	bool is_bpf_enabled();
 
 	static unsigned num_possible_cpus();
+
+#ifdef HAS_CAPTURE
+	static std::shared_ptr<std::string> lookup_cgroup_dir(const std::string& subsys);
+#endif
 #ifdef CYGWING_AGENT
 	wh_t* get_wmi_handle()
 	{

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -893,6 +893,21 @@ uint64_t sinsp_threadinfo::get_fd_limit()
 	return get_main_thread()->m_fdlimit;
 }
 
+const std::string& sinsp_threadinfo::get_cgroup(const std::string& subsys) const
+{
+	static const std::string notfound = "/";
+
+	for(const auto& it : m_cgroups)
+	{
+		if(it.first == subsys)
+		{
+			return it.second;
+		}
+	}
+
+	return notfound;
+}
+
 void sinsp_threadinfo::traverse_parent_state(visitor_func_t &visitor)
 {
 	// Use two pointers starting at this, traversing the parent

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -226,6 +226,11 @@ public:
 	*/
 	uint64_t get_fd_limit();
 
+	/*!
+	  \brief Return the cgroup name for a specific subsystem
+	 */
+	 const std::string& get_cgroup(const std::string& subsys) const;
+
 	//
 	// Walk up the parent process hierarchy, calling the provided
 	// function for each node. If the function returns false, the


### PR DESCRIPTION
If the CRI runtime is not containerd (or does not implement the same extensions), we have no way to query the API for current resource limits, so just read them from cgroups directly. However, we cannot do this synchronously in `cri::resolve()`, because at this point the values may not yet be set completely. Instead, we delay the cgroup lookup by one second.

*Note:* we do try to get the limits synchronously as well and if we succeed for all the values we expect (memory limit, cpu shares, cpu quota and period), we don't do the second delayed lookup.

*Note:* success is defined as having values both larger than zero and smaller than an arbitrary "too large" value (4 TiB, to avoid overflow when converting to a 32-bit number of kilobytes)

*Note:* the code is pretty generic, so we may want to use it for all container engines (except maybe Docker, where we could still rely on the API)