### PR TITLE
Don't consider a lack of s_cri to be an error [SMAGENT-1578]

### DIFF
--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -73,7 +73,11 @@ bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container
 {
 	if(!s_cri)
 	{
-		g_logger.format(sinsp_logger::SEV_ERROR,
+		// This isn't an error in the case where the
+		// configured unix domain socket doesn't exist. In
+		// that case, s_cri isn't initialized at all. Hence,
+		// the DEBUG.
+		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"cri (%s): Could not parse cri (no s_cri object)",
 				container->m_id.c_str());
 		return false;


### PR DESCRIPTION
In cases where the cri domain socket doesn't exist, s_cri will not be
initialized, but the cri engine is added to the list of resolvers
anyway. Given that, s_cri not existing is not an error.

So make the ERROR message a DEBUG message (there used to be no message
at all).

This fixes SMAGENT-1578.