### PR TITLE
Reliably detect forks in containers [SMAGENT-1582]

### DIFF
--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -163,6 +163,8 @@ or GPL2.txt for full copies of the license.
 #define PPM_CL_CLONE_STOPPED (1 << 26)
 #define PPM_CL_CLONE_VFORK (1 << 27)
 #define PPM_CL_CLONE_NEWCGROUP (1 << 28)
+#define PPM_CL_CHILD_IN_PIDNS (1<<29)			/* true if the thread created by clone() is *not*
+									in the init pid namespace */
 
 /*
  * Futex Operations

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -983,7 +983,8 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 		ASSERT(false);
 	}
 
-	if(tid != vtid)
+	// the flag check should always suffice but leave the tid/vtid check for older driver versions
+	if(flags & PPM_CL_CHILD_IN_PIDNS || tid != vtid)
 	{
 		in_container = true;
 	}


### PR DESCRIPTION
It's possible to have a process in a PID namespace that nevertheless has tid == vtid (when the parent and nested PID counters happen to overlap). In this case, we wrongly take the non-container path
while handling clone events and end up overwriting an unrelated threadinfo (one that happened to have real pid == new child's vpid).

Fix by explicitly passing a flag meaning "the child process is in a nested PID namespace" from the driver.