### PR TITLE
Don't log docker fetch errors as SEV_ERRORs

### DIFF
--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -66,7 +66,12 @@ void docker_async_source::run_impl()
 
 		if(!parse_docker(container_id, &res.m_container_info))
 		{
-			g_logger.format(sinsp_logger::SEV_ERROR,
+			// This is not always an error e.g. when using
+			// containerd as the runtime. Since the cgroup
+			// names are often identical between
+			// containerd and docker, we have to try to
+			// fetch both.
+			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"docker_async (%s): Failed to get Docker metadata, returning successful=false",
 					container_id.c_str());
 			res.m_successful = false;


### PR DESCRIPTION
When using containerd as the runtime, you can't tell based on the cgroup
name alone whether a container is docker or cri. In that case, you have
to try to fetch both docker and cri metadata, and in that case, you
would expect to see docker errors if containerd is the runtime.

So decrease the severity of this log messae to DEBUG.

This is part of the fixes for SMAGENT-1588.