### PR TITLE
Fix build for older kernels (<3.9)

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -47,6 +47,13 @@ or GPL2.txt for full copies of the license.
 #include <linux/bpf.h>
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 9, 0)
+static inline struct inode *file_inode(struct file *f)
+{
+	return f->f_path.dentry->d_inode;
+}
+#endif
+
 #define merge_64(hi, lo) ((((unsigned long long)(hi)) << 32) + ((lo) & 0xffffffffUL))
 
 int f_sys_generic(struct event_filler_arguments *args)
@@ -154,7 +161,7 @@ static inline uint32_t get_fd_dev(int64_t fd)
 	if (unlikely(!file))
 		goto out_unlock;
 
-	inode = file->f_inode;
+	inode = file_inode(file);
 	if (unlikely(!inode))
 		goto out_unlock;
 


### PR DESCRIPTION
Commit 99ed13646da373951fd3eca2ce343712b0be5a32 introduced a failure to build on kernels < 3.9.

Since the `file_inode()` helper is introduced in the same kernel version, for 3.9+ use the shipped definition and provide our own (matching the older struct layout) for older kernels.