### PR TITLE
SMAGENT-1559: Separate logging concerns

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -111,6 +111,7 @@ set(SINSP_SOURCES
 	stopwatch.cpp
 	uri_parser.c
 	uri.cpp
+	user_event_logger.cpp
 	utils.cpp
 	user_event.cpp
 	value_parser.cpp

--- a/userspace/libsinsp/json_error_log.cpp
+++ b/userspace/libsinsp/json_error_log.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include <user_event.h>
 #include <logger.h>
 
+#include "user_event_logger.h"
 #include "json_error_log.h"
 
 json_error_log g_json_error_log;
@@ -96,7 +97,7 @@ void json_error_log::log(const std::string &json, const std::string &errstr,
 
 		g_logger.log("Logging user event: " + evtstr, sinsp_logger::SEV_DEBUG);
 
-		g_logger.log(evtstr, sinsp_logger::SEV_EVT_WARNING);
+		user_event_logger::log(evtstr, user_event_logger::SEV_EVT_WARNING);
 	}
 }
 

--- a/userspace/libsinsp/k8s_component.cpp
+++ b/userspace/libsinsp/k8s_component.cpp
@@ -793,7 +793,7 @@ bool k8s_event_t::update(const Json::Value& item, k8s_state_t& state)
 	time_t      epoch_time_now_s = get_epoch_utc_seconds_now();
 	std::string event_name;
 	std::string description;
-	severity_t  severity = sinsp_logger::SEV_EVT_INFORMATION;
+	severity_t  severity = user_event_logger::SEV_EVT_INFORMATION;
 	event_scope scope;
 	tag_map_t   tags;
 
@@ -806,8 +806,8 @@ bool k8s_event_t::update(const Json::Value& item, k8s_state_t& state)
 	{
 		std::string sev = get_json_string(item, "type");
 		// currently, only "Normal" and "Warning"
-		severity = sinsp_logger::SEV_EVT_INFORMATION;
-		if(sev == "Warning") { severity = sinsp_logger::SEV_EVT_WARNING; }
+		severity = user_event_logger::SEV_EVT_INFORMATION;
+		if(sev == "Warning") { severity = user_event_logger::SEV_EVT_WARNING; }
 		if(g_logger.get_severity() >= sinsp_logger::SEV_TRACE)
 		{
 			g_logger.log("K8s EVENT:"
@@ -909,8 +909,12 @@ bool k8s_event_t::update(const Json::Value& item, k8s_state_t& state)
 	}
 
 	tags["source"] = "kubernetes";
-	g_logger.log(sinsp_user_event::to_string(epoch_time_evt_s, std::move(event_name), std::move(description),
-											 std::move(scope), std::move(tags)), severity);
+	user_event_logger::log(sinsp_user_event::to_string(epoch_time_evt_s,
+	                                                   std::move(event_name),
+	                                                   std::move(description),
+	                                                   std::move(scope),
+	                                                   std::move(tags)),
+	                  severity);
 
 	// TODO: sysdig capture?
 #endif // _WIN32

--- a/userspace/libsinsp/k8s_component.cpp
+++ b/userspace/libsinsp/k8s_component.cpp
@@ -914,7 +914,7 @@ bool k8s_event_t::update(const Json::Value& item, k8s_state_t& state)
 	                                                   std::move(description),
 	                                                   std::move(scope),
 	                                                   std::move(tags)),
-	                  severity);
+	                       severity);
 
 	// TODO: sysdig capture?
 #endif // _WIN32

--- a/userspace/libsinsp/k8s_component.h
+++ b/userspace/libsinsp/k8s_component.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include "sinsp_int.h"
 #include "logger.h"
 #include "user_event.h"
+#include "user_event_logger.h"
 #include <vector>
 #include <unordered_set>
 
@@ -537,7 +538,7 @@ public:
 
 private:
 	typedef sinsp_user_event::tag_map_t tag_map_t;
-	typedef sinsp_logger::event_severity severity_t;
+	typedef user_event_logger::severity severity_t;
 	typedef std::unordered_map<std::string, std::string> name_translation_map_t;
 
 	void make_scope(const Json::Value& obj, event_scope& scope);

--- a/userspace/libsinsp/logger.cpp
+++ b/userspace/libsinsp/logger.cpp
@@ -65,12 +65,6 @@ bool sinsp_logger::is_callback() const
 	 return (m_flags & sinsp_logger::OT_CALLBACK) != 0;
 }
 
-bool sinsp_logger::is_event_severity(const severity sev)
-{
-	 return (static_cast<int>(sev) >= static_cast<int>(SEV_EVT_MIN) &&
-			static_cast<int>(sev) <= static_cast<int>(SEV_EVT_MAX));
-}
-
 uint32_t sinsp_logger::get_log_output_type() const
 {
 	return m_flags;
@@ -143,26 +137,11 @@ sinsp_logger::severity sinsp_logger::get_severity() const
 	return m_sev;
 }
 
