### PR TITLE
Switch to long-lived container resolvers

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SINSP_SOURCES
 	chisel.cpp
 	chisel_api.cpp
 	container.cpp
+	container_engine/container_engine.cpp
 	container_engine/docker_common.cpp
 	container_info.cpp
 	ctext.cpp

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -29,10 +29,22 @@ limitations under the License.
 #include "container.h"
 #include "utils.h"
 
+using namespace libsinsp;
+
 sinsp_container_manager::sinsp_container_manager(sinsp* inspector) :
 	m_inspector(inspector),
 	m_last_flush_time_ns(0)
 {
+	m_container_engines.emplace_back(new container_engine::docker());
+#ifndef CYGWING_AGENT
+#if defined(HAS_CAPTURE)
+	m_container_engines.emplace_back(new container_engine::cri());
+#endif
+	m_container_engines.emplace_back(new container_engine::lxc());
+	m_container_engines.emplace_back(new container_engine::libvirt_lxc());
+	m_container_engines.emplace_back(new container_engine::mesos());
+	m_container_engines.emplace_back(new container_engine::rkt());
+#endif
 }
 
 sinsp_container_manager::~sinsp_container_manager()
@@ -111,22 +123,15 @@ bool sinsp_container_manager::resolve_container(sinsp_threadinfo* tinfo, bool qu
 		matches = m_inspector->m_parser->m_fd_listener->on_resolve_container(this, tinfo, query_os_for_missing_info);
 	}
 
-#ifdef CYGWING_AGENT
-	matches = matches || resolve_container_impl<sinsp_container_engine_docker>(tinfo, query_os_for_missing_info);
+	for(auto &eng : m_container_engines)
+	{
+		matches = matches || eng->resolve(this, tinfo, query_os_for_missing_info);
 
-#else
-	matches = matches || resolve_container_impl<
-		libsinsp::container_engine::docker,
-#if defined(HAS_CAPTURE)
-		libsinsp::container_engine::cri,
-#endif
-		libsinsp::container_engine::lxc,
-		libsinsp::container_engine::libvirt_lxc,
-		libsinsp::container_engine::mesos,
-		libsinsp::container_engine::rkt
-	>(tinfo, query_os_for_missing_info);
-
-#endif // CYGWING_AGENT
+		if(matches)
+		{
+			break;
+		}
+	}
 
 	// Also identify if this thread is part of a container healthcheck
 	identify_healthcheck(tinfo);
