### PR TITLE
Asynchronous metadata lookup for CRI containers

### DIFF
--- a/userspace/libsinsp/async_container.h
+++ b/userspace/libsinsp/async_container.h
@@ -60,7 +60,7 @@ void async_container_source<key_type>::lookup_container(const key_type& key, sin
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"async_container_source (%s): Source callback result successful=%s",
 				static_cast<const std::string&>(key).c_str(),
-				(res.m_successful ? "true" : "false"));
+				(res.m_status == sinsp_container_lookup_state::SUCCESSFUL ? "true" : "false"));
 
 		// store the container metadata in container_manager regardless of the result
 		// this ensures that we don't get stuck with incomplete containers
@@ -71,7 +71,7 @@ void async_container_source<key_type>::lookup_container(const key_type& key, sin
 		//
 		// if we did use the metadata and the lookup succeeded,
 		// generate a container event for libsinsp consumers
-		if(manager->update_container(res) && res.m_successful)
+		if(manager->update_container(res) && res.m_status == sinsp_container_lookup_state::SUCCESSFUL)
 		{
 			manager->notify_new_container(res);
 		}

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -140,7 +140,7 @@ sinsp_container_info* sinsp_container_manager::get_or_create_container(
 	container_info.m_imagetag = s_incomplete_info_name;
 	container_info.m_imagedigest = s_incomplete_info_name;
 	container_info.m_metadata_complete = false;
-	container_info.m_successful = false;
+	container_info.m_status = sinsp_container_lookup_result::STARTED;
 
 	set_lookup_status(id, type, sinsp_container_lookup_state::STARTED);
 	add_container(container_info, tinfo, containers);
@@ -340,23 +340,11 @@ bool sinsp_container_manager::update_container(const sinsp_container_info& conta
 {
 	auto containers = m_containers.lock();
 
-	if(container_info.m_metadata_complete)
-	{
-		sinsp_container_lookup_result result;
-		if(container_info.m_successful)
-		{
-			result = sinsp_container_lookup_result::SUCCESSFUL;
-		}
-		else
-		{
-			result = sinsp_container_lookup_result::FAILED;
-		}
-		set_lookup_status(container_info.m_id, container_info.m_type, result);
-	}
+	set_lookup_status(container_info.m_id, container_info.m_type, container_info.m_status);
 
 	auto it = containers->find(container_info.m_id);
 	if(it == containers->end() ||
-		(container_info.m_metadata_complete && !it->second.m_successful))
+		(container_info.m_metadata_complete && it->second.m_status != sinsp_container_lookup_result::SUCCESSFUL))
 	{
 		auto thread_info = container_info.get_tinfo(m_inspector);
 		add_container(container_info, thread_info.get(), containers);

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -139,8 +139,7 @@ sinsp_container_info* sinsp_container_manager::get_or_create_container(
 	container_info.m_imagerepo = s_incomplete_info_name;
 	container_info.m_imagetag = s_incomplete_info_name;
 	container_info.m_imagedigest = s_incomplete_info_name;
-	container_info.m_metadata_complete = false;
-	container_info.m_status = sinsp_container_lookup_result::STARTED;
+	container_info.m_status = sinsp_container_lookup_state::STARTED;
 
 	set_lookup_status(id, type, sinsp_container_lookup_state::STARTED);
 	add_container(container_info, tinfo, containers);
@@ -344,7 +343,8 @@ bool sinsp_container_manager::update_container(const sinsp_container_info& conta
 
 	auto it = containers->find(container_info.m_id);
 	if(it == containers->end() ||
-		(container_info.m_metadata_complete && it->second.m_status != sinsp_container_lookup_result::SUCCESSFUL))
+		(container_info.m_status != sinsp_container_lookup_state::STARTED &&
+		 it->second.m_status != sinsp_container_lookup_state::SUCCESSFUL))
 	{
 		auto thread_info = container_info.get_tinfo(m_inspector);
 		add_container(container_info, thread_info.get(), containers);
@@ -468,7 +468,7 @@ void sinsp_container_manager::identify_category(sinsp_threadinfo *tinfo)
 		return;
 	}
 
-	if(!cinfo->m_metadata_complete)
+	if(cinfo->m_status != sinsp_container_lookup_state::SUCCESSFUL)
 	{
 		if(g_logger.get_severity() >= sinsp_logger::SEV_DEBUG)
 		{

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -77,6 +77,7 @@ bool sinsp_container_manager::remove_inactive_containers()
 		});
 
 		auto containers = m_containers.lock();
+		auto lookups = m_lookups.lock();
 		for(auto it = containers->begin(); it != containers->end();)
 		{
 			if(containers_in_use.find(it->first) == containers_in_use.end())
@@ -85,6 +86,7 @@ bool sinsp_container_manager::remove_inactive_containers()
 				{
 					remove_cb((*containers)[it->first]);
 				}
+				lookups->erase(it->first);
 				it = containers->erase(it);
 			}
 			else
@@ -140,6 +142,7 @@ sinsp_container_info* sinsp_container_manager::get_or_create_container(
 	container_info.m_metadata_complete = false;
 	container_info.m_successful = false;
 
+	set_lookup_status(id, type, sinsp_container_lookup_state::STARTED);
 	add_container(container_info, tinfo, containers);
 	return &(*containers)[id];
 }
@@ -336,6 +339,21 @@ void sinsp_container_manager::add_container(const sinsp_container_info& containe
 bool sinsp_container_manager::update_container(const sinsp_container_info& container_info)
 {
 	auto containers = m_containers.lock();
+
+	if(container_info.m_metadata_complete)
+	{
+		sinsp_container_lookup_result result;
+		if(container_info.m_successful)
+		{
+			result = sinsp_container_lookup_result::SUCCESSFUL;
+		}
+		else
+		{
+			result = sinsp_container_lookup_result::FAILED;
+		}
+		set_lookup_status(container_info.m_id, container_info.m_type, result);
+	}
+
 	auto it = containers->find(container_info.m_id);
 	if(it == containers->end() ||
 		(container_info.m_metadata_complete && !it->second.m_successful))

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -85,7 +85,7 @@ bool sinsp_container_manager::remove_inactive_containers()
 				{
 					remove_cb((*containers)[it->first]);
 				}
-				containers->erase(it++);
+				it = containers->erase(it);
 			}
 			else
 			{
@@ -97,7 +97,7 @@ bool sinsp_container_manager::remove_inactive_containers()
 	return res;
 }
 
-sinsp_container_info* sinsp_container_manager::get_container(const string& container_id)
+sinsp_container_info* sinsp_container_manager::get_container(const std::string& container_id)
 {
 	auto containers = m_containers.lock();
 	auto it = containers->find(container_id);

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -601,3 +601,17 @@ void sinsp_container_manager::set_cri_timeout(int64_t timeout_ms)
 	libsinsp::container_engine::cri::set_cri_timeout(timeout_ms);
 #endif
 }
+
+void sinsp_container_manager::set_cri_async(bool async)
+{
+#if defined(HAS_CAPTURE)
+	libsinsp::container_engine::cri::set_async(async);
+#endif
+}
+
+void sinsp_container_manager::set_cri_async_limits(bool async_limits)
+{
+#if defined(HAS_CAPTURE)
+	libsinsp::container_engine::cri::set_async_limits(async_limits);
+#endif
+}

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -39,6 +39,15 @@ limitations under the License.
 struct scap_dumper;
 class sinsp_evt;
 
+/**
+ * \brief Repository of known containers
+ *
+ * This class is responsible for
+ * - keeping metadata about known containers. This includes container name,
+ *   type (underlying runtime), image information (image id, name etc.)
+ * - detecting containers for new processes (by delegating to
+ *   libsinsp::container_engine::resolver objects)
+ */
 class sinsp_container_manager
 {
 public:
@@ -89,7 +98,6 @@ public:
 private:
 	std::string container_to_json(const sinsp_container_info& container_info);
 	bool container_to_sinsp_event(const std::string& json, sinsp_evt* evt, std::shared_ptr<sinsp_threadinfo> tinfo);
-	std::string get_docker_env(const Json::Value &env_vars, const std::string &mti);
 
 	std::list<std::unique_ptr<libsinsp::container_engine::resolver>> m_container_engines;
 

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -83,6 +83,8 @@ public:
 	void set_cri_extra_queries(bool extra_queries);
 	void set_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
+	void set_cri_async(bool async);
+	void set_cri_async_limits(bool async_limits);
 	sinsp* get_inspector() { return m_inspector; }
 private:
 	std::string container_to_json(const sinsp_container_info& container_info);

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -62,8 +62,6 @@ public:
 	sinsp_container_info * get_container(const std::string &id);
 	sinsp_container_info * get_or_create_container(sinsp_container_type type, const std::string &id, const std::string& name, sinsp_threadinfo* tinfo);
 	void notify_new_container(const sinsp_container_info& container_info);
-	template<typename E> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
-	template<typename E1, typename E2, typename... Args> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	bool resolve_container(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	void dump_containers(struct scap_dumper* dumper);
 	std::string get_container_name(sinsp_threadinfo* tinfo);

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -315,6 +315,7 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 	}
 	sinsp_container_info *container_info = manager->get_container(container_id);
 	sinsp_container_info sync_container_info;
+	bool success = true;
 
 	if (!container_info || manager->should_lookup(container_id, s_cri_runtime_type))
 	{
@@ -338,7 +339,7 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 						"cri (%s): Performing sync lookup",
 						container_id.c_str());
 
-				bool success = m_cri_info_source->parse_cri(
+				success = m_cri_info_source->parse_cri(
 					&sync_container_info, key);
 
 				sync_container_info.m_type = s_cri_runtime_type;
@@ -351,7 +352,6 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 					"cri (%s) sync lookup done, successful=%s",
 					container_id.c_str(), success ? "true" : "false");
 
-				sync_container_info.m_metadata_complete = true;
 				if(manager->update_container(sync_container_info) && success)
 				{
 					manager->notify_new_container(sync_container_info);
@@ -366,5 +366,5 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 		}
 	}
 
-	return container_info ? container_info->m_metadata_complete : true;
+	return success;
 }

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 #include "cri.grpc.pb.h"
 
 #include "async_cgroup.h"
+#include "async_key_value_source.h"
 #include "runc.h"
 #include "container_engine/mesos.h"
 #include "grpc_channel_registry.h"
@@ -40,25 +41,24 @@ using namespace libsinsp::cri;
 using namespace libsinsp::container_engine;
 using namespace libsinsp::runc;
 
+constexpr const uint64_t cri_async_source::CGROUP_LOOKUP_DELAY_MS;
+
 namespace {
-// how long do we wait
-constexpr uint64_t CGROUP_LOOKUP_DELAY_MS = 1000;
-
-// how long do we wait on cgroup lookup result before giving up
-// Note: this value includes the initial delay
-constexpr uint64_t CGROUP_MAX_DELAY_MS = 2000;
-libsinsp::async_cgroup::delayed_cgroup_lookup s_async_cgroups(0, CGROUP_MAX_DELAY_MS);
-
-void init_cri()
+bool init_cri()
 {
-	if(s_cri || s_cri_unix_socket_path.empty()) {
-		return;
+	if(s_cri)
+	{
+		return true;
+	}
+
+	if(s_cri_unix_socket_path.empty()) {
+		return false;
 	}
 
 	auto cri_path = scap_get_host_root() + s_cri_unix_socket_path;
 	struct stat s = {};
 	if(stat(cri_path.c_str(), &s) != 0 || (s.st_mode & S_IFMT) != S_IFSOCK) {
-		return;
+		return false;
 	}
 
 	std::shared_ptr<grpc::Channel> channel = libsinsp::grpc_channel_registry::get_channel("unix://" + cri_path);
@@ -80,14 +80,24 @@ void init_cri()
 				s_cri_unix_socket_path.c_str(), status.error_message().c_str());
 		s_cri.reset(nullptr);
 		s_cri_unix_socket_path = "";
-		return;
+		return false;
 	}
 
 	g_logger.format(sinsp_logger::SEV_INFO, "cri: CRI runtime: %s %s", vresp.runtime_name().c_str(), vresp.runtime_version().c_str());
 	s_cri_runtime_type = get_cri_runtime_type(vresp.runtime_name());
+	return true;
 }
 
-bool parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, sinsp_container_info *container, sinsp_threadinfo *tinfo)
+constexpr const cgroup_layout CRI_CGROUP_LAYOUT[] = {
+	{"/", ""}, // non-systemd containerd
+	{"/crio-", ""}, // non-systemd cri-o
+	{"/cri-containerd-", ".scope"}, // systemd containerd
+	{"/crio-", ".scope"}, // systemd cri-o
+	{nullptr, nullptr}
+};
+}
+
+bool cri_async_source::parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, sinsp_container_info *container)
 {
 	const auto &info_it = status.info().find("info");
 	if(info_it == status.info().end())
@@ -116,7 +126,7 @@ bool parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, 
 	return true;
 }
 
-bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container, sinsp_threadinfo *tinfo)
+bool cri_async_source::parse_cri(sinsp_container_info *container, const libsinsp::async_cgroup::delayed_cgroup_key& key)
 {
 	if(!s_cri)
 	{
@@ -180,15 +190,11 @@ bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container
 	parse_cri_image(resp_container, container);
 	parse_cri_mounts(resp_container, container);
 
-	if(parse_containerd(resp, container, tinfo))
+	if(parse_containerd(resp, container))
 	{
 		return true;
 	}
 
-	libsinsp::async_cgroup::delayed_cgroup_key key(
-		container->m_id,
-		tinfo->get_cgroup("cpu"),
-		tinfo->get_cgroup("memory"));
 	libsinsp::async_cgroup::delayed_cgroup_value limits;
 	bool found_all = libsinsp::async_cgroup::get_cgroup_resource_limits(key, limits);
 
@@ -203,11 +209,12 @@ bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container
 			"cri (%s) not all limits read from cgroups, will retry in %d ms",
 			container->m_id.c_str(), CGROUP_LOOKUP_DELAY_MS);
 
+		auto manager = m_container_manager;
 		auto cb = [manager](const libsinsp::async_cgroup::delayed_cgroup_key& key, const libsinsp::async_cgroup::delayed_cgroup_value& value) {
 			libsinsp::async_cgroup::delayed_cgroup_lookup::update(manager, key, value);
 		};
 
-		s_async_cgroups.lookup_delayed(key, limits, std::chrono::milliseconds(CGROUP_LOOKUP_DELAY_MS), cb);
+		m_async_cgroups.lookup_delayed(key, limits, std::chrono::milliseconds(CGROUP_LOOKUP_DELAY_MS), cb);
 	}
 
 	if(s_cri_extra_queries)
@@ -219,23 +226,38 @@ bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container
 	return true;
 }
 
