### PR TITLE
Add conversion guards [SMAGENT-1644]

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4499,6 +4499,40 @@ void sinsp_parser::parse_setgid_exit(sinsp_evt *evt)
 	}
 }
 
+static string convert_to_string(Json::ValueType other) {
+	std::string value_type("Not a valide type");
+	switch(other) {
+	case nullValue:
+		return "nullValue";
+	case intValue:
+		return "intValue";
+	case uintValue:
+		return "uintValue";
+	case realValue:
+		return "realValue";
+	case stringValue:
+		return "stringValue";
+	case booleanValue:
+		return "booleanValue";
+	case arrayValue:
+		return "arrayValue";
+	case objectValue:
+		return "objectValue";
+	default:
+		// fall through
+	}
+	return value_type;
+}
+
+bool check_is_convertible_and_log_msg(const Json::Value& value, Json::ValueType other)
+{
+	if(!value.isConvertibleTo(other)) {
+		string value_type_as_string = convert_to_string(other);
+		SINSP_WARNING("Unable to convert json value %s into type %s",value.asString().c_str(), value_type_as_string.c_str());
+	}
+	return true;
+}
+
 void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 {
 	sinsp_evt_param *parinfo = evt->get_param(0);
@@ -4588,6 +4622,7 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 			for (Json::Value::ArrayIndex i = 0; i != port_mappings.size(); i++)
 			{
 				sinsp_container_info::container_port_mapping map;
+				check_is_convertible_and_log_msg(port_mappings[i]["HostIp"] , Json::objectValue);
 				map.m_host_ip = port_mappings[i]["HostIp"].asInt();
 				map.m_host_port = (uint16_t) port_mappings[i]["HostPort"].asInt();
 				map.m_container_port = (uint16_t) port_mappings[i]["ContainerPort"].asInt();

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4520,8 +4520,8 @@ bool sinsp_parser::check_json_val_is_convertible(const Json::Value& value, Json:
 		} else {
 			if(g_logger.get_severity() >= sinsp_logger::SEV_DEBUG) {
 				err_msg = generate_error_message(value, field);
+				SINSP_DEBUG("%s",err_msg.c_str());
 			}
-			SINSP_DEBUG("%s",err_msg.c_str());
 		}			
 		return false;
 	}

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4499,8 +4499,8 @@ void sinsp_parser::parse_setgid_exit(sinsp_evt *evt)
 	}
 }
 
