### PR TITLE
Raise the iov limit in eBPF

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -343,7 +343,7 @@ FILLER(sys_poll_x, true)
 	return res;
 }
 
-#define MAX_IOVCNT 8
+#define MAX_IOVCNT 32
 
 static __always_inline int bpf_parse_readv_writev_bufs(struct filler_data *data,
 						       const struct iovec __user *iovsrc,


### PR DESCRIPTION
While playing with HTTP/2, I noticed gRPC tends to make heavy use of
vectorized I/O with sendmsg()/recvmsg(). Basically every single request
translates into many HTTP/2 frames, and gRPC seems to like sending each one
of them as a separate element of the vector and then batch all of them into
a single system call. So, it's pretty normal to see requests that reach
numbers as high as 32 (possibly even higher, I haven't encountered them
yet). Since each element of the vector is very small (e.g. 9 bytes HTTP/2
header), with the current limit of 8 it's easy to reach a situation where
we get truncated data even if the snaplen is set to a higher number,
because we just collect the first 8 elements of the vector.

The limit of 8 was initially (empirically) set by me because it was the
only way to make old kernels (4.12-4.13) accept those programs and not run
into a state explosion. Since we now support just 4.14.0+, 32 should be a
more decent limit, and I confirm it doesn't break 4.14.0, which is the
version with the oldest (aka stringent) verifier we support.