-constexpr const cgroup_layout CRI_CGROUP_LAYOUT[] = {
-	{"/", ""}, // non-systemd containerd
-	{"/crio-", ""}, // non-systemd cri-o
-	{"/cri-containerd-", ".scope"}, // systemd containerd
-	{"/crio-", ".scope"}, // systemd cri-o
-	{nullptr, nullptr}
-};
-}
-
-cri::cri()
+void cri_async_source::run_impl()
 {
-	init_cri();
+	libsinsp::async_cgroup::delayed_cgroup_key key;
+
+	while (dequeue_next_key(key))
+	{
+		sinsp_container_info res;
+
+		res.m_successful = true;
+		res.m_id = key.m_container_id;
+		res.m_type = s_cri_runtime_type;
+
+		if(!parse_cri(&res, key))
+		{
+			g_logger.format(sinsp_logger::SEV_ERROR, "Failed to get CRI metadata for container %s",
+					key.m_container_id.c_str());
+			res.m_successful = false;
+		}
+
+		// Return a result object either way, to ensure any
+		// new container callbacks are called.
+		store_value(key, res);
+	}
 }
 
 void cri::cleanup()
 {
-	s_async_cgroups.quiesce();
+	if (m_cri_info_source)
+	{
+		m_cri_info_source->quiesce();
+	}
+	m_cri_info_source.reset(nullptr);
 	s_cri.reset(nullptr);
 	s_cri_image.reset(nullptr);
 	s_cri_extra_queries = true;
@@ -265,6 +287,18 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 	}
 	tinfo->m_container_id = container_id;
 