-void sinsp_logger::log(std::string msg, const event_severity sev)
-{
-	sinsp_logger_callback cb = nullptr;
-
-	if(is_callback())
-	{
-		cb = m_callback;
-	}
-
-	if(cb != nullptr)
-	{
-		cb(std::move(msg), static_cast<uint32_t>(sev));
-	}
-}
-
 void sinsp_logger::log(std::string msg, const severity sev)
 {
 	sinsp_logger_callback cb = nullptr;
 
-	if((sev > m_sev) || is_event_severity(sev))
+	if(sev > m_sev)
 	{
 		return;
 	}
@@ -208,7 +187,7 @@ void sinsp_logger::log(std::string msg, const severity sev)
 
 	if(cb != nullptr)
 	{
-		cb(std::move(msg), static_cast<uint32_t>(sev));
+		cb(std::move(msg), sev);
 	}
 	else if((m_flags & sinsp_logger::OT_FILE) && m_file)
 	{
@@ -229,12 +208,6 @@ void sinsp_logger::log(std::string msg, const severity sev)
 
 const char* sinsp_logger::format(const severity sev, const char* const fmt, ...)
 {
-	if(!is_callback() && is_event_severity(sev))
-	{
-		s_tbuf[0] = '\0';
-		return s_tbuf;
-	}
-
 	va_list ap;
 
 	va_start(ap, fmt);

--- a/userspace/libsinsp/logger.h
+++ b/userspace/libsinsp/logger.h
@@ -24,8 +24,6 @@ limitations under the License.
 #include <atomic>
 #include <string>
 
-using sinsp_logger_callback = void (*)(std::string&& str, uint32_t sev);
-
 /**
  * Sysdig component logging API.  This API exposes the ability to log to a
  * variety of log sinks.  sinsp_logger will use only one enabled log* sink;
@@ -51,24 +49,7 @@ public:
 	const static severity SEV_MIN = SEV_FATAL;
 	const static severity SEV_MAX = SEV_TRACE;
 
-	enum event_severity
-	{
-		SEV_EVT_EMERGENCY = 10,
-		SEV_EVT_FATAL = 11,
-		SEV_EVT_CRITICAL = 12,
-		SEV_EVT_ERROR = 13,
-		SEV_EVT_WARNING = 14,
-		SEV_EVT_NOTICE = 15,
-		SEV_EVT_INFORMATION = 16,
-		SEV_EVT_DEBUG = 17,
-	};
-	const static event_severity SEV_EVT_MIN = SEV_EVT_EMERGENCY;
-	const static event_severity SEV_EVT_MAX = SEV_EVT_DEBUG;
-
-	enum event_memdump_severity
-	{
-		SEV_EVT_MDUMP = SEV_EVT_MAX + 1
-	};
+	using callback_t = void (*)(std::string&& str, severity sev);
 
 	const static uint32_t OT_NONE;
 	const static uint32_t OT_STDOUT;
@@ -116,7 +97,7 @@ public:
 	 *
 	 * Note: the given callback must be thread-safe.
 	 */
-	void add_callback_log(sinsp_logger_callback callback);
+	void add_callback_log(callback_t callback);
 
 	/** Deregister any registered logging callbacks.  */
 	void remove_callback_log();
@@ -137,8 +118,6 @@ public:
 	 * is greater than or equal to the minimum configured logging severity.
 	 */
 	void log(std::string msg, severity sev = SEV_INFO);
-
-	void log(std::string msg, event_severity sev);
 
 	/**
 	 * Write the given printf-style log message of the given severity
@@ -168,22 +147,15 @@ private:
 	/** Returns true if the callback log sync is enabled, false otherwise. */
 	bool is_callback() const;
 
-	/**
-	 * Returns true if the given severity is an event.  The type here
-	 * doesn't match the behavior; the implementation checks for a value
-	 * of type event_severity even though the parameter is of type
-	 * severity.  This component seems to treat the two distinct types
-	 * as a single type.
-	 */
-	static bool is_event_severity(severity sev);
 
 	/** Returns a string containing encoded severity, for OT_ENCODE_SEV. */
 	static const char* encode_severity(severity sev);
-
 	std::atomic<FILE*> m_file;
-	std::atomic<sinsp_logger_callback> m_callback;
+	std::atomic<callback_t> m_callback;
 	std::atomic<uint32_t> m_flags;
 	std::atomic<severity> m_sev;
 };
+
+using sinsp_logger_callback = sinsp_logger::callback_t;
 
 extern sinsp_logger g_logger;

--- a/userspace/libsinsp/user_event.cpp
+++ b/userspace/libsinsp/user_event.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include "sinsp.h"
 #include "sinsp_int.h"
 #include "user_event.h"
+#include "user_event_logger.h"
 
 //
 // event_scope
@@ -441,6 +442,10 @@ void sinsp_user_event::emit_event_overflow(const std::string& component,
 		scope.append("host.mac=").append(machine_id);
 	}
 	tag_map_t tags{{"source", source}};
-	g_logger.log(sinsp_user_event::to_string(get_epoch_utc_seconds_now(), std::move(event_name),
-				 description.str(), std::move(scope), std::move(tags)), sinsp_logger::SEV_EVT_WARNING);
+	user_event_logger::log(sinsp_user_event::to_string(get_epoch_utc_seconds_now(),
+	                                                   std::move(event_name),
+	                                                   description.str(),
+	                                                   std::move(scope),
+	                                                   std::move(tags)),
+	                  user_event_logger::SEV_EVT_WARNING);
 }

--- a/userspace/libsinsp/user_event.cpp
+++ b/userspace/libsinsp/user_event.cpp
@@ -447,5 +447,5 @@ void sinsp_user_event::emit_event_overflow(const std::string& component,
 	                                                   description.str(),
 	                                                   std::move(scope),
 	                                                   std::move(tags)),
-	                  user_event_logger::SEV_EVT_WARNING);
+	                       user_event_logger::SEV_EVT_WARNING);
 }