@@ -424,10 +429,10 @@ void sinsp_container_manager::subscribe_on_remove_container(remove_container_cb 
 
 void sinsp_container_manager::cleanup()
 {
-	libsinsp::container_engine::docker::cleanup();
-#if defined(HAS_CAPTURE)
-	libsinsp::container_engine::cri::cleanup();
-#endif
+	for(auto &eng : m_container_engines)
+	{
+		eng->cleanup();
+	}
 }
 
 void sinsp_container_manager::set_query_docker_image_info(bool query_image_info)

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -64,6 +64,7 @@ public:
 	void subscribe_on_new_container(new_container_cb callback);
 	void subscribe_on_remove_container(remove_container_cb callback);
 
+	void create_engines();
 	void cleanup();
 
 	void set_query_docker_image_info(bool query_image_info);

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -29,6 +29,8 @@ limitations under the License.
 #include <curl/multi.h>
 #endif
 
+#include "container_engine/container_engine.h"
+
 class sinsp_container_manager
 {
 public:
@@ -74,6 +76,8 @@ private:
 	bool container_to_sinsp_event(const string& json, sinsp_evt* evt, shared_ptr<sinsp_threadinfo> tinfo);
 	string get_docker_env(const Json::Value &env_vars, const string &mti);
 
+	std::list<std::unique_ptr<libsinsp::container_engine::resolver>> m_container_engines;
+
 	sinsp* m_inspector;
 	unordered_map<string, sinsp_container_info> m_containers;
 	uint64_t m_last_flush_time_ns;
@@ -82,18 +86,3 @@ private:
 
 	friend class test_helper;
 };
-
-template<typename E> bool sinsp_container_manager::resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
-{
-	E engine;
-	return engine.resolve(this, tinfo, query_os_for_missing_info);
-}
-
-template<typename E1, typename E2, typename... Args> bool sinsp_container_manager::resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
-{
-	if (resolve_container_impl<E1>(tinfo, query_os_for_missing_info))
-	{
-		return true;
-	}
-	return resolve_container_impl<E2, Args...>(tinfo, query_os_for_missing_info);
-}

--- a/userspace/libsinsp/container_engine/container_engine.cpp
+++ b/userspace/libsinsp/container_engine/container_engine.cpp
@@ -17,28 +17,10 @@ limitations under the License.
 
 */
 
-#pragma once
-
-#include <string>
-
-class sinsp_container_manager;
-class sinsp_container_info;
-class sinsp_threadinfo;
-
 #include "container_engine/container_engine.h"
 
-namespace libsinsp {
-namespace container_engine {
-class mesos : public resolver {
-public:
-	bool resolve(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+using namespace libsinsp::container_engine;
 
-	static bool set_mesos_task_id(sinsp_container_info *container, sinsp_threadinfo *tinfo);
-
-protected:
-	bool match(sinsp_threadinfo *tinfo, sinsp_container_info *container_info);
-
-	static std::string get_env_mesos_task_id(sinsp_threadinfo *tinfo);
-};
-}
+void resolver::cleanup()
+{
 }

--- a/userspace/libsinsp/container_engine/container_engine.h
+++ b/userspace/libsinsp/container_engine/container_engine.h
@@ -19,26 +19,20 @@ limitations under the License.
 
 #pragma once
 
-#include <string>
-
 class sinsp_container_manager;
-class sinsp_container_info;
 class sinsp_threadinfo;
-
-#include "container_engine/container_engine.h"
 
 namespace libsinsp {
 namespace container_engine {
-class mesos : public resolver {
+
+class resolver {
 public:
-	bool resolve(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	virtual ~resolver() = default;
 
-	static bool set_mesos_task_id(sinsp_container_info *container, sinsp_threadinfo *tinfo);
+	virtual bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) = 0;
 
-protected:
-	bool match(sinsp_threadinfo *tinfo, sinsp_container_info *container_info);
-
-	static std::string get_env_mesos_task_id(sinsp_threadinfo *tinfo);
+	virtual void cleanup();
 };
 }
 }
+

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -26,15 +26,17 @@ class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
+#include "container_engine/container_engine.h"
+
 namespace libsinsp {
 namespace container_engine {
-class cri
+class cri : public resolver
 {
 public:
 	cri();
 
-	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
-	static void cleanup();
+	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;
+	void cleanup() override;
 	static void set_cri_socket_path(const std::string& path);
 	static void set_cri_timeout(int64_t timeout_ms);
 	static void set_extra_queries(bool extra_queries);

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -36,6 +36,8 @@ limitations under the License.
 
 #include "container_info.h"
 
+#include "container_engine/container_engine.h"
+
 class sinsp;
 class sinsp_container_manager;
 class sinsp_container_info;
@@ -90,13 +92,13 @@ private:
 	static bool m_query_image_info;
 };
 
-class docker
+class docker : public resolver
 {
 public:
 	docker();
 
-	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
-	static void cleanup();
+	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;
+	void cleanup() override;
 	static void parse_json_mounts(const Json::Value &mnt_obj, std::vector<sinsp_container_info::container_mount_info> &mounts);
 
 	// Container name only set for windows. For linux name must be fetched via lookup
@@ -104,7 +106,7 @@ public:
 protected:
 	void parse_docker_async(sinsp *inspector, std::string &container_id, sinsp_container_manager *manager);
 
-	static std::unique_ptr<docker_async_source> g_docker_info_source;
+	std::unique_ptr<docker_async_source> m_docker_info_source;
 
 	static std::string s_incomplete_info_name;
 };

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -119,13 +119,13 @@ bool docker::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, 
 		return false;
 	}
 
-	if(!g_docker_info_source)
+	if(!m_docker_info_source)
 	{
 		g_logger.log("docker_async: Creating docker async source",
 			     sinsp_logger::SEV_DEBUG);
 		uint64_t max_wait_ms = 10000;
 		docker_async_source *src = new docker_async_source(docker_async_source::NO_WAIT_LOOKUP, max_wait_ms, manager->get_inspector());
-		g_docker_info_source.reset(src);
+		m_docker_info_source.reset(src);
 	}
 
 	tinfo->m_container_id = container_id;
@@ -192,7 +192,7 @@ void docker::parse_docker_async(sinsp *inspector, std::string &container_id, sin
 
         container_lookup_result result;
 
-	if (g_docker_info_source->lookup(container_id, result, cb))
+	if (m_docker_info_source->lookup(container_id, result, cb))
 	{
 		// if a previous lookup call already found the metadata, process it now
 		cb(container_id, result);

--- a/userspace/libsinsp/container_engine/docker_linux.cpp
+++ b/userspace/libsinsp/container_engine/docker_linux.cpp
@@ -43,15 +43,13 @@ constexpr const cgroup_layout DOCKER_CGROUP_LAYOUT[] = {
 };
 }
 
-std::unique_ptr<docker_async_source> docker::g_docker_info_source;
-
 docker::docker()
 {
 }
 
 void docker::cleanup()
 {
-	g_docker_info_source.reset(NULL);
+	m_docker_info_source.reset(NULL);
 }
 
 void docker_async_source::init_docker_conn()

--- a/userspace/libsinsp/container_engine/libvirt_lxc.h
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.h
@@ -23,12 +23,14 @@ class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
+#include "container_engine/container_engine.h"
+
 namespace libsinsp {
 namespace container_engine {
-class libvirt_lxc
+class libvirt_lxc : public resolver
 {
 public:
-	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
+	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;
 protected:
 	bool match(sinsp_threadinfo* tinfo, sinsp_container_info* container_info);
 };

--- a/userspace/libsinsp/container_engine/lxc.h
+++ b/userspace/libsinsp/container_engine/lxc.h
@@ -23,12 +23,14 @@ class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
+#include "container_engine/container_engine.h"
+
 namespace libsinsp {
 namespace container_engine {
-class lxc
+class lxc : public resolver
 {
 public:
-	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
+	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;
 };
 }
 }

--- a/userspace/libsinsp/container_engine/rkt.h
+++ b/userspace/libsinsp/container_engine/rkt.h
@@ -25,11 +25,13 @@ class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
+#include "container_engine/container_engine.h"
+
 namespace libsinsp {
 namespace container_engine {
-class rkt {
+class rkt : public resolver {
 public:
-	bool resolve(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, bool query_os_for_missing_info);
+	bool resolve(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
 protected:
 	bool match(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, sinsp_container_info *container_info,


### PR DESCRIPTION
Instead of having container engine objects be short-lived, only created
at the instant resolve() is called, have them be long-lived and a part
of the sinsp_container_manager object. This involves:

 - create a stub base class libsinsp::container_engine::resolver that
   defines virtual void resolve() and virtual cleanup() methods.
 - making all the classes in container_engine/* derive from the base
   class.
 - in sinsp_container_manager, create a list of
   container_engine::resolver objects.
 - when resolving containers, iterate over the list instead of using the
   templated functions resolve_container_impl().

This fixes SMAGENT-1569, because there is no global state related to the
container engines.