### PR TITLE
Increase size of sinsp meta evt storage

### DIFF
--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -28,7 +28,7 @@ limitations under the License.
 // Memory storage size for an entry in the event storage LIFO.
 // Events bigger than SP_EVT_BUF_SIZE won't be be stored in the LIFO.
 //
-#define SP_EVT_BUF_SIZE 4096
+#define SP_EVT_BUF_SIZE 40960
 
 //
 // If defined, the filtering system is compiled


### PR DESCRIPTION
This meta event is used for a few things:

 - k8s/mesos events, where they are injected into the event stream
 - As temporary storage when dumping containers or creating events from
 - container json.

If this doesn't cause problems, it's a simpler fix than
https://github.com/draios/sysdig/pull/1408.