### PR TITLE
Async framework extensions

### DIFF
--- a/userspace/async/async_key_value_source.h
+++ b/userspace/async/async_key_value_source.h
@@ -59,7 +59,7 @@ namespace sysdig
  * <li>If the client did not supply a handler, then the value will be stored,
  *     and the next call to the lookup() method with the same key will return
  *     the previously collected value.  If lookup() is not called with the
- *     specified ttl time, then this compoment will prune the stored value.</li>
+ *     specified ttl time, then this component will prune the stored value.</li>
  * </ol>
  *
  * @tparam key_type   The type of the keys for which concrete subclasses will
@@ -123,7 +123,7 @@ public:
 	 * for the desired value(s) to be available.
 	 *
 	 * @param[in] key       The key to the value for which the client
-	 *                      wishs to query.
+	 *                      wishes to query.
 	 * @param[out] value    If this method is able to fetch the desired
 	 *                      value within the max_wait_ms specified at
 	 *                      construction time, then this output parameter
@@ -150,7 +150,7 @@ public:
                     const callback_handler& handler = callback_handler());
 
 	/**
-	 * Determines if the async thread assocaited with this
+	 * Determines if the async thread associated with this
 	 * async_key_value_source is running.
 	 *
 	 * <b>Note:</b> This API is for information only.  Clients should
@@ -165,7 +165,7 @@ public:
 
 protected:
 	/**
-	 * Stops the thread assocaited with this async_key_value_source, if
+	 * Stops the thread associated with this async_key_value_source, if
 	 * it is running; otherwise, does nothing.  The only use for this is
 	 * in a destructor to ensure that the async thread stops when the
 	 * object is destroyed.
@@ -193,7 +193,7 @@ protected:
 	/**
 	 * Stores a value for the given key.  Concrete subclasses will call
 	 * this method from their run_impl() method to save (or otherwise
-	 * notifiy the client about) an available value.
+	 * notify the client about) an available value.
 	 *
 	 * @param[in] key   The key for which the client asked for the value.
 	 * @param[in] value The collected value.
@@ -270,7 +270,7 @@ private:
 	/**
 	 * Protects the state of instances of this class.  This protected does
 	 * not extend to subclasses (i.e., this mutex should not be held when
-	 * dispatching to overridden methbods).
+	 * dispatching to overridden methods).
 	 */
 	mutable std::mutex m_mutex;
 

--- a/userspace/async/async_key_value_source.h
+++ b/userspace/async/async_key_value_source.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include <mutex>
 #include <set>
 #include <thread>
+#include <unordered_map>
 #include <stdint.h>
 
 namespace sysdig
@@ -162,6 +163,30 @@ public:
 	 * @returns true if the async thread is running, false otherwise.
 	 */
 	bool is_running() const;
+
+	/**
+	 * Return all results available so far
+	 *
+	 * All available results are moved from the internal map to the returned map
+	 * so subsequent `lookup()` and/or `get_complete_results()` calls won't
+	 * return them again.
+	 *
+	 * Sometimes there's no good place to call `lookup()` again
+	 * on the async data source -- e.g. the container detection engine
+	 * may never be called again for a particular container (if the only
+	 * process in that container never calls `execve()` or `chroot()`
+	 * or `clone()`).
+	 *
+	 * The best solution in that case is to supply a callback to be ran
+	 * from the async lookup, but that introduces thread safety issues
+	 * to the involved data.
+	 *
+	 * `get_complete_results()` allows batch processing of lookup results
+	 * in the main thread.
+	 *
+	 * @return a map of lookup key -> result
+	 */
+	std::unordered_map<key_type, value_type> get_complete_results();
 
 protected:
 	/**

--- a/userspace/async/async_key_value_source.h
+++ b/userspace/async/async_key_value_source.h
@@ -98,7 +98,7 @@ public:
 	 *                        value will live before being considered
 	 *                        "too old" and being pruned.
 	 */
-	async_key_value_source(uint64_t max_wait_ms, uint64_t ttl_ms);
+	async_key_value_source(uint64_t max_wait_ms, uint64_t ttl_ms) noexcept;
 
 	async_key_value_source(const async_key_value_source&) = delete;
 	async_key_value_source(async_key_value_source&&) = delete;

--- a/userspace/async/async_key_value_source.tpp
+++ b/userspace/async/async_key_value_source.tpp
@@ -32,7 +32,7 @@ namespace sysdig
 template<typename key_type, typename value_type>
 async_key_value_source<key_type, value_type>::async_key_value_source(
 		const uint64_t max_wait_ms,
-		const uint64_t ttl_ms):
+		const uint64_t ttl_ms) noexcept:
 	m_max_wait_ms(max_wait_ms),
 	m_ttl_ms(ttl_ms),
 	m_thread(),

--- a/userspace/async/async_key_value_source.tpp
+++ b/userspace/async/async_key_value_source.tpp
@@ -288,4 +288,27 @@ void async_key_value_source<key_type, value_type>::prune_stale_requests()
 	}
 }
 
+template<typename key_type, typename value_type>
+std::unordered_map<key_type, value_type> async_key_value_source<key_type, value_type>::get_complete_results()
+{
+	std::unordered_map<key_type, value_type> results;
+
+	std::lock_guard<std::mutex> guard(m_mutex);
+
+	for(const auto& it : m_value_map)
+	{
+		if(it.second.m_available)
+		{
+			results[it.first] = it.second.m_value;
+		}
+	}
+
+	for(const auto& it : results)
+	{
+		m_value_map.erase(it.first);
+	}
+
+	return results;
+}
+
 } // end namespace sysdig

--- a/userspace/async/async_key_value_source.tpp
+++ b/userspace/async/async_key_value_source.tpp
@@ -270,7 +270,7 @@ void async_key_value_source<key_type, value_type>::prune_stale_requests()
 	{
 		const auto now = std::chrono::steady_clock::now();
 
-		const auto age_ms =
+		const uint64_t age_ms =
 			std::chrono::duration_cast<std::chrono::milliseconds>(
 					now - i->second.m_start_time).count();
 


### PR DESCRIPTION
This PR adds two new features to the async framework:
* delayed lookups that start a specified time after the request (as opposed to immediately)
* an API to fetch all already computed results with a single method call