### PR TITLE
Don't modify source directory during build

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -8,21 +8,61 @@
 option(BUILD_DRIVER "Build the driver on Linux" ON)
 option(ENABLE_DKMS "Enable DKMS on Linux" ON)
 
-configure_file(dkms.conf.in dkms.conf)
-configure_file(Makefile.in Makefile.dkms)
-configure_file(driver_config.h.in driver_config.h)
-configure_file(driver_config.h.in "${CMAKE_CURRENT_SOURCE_DIR}/driver_config.h")
+# The driver build process is somewhat involved because we use the same
+# sources for building the driver locally and for shipping as a DKMS module.
+#
+# We need a single directory with the following files inside:
+# - all the driver *.c/*.h sources
+# - Makefile generated from Makefile.in
+# - driver_config.h generated from driver_config.h.in
+#
+# The Makefile _must_ be called just Makefile (and not e.g. Makefile.dkms)
+# because of the module build process, which looks like this:
+# 1. The user (or some script) runs make in our driver directory
+# 2. Our Makefile runs the Makefile from kernel sources/headers
+# 3. The kernel Makefile calls our original Makefile again, with options that
+#    trigger the actual build. This step cannot know that our Makefile has
+#    a different name.
+#
+# (DKMS needs a Makefile called Makefile as well).
+#
+# The files need to be in a single directory because we cannot know where
+# the sources will be built (especially by DKMS) so we cannot put _any_ paths
+# in the Makefile.
+#
+# The chosen directory must not be ${CMAKE_CURRENT_BINARY_DIR} because CMake
+# puts its own generated Makefile in there, so we (arbitrarily) choose
+# ${CMAKE_CURRENT_BINARY_DIR}/src. To maintain compatibility with older versions,
+# after the build we copy the compiled module one directory up,
+# to ${CMAKE_CURRENT_BINARY_DIR}.
 
-set(CLEAN_FILES
-	"${CMAKE_CURRENT_SOURCE_DIR}/Makefile"
-	"${CMAKE_CURRENT_SOURCE_DIR}/driver_config.h")
+configure_file(dkms.conf.in src/dkms.conf)
+configure_file(Makefile.in src/Makefile)
+configure_file(driver_config.h.in src/driver_config.h)
 
-set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${CLEAN_FILES}")
+set(DRIVER_SOURCES
+	dynamic_params_table.c
+	event_table.c
+	fillers_table.c
+	flags_table.c
+	main.c
+	ppm.h
+	ppm_events.c
+	ppm_events.h
+	ppm_events_public.h
+	ppm_fillers.c
+	ppm_fillers.h
+	ppm_flag_helpers.h
+	ppm_ringbuffer.h
+	ppm_syscall.h
+	syscall_table.c
+	ppm_cputime.c
+	ppm_compat_unistd_32.h
+)
 
-add_custom_target(configure_driver ALL
-	COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/driver_config.h driver_config.h
-	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-	VERBATIM)
+foreach(FILENAME IN LISTS DRIVER_SOURCES)
+	configure_file(${FILENAME} src/${FILENAME} COPYONLY)
+endforeach()
 
 # make can be self-referenced as $(MAKE) only from Makefiles but this
 # triggers syntax errors with other generators such as Ninja
@@ -37,54 +77,29 @@ endif()
 # http://public.kitware.com/Bug/view.php?id=8438
 if(BUILD_DRIVER)
 	add_custom_target(driver ALL
-		COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/Makefile.dkms Makefile
 		COMMAND ${MAKE_COMMAND}
 		COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${PROBE_NAME}.ko "${CMAKE_CURRENT_BINARY_DIR}"
-		DEPENDS configure_driver
-		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+		WORKING_DIRECTORY src
 		VERBATIM)
 else()
 	add_custom_target(driver
-		COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/Makefile.dkms Makefile
 		COMMAND ${MAKE_COMMAND}
 		COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${PROBE_NAME}.ko "${CMAKE_CURRENT_BINARY_DIR}"
-		DEPENDS configure_driver
-		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+		WORKING_DIRECTORY src
 		VERBATIM)
 endif()
 
 add_custom_target(install_driver
 	COMMAND ${MAKE_COMMAND} install
 	DEPENDS driver
-	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+	WORKING_DIRECTORY src
 	VERBATIM)
 
 if(ENABLE_DKMS)
-	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Makefile.dkms
-		RENAME Makefile
-		DESTINATION "src/${PACKAGE_NAME}-${PROBE_VERSION}"
-		COMPONENT agent-kmodule)
-
-	install(FILES
-		${CMAKE_CURRENT_BINARY_DIR}/dkms.conf
-		dynamic_params_table.c
-		driver_config.h
-		event_table.c
-		fillers_table.c
-		flags_table.c
-		main.c
-		ppm.h
-		ppm_events.c
-		ppm_events.h
-		ppm_events_public.h
-		ppm_fillers.c
-		ppm_fillers.h
-		ppm_flag_helpers.h
-		ppm_ringbuffer.h
-		ppm_syscall.h
-		syscall_table.c
-		ppm_cputime.c
-		ppm_compat_unistd_32.h
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/Makefile
+		${CMAKE_CURRENT_BINARY_DIR}/src/dkms.conf
+		${CMAKE_CURRENT_BINARY_DIR}/src/driver_config.h
+		${DRIVER_SOURCES}
 		DESTINATION "src/${PACKAGE_NAME}-${PROBE_VERSION}"
 		COMPONENT agent-kmodule)
 

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -39,6 +39,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 		scap_bpf.c
 		../../driver/syscall_table.c
 		../../driver/fillers_table.c)
+
+    include_directories(${PROJECT_BINARY_DIR}/driver/src)
 endif()
 
 if(CYGWIN)

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -39,7 +39,7 @@ limitations under the License.
 #include "scap.h"
 #ifdef HAS_CAPTURE
 #ifndef CYGWING_AGENT
-#include "../../driver/driver_config.h"
+#include "driver_config.h"
 #endif // CYGWING_AGENT
 #endif // HAS_CAPTURE
 #include "../../driver/ppm_ringbuffer.h"

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -36,7 +36,7 @@ limitations under the License.
 #include "scap.h"
 #include "scap-int.h"
 #include "scap_bpf.h"
-#include "../../driver/driver_config.h"
+#include "driver_config.h"
 #include "../../driver/bpf/types.h"
 #include "compat/misc.h"
 #include "compat/bpf.h"

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -53,7 +53,7 @@ add_executable(sysdig ${SOURCE_FILES})
 add_executable(csysdig ${SOURCE_FILES_CSYSDIG})
 
 if(NOT WIN32)
-
+	include_directories(${PROJECT_BINARY_DIR}/driver/src)
 	target_link_libraries(sysdig
 		sinsp)
 

--- a/userspace/sysdig/sysdig.h
+++ b/userspace/sysdig/sysdig.h
@@ -21,7 +21,7 @@ limitations under the License.
 
 #include <config_sysdig.h>
 #ifdef HAS_CAPTURE
-#include "../../driver/driver_config.h"
+#include "driver_config.h"
 #endif // HAS_CAPTURE
 
 //


### PR DESCRIPTION
The only thing that touches the source directory is the driver build process, so we can just copy the sources to the binary directory and run the build from there.

This also lets us avoid stepping on cmake's toes with our generated Makefile (it has to be called Makefile while building the driver)