### PR TITLE
gRPC fails to build on gcc-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,7 +515,7 @@ if(NOT WIN32 AND NOT APPLE)
 		BUILD_BYPRODUCTS ${GRPC_LIB} ${GRPCPP_LIB}
 		# TODO s390x support
 		# TODO what if using system zlib
-		PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && wget https://download.sysdig.com/dependencies/grpc-1.1.4-Makefile.patch && patch < grpc-1.1.4-Makefile.patch
+		PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && wget https://download.sysdig.com/dependencies/grpc-1.8.1-Makefile.patch && patch < grpc-1.8.1-Makefile.patch
 		INSTALL_COMMAND "")
 	endif()
 endif()


### PR DESCRIPTION
Due to new warnings in gcc-8, sysdig fails to build on e.g. Fedora 28:
```
src/core/ext/transport/chttp2/transport/flow_control.cc: In member function 'uint32_t grpc_core::chttp2::TransportFlowControl::MaybeSendUpdate(bool)':
src/core/ext/transport/chttp2/transport/flow_control.cc:170:74: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
   const uint32_t target_announced_window = (const uint32_t)target_window();
```
gRPC uses hardcoded -Werror which isn't really the best idea ever so let's patch it out