### PR TITLE
Fix reading scap files without device numbers

### DIFF
--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -522,7 +522,7 @@ uint32_t scap_fd_read_from_disk(scap_t *handle, OUT scap_fdinfo *fdi, OUT size_t
 
 		(*nbytes) += sizeof(uint32_t);
 		res = scap_fd_read_fname_from_disk(handle, fdi->info.regularinfo.fname, nbytes, f);
-		if (sub_len && (*nbytes + sizeof(uint32_t)) > sub_len)
+		if (!sub_len || (sub_len < *nbytes + sizeof(uint32_t)))
 		{
 			break;
 		}


### PR DESCRIPTION
Commit 9ef2d648cd7f905d69130689c17e0829d85ad546 accidentally broke compatibility with scap files written without device number info