+	if(!init_cri())
+	{
+		return false;
+	}
+
+	if(!m_cri_info_source)
+	{
+		// we do 4 gRPC requests so set the timeout to 5x the individual request timeout
+		// s_cri_timeout is in milliseconds and we want nanoseconds -- that's where the 1000000 factor comes from
+		auto cri_source = new cri_async_source(manager, s_cri_timeout * 5 * 1000000);
+		m_cri_info_source.reset(cri_source);
+	}
 	sinsp_container_info *container_info = manager->get_container(container_id);
 
 	if (!container_info ||
@@ -279,18 +313,11 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 					"cri (%s): Performing lookup",
 					container_id.c_str());
 
-			container_info->m_successful = parse_cri(manager, container_info, tinfo);
-			if (!container_info->m_successful)
-			{
-				g_logger.format(sinsp_logger::SEV_DEBUG, "cri (%s): Failed to get CRI metadata for container",
-						container_id.c_str());
-				return false;
-			}
-
-			// If here, parse_cri succeeded so we can
-			// assign an actual type.
-			container_info->m_type = s_cri_runtime_type;
-			container_info->m_metadata_complete = true;
+			libsinsp::async_cgroup::delayed_cgroup_key key(
+				container_id,
+				tinfo->get_cgroup("cpu"),
+				tinfo->get_cgroup("memory"));
+			m_cri_info_source->lookup_container(key, manager);
 		}
 		if (mesos::set_mesos_task_id(container_info, tinfo))
 		{
@@ -298,11 +325,7 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 					"cri (%s) Mesos CRI container, Mesos task ID: [%s]",
 					container_id.c_str(), container_info->m_mesos_task_id.c_str());
 		}
