### PR TITLE
Use a synthetic threadinfo for container events

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -220,7 +220,7 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 	return Json::FastWriter().write(obj);
 }
 
-bool sinsp_container_manager::container_to_sinsp_event(const string& json, sinsp_evt* evt, int64_t tid)
+bool sinsp_container_manager::container_to_sinsp_event(const string& json, sinsp_evt* evt, shared_ptr<sinsp_threadinfo> tinfo)
 {
 	// TODO: variable event length
 	size_t evt_len = SP_EVT_BUF_SIZE;
@@ -239,7 +239,7 @@ bool sinsp_container_manager::container_to_sinsp_event(const string& json, sinsp
 	scap_evt* scapevt = evt->m_pevt;
 
 	scapevt->ts = m_inspector->m_lastevent_ts;
-	scapevt->tid = tid;
+	scapevt->tid = -1;
 	scapevt->len = (uint32_t)totlen;
 	scapevt->type = PPME_CONTAINER_JSON_E;
 	scapevt->nparams = 1;
@@ -251,6 +251,9 @@ bool sinsp_container_manager::container_to_sinsp_event(const string& json, sinsp
 	memcpy(valptr, json.c_str(), *lens);
 
 	evt->init();
+	evt->m_tinfo_ref = tinfo;
+	evt->m_tinfo = tinfo.get();
+
 	return true;
 }
 
@@ -269,13 +272,13 @@ void sinsp_container_manager::add_container(const sinsp_container_info& containe
 	}
 }
 
-void sinsp_container_manager::notify_new_container(const sinsp_container_info& container_info, int64_t tid)
+void sinsp_container_manager::notify_new_container(const sinsp_container_info& container_info)
 {
 	sinsp_evt *evt = new sinsp_evt();
 	evt->m_pevt_storage = new char[SP_EVT_BUF_SIZE];
 	evt->m_pevt = (scap_evt *) evt->m_pevt_storage;
 
-	if(container_to_sinsp_event(container_to_json(container_info), evt, tid))
+	if(container_to_sinsp_event(container_to_json(container_info), evt, container_info.get_tinfo(m_inspector)))
 	{
 		std::shared_ptr<sinsp_evt> cevt(evt);
 
@@ -292,7 +295,7 @@ void sinsp_container_manager::dump_containers(scap_dumper_t* dumper)
 {
 	for(unordered_map<string, sinsp_container_info>::const_iterator it = m_containers.begin(); it != m_containers.end(); ++it)
 	{
-		if(container_to_sinsp_event(container_to_json(it->second), &m_inspector->m_meta_evt))
+		if(container_to_sinsp_event(container_to_json(it->second), &m_inspector->m_meta_evt, it->second.get_tinfo(m_inspector)))
 		{
 			int32_t res = scap_dump(m_inspector->m_h, dumper, m_inspector->m_meta_evt.m_pevt, m_inspector->m_meta_evt.m_cpuid, 0);
 			if(res != SCAP_SUCCESS)

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -39,7 +39,7 @@ public:
 	bool remove_inactive_containers();
 	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread);
 	sinsp_container_info * get_container(const string &id);
-	void notify_new_container(const sinsp_container_info& container_info, int64_t tid);
+	void notify_new_container(const sinsp_container_info& container_info);
 	template<typename E> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	template<typename E1, typename E2, typename... Args> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	bool resolve_container(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
@@ -71,7 +71,7 @@ public:
 	sinsp* get_inspector() { return m_inspector; }
 private:
 	string container_to_json(const sinsp_container_info& container_info);
-	bool container_to_sinsp_event(const string& json, sinsp_evt* evt, int64_t tid=0);
+	bool container_to_sinsp_event(const string& json, sinsp_evt* evt, shared_ptr<sinsp_threadinfo> tinfo);
 	string get_docker_env(const Json::Value &env_vars, const string &mti);
 
 	sinsp* m_inspector;

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -232,7 +232,7 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 					container_info.m_id.c_str(), container_info.m_mesos_task_id.c_str());
 		}
 		manager->add_container(container_info, tinfo);
-		manager->notify_new_container(container_info, tinfo->m_tid);
+		manager->notify_new_container(container_info);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -30,8 +30,6 @@ limitations under the License.
 #include <curl/multi.h>
 #endif
 
-#include "tbb/concurrent_hash_map.h"
-
 #include "json/json.h"
 
 #include "async_key_value_source.h"
@@ -67,18 +65,6 @@ public:
 
 	static void set_query_image_info(bool query_image_info);
 
-	// Note that this tid is the current top tid for this container
-	void set_top_tid(const std::string &container_id, sinsp_threadinfo *tinfo);
-
-	// Update the mapping from container id to top running tid for
-	// that container.
-	void update_top_tid(std::string &container_id, sinsp_threadinfo *tinfo);
-
-	// Get the thread id of the top thread running in this container.
-	int64_t get_top_tid(const std::string &container_id);
-
-        bool pending_lookup(std::string &container_id);
-
 protected:
 	void run_impl();
 
@@ -102,23 +88,6 @@ private:
 #endif
 
 	static bool m_query_image_info;
-
-	// Maps from container id to the "top" threadinfo in the
-	// process heirarchy having that container id that
-	// exists. These associations are only maintained while an
-	// async lookup of container information is in progress. We
-	// use this to ensure that the tid of the CONTAINER_JSON event
-	// we eventually emit is a valid thread, and the top running
-	// thread, in the container.
-	//
-        // We want the container event to have a valid thread because
-        // all the container.* filterchecks first look up the
-        // threadinfo for the event and then use the threadinfo's
-        // m_container_id to look up to the container. If the container
-        // event didn't have a valid threadinfo, that lookup would
-        // fail and the container.* filterchecks would not return anything.
-	typedef tbb::concurrent_hash_map<std::string, int64_t> top_tid_table;
-	top_tid_table m_top_tids;
 };
 
 class docker

--- a/userspace/libsinsp/container_engine/libvirt_lxc.cpp
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.cpp
@@ -87,7 +87,7 @@ bool libvirt_lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* ti
 	{
 		container_info.m_name = container_info.m_id;
 		manager->add_container(container_info, tinfo);
-		manager->notify_new_container(container_info, tinfo->m_tid);
+		manager->notify_new_container(container_info);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/lxc.cpp
+++ b/userspace/libsinsp/container_engine/lxc.cpp
@@ -66,7 +66,7 @@ bool lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 	{
 		container_info.m_name = container_info.m_id;
 		manager->add_container(container_info, tinfo);
-		manager->notify_new_container(container_info, tinfo->m_tid);
+		manager->notify_new_container(container_info);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/mesos.cpp
+++ b/userspace/libsinsp/container_engine/mesos.cpp
@@ -64,7 +64,7 @@ bool libsinsp::container_engine::mesos::resolve(sinsp_container_manager* manager
 	{
 		container_info.m_name = container_info.m_id;
 		manager->add_container(container_info, tinfo);
-		manager->notify_new_container(container_info, tinfo->m_tid);
+		manager->notify_new_container(container_info);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/rkt.cpp
+++ b/userspace/libsinsp/container_engine/rkt.cpp
@@ -190,7 +190,7 @@ bool rkt::rkt::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo
 	if (have_rkt)
 	{
 		manager->add_container(container_info, tinfo);
-		manager->notify_new_container(container_info, tinfo->m_tid);
+		manager->notify_new_container(container_info);
 		return true;
 	}
 	else

--- a/userspace/libsinsp/container_info.cpp
+++ b/userspace/libsinsp/container_info.cpp
@@ -109,3 +109,17 @@ void sinsp_container_info::parse_healthcheck(const Json::Value &healthcheck_obj)
 		}
 	}
 }
+
+std::shared_ptr<sinsp_threadinfo> sinsp_container_info::get_tinfo(sinsp* inspector) const
+{
+	auto tinfo = make_shared<sinsp_threadinfo>(inspector);
+	tinfo->m_tid = -1;
+	tinfo->m_pid = -1;
+	tinfo->m_vtid = -2;
+	tinfo->m_vpid = -2;
+	tinfo->m_comm = "container:" + m_id;
+	tinfo->m_container_id = m_id;
+
+	return tinfo;
+}
+

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -21,10 +21,14 @@ limitations under the License.
 
 #include <cstdint>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "json/json.h"
+
+class sinsp;
+class sinsp_threadinfo;
 
 enum sinsp_container_type
 {
@@ -152,6 +156,8 @@ public:
 	bool is_pod_sandbox() const {
 		return m_is_pod_sandbox;
 	}
+
+	std::shared_ptr<sinsp_threadinfo> get_tinfo(sinsp* inspector) const;
 
 	std::string m_id;
 	sinsp_container_type m_type;

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -366,6 +366,7 @@ private:
 	{
 		m_flags = EF_NONE;
 		m_info = &(m_event_info_table[m_pevt->type]);
+		m_tinfo_ref.reset();
 		m_tinfo = NULL;
 		m_fdinfo = NULL;
 		m_fdinfo_name_changed = false;
@@ -377,6 +378,7 @@ private:
 		m_flags = EF_NONE;
 		m_pevt = (scap_evt *)evdata;
 		m_info = &(m_event_info_table[m_pevt->type]);
+		m_tinfo_ref.reset();
 		m_tinfo = NULL;
 		m_fdinfo = NULL;
 		m_fdinfo_name_changed = false;
@@ -392,6 +394,7 @@ private:
 	{
 		m_pevt = scap_event;
 		m_info = ppm_event;
+		m_tinfo_ref.reset(); // we don't own the threadinfo so don't try to manage its lifetime
 		m_tinfo = threadinfo;
 		m_fdinfo = fdinfo;
 	}
@@ -446,6 +449,9 @@ VISIBILITY_PRIVATE
 	std::vector<char> m_paramstr_storage;
 	std::vector<char> m_resolved_paramstr_storage;
 
+	// reference to keep threadinfo alive. currently only used for synthetic container event thread info
+	// it should either be null, or point to the same place as m_tinfo
+	std::shared_ptr<sinsp_threadinfo> m_tinfo_ref;
 	sinsp_threadinfo* m_tinfo;
 	sinsp_fdinfo_t* m_fdinfo;
 

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1239,6 +1239,10 @@ uint8_t* sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT uint32_t* len, bool 
 		break;
 	case TYPE_UID:
 		{
+			if(evt->get_type() == PPME_CONTAINER_JSON_E)
+			{
+				return NULL;
+			}
 			ASSERT(m_tinfo != NULL);
 
 			m_tstr = to_string(m_tinfo->m_tid) + to_string(m_tinfo->m_lastevent_fd);


### PR DESCRIPTION
Containers aren't really associated with a particular thread (the dependency is the other way round) so just accept that fact and synthesize a thread info that contains only the container id.