### PR TITLE
Use m_tinfo_ref in get_thread_info()

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -130,6 +130,12 @@ sinsp_threadinfo* sinsp_evt::get_thread_info(bool query_os_if_not_found)
 	{
 		return m_tinfo;
 	}
+	else if(m_tinfo_ref)
+	{
+		m_tinfo = m_tinfo_ref.get();
+
+		return m_tinfo;
+	}
 
 	return m_inspector->get_thread(m_pevt->tid, query_os_if_not_found, false);
 }


### PR DESCRIPTION
In https://github.com/draios/sysdig/pull/1374, we added a synthetic
threadinfo object m_tinfo_ref that is used only for container json
events. A given event's m_tinfo pointer is set to this object in
sinsp_container_manager::container_to_sinsp_event(), but the analyzer
can set m_tinfo to NULL in
analyzer::flush (https://github.com/draios/agent/blob/dev/userspace/libsanalyzer/src/analyzer.cpp#L4837).

To address this, modify sinsp_evt::get_thread_info to see if m_tinfo_ref
is valid and if so set m_tinfo to this object's underlying pointer.