### PR TITLE
Support cri-o container metadata caching

### DIFF
--- a/userspace/libsinsp/k8s_state.cpp
+++ b/userspace/libsinsp/k8s_state.cpp
@@ -35,6 +35,7 @@ limitations under the License.
 const std::string k8s_state_t::m_docker_prefix = "docker://";
 const std::string k8s_state_t::m_rkt_prefix = "rkt://";
 const std::string k8s_state_t::m_containerd_prefix = "containerd://";
+const std::string k8s_state_t::m_crio_prefix = "cri-o://";
 const unsigned    k8s_state_t::m_id_length = 12u;
 
 k8s_state_t::k8s_state_t(bool is_captured, int capture_version):
@@ -60,26 +61,32 @@ void k8s_state_t::cache_pod(container_pod_map& map, const std::string& id, const
 	ASSERT(pod);
 	ASSERT(!pod->get_name().empty());
 	std::string::size_type pos = id.find(m_docker_prefix);
-	if (pos == 0)
+	if(pos == 0)
 	{
 		map[id.substr(m_docker_prefix.size(), m_id_length)] = pod;
 		return;
 	}
 	pos = id.find(m_rkt_prefix);
-	if( pos == 0)
+	if(pos == 0)
 	{
 		map[id.substr(m_rkt_prefix.size())] = pod;
 		return;
 	}
 	pos = id.find(m_containerd_prefix);
-	if( pos == 0)
+	if(pos == 0)
 	{
 		map[id.substr(m_containerd_prefix.size(), m_id_length)] = pod;
 		return;
 	}
+	pos = id.find(m_crio_prefix);
+	if(pos == 0)
+	{
+		map[id.substr(m_crio_prefix.size(), m_id_length)] = pod;
+		return;
+	}
 	throw sinsp_exception("Invalid container ID (expected one of: '" + m_docker_prefix +
 						 "{ID}', '" + m_rkt_prefix + "{ID}', '" + m_containerd_prefix +
-						 "{ID}'): " + id);
+						 "{ID}', '" + m_crio_prefix + "{ID}'): " + id);
 }
 
 bool k8s_state_t::has_pod(k8s_pod_t& pod)

--- a/userspace/libsinsp/k8s_state.h
+++ b/userspace/libsinsp/k8s_state.h
@@ -354,6 +354,7 @@ private:
 	static const std::string m_docker_prefix; // "docker://"
 	static const std::string m_rkt_prefix; // "rkt://"
 	static const std::string m_containerd_prefix; // "containerd://"
+	static const std::string m_crio_prefix; // "cri-o://"
 	static const unsigned    m_id_length; // portion of the ID to be cached (=12)
 
 #ifndef HAS_ANALYZER


### PR DESCRIPTION
This PR adds support for caching CRI-O container metadata while using 
CRI-O as container runtime in Kubernetes.

This is the last missing piece to inspect CRI-O containers with Sysdig.

Here it is a demo we recorded during the manual testing of the feature.

[![asciicast](https://asciinema.org/a/MTS111X2glgS0J3oLhJU2p8UR.svg)](https://asciinema.org/a/MTS111X2glgS0J3oLhJU2p8UR)

To test it out:

```
sudo csysdig --cri /var/run/crio/crio.sock \
  -k https://127.0.0.1:6443 \
  -K /tmp/kubernetes-local/certs/client-admin.crt:/tmp/kubernetes-local/certs/client-admin.key
```


