### PR TITLE
as described in issue #1350, the limited size of sinsp_chisel::m_lua_…

### DIFF
--- a/userspace/libsinsp/chisel.h
+++ b/userspace/libsinsp/chisel.h
@@ -153,7 +153,7 @@ private:
 	uint64_t m_lua_last_interval_sample_time;
 	uint64_t m_lua_last_interval_ts;
 	vector<sinsp_filter_check*> m_allocated_fltchecks;
-	char m_lua_fld_storage[16384];
+	char m_lua_fld_storage[PPM_MAX_ARG_SIZE];
 	chiselinfo* m_lua_cinfo;
 	string m_new_chisel_to_exec;
 	int m_udp_socket;


### PR DESCRIPTION
…fld_storage prevents chisels from receving the full content of big buffers. This patch sets the size to PPM_MAX_ARG_SIZE, so that anything that is captured by the driver can reach chisels.