### PR TITLE
Modified the behavior of fullcapture port range

### DIFF
--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -128,6 +128,11 @@ limitations under the License.
 #define FALCOBL_FULL_PROCESSING
 
 //
+// Port range to enable larger snaplen on
+//
+#define DEFAULT_INCREASE_SNAPLEN_PORT_RANGE {0, 0}
+
+//
 // FD class customized with the storage we need
 //
 #ifdef HAS_ANALYZER

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -128,6 +128,7 @@ sinsp::sinsp() :
 	m_flush_memory_dump = false;
 	m_next_stats_print_time_ns = 0;
 	m_large_envs_enabled = false;
+	m_increased_snaplen_port_range = DEFAULT_INCREASE_SNAPLEN_PORT_RANGE;
 
 	// Unless the cmd line arg "-pc" or "-pcontainer" is supplied this is false
 	m_print_container_data = false;
@@ -424,6 +425,15 @@ void sinsp::init()
 	if(m_snaplen != DEFAULT_SNAPLEN)
 	{
 		set_snaplen(m_snaplen);
+	}
+
+	//
+	// If the port range for increased snaplen was modified, set it now
+	//
+	if(increased_snaplen_port_range_set())
+	{
+		set_fullcapture_port_range(m_increased_snaplen_port_range.range_start,
+		                           m_increased_snaplen_port_range.range_end);
 	}
 
 #if defined(HAS_CAPTURE)
@@ -1649,12 +1659,13 @@ void sinsp::set_snaplen(uint32_t snaplen)
 void sinsp::set_fullcapture_port_range(uint16_t range_start, uint16_t range_end)
 {
 	//
-	// If set_snaplen is called before opening of the inspector,
+	// If set_fullcapture_port_range is called before opening of the inspector,
 	// we register the value to be set after its initialization.
 	//
 	if(m_h == NULL)
 	{
-		throw sinsp_exception("set_fullcapture_port_range called before capture start");
+		m_increased_snaplen_port_range = {range_start, range_end};
+		return;
 	}
 
 	if(!is_live())

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -985,6 +985,12 @@ private:
 
 	void add_suppressed_comms(scap_open_args &oargs);
 
+	bool increased_snaplen_port_range_set() const
+	{
+		return m_increased_snaplen_port_range.range_start > 0 &&
+		       m_increased_snaplen_port_range.range_end > 0;
+	}
+
 	scap_t* m_h;
 	uint32_t m_nevts;
 	int64_t m_filesize;
@@ -1098,6 +1104,15 @@ public:
 	// Saved snaplen
 	//
 	uint32_t m_snaplen;
+
+	//
+	// Saved increased capture range
+	//
+	struct
+	{
+		uint16_t range_start;
+		uint16_t range_end;
+	} m_increased_snaplen_port_range;
 
 	//
 	// Some thread table limits


### PR DESCRIPTION
- Put the check for the port range before the well-known ports so the
  user can configure snaplen for hard-coded ports as well.
- Allowed the option to be set before sinsp starts (by storing the value
  and applying it after startup).