### PR TITLE
Build fixes for Gentoo

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -163,6 +163,9 @@ if(NOT WIN32)
 	if(USE_BUNDLED_TBB)
 		add_dependencies(sinsp tbb)
 	endif()
+	if(USE_BUNDLED_GRPC)
+		add_dependencies(sinsp grpc)
+	endif()
 
 	if(NOT APPLE)
 		add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cri.grpc.pb.cc
@@ -175,7 +178,6 @@ if(NOT WIN32)
 				COMMAND ${PROTOC} -I ${CMAKE_CURRENT_SOURCE_DIR} --grpc_out=. --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN} ${CMAKE_CURRENT_SOURCE_DIR}/cri.proto
 				WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-		add_dependencies(sinsp grpc)
 		target_link_libraries(sinsp
 			"${GRPCPP_LIB}"
 			"${GRPC_LIB}"

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -145,7 +145,9 @@ add_library(sinsp STATIC ${SINSP_SOURCES})
 
 target_link_libraries(sinsp 
 	scap
-	"${JSONCPP_LIB}")
+	"${CURL_LIBRARIES}"
+	"${JSONCPP_LIB}"
+	"${TBB_LIB}")
 
 if(USE_BUNDLED_LUAJIT)
 	add_dependencies(sinsp luajit)
@@ -157,13 +159,9 @@ if(NOT WIN32)
 	endif()
 	if(USE_BUNDLED_CURL)
 		add_dependencies(sinsp curl)
-		target_link_libraries(sinsp
-			"${CURL_LIBRARIES}")
 	endif()
 	if(USE_BUNDLED_TBB)
 		add_dependencies(sinsp tbb)
-		target_link_libraries(sinsp
-			"${TBB_LIB}")
 	endif()
 
 	if(NOT APPLE)


### PR DESCRIPTION
This includes fixes for two failures preventing sysdig 0.26.0 from building on Gentoo, and a warning:
1. <del>Missing `sys/sysmacros.h` include that is needed by newer glibc versions.</del>
2. Missing linking to curl & tbb when using system libraries.
3. Missing target warning when using system grpc.