### PR TITLE
SMAGENT-1635: Fix container repo digest for locally tagged images

### DIFF
--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -331,7 +331,7 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 					{
 						string repodigest = rdig.asString();
 						string digest = repodigest.substr(repodigest.find('@')+1);
-                        imageDigestSet.insert(digest);
+						imageDigestSet.insert(digest);
 						if(container->m_imagerepo.empty())
 						{
 							container->m_imagerepo = repodigest.substr(0, repodigest.find('@'));

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -320,6 +320,10 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 			Json::Value img_root;
 			if(reader.parse(img_json, img_root))
 			{
+			    // img_root["RepoDigests"] contains only digests for images pulled from registries.
+			    // If an image gets retagged and is never pushed to any registry, we will not find
+			    // that entry in container->m_imagerepo. Also, for locally built images we have the
+			    // same issue. This leads to container->m_imagedigest being empty as well.
 			    unordered_set<std::string> imageDigestSet;
 				for(const auto& rdig : img_root["RepoDigests"])
 				{
@@ -358,8 +362,7 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 				// fix image digest for locally tagged images or multiple repo digests.
 				// Case 1: One repo digest with many tags.
 				// Case 2: Many repo digests with the same digest value.
-				if(container->m_imagedigest.empty() && img_root["RepoDigests"].size() >= 1 &&
-				   imageDigestSet.size() == 1) {
+				if(container->m_imagedigest.empty() && imageDigestSet.size() == 1) {
 				    container->m_imagedigest = *imageDigestSet.begin();
 				}
 			}

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -320,11 +320,11 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 			Json::Value img_root;
 			if(reader.parse(img_json, img_root))
 			{
-			    // img_root["RepoDigests"] contains only digests for images pulled from registries.
-			    // If an image gets retagged and is never pushed to any registry, we will not find
-			    // that entry in container->m_imagerepo. Also, for locally built images we have the
-			    // same issue. This leads to container->m_imagedigest being empty as well.
-			    unordered_set<std::string> imageDigestSet;
+				// img_root["RepoDigests"] contains only digests for images pulled from registries.
+				// If an image gets retagged and is never pushed to any registry, we will not find
+				// that entry in container->m_imagerepo. Also, for locally built images we have the
+				// same issue. This leads to container->m_imagedigest being empty as well.
+				unordered_set<std::string> imageDigestSet;
 				for(const auto& rdig : img_root["RepoDigests"])
 				{
 					if(rdig.isString())
@@ -363,7 +363,7 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 				// Case 1: One repo digest with many tags.
 				// Case 2: Many repo digests with the same digest value.
 				if(container->m_imagedigest.empty() && imageDigestSet.size() == 1) {
-				    container->m_imagedigest = *imageDigestSet.begin();
+					container->m_imagedigest = *imageDigestSet.begin();
 				}
 			}
 			else


### PR DESCRIPTION
Currently, image digest is empty for images that are locally tagged (but not pushed to any registry). This PR fixes the image digest in such cases, specifically,
1) If there is one repo digest but several repo tags, we can safely assume the digest to be the repo digest.
2) If there are several repo digest for a single tag and all repo digests have the same value, we can use the same digest.