-
-		if (manager->update_container(*container_info) && container_info->m_successful)
-		{
-			manager->notify_new_container(*container_info);
-		}
 	}
-	return true;
+
+	return container_info->m_metadata_complete;
 }

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -239,7 +239,7 @@ void cri_async_source::run_impl()
 	{
 		sinsp_container_info res;
 
-		res.m_successful = true;
+		res.m_status = sinsp_container_lookup_state::SUCCESSFUL;
 		res.m_id = key.m_container_id;
 		res.m_type = s_cri_runtime_type;
 
@@ -247,7 +247,7 @@ void cri_async_source::run_impl()
 		{
 			g_logger.format(sinsp_logger::SEV_ERROR, "Failed to get CRI metadata for container %s",
 					key.m_container_id.c_str());
-			res.m_successful = false;
+			res.m_status = sinsp_container_lookup_state::FAILED;
 		}
 
 		// Return a result object either way, to ensure any
@@ -338,17 +338,21 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 						"cri (%s): Performing sync lookup",
 						container_id.c_str());
 
+				bool success = m_cri_info_source->parse_cri(
+					&sync_container_info, key);
+
 				sync_container_info.m_type = s_cri_runtime_type;
 				sync_container_info.m_id = container_id;
-				sync_container_info.m_successful = m_cri_info_source->parse_cri(
-					&sync_container_info, key);
+				sync_container_info.m_status = success ?
+							       sinsp_container_lookup_state::SUCCESSFUL :
+							       sinsp_container_lookup_state::FAILED;
 
 				g_logger.format(sinsp_logger::SEV_DEBUG,
 					"cri (%s) sync lookup done, successful=%s",
-					container_id.c_str(), sync_container_info.m_successful ? "true" : "false");
+					container_id.c_str(), success ? "true" : "false");
 
 				sync_container_info.m_metadata_complete = true;
