### PR TITLE
Compress/trim container json so it fits in 4k

### DIFF
--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -72,7 +72,19 @@ public:
 	void set_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
 	sinsp* get_inspector() { return m_inspector; }
+
+	static bool deserialize_container_json(const std::string &json, Json::Value &obj);
+
+	static uint32_t s_compress_json_magic;
+
 private:
+
+	// In cases where the container json is compressed, this
+	// struct holds a magic number + the uncompressed length.
+	struct compress_json_hdr {
+		uint32_t m_magic;
+		uint32_t m_uncompress_len;
+	};
 
 	size_t container_json_evt_len(size_t size);
 	bool serialize_json_fits_in_event(size_t size);

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -73,6 +73,20 @@ public:
 	void set_cri_timeout(int64_t timeout_ms);
 	sinsp* get_inspector() { return m_inspector; }
 private:
+
+	size_t container_json_evt_len(size_t size);
+	bool serialize_json_fits_in_event(size_t size);
+
+	void serialize_container_json(const Json::Value &obj, std::string &json);
+
+	enum trim_level {
+		LEVEL_SOME_LABELS = 0,
+		LEVEL_ALL_LABELS,
+		LEVEL_MIN_INFO,
+		LEVEL_END
+	};
+
+	void trim_container_json(Json::Value &obj, trim_level level);
 	string container_to_json(const sinsp_container_info& container_info);
 	bool container_to_sinsp_event(const string& json, sinsp_evt* evt, shared_ptr<sinsp_threadinfo> tinfo);
 	string get_docker_env(const Json::Value &env_vars, const string &mti);

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -113,6 +113,8 @@ sinsp::sinsp() :
 	m_hostname_and_port_resolution_enabled = false;
 	m_output_time_flag = 'h';
 	m_max_evt_output_len = 0;
+	m_compress_container_json = true;
+	m_trim_container_json = true;
 	m_filesize = -1;
 	m_track_tracers_state = false;
 	m_import_users = true;
@@ -1920,6 +1922,26 @@ void sinsp::set_log_stderr()
 void sinsp::set_min_log_severity(sinsp_logger::severity sev)
 {
 	g_logger.set_severity(sev);
+}
+
+void sinsp::set_compress_container_json(bool enabled)
+{
+	m_compress_container_json = enabled;
+}
+
+bool sinsp::get_compress_container_json()
+{
+	return m_compress_container_json;
+}
+
+void sinsp::set_trim_container_json(bool enabled)
+{
+	m_trim_container_json = enabled;
+}
+
+bool sinsp::get_trim_container_json()
+{
+	return m_trim_container_json;
 }
 
 sinsp_evttables* sinsp::get_event_info_tables()

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -417,6 +417,15 @@ public:
 	*/
 	void set_min_log_severity(sinsp_logger::severity sev);
 
+	// Whether to compress container info in CONTAINER_JSON events
+	void set_compress_container_json(bool enabled);
+	bool get_compress_container_json();
+
+	// Whether to try to drop properties from container info when
+	// creating CONTAINER_JSON events
+	void set_trim_container_json(bool enabled);
+	bool get_trim_container_json();
+
 	/*!
 	  \brief Start writing the captured events to file.
 
@@ -1030,6 +1039,8 @@ private:
 	char m_output_time_flag;
 	uint32_t m_max_evt_output_len;
 	bool m_compress;
+	bool m_compress_container_json;
+	bool m_trim_container_json;
 	sinsp_evt m_evt;
 	std::string m_lasterr;
 	int64_t m_tid_to_remove;


### PR DESCRIPTION
THIS IS NOT READY FOR MERGE YET. But please take a look at the general approach and we can get the review process going.

Add the ability to compress the json representation of containers in
PPME_CONTAINER_JSON events. There are two options:

 - Optional compression: when set via
   sinsp::set_compress_container_json() (default true), the
   json-as-string will be compressed before writing.
 - Optional trimming: when set via
   sinsp::set_trim_container_json() (default true), unneeded properties
   from the json representation of the container will be removed before
   serializing. There are several progressive attempts, as specified in
   trim_level:
     - Trim specific unneeded labels
     - Trim all labels
     - Remove everything other than the name/image information.