### PR TITLE
start the analyzer before forcing next for a scap file

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -366,6 +366,17 @@ void sinsp::init()
 			}
 		}
 
+
+#ifdef HAS_ANALYZER
+		//
+		// Notify the analyzer that we're starting
+		//
+		if(m_analyzer)
+		{
+			m_analyzer->on_capture_start();
+		}
+#endif
+
 		//
 		// Rewind, reset the event count, and consume the exact number of events
 		//
@@ -677,9 +688,9 @@ void sinsp::open_int()
 	init();
 }
 
-void sinsp::open(string filename)
+void sinsp::open(const std::string &filename)
 {
-	if(filename == "")
+	if(filename.empty())
 	{
 		open();
 		return;

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -258,7 +258,7 @@ public:
 	  @throws a sinsp_exception containing the error string is thrown in case
 	   of failure.
 	*/
-	void open(string filename);
+	void open(const std::string &filename);
 
 	/*!
 	  \brief Start an event capture from a file descriptor.


### PR DESCRIPTION
When an scap file is loaded, sinsp::next() is called in a loop during initialization. If an analyzer exists, this is done before `on_capture_start` has ever been called.

This change adds an additional call to `m_analyzer->on_capture_start` before the next loop.