-				if(manager->update_container(sync_container_info) && sync_container_info.m_successful)
+				if(manager->update_container(sync_container_info) && success)
 				{
 					manager->notify_new_container(sync_container_info);
 				}

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -44,6 +44,11 @@ using namespace libsinsp::runc;
 constexpr const uint64_t cri_async_source::CGROUP_LOOKUP_DELAY_MS;
 
 namespace {
+// use asynchronous lookups?
+bool s_async = true;
+// get resource limits asynchronously?
+bool s_async_limits = true;
+
 bool init_cri()
 {
 	if(s_cri)
@@ -203,7 +208,7 @@ bool cri_async_source::parse_cri(sinsp_container_info *container, const libsinsp
 	container->m_cpu_quota = limits.m_cpu_quota;
 	container->m_cpu_period = limits.m_cpu_period;
 
-	if(!found_all)
+	if(s_async_limits && !found_all)
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 			"cri (%s) not all limits read from cgroups, will retry in %d ms",
@@ -273,8 +278,17 @@ void cri::set_cri_timeout(int64_t timeout_ms)
 	s_cri_timeout = timeout_ms;
 }
 
-void cri::set_extra_queries(bool extra_queries) {
+void cri::set_extra_queries(bool extra_queries)
+{
 	s_cri_extra_queries = extra_queries;
+}
+
+void cri::set_async(bool async) {
+	s_async = async;
+}
+
+void cri::set_async_limits(bool async_limits) {
+	s_async_limits = async_limits;
 }
 
 bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
@@ -300,26 +314,48 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 		m_cri_info_source.reset(cri_source);
 	}
 	sinsp_container_info *container_info = manager->get_container(container_id);
+	sinsp_container_info sync_container_info;
 
 	if (!container_info ||
 	    container_info->query_anyway(s_cri_runtime_type))
 	{
-		container_info = manager->get_or_create_container(
-			s_cri_runtime_type, container_id, "", tinfo);
-
 		if (query_os_for_missing_info)
 		{
-			g_logger.format(sinsp_logger::SEV_DEBUG,
-					"cri (%s): Performing lookup",
-					container_id.c_str());
-
 			libsinsp::async_cgroup::delayed_cgroup_key key(
 				container_id,
 				tinfo->get_cgroup("cpu"),
 				tinfo->get_cgroup("memory"));
-			m_cri_info_source->lookup_container(key, manager);
+			if(s_async)
+			{
+				container_info = manager->get_or_create_container(
+					s_cri_runtime_type, container_id, "", tinfo);
+
+				m_cri_info_source->lookup_container(key, manager);
+			}
+			else
+			{
+				container_info = &sync_container_info;
+				g_logger.format(sinsp_logger::SEV_DEBUG,
+						"cri (%s): Performing sync lookup",
+						container_id.c_str());
+
+				sync_container_info.m_type = s_cri_runtime_type;
+				sync_container_info.m_id = container_id;
+				sync_container_info.m_successful = m_cri_info_source->parse_cri(
+					&sync_container_info, key);
+
+				g_logger.format(sinsp_logger::SEV_DEBUG,
+					"cri (%s) sync lookup done, successful=%s",
+					container_id.c_str(), sync_container_info.m_successful ? "true" : "false");
+
+				sync_container_info.m_metadata_complete = true;
+				if(manager->update_container(sync_container_info) && sync_container_info.m_successful)
+				{
+					manager->notify_new_container(sync_container_info);
+				}
+			}
 		}
-		if (mesos::set_mesos_task_id(container_info, tinfo))
+		if (container_info && mesos::set_mesos_task_id(container_info, tinfo))
 		{
 			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"cri (%s) Mesos CRI container, Mesos task ID: [%s]",
@@ -327,5 +363,5 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 		}
 	}
 
-	return container_info->m_metadata_complete;
+	return container_info ? container_info->m_metadata_complete : true;
 }

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -316,8 +316,7 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 	sinsp_container_info *container_info = manager->get_container(container_id);
 	sinsp_container_info sync_container_info;
 
-	if (!container_info ||
-	    container_info->query_anyway(s_cri_runtime_type))
+	if (!container_info || manager->should_lookup(container_id, s_cri_runtime_type))
 	{
 		if (query_os_for_missing_info)
 		{

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -252,48 +252,51 @@ void cri::set_extra_queries(bool extra_queries) {
 
 bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 {
-	sinsp_container_info container_info;
-	sinsp_container_info *existing_container_info;
+	std::string container_id;
 
-	if(!matches_runc_cgroups(tinfo, CRI_CGROUP_LAYOUT, container_info.m_id))
+	if(!matches_runc_cgroups(tinfo, CRI_CGROUP_LAYOUT, container_id))
 	{
 		return false;
 	}
-	tinfo->m_container_id = container_info.m_id;
+	tinfo->m_container_id = container_id;
 
-	existing_container_info = manager->get_container(container_info.m_id);
+	sinsp_container_info *container_info = manager->get_container(container_id);
 
-	if (!existing_container_info ||
-	    existing_container_info->query_anyway(s_cri_runtime_type))
+	if (!container_info ||
+	    container_info->query_anyway(s_cri_runtime_type))
 	{
+		container_info = manager->get_or_create_container(
+			s_cri_runtime_type, container_id, "", tinfo);
+
 		if (query_os_for_missing_info)
 		{
 			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"cri (%s): Performing lookup",
-					container_info.m_id.c_str());
+					container_id.c_str());
 
-			container_info.m_successful = parse_cri(manager, &container_info, tinfo);
-			if (!container_info.m_successful)
+			container_info->m_successful = parse_cri(manager, container_info, tinfo);
+			if (!container_info->m_successful)
 			{
 				g_logger.format(sinsp_logger::SEV_DEBUG, "cri (%s): Failed to get CRI metadata for container",
-						container_info.m_id.c_str());
+						container_id.c_str());
 				return false;
 			}
 
 			// If here, parse_cri succeeded so we can
 			// assign an actual type.
-			container_info.m_type = s_cri_runtime_type;
-
+			container_info->m_type = s_cri_runtime_type;
+			container_info->m_metadata_complete = true;
 		}
-		if (mesos::set_mesos_task_id(&container_info, tinfo))
+		if (mesos::set_mesos_task_id(container_info, tinfo))
 		{
 			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"cri (%s) Mesos CRI container, Mesos task ID: [%s]",
-					container_info.m_id.c_str(), container_info.m_mesos_task_id.c_str());
+					container_id.c_str(), container_info->m_mesos_task_id.c_str());
 		}
-		if (manager->update_container(container_info) && container_info.m_successful)
+
+		if (manager->update_container(*container_info) && container_info->m_successful)
 		{
-			manager->notify_new_container(container_info);
+			manager->notify_new_container(*container_info);
 		}
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -21,24 +21,83 @@ limitations under the License.
 
 #include <string>
 #include <stdint.h>
+#include <async_cgroup.h>
+#include <async_container.h>
 
 class sinsp_container_manager;
 class sinsp_threadinfo;
 
 #include "container_engine/container_engine.h"
 
+namespace runtime {
+namespace v1alpha2 {
+class ContainerStatusResponse;
+}
+}
+
 namespace libsinsp {
 namespace container_engine {
+
+/**
+ * Asynchronous metadata lookup for CRI containers
+ *
+ * There are two related async data sources:
+ * 1. `cri_async_source`, which is responsible for doing the actual gRPC calls
+ * to the CRI API. This happens by executing synchronous gRPC requests
+ * in a separate thread. The execution happens (as close as possible to)
+ * immediately after matching the cgroup. This source is owned by the resolver
+ * object.
+ *
+ * 2. We only get resource limits (CPU, memory) from containerd, so for other
+ * runtimes we need to read them directly from cgroups. This is race-prone
+ * as the runtime might not be done with setting up the limits by the time
+ * we see the new process, so (if not all limits are set to reasonable values)
+ * we repeat the read after CGROUP_LOOKUP_DELAY_MS milliseconds, which should
+ * give the runtime enough time to set up the cgroups.
+ */
+class cri_async_source : public sysdig::async_container_source<libsinsp::async_cgroup::delayed_cgroup_key> {
+
+	// how long do we wait
+	static constexpr const uint64_t CGROUP_LOOKUP_DELAY_MS = 1000;
+
+	// how long do we wait on cgroup lookup result before giving up
+	// Note: this value includes the initial delay
+	static constexpr const uint64_t CGROUP_MAX_DELAY_MS = 2000;
+
+public:
+	explicit cri_async_source(sinsp_container_manager* manager, uint64_t ttl_ms) :
+		async_container_source(NO_WAIT_LOOKUP, ttl_ms),
+		m_async_cgroups(NO_WAIT_LOOKUP, CGROUP_MAX_DELAY_MS),
+		m_container_manager(manager)
+	{
+	}
+
+	void quiesce() override {
+		m_async_cgroups.quiesce();
+		async_container_source::stop();
+	}
+
+	bool parse_cri(sinsp_container_info *container, const libsinsp::async_cgroup::delayed_cgroup_key& key);
+private:
+	bool parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, sinsp_container_info *container);
+	void run_impl() override;
+
+	libsinsp::async_cgroup::delayed_cgroup_lookup m_async_cgroups;
+	sinsp_container_manager* m_container_manager;
+};
+
 class cri : public resolver
 {
 public:
-	cri();
-
+	using resolver::resolver;
 	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;
 	void cleanup() override;
 	static void set_cri_socket_path(const std::string& path);
 	static void set_cri_timeout(int64_t timeout_ms);
 	static void set_extra_queries(bool extra_queries);
+
+private:
+	std::unique_ptr<cri_async_source> m_cri_info_source;
 };
 }
 }

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -95,6 +95,8 @@ public:
 	static void set_cri_socket_path(const std::string& path);
 	static void set_cri_timeout(int64_t timeout_ms);
 	static void set_extra_queries(bool extra_queries);
