### PR TITLE
Optimize single thread /proc lookups [SMAGENT-1749]

### DIFF
--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -199,6 +199,8 @@ struct scap_ns_socket_list
 
 // Read the full event buffer for the given processor
 int32_t scap_readbuf(scap_t* handle, uint32_t proc, OUT char** buf, OUT uint32_t* len);
+// Read a single thread info from /proc
+int32_t scap_proc_read_thread(scap_t* handle, char* procdirname, uint64_t tid, struct scap_threadinfo** pi, char *error, bool scan_sockets);
 // Scan a directory containing process information
 int32_t scap_proc_scan_proc_dir(scap_t* handle, char* procdirname, char *error);
 // Remove an entry from the process list by parsing a PPME_PROC_EXIT event

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -200,7 +200,7 @@ struct scap_ns_socket_list
 // Read the full event buffer for the given processor
 int32_t scap_readbuf(scap_t* handle, uint32_t proc, OUT char** buf, OUT uint32_t* len);
 // Scan a directory containing process information
-int32_t scap_proc_scan_proc_dir(scap_t* handle, char* procdirname, int parenttid, int tid_to_scan, struct scap_threadinfo** pi, char *error, bool scan_sockets);
+int32_t scap_proc_scan_proc_dir(scap_t* handle, char* procdirname, char *error);
 // Remove an entry from the process list by parsing a PPME_PROC_EXIT event
 // void scap_proc_schedule_removal(scap_t* handle, scap_evt* e);
 // Remove the process that was scheduled for deletion for this handle

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -411,7 +411,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 	//
 	error[0] = '\0';
 	snprintf(filename, sizeof(filename), "%s/proc", scap_get_host_root());
