### PR TITLE
Create a grpc_channel_registry for all channels

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SINSP_SOURCES
 	filter.cpp
 	filterchecks.cpp
 	gen_filter.cpp
+	grpc_channel_registry.cpp
 	http_parser.c
 	http_reason.cpp
 	ifinfo.cpp

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -57,7 +57,6 @@ set(SINSP_SOURCES
 	filter.cpp
 	filterchecks.cpp
 	gen_filter.cpp
-	grpc_channel_registry.cpp
 	http_parser.c
 	http_reason.cpp
 	ifinfo.cpp
@@ -132,7 +131,8 @@ endif()
 
 if(NOT WIN32 AND NOT APPLE)
 list(APPEND SINSP_SOURCES
-    cri.cpp
+	grpc_channel_registry.cpp
+	cri.cpp
 	container_engine/cri.cpp
 	${CMAKE_CURRENT_BINARY_DIR}/cri.grpc.pb.cc
 	${CMAKE_CURRENT_BINARY_DIR}/cri.pb.cc)

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -30,6 +30,7 @@ limitations under the License.
 
 #include "runc.h"
 #include "container_engine/mesos.h"
+#include "grpc_channel_registry.h"
 #include <cri.h>
 #include "sinsp.h"
 #include "sinsp_int.h"
@@ -147,7 +148,7 @@ cri::cri()
 		return;
 	}
 
-	auto channel = grpc::CreateChannel("unix://" + cri_path, grpc::InsecureChannelCredentials());
+	std::shared_ptr<grpc::Channel> channel = libsinsp::grpc_channel_registry::get_channel("unix://" + cri_path);
 	s_cri = runtime::v1alpha2::RuntimeService::NewStub(channel);
 	s_cri_image = runtime::v1alpha2::ImageService::NewStub(channel);
 

--- a/userspace/libsinsp/grpc_channel_registry.cpp
+++ b/userspace/libsinsp/grpc_channel_registry.cpp
@@ -20,18 +20,26 @@ limitations under the License.
 #include "grpc_channel_registry.h"
 
 
-std::map<std::string, std::shared_ptr<grpc::Channel>> libsinsp::grpc_channel_registry::s_channels;
+std::map<std::string, std::weak_ptr<grpc::Channel>> libsinsp::grpc_channel_registry::s_channels;
 
 std::shared_ptr<grpc::Channel> libsinsp::grpc_channel_registry::get_channel(const std::string &url)
 {
 	auto it = s_channels.find(url);
 	if(it == s_channels.end())
 	{
-		std::shared_ptr<grpc::Channel> chan = grpc::CreateChannel(url, grpc::InsecureChannelCredentials());
-		s_channels.insert(std::pair<std::string, std::shared_ptr<grpc::Channel>>(url, chan));
+		auto chan = grpc::CreateChannel(url, grpc::InsecureChannelCredentials());
+		s_channels[url] = chan;
 
 		return chan;
 	}
-
-	return it->second;
+	else
+	{
+		auto chan = it->second.lock();
+		if(chan == nullptr)
+		{
+			chan = grpc::CreateChannel(url, grpc::InsecureChannelCredentials());
+			s_channels[url] = chan;
+		}
+		return chan;
+	}
 }

--- a/userspace/libsinsp/grpc_channel_registry.cpp
+++ b/userspace/libsinsp/grpc_channel_registry.cpp
@@ -1,0 +1,37 @@
+/*
+Copyright (C) 2013-2019 Draios Inc dba Sysdig.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "grpc_channel_registry.h"
+
+
+std::map<std::string, std::shared_ptr<grpc::Channel>> libsinsp::grpc_channel_registry::s_channels;
+
+std::shared_ptr<grpc::Channel> libsinsp::grpc_channel_registry::get_channel(const std::string &url)
+{
+	auto it = s_channels.find(url);
+	if(it == s_channels.end())
+	{
+		std::shared_ptr<grpc::Channel> chan = grpc::CreateChannel(url, grpc::InsecureChannelCredentials());
+		s_channels.insert(std::pair<std::string, std::shared_ptr<grpc::Channel>>(url, chan));
+
+		return chan;
+	}
+
+	return it->second;
+}

--- a/userspace/libsinsp/grpc_channel_registry.h
+++ b/userspace/libsinsp/grpc_channel_registry.h
@@ -1,0 +1,36 @@
+/*
+Copyright (C) 2013-2019 Draios Inc dba Sysdig.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <memory>
+#include <grpc++/grpc++.h>
+
+namespace libsinsp
+{
+class grpc_channel_registry
+{
+public:
+	// Return a (shared) grpc::Channel for the provided url.
+	static std::shared_ptr<grpc::Channel> get_channel(const std::string &url);
+
+private:
+	static std::map<std::string, std::shared_ptr<grpc::Channel>> s_channels;
+};
+}

--- a/userspace/libsinsp/grpc_channel_registry.h
+++ b/userspace/libsinsp/grpc_channel_registry.h
@@ -20,7 +20,11 @@ limitations under the License.
 #pragma once
 
 #include <memory>
-#include <grpc++/grpc++.h>
+#ifdef GRPC_INCLUDE_IS_GRPCPP
+#	include <grpcpp/grpcpp.h>
+#else
+#	include <grpc++/grpc++.h>
+#endif
 
 namespace libsinsp
 {

--- a/userspace/libsinsp/grpc_channel_registry.h
+++ b/userspace/libsinsp/grpc_channel_registry.h
@@ -35,6 +35,6 @@ public:
 	static std::shared_ptr<grpc::Channel> get_channel(const std::string &url);
 
 private:
-	static std::map<std::string, std::shared_ptr<grpc::Channel>> s_channels;
+	static std::map<std::string, std::weak_ptr<grpc::Channel>> s_channels;
 };
 }


### PR DESCRIPTION
Create a new top-level static method
libsinsp::grpc_channel_registry::get_channel(url), backed by a static
map from url to grpc::Channel objects.

This ensures that when creating channels there is only a single channel
for a given url. It appears that if multiple channels are created for a
single url, the underlying grpc implementation may not actually refresh
the connection to each fd (unix socket, connection) if the server goes
away.