--- a/userspace/libsinsp/user_event_logger.cpp
+++ b/userspace/libsinsp/user_event_logger.cpp
@@ -1,0 +1,64 @@
+/*
+Copyright (C) 2019 Sysdig Inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+#include "user_event_logger.h"
+#include <memory>
+
+namespace
+{
+
+/**
+ * Do-nothing realization of the user_event_logger::callback interface.
+ */
+class null_callback : public user_event_logger::callback
+{
+public:
+	void log(std::string&& str,
+	         const user_event_logger::severity severity) override
+	{ }
+
+	bool is_null() const override { return true; }
+};
+
+/** The current callback handler. */
+user_event_logger::callback::ptr_t s_callback = std::make_shared<null_callback>();
+
+} // end namespace
+
+void user_event_logger::log(std::string msg,
+                            const user_event_logger::severity severity)
+{
+	s_callback->log(std::move(msg), severity);
+}
+
+void user_event_logger::register_callback(callback::ptr_t callback)
+{
+	if(callback)
+	{
+		s_callback = callback;
+	}
+	else
+	{
+		s_callback = std::make_shared<null_callback>();
+	}
+}
+
+const user_event_logger::callback& user_event_logger::get_callback()
+{
+	return *s_callback;
+}

--- a/userspace/libsinsp/user_event_logger.cpp
+++ b/userspace/libsinsp/user_event_logger.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 */
 #include "user_event_logger.h"
 #include <memory>
+#include <string>
 
 namespace
 {

--- a/userspace/libsinsp/user_event_logger.h
+++ b/userspace/libsinsp/user_event_logger.h
@@ -1,0 +1,86 @@
+/*
+Copyright (C) 2019 Sysdig Inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+#pragma once
+#include <memory>
+
+/**
+ * This namespace exposes an API for logging user events.
+ */
+namespace user_event_logger
+{
+
+/**
+ * The severities at which user events may be logged.
+ */
+enum severity
+{
+	SEV_EVT_FATAL,
+	SEV_EVT_CRITICAL,
+	SEV_EVT_ERROR,
+	SEV_EVT_WARNING,
+	SEV_EVT_NOTICE,
+	SEV_EVT_INFORMATION,
+	SEV_EVT_DEBUG,
+};
+
+/**
+ * Interface to an object that will receive callbacks whenever user event
+ * logs are generated.
+ */
+class callback
+{
+public:
+	using ptr_t = std::shared_ptr<callback>;
+
+	virtual ~callback() = default;
+
+	/**
+	 * Write the given log str with the given severity.
+	 */
+	virtual void log(std::string&& str, user_event_logger::severity sev) = 0;
+
+	/**
+	 * We use the "Null Object Pattern" with this interface; this will
+	 * return true for do-nothing implementations, false otherwise.
+	 */
+	virtual bool is_null() const { return false; }
+};
+
+/**
+ * Write the given user event log message with the given severity to the
+ * registered callback.
+ */
+void log(std::string msg, user_event_logger::severity sev);
+
+/**
+ * Register the given callback.  If a callback is already registered, it will
+ * be replaced with the given callback.  The given callback may be nullptr,
+ * in which case the registered callback will be replaced with a null
+ * callback handler.
+ */
+void register_callback(user_event_logger::callback::ptr_t callback);
+
+/**
+ * Returns a reference to the current callback handler.  Use the is_null()
+ * method on the returned object to determine if the handler is expected to
+ * perform useful logging.
+ */
+const callback& get_callback();
+
+} // end namespace user_event_logger


### PR DESCRIPTION
Current `sinsp_logger` is responsible for handling various unrelated
tasks:

* trace logging
* user event logging
* memdump logging

This change pulls user event logging out into a separate component.
Memdump logging is not needed in Sysdig.