### PR TITLE
README - update Build Status link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 sysdig
 ======
 
-[![Build Status](https://travis-ci.org/draios/sysdig.png?branch=master)](https://travis-ci.org/draios/sysdig)
+[![Build Status](https://travis-ci.com/draios/sysdig.png?branch=master)](https://travis-ci.com/draios/sysdig)
 
 # Welcome to **sysdig**!
 


### PR DESCRIPTION
The Build Status link here currently points to https://travis-ci.org/draios/sysdig which says

>This repository has been migrated to travis-ci.com

Proposing updating the link to https://travis-ci.com/draios/sysdig