+	static void set_async(bool async);
+	static void set_async_limits(bool async_limits);
 
 private:
 	std::unique_ptr<cri_async_source> m_cri_info_source;

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -371,7 +371,7 @@ bool docker::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, 
 
 #ifdef HAS_CAPTURE
 	// Possibly start a lookup for this container info
-	if(container_info == nullptr || container_info->query_anyway(CT_DOCKER))
+	if(container_info == nullptr || manager->should_lookup(container_id, CT_DOCKER))
 	{
 		container_info = manager->get_or_create_container(CT_DOCKER, container_id, container_name, tinfo);
 		if (query_os_for_missing_info)

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -66,7 +66,7 @@ void docker_async_source::run_impl()
 
 		sinsp_container_info res;
 
-		res.m_successful = true;
+		res.m_status = sinsp_container_lookup_state::SUCCESSFUL;
 		res.m_type = CT_DOCKER;
 		res.m_id = container_id;
 
@@ -80,7 +80,7 @@ void docker_async_source::run_impl()
 			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"docker_async (%s): Failed to get Docker metadata, returning successful=false",
 					container_id.c_str());
-			res.m_successful = false;
+			res.m_status = sinsp_container_lookup_state::FAILED;
 		}
 
 		g_logger.format(sinsp_logger::SEV_DEBUG,

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -385,7 +385,7 @@ bool docker::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, 
 	// Returning true will prevent other container engines from
 	// trying to resolve the container, so only return true if we
 	// have complete metadata.
-	return container_info->m_metadata_complete;
+	return container_info->m_status == sinsp_container_lookup_state::SUCCESSFUL;
 }
 
 bool docker_async_source::parse_docker(std::string &container_id, sinsp_container_info *container)

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -210,8 +210,10 @@ public:
 		m_cpu_quota(0),
 		m_cpu_period(100000),
 		m_is_pod_sandbox(false),