-static string convert_to_string(Json::ValueType other) {
-	std::string value_type("Not a valide type");
+static std::string convert_to_string(Json::ValueType other) {
+	std::string value_type("Not a valid json type");
 	switch(other) {
 	case Json::ValueType::nullValue:
 		return "nullValue";
@@ -4527,8 +4527,8 @@ static string convert_to_string(Json::ValueType other) {
 bool sinsp_parser::check_is_convertible(const Json::Value& value, Json::ValueType other, std::string field, bool log_message)
 {
 	if(!value.isConvertibleTo(other)) {
-		std::string valueAsString = value.isConvertibleTo(Json::stringValue) ? value.asString() : "value not convertible to string";
-		std::string err_msg = "Unable to convert json value '" + valueAsString + "' of type '" + convert_to_string(value.type()) + "' into type '" + convert_to_string(other) + "' for the field: '" + field +"'";
+		std::string value_as_string = value.isConvertibleTo(Json::stringValue) ? value.asString() : "value not convertible to string";
+		std::string err_msg = "Unable to convert json value '" + value_as_string + "' of type '" + convert_to_string(value.type()) + "' into type '" + convert_to_string(other) + "' for the field: '" + field +"'";
 		if(log_message) {
 			SINSP_WARNING("%s",err_msg.c_str());
 		} else {

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4502,24 +4502,24 @@ void sinsp_parser::parse_setgid_exit(sinsp_evt *evt)
 static string convert_to_string(Json::ValueType other) {
 	std::string value_type("Not a valide type");
 	switch(other) {
-	case nullValue:
+	case Json::ValueType::nullValue:
 		return "nullValue";
-	case intValue:
+	case Json::ValueType::intValue:
 		return "intValue";
-	case uintValue:
+	case Json::ValueType::uintValue:
 		return "uintValue";
-	case realValue:
+	case Json::ValueType::realValue:
 		return "realValue";
-	case stringValue:
+	case Json::ValueType::stringValue:
 		return "stringValue";
-	case booleanValue:
+	case Json::ValueType::booleanValue:
 		return "booleanValue";
-	case arrayValue:
+	case Json::ValueType::arrayValue:
 		return "arrayValue";
-	case objectValue:
+	case Json::ValueType::objectValue:
 		return "objectValue";
 	default:
-		// fall through
+		break;
 	}
 	return value_type;
 }

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4527,7 +4527,8 @@ static string convert_to_string(Json::ValueType other) {
 bool sinsp_parser::check_is_convertible(const Json::Value& value, Json::ValueType other, std::string field, bool log_message)
 {
 	if(!value.isConvertibleTo(other)) {
-		std::string err_msg = "Unable to convert json value '" + value.asString() + "' of type '" + convert_to_string(value.type()) + "' into type '" + convert_to_string(other) + "' for the field: '" + field +"'";
+		std::string valueAsString = value.isConvertibleTo(Json::stringValue) ? value.asString() : "value not convertible to string";
+		std::string err_msg = "Unable to convert json value '" + valueAsString + "' of type '" + convert_to_string(value.type()) + "' into type '" + convert_to_string(other) + "' for the field: '" + field +"'";
 		if(log_message) {
 			SINSP_WARNING("%s",err_msg.c_str());
 		} else {

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4524,11 +4524,14 @@ static string convert_to_string(Json::ValueType other) {
 	return value_type;
 }
 
-bool check_is_convertible_and_log_msg(const Json::Value& value, Json::ValueType other)
+bool sinsp_parser::check_is_convertible(const Json::Value& value, Json::ValueType other)
 {
 	if(!value.isConvertibleTo(other)) {
-		string value_type_as_string = convert_to_string(other);
-		SINSP_WARNING("Unable to convert json value %s into type %s",value.asString().c_str(), value_type_as_string.c_str());
+		SINSP_WARNING("Unable to convert json value %s of type %s into type %s",
+			      value.asString().c_str(),
+			      convert_to_string(value.type()).c_str(),
+			      convert_to_string(other).c_str());
+		return false;
 	}
 	return true;
 }
@@ -4622,11 +4625,16 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 			for (Json::Value::ArrayIndex i = 0; i != port_mappings.size(); i++)
 			{
 				sinsp_container_info::container_port_mapping map;
-				check_is_convertible_and_log_msg(port_mappings[i]["HostIp"] , Json::objectValue);
-				map.m_host_ip = port_mappings[i]["HostIp"].asInt();
-				map.m_host_port = (uint16_t) port_mappings[i]["HostPort"].asInt();
-				map.m_container_port = (uint16_t) port_mappings[i]["ContainerPort"].asInt();
+				if(check_is_convertible(port_mappings[i]["HostIp"] , Json::intValue)) {
+					map.m_host_ip = port_mappings[i]["HostIp"].asInt();
+				}
 
+				if(check_is_convertible(port_mappings[i]["HostPort"], Json::intValue)) {
+					map.m_host_port = (uint16_t) port_mappings[i]["HostPort"].asInt();
+				}
+				if(check_is_convertible(port_mappings[i]["ContainerPort"], Json::intValue)) {
+					map.m_container_port = (uint16_t) port_mappings[i]["ContainerPort"].asInt();
+				}
 				container_info.m_port_mappings.push_back(map);
 			}
 		}

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4524,13 +4524,15 @@ static string convert_to_string(Json::ValueType other) {
 	return value_type;
 }
 
-bool sinsp_parser::check_is_convertible(const Json::Value& value, Json::ValueType other)
+bool sinsp_parser::check_is_convertible(const Json::Value& value, Json::ValueType other, std::string field, bool log_message)
 {
 	if(!value.isConvertibleTo(other)) {
-		SINSP_WARNING("Unable to convert json value %s of type %s into type %s",
-			      value.asString().c_str(),
-			      convert_to_string(value.type()).c_str(),
-			      convert_to_string(other).c_str());
+		std::string err_msg = "Unable to convert json value '" + value.asString() + "' of type '" + convert_to_string(value.type()) + "' into type '" + convert_to_string(other) + "' for the field: '" + field +"'";
+		if(log_message) {
+			SINSP_WARNING("%s",err_msg.c_str());
+		} else {
+			SINSP_DEBUG("%s",err_msg.c_str());
+		}			
 		return false;
 	}
 	return true;
@@ -4550,54 +4552,54 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		sinsp_container_info container_info;
 		const Json::Value& container = root["container"];
 		const Json::Value& id = container["id"];
-		if(!id.isNull() && id.isConvertibleTo(Json::stringValue))
+		if(!id.isNull() && check_is_convertible(id, Json::stringValue, std::string("id")))
 		{
 			container_info.m_id = id.asString();
 		}
 		const Json::Value& type = container["type"];
-		if(!type.isNull() && type.isConvertibleTo(Json::uintValue))
+		if(!type.isNull() && check_is_convertible(type,Json::uintValue,std::string("type")))
 		{
 			container_info.m_type = static_cast<sinsp_container_type>(type.asUInt());
 		}
 		const Json::Value& name = container["name"];
-		if(!name.isNull() && name.isConvertibleTo(Json::stringValue))
+		if(!name.isNull() && check_is_convertible(name, Json::stringValue, std::string("name")))
 		{
 			container_info.m_name = name.asString();
 		}
 
 		const Json::Value& is_pod_sandbox = container["is_pod_sandbox"];
-		if(!is_pod_sandbox.isNull() && is_pod_sandbox.isConvertibleTo(Json::booleanValue))
+		if(!is_pod_sandbox.isNull() && check_is_convertible(is_pod_sandbox,Json::booleanValue,std::string("is_pod_sandbox")))
 		{
 			container_info.m_is_pod_sandbox = is_pod_sandbox.asBool();
 		}
 
 		const Json::Value& image = container["image"];
-		if(!image.isNull() && image.isConvertibleTo(Json::stringValue))
+		if(!image.isNull() && check_is_convertible(image,Json::stringValue,std::string("image")))
 		{
 			container_info.m_image = image.asString();
 		}
 		const Json::Value& imageid = container["imageid"];
-		if(!imageid.isNull() && imageid.isConvertibleTo(Json::stringValue))
+		if(!imageid.isNull() && check_is_convertible(imageid,Json::stringValue,std::string("imageid")))
 		{
 			container_info.m_imageid = imageid.asString();
 		}
 		const Json::Value& imagerepo = container["imagerepo"];
-		if(!imagerepo.isNull() && imagerepo.isConvertibleTo(Json::stringValue))
+		if(!imagerepo.isNull() && check_is_convertible(imagerepo,Json::stringValue,std::string("imagerepo")))
 		{
 			container_info.m_imagerepo = imagerepo.asString();
 		}
 		const Json::Value& imagetag = container["imagetag"];
-		if(!imagetag.isNull() && imagetag.isConvertibleTo(Json::stringValue))
+		if(!imagetag.isNull() && check_is_convertible(imagetag, Json::stringValue, std::string("imagetag")))
 		{
 			container_info.m_imagetag = imagetag.asString();
 		}
 		const Json::Value& imagedigest = container["imagedigest"];
-		if(!imagedigest.isNull() && imagedigest.isConvertibleTo(Json::stringValue))
+		if(!imagedigest.isNull() && check_is_convertible(imagedigest,Json::stringValue,std::string("imagedigest")))
 		{
 			container_info.m_imagedigest = imagedigest.asString();
 		}
 		const Json::Value& privileged = container["privileged"];
-		if(!privileged.isNull() && privileged.isConvertibleTo(Json::booleanValue))
+		if(!privileged.isNull() && check_is_convertible(privileged, Json::booleanValue, std::string("privileged")))
 		{
 			container_info.m_privileged = privileged.asBool();
 		}
@@ -4606,7 +4608,7 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 
 		container_info.parse_healthcheck(container["Healthcheck"]);
 		const Json::Value& contip = container["ip"];
-		if(!contip.isNull() && contip.isConvertibleTo(Json::stringValue))
+		if(!contip.isNull() && check_is_convertible(contip,Json::stringValue,std::string("ip")))
 		{
 			uint32_t ip;
 
@@ -4620,20 +4622,25 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 
 		const Json::Value &port_mappings = container["port_mappings"];
 
-		if(!port_mappings.isNull() && port_mappings.isConvertibleTo(Json::arrayValue))
+		if(!port_mappings.isNull() && check_is_convertible(port_mappings,Json::arrayValue,std::string("port_mappings")))
 		{
 			for (Json::Value::ArrayIndex i = 0; i != port_mappings.size(); i++)
 			{
 				sinsp_container_info::container_port_mapping map;
-				if(check_is_convertible(port_mappings[i]["HostIp"] , Json::intValue)) {
-					map.m_host_ip = port_mappings[i]["HostIp"].asInt();
+				const Json::Value &host_ip = port_mappings[i]["HostIp"];
+				// We log message for HostIp conversion failure at Warning level
+				if(!host_ip.isNull() && check_is_convertible(host_ip, Json::intValue, std::string("HostIp"),true)) {
+					map.m_host_ip = host_ip.asInt();
 				}
-
-				if(check_is_convertible(port_mappings[i]["HostPort"], Json::intValue)) {
-					map.m_host_port = (uint16_t) port_mappings[i]["HostPort"].asInt();
+				const Json::Value& host_port = port_mappings[i]["HostPort"];
+				// We log message for HostPort conversion failure at Warning level
+				if(!host_port.isNull() && check_is_convertible(host_port, Json::intValue, std::string("HostPort"), true)) {
+					map.m_host_port = (uint16_t) host_port.asInt();
 				}
-				if(check_is_convertible(port_mappings[i]["ContainerPort"], Json::intValue)) {
-					map.m_container_port = (uint16_t) port_mappings[i]["ContainerPort"].asInt();
+				const Json::Value& container_port = port_mappings[i]["ContainerPort"];
+				// We log message for ContainerPort conversion failure at Warning level
+				if(!container_port.isNull() && check_is_convertible(container_port, Json::intValue, std::string("ContainerPort"),true)) {
+					map.m_container_port = (uint16_t) container_port.asInt();
 				}
 				container_info.m_port_mappings.push_back(map);
 			}
@@ -4657,46 +4664,50 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		}
 
 		const Json::Value& memory_limit = container["memory_limit"];
-		if(!memory_limit.isNull() && memory_limit.isConvertibleTo(Json::uintValue))
+		if(!memory_limit.isNull() && check_is_convertible(memory_limit,Json::uintValue, std::string("memory_limit")))
 		{
 			container_info.m_memory_limit = memory_limit.asUInt();
 		}
 
 		const Json::Value& swap_limit = container["swap_limit"];
-		if(!swap_limit.isNull() && swap_limit.isConvertibleTo(Json::uintValue))
+		if(!swap_limit.isNull() && check_is_convertible(swap_limit,Json::uintValue,std::string("swap_limit")))
 		{
 			container_info.m_swap_limit = swap_limit.asUInt();
 		}
 
 		const Json::Value& cpu_shares = container["cpu_shares"];
-		if(!cpu_shares.isNull() && cpu_shares.isConvertibleTo(Json::uintValue))
+		if(!cpu_shares.isNull() && check_is_convertible(cpu_shares, Json::uintValue, std::string("cpu_shares")))
 		{
 			container_info.m_cpu_shares = cpu_shares.asUInt();
 		}
 
 		const Json::Value& cpu_quota = container["cpu_quota"];
-		if(!cpu_quota.isNull() && cpu_quota.isConvertibleTo(Json::uintValue))
+		if(!cpu_quota.isNull() && check_is_convertible(cpu_quota, Json::uintValue, std::string("cpu_quota")))
 		{
 			container_info.m_cpu_quota = cpu_quota.asUInt();
 		}
 
 		const Json::Value& cpu_period = container["cpu_period"];
-		if(!cpu_period.isNull() && cpu_period.isConvertibleTo(Json::uintValue))
+		if(!cpu_period.isNull() && check_is_convertible(cpu_period,Json::uintValue,std::string("cpu_period")))
 		{
 			container_info.m_cpu_period = cpu_period.asUInt();
 		}
 
 		const Json::Value& mesos_task_id = container["mesos_task_id"];
-		if(!mesos_task_id.isNull() && mesos_task_id.isConvertibleTo(Json::stringValue))
+		if(!mesos_task_id.isNull() && check_is_convertible(mesos_task_id,Json::stringValue,std::string("mesos_task_id")))
 		{
 			container_info.m_mesos_task_id = mesos_task_id.asString();
 		}
 
 		const Json::Value& metadata_deadline = container["metadata_deadline"];
-		// isConvertibleTo doesn't seem to work on large 64 bit numbers
-		if(!metadata_deadline.isNull() && metadata_deadline.isUInt64())
+		if(!metadata_deadline.isNull())
 		{
-			container_info.m_metadata_deadline = metadata_deadline.asUInt64();
+			// isConvertibleTo doesn't seem to work on large 64 bit numbers
+			if(metadata_deadline.isUInt64()) {
+				container_info.m_metadata_deadline = metadata_deadline.asUInt64();
+			} else {
+				SINSP_DEBUG("Unable to convert json value for field: %s", "metadata_deadline");
+			}
 		}
 
 		evt->m_tinfo_ref = container_info.get_tinfo(m_inspector);

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -161,7 +161,7 @@ private:
 	uint8_t* reserve_event_buffer();
 	void free_event_buffer(uint8_t*);
 
-	bool check_is_convertible(const Json::Value& value, Json::ValueType other);
+	bool check_is_convertible(const Json::Value& value, Json::ValueType other, std::string field, bool log_message=false);
 
 	//
 	// Pointers to inspector context

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -161,6 +161,8 @@ private:
 	uint8_t* reserve_event_buffer();
 	void free_event_buffer(uint8_t*);
 
+	void check_is_convertible_and_log_msg(const Json::Value& value, Json::ValueType other);
+
 	//
 	// Pointers to inspector context
 	//

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -161,7 +161,7 @@ private:
 	uint8_t* reserve_event_buffer();
 	void free_event_buffer(uint8_t*);
 
-	void check_is_convertible_and_log_msg(const Json::Value& value, Json::ValueType other);
+	bool check_is_convertible(const Json::Value& value, Json::ValueType other);
 
 	//
 	// Pointers to inspector context

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -161,7 +161,7 @@ private:
 	uint8_t* reserve_event_buffer();
 	void free_event_buffer(uint8_t*);
 
-	bool check_is_convertible(const Json::Value& value, Json::ValueType other, std::string field, bool log_message=false);
+	bool check_json_val_is_convertible(const Json::Value& value, Json::ValueType other, const char* field, bool log_message=false);
 
 	//
 	// Pointers to inspector context


### PR DESCRIPTION
In the above issue, we observe a backtrace which was traced down to an un-guarded `asInt` json conversion. Curiously all the other meta-data had conversion guards. So provide conversion guards for `port_mappings` fields too. 
Additionally log the message when conversion fails. For most, we will do it at the default DEBUG level. But for a few we log at WARNING. This will hopefully reveal what's happening. 