### PR TITLE
flush flags change to new namespace, add code enabling easy use of sinsp_threadinfo in std::set/map

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1102,7 +1102,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 	#ifdef HAS_ANALYZER
 				if(m_analyzer)
 				{
-					m_analyzer->process_event(NULL, sinsp_analyzer::DF_TIMEOUT);
+					m_analyzer->process_event(NULL, analyzer_emitter::DF_TIMEOUT);
 				}
 	#endif
 				*puevt = NULL;
@@ -1113,7 +1113,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 	#ifdef HAS_ANALYZER
 				if(m_analyzer)
 				{
-					m_analyzer->process_event(NULL, sinsp_analyzer::DF_EOF);
+					m_analyzer->process_event(NULL, analyzer_emitter::DF_EOF);
 				}
 	#endif
 			}
@@ -1397,19 +1397,19 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 		{
 			if(m_isdropping)
 			{
-				m_analyzer->process_event(evt, sinsp_analyzer::DF_FORCE_FLUSH);
+				m_analyzer->process_event(evt, analyzer_emitter::DF_FORCE_FLUSH);
 			}
 			else if(sw)
 			{
-				m_analyzer->process_event(evt, sinsp_analyzer::DF_FORCE_FLUSH_BUT_DONT_EMIT);
+				m_analyzer->process_event(evt, analyzer_emitter::DF_FORCE_FLUSH_BUT_DONT_EMIT);
 			}
 			else
 			{
-				m_analyzer->process_event(evt, sinsp_analyzer::DF_FORCE_NOFLUSH);
+				m_analyzer->process_event(evt, analyzer_emitter::DF_FORCE_NOFLUSH);
 			}
 		}
 #else // SIMULATE_DROP_MODE
-		m_analyzer->process_event(evt, sinsp_analyzer::DF_NONE);
+		m_analyzer->process_event(evt, analyzer_emitter::DF_NONE);
 #endif // SIMULATE_DROP_MODE
 	}
 #endif

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -120,7 +120,7 @@ public:
 	  \brief Get the main thread of the process containing this thread.
 	*/
 #ifndef _WIN32
-	inline sinsp_threadinfo* get_main_thread()
+	inline sinsp_threadinfo* get_main_thread() 
 	{
 		auto main_thread = m_main_thread.lock();
 		if(!main_thread)
@@ -313,6 +313,21 @@ public:
 	// Global state
 	//
 	sinsp *m_inspector;
+
+public: // types required for use in sets
+	struct hasher {
+		size_t operator()(sinsp_threadinfo* tinfo) const
+		{
+			return tinfo->get_main_thread()->m_program_hash;
+		}
+	};
+
+	struct comparer {
+		size_t operator()(sinsp_threadinfo* lhs, sinsp_threadinfo* rhs) const
+		{
+			return lhs->get_main_thread()->m_program_hash == rhs->get_main_thread()->m_program_hash;
+		}
+	};
 
 VISIBILITY_PRIVATE
 	void init();


### PR DESCRIPTION
as the title says. the flush flags have moved into a new namespace, and the other change is required for using sinsp_threadinfo in hashed collections