+		// sync lookups can basically only return success
+		// so make it a little bit easier for them
+		m_status(sinsp_container_lookup_state::SUCCESSFUL),
 		m_metadata_complete(true),
-		m_successful(true),
 		m_metadata_deadline(0)
 	{
 	}
@@ -255,13 +257,11 @@ public:
 
 	bool m_is_pod_sandbox;
 
+	sinsp_container_lookup_state m_status;
 	// If false, this represents incomplete information about the
 	// container that will be filled in later as a result of an
 	// async fetch of container info.
 	bool m_metadata_complete;
-
-	// if false, the lookup finished unsuccessfully
-	bool m_successful;
 #ifdef HAS_ANALYZER
 	std::string m_sysdig_agent_conf;
 #endif

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -213,7 +213,6 @@ public:
 		// sync lookups can basically only return success
 		// so make it a little bit easier for them
 		m_status(sinsp_container_lookup_state::SUCCESSFUL),
-		m_metadata_complete(true),
 		m_metadata_deadline(0)
 	{
 	}
@@ -258,10 +257,6 @@ public:
 	bool m_is_pod_sandbox;
 
 	sinsp_container_lookup_state m_status;
-	// If false, this represents incomplete information about the
-	// container that will be filled in later as a result of an
-	// async fetch of container info.
-	bool m_metadata_complete;
 #ifdef HAS_ANALYZER
 	std::string m_sysdig_agent_conf;
 #endif

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -253,7 +253,7 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 				// host interfaces.
 				//
 