-	if((*rc = scap_proc_scan_proc_dir(handle, filename, -1, -1, NULL, error, true)) != SCAP_SUCCESS)
+	if((*rc = scap_proc_scan_proc_dir(handle, filename, error)) != SCAP_SUCCESS)
 	{
 		scap_close(handle);
 		snprintf(error, SCAP_LASTERR_SIZE, "error creating the process list. Make sure you have root credentials.");
@@ -669,7 +669,7 @@ scap_t* scap_open_nodriver_int(char *error, int32_t *rc,
 	//
 	error[0] = '\0';
 	snprintf(filename, sizeof(filename), "%s/proc", scap_get_host_root());
-	if((*rc = scap_proc_scan_proc_dir(handle, filename, -1, -1, NULL, error, true)) != SCAP_SUCCESS)
+	if((*rc = scap_proc_scan_proc_dir(handle, filename, error)) != SCAP_SUCCESS)
 	{
 		scap_close(handle);
 		snprintf(error, SCAP_LASTERR_SIZE, "error creating the process list. Make sure you have root credentials.");

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -942,7 +942,6 @@ static int32_t _scap_proc_scan_proc_dir_impl(scap_t* handle, char* procdirname, 
 
 	struct scap_ns_socket_list* sockets_by_ns = NULL;
 
-	tid = 0;
 	dir_p = opendir(procdirname);
 
 	if(dir_p == NULL)
@@ -1095,9 +1094,9 @@ int32_t scap_getpid_global(scap_t* handle, int64_t* pid)
 #endif // HAS_CAPTURE
 
 #ifdef CYGWING_AGENT
-int32_t scap_proc_scan_proc_dir(scap_t* handle, char* procdirname, int parenttid, int tid_to_scan, struct scap_threadinfo** procinfo, char *error, bool scan_sockets)
+int32_t scap_proc_scan_proc_dir(scap_t* handle, char* procdirname, char *error)
 {
-	return scap_proc_scan_proc_dir_windows(handle, procinfo, error);
+	return scap_proc_scan_proc_dir_windows(handle, error);
 }
 #endif
 

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -563,7 +563,7 @@ int32_t scap_proc_fill_loginuid(scap_t *handle, struct scap_threadinfo* tinfo, c
 //
 // Add a process to the list by parsing its entry under /proc
 //
-static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, int parenttid, int tid_to_scan, char* procdirname, struct scap_ns_socket_list** sockets_by_ns, scap_threadinfo** procinfo, char *error)
+static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, int tid_to_scan, char* procdirname, struct scap_ns_socket_list** sockets_by_ns, scap_threadinfo** procinfo, char *error)
 {
 	char dir_name[256];
 	char target_name[SCAP_MAX_PATH_SIZE];
@@ -633,14 +633,6 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, int parentt
 	}
 
 	tinfo->tid = tid;
-	if(parenttid != -1)
-	{
-		tinfo->pid = parenttid;
-	}
-	else
-	{
-		tinfo->pid = tid;
-	}
 
 	tinfo->fdlist = NULL;
 
@@ -899,7 +891,7 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, int parentt
 	//
 	// Only add fds for processes, not threads
 	//
-	if(parenttid == -1)
+	if(tinfo->pid == tinfo->tid)
 	{
 		res = scap_fd_scan_fd_dir(handle, dir_name, tinfo, sockets_by_ns, error);
 	}
@@ -927,7 +919,7 @@ int32_t scap_proc_read_thread(scap_t* handle, char* procdirname, uint64_t tid, s
 		sockets_by_ns = (void*)-1;
 	}
 
-	res = scap_proc_add_from_proc(handle, tid, -1, tid, procdirname, &sockets_by_ns, pi, add_error);
+	res = scap_proc_add_from_proc(handle, tid, tid, procdirname, &sockets_by_ns, pi, add_error);
 	if(res != SCAP_SUCCESS)
 	{
 		snprintf(error, SCAP_LASTERR_SIZE, "cannot add proc tid = %"PRIu64", dirname = %s, error=%s", tid, procdirname, add_error);
@@ -999,7 +991,7 @@ static int32_t _scap_proc_scan_proc_dir_impl(scap_t* handle, char* procdirname, 
 		//
 		// We have a process that needs to be explored
 		//
-		res = scap_proc_add_from_proc(handle, tid, parenttid, tid, procdirname, &sockets_by_ns, NULL, add_error);
+		res = scap_proc_add_from_proc(handle, tid, tid, procdirname, &sockets_by_ns, NULL, add_error);
 		if(res != SCAP_SUCCESS)
 		{
 			snprintf(error, SCAP_LASTERR_SIZE, "cannot add procs tid = %"PRIu64", parenttid = %"PRIi32", dirname = %s, error=%s", tid, parenttid, procdirname, add_error);

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -563,7 +563,7 @@ int32_t scap_proc_fill_loginuid(scap_t *handle, struct scap_threadinfo* tinfo, c
 //
 // Add a process to the list by parsing its entry under /proc
 //
-static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, int tid_to_scan, char* procdirname, struct scap_ns_socket_list** sockets_by_ns, scap_threadinfo** procinfo, char *error)
+static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, char* procdirname, struct scap_ns_socket_list** sockets_by_ns, scap_threadinfo** procinfo, char *error)
 {
 	char dir_name[256];
 	char target_name[SCAP_MAX_PATH_SIZE];
@@ -679,7 +679,7 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, int tid_to_
 		return res;
 	}
 
-	if (suppressed && tid_to_scan == -1)
+	if (suppressed && !procinfo)
 	{
 		free(tinfo);
 		return SCAP_SUCCESS;
@@ -860,10 +860,10 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, int tid_to_
 	}
 
 	//
-	// if tid_to_scan is set we assume this is a runtime lookup so no
+	// if procinfo is set we assume this is a runtime lookup so no
 	// need to use the table
 	//
-	if(tid_to_scan == -1)
+	if(!procinfo)
 	{
 		//
 		// Done. Add the entry to the process table, or fire the notification callback
@@ -919,7 +919,7 @@ int32_t scap_proc_read_thread(scap_t* handle, char* procdirname, uint64_t tid, s
 		sockets_by_ns = (void*)-1;
 	}
 
-	res = scap_proc_add_from_proc(handle, tid, tid, procdirname, &sockets_by_ns, pi, add_error);
+	res = scap_proc_add_from_proc(handle, tid, procdirname, &sockets_by_ns, pi, add_error);
 	if(res != SCAP_SUCCESS)
 	{
 		snprintf(error, SCAP_LASTERR_SIZE, "cannot add proc tid = %"PRIu64", dirname = %s, error=%s", tid, procdirname, add_error);
@@ -991,7 +991,7 @@ static int32_t _scap_proc_scan_proc_dir_impl(scap_t* handle, char* procdirname, 
 		//
 		// We have a process that needs to be explored
 		//
-		res = scap_proc_add_from_proc(handle, tid, tid, procdirname, &sockets_by_ns, NULL, add_error);
+		res = scap_proc_add_from_proc(handle, tid, procdirname, &sockets_by_ns, NULL, add_error);
 		if(res != SCAP_SUCCESS)
 		{
 			snprintf(error, SCAP_LASTERR_SIZE, "cannot add procs tid = %"PRIu64", parenttid = %"PRIi32", dirname = %s, error=%s", tid, parenttid, procdirname, add_error);

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -825,7 +825,7 @@ int32_t scap_setup_dump(scap_t *handle, scap_dumper_t* d, const char *fname)
 		scap_proc_free_table(handle);
 		char filename[SCAP_MAX_PATH_SIZE];
 		snprintf(filename, sizeof(filename), "%s/proc", scap_get_host_root());
-		if(scap_proc_scan_proc_dir(handle, filename, -1, -1, NULL, handle->m_lasterr, true) != SCAP_SUCCESS)
+		if(scap_proc_scan_proc_dir(handle, filename, handle->m_lasterr) != SCAP_SUCCESS)
 		{
 			handle->m_proc_callback = tcb;
 			return SCAP_FAILURE;

--- a/userspace/libscap/windows_hal.c
+++ b/userspace/libscap/windows_hal.c
@@ -27,7 +27,7 @@ limitations under the License.
 #include "scap-int.h"
 #include "windows_hal.h"
 
-int32_t addprocess_windows(wh_procinfo* wpi, scap_t* handle, struct scap_threadinfo** procinfo, char *error)
+static int32_t addprocess_windows(wh_procinfo* wpi, scap_t* handle, char *error)
 {
 	struct scap_threadinfo* tinfo;
 
@@ -99,7 +99,7 @@ int32_t addprocess_windows(wh_procinfo* wpi, scap_t* handle, struct scap_threadi
 
 typedef int (CALLBACK* LPFNDLLFUNC1)();
 
-int32_t scap_proc_scan_proc_dir_windows(scap_t* handle, struct scap_threadinfo** procinfo, char *error)
+int32_t scap_proc_scan_proc_dir_windows(scap_t* handle, char *error)
 {
 	wh_proclist wgpres;
 
@@ -138,7 +138,7 @@ int32_t scap_proc_scan_proc_dir_windows(scap_t* handle, struct scap_threadinfo**
 	{
 		wh_procinfo* wpi = &(wgpres.m_procs[j]);
 
-		if(addprocess_windows(wpi, handle, procinfo, error) != SCAP_SUCCESS)
+		if(addprocess_windows(wpi, handle, error) != SCAP_SUCCESS)
 		{
 			return SCAP_FAILURE;
 		}

--- a/userspace/libscap/windows_hal.h
+++ b/userspace/libscap/windows_hal.h
@@ -18,4 +18,4 @@ limitations under the License.
 */
 #pragma once
 
-int32_t scap_proc_scan_proc_dir_windows(scap_t* handle, struct scap_threadinfo** procinfo, char *error);
+int32_t scap_proc_scan_proc_dir_windows(scap_t* handle, char *error);


### PR DESCRIPTION
When we're looking up a single thread in /proc, we don't need to scan all of /proc, we can read the process id from /proc/<pid>/status (the `Tgid` entry has been there since before git history so it should not introduce compatibility issues).

This should allow us to increase process lookup limits and reduce the number of dummy "<NA>" `threadinfo`s.