-				if(!container_info->m_metadata_complete)
+				if(container_info->m_status != sinsp_container_lookup_state::SUCCESSFUL)
 				{
 					g_logger.format(sinsp_logger::SEV_DEBUG, "Checking IP address of container %s with incomplete metadata",
 						tinfo->m_container_id.c_str());
@@ -263,7 +263,7 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 
 				for(auto it = clist->begin(); it != clist->end(); ++it)
 				{
-					if(!it->second.m_metadata_complete)
+					if(it->second.m_status != sinsp_container_lookup_state::SUCCESSFUL)
 					{
 						g_logger.format(sinsp_logger::SEV_DEBUG, "Checking IP address of container %s with incomplete metadata (in context of %s)",
 								it->second.m_id.c_str(), tinfo->m_container_id.c_str());

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1615,6 +1615,16 @@ void sinsp::set_cri_timeout(int64_t timeout_ms)
 	m_container_manager.set_cri_timeout(timeout_ms);
 }
 
+void sinsp::set_cri_async(bool async)
+{
+	m_container_manager.set_cri_async(async);
+}
+
+void sinsp::set_cri_async_limits(bool async_limits)
+{
+	m_container_manager.set_cri_async_limits(async_limits);
+}
+
 void sinsp::set_snaplen(uint32_t snaplen)
 {
 	//

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -909,6 +909,8 @@ public:
 
 	void set_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
+	void set_cri_async(bool async);
+	void set_cri_async_limits(bool async_limits);
 
 VISIBILITY_PROTECTED
 	bool add_thread(const sinsp_threadinfo *ptinfo);


### PR DESCRIPTION
There are two related async data sources:

1. `cri_async_source`, which is responsible for doing the actual gRPC calls to the CRI API. This happens by executing synchronous gRPC requests in a separate thread. The execution happens (as close as possible to) immediately after matching the cgroup. This source is owned by the resolver object.

2. We only get resource limits (CPU, memory) from containerd, so for other runtimes we need to read them directly from cgroups. This is race-prone as the runtime might not be done with setting up the limits by the time we see the new process, so (if not all limits are set to reasonable values) we repeat the read after CGROUP_LOOKUP_DELAY_MS milliseconds, which should give the runtime enough time to set up the cgroups.

Builds on top of https://github.com/draios/sysdig/pull/1359 so we might want to review and merge that first