### PR TITLE
SMAGENT-1698: Kernel support for statsd port conf

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -383,7 +383,7 @@ static __always_inline u32 bpf_compute_snaplen(struct filler_data *data,
 						  *(s32 *)&get_buf(12) == 2006 ||
 						  *(s32 *)&get_buf(12) == 2007))) {
 		return 2000;
-	} else if (dport == PPM_PORT_STATSD) {
+	} else if (dport == data->settings->statsd_port) {
 		return 2000;
 	} else {
 		if (lookahead_size >= 5) {

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -208,6 +208,7 @@ struct sysdig_bpf_settings {
 	bool tracers_enabled;
 	uint16_t fullcapture_port_range_start;
 	uint16_t fullcapture_port_range_end;
+	uint16_t statsd_port;
 } __attribute__((packed));
 
 struct tail_context {

--- a/driver/main.c
+++ b/driver/main.c
@@ -439,6 +439,7 @@ static int ppm_open(struct inode *inode, struct file *filp)
 	consumer->need_to_insert_drop_x = 0;
 	consumer->fullcapture_port_range_start = 0;
 	consumer->fullcapture_port_range_end = 0;
+	consumer->statsd_port = PPM_PORT_STATSD;
 	bitmap_fill(g_events_mask, PPM_EVENT_MAX); /* Enable all syscall to be passed to userspace */
 	reset_ring_buffer(ring);
 	ring->open = true;
@@ -906,6 +907,15 @@ cleanup_ioctl_procinfo:
 
 		pr_info("new fullcapture_port_range_start: %d\n", (int)consumer->fullcapture_port_range_start);
 		pr_info("new fullcapture_port_range_end: %d\n", (int)consumer->fullcapture_port_range_end);
+
+		ret = 0;
+		goto cleanup_ioctl;
+	}
+	case PPM_IOCTL_SET_STATSD_PORT:
+	{
+		consumer->statsd_port = (u16)arg;
+
+		pr_info("new statsd_port: %d\n", (int)consumer->statsd_port);
 
 		ret = 0;
 		goto cleanup_ioctl;

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -74,6 +74,7 @@ struct ppm_consumer_t {
 	struct list_head node;
 	uint16_t fullcapture_port_range_start;
 	uint16_t fullcapture_port_range_end;
+	uint16_t statsd_port;
 };
 
 #define STR_STORAGE_SIZE PAGE_SIZE

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -404,7 +404,7 @@ inline u32 compute_snaplen(struct event_filler_arguments *args, char *buf, u32 l
 							) {
 						sockfd_put(sock);
 						return 2000;
-					} else if (dport == PPM_PORT_STATSD) {
+					} else if (dport == args->consumer->statsd_port) {
 						sockfd_put(sock);
 						return 2000;
 					} else {

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1454,6 +1454,7 @@ struct ppm_evt_hdr {
 #define PPM_IOCTL_GET_N_TRACEPOINT_HIT _IO(PPM_IOCTL_MAGIC, 20)
 #define PPM_IOCTL_GET_PROBE_VERSION _IO(PPM_IOCTL_MAGIC, 21)
 #define PPM_IOCTL_SET_FULLCAPTURE_PORT_RANGE _IO(PPM_IOCTL_MAGIC, 22)
+#define PPM_IOCTL_SET_STATSD_PORT _IO(PPM_IOCTL_MAGIC, 23)
 #endif // CYGWING_AGENT
 
 extern const struct ppm_name_value socket_families[];

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -2088,3 +2088,65 @@ int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, ui
 	return SCAP_SUCCESS;
 #endif
 }
+
+int32_t scap_set_statsd_port(scap_t* const handle, const uint16_t port)
+{
+	//
+	// Not supported on files
+	//
+	if(handle->m_mode != SCAP_MODE_LIVE)
+	{
+		snprintf(handle->m_lasterr,
+		         SCAP_LASTERR_SIZE,
+		         "scap_set_statsd_port not supported on this scap mode");
+		return SCAP_FAILURE;
+	}
+
+#if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT)
+	snprintf(handle->m_lasterr,
+	         SCAP_LASTERR_SIZE,
+	         "live capture not supported on %s",
+	         PLATFORM_NAME);
+	return SCAP_FAILURE;
+#else
+
+	if(handle->m_bpf)
+	{
+		return scap_bpf_set_statsd_port(handle, port);
+	}
+	else
+	{
+		//
+		// Beam the value down to the module
+		//
+		if(ioctl(handle->m_devs[0].m_fd, PPM_IOCTL_SET_STATSD_PORT, port))
+		{
+			snprintf(handle->m_lasterr,
+			         SCAP_LASTERR_SIZE,
+			         "scap_set_statsd_port: ioctl failed");
+			ASSERT(false);
+			return SCAP_FAILURE;
+		}
+
+		{
+			uint32_t j;
+
+			//
+			// Force a flush of the read buffers, so we don't
+			// capture events with the old snaplen
+			//
+			for(j = 0; j < handle->m_ndevs; j++)
+			{
+				scap_readbuf(handle,
+				             j,
+				             &handle->m_devs[j].m_sn_next_event,
+				             &handle->m_devs[j].m_sn_len);
+
+				handle->m_devs[j].m_sn_len = 0;
+			}
+		}
+	}
+
+	return SCAP_SUCCESS;
+#endif
+}

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -1041,6 +1041,13 @@ wh_t* scap_get_wmi_handle(scap_t* handle);
 #endif
 int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, uint16_t range_end);
 
+/**
+ * By default we have an expanded snaplen for the default statsd port. If the
+ * statsd port is non-standard, communicate that port value to the kernel to
+ * get the expanded snaplen for the correct port.
+ */
+int32_t scap_set_statsd_port(scap_t* handle, uint16_t port);
+
 #ifdef __cplusplus
 }
 #endif

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -903,6 +903,28 @@ int32_t scap_bpf_set_fullcapture_port_range(scap_t* handle, uint16_t range_start
 	return SCAP_SUCCESS;
 }
 
+int32_t scap_bpf_set_statsd_port(scap_t* const handle, const uint16_t port)
+{
+	struct sysdig_bpf_settings settings = {};
+	int k = 0;
+
+	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings) != 0)
+	{
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_lookup_elem < 0");
+		return SCAP_FAILURE;
+	}
+
+	settings.statsd_port = port;
+
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	{
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		return SCAP_FAILURE;
+	}
+
+	return SCAP_SUCCESS;
+}
+
 int32_t scap_bpf_disable_dynamic_snaplen(scap_t* handle)
 {
 	struct sysdig_bpf_settings settings;
@@ -1225,6 +1247,7 @@ static int32_t set_default_settings(scap_t *handle)
 	settings.tracers_enabled = false;
 	settings.fullcapture_port_range_start = 0;
 	settings.fullcapture_port_range_end = 0;
+	settings.statsd_port = 8125;
 
 	int k = 0;
 	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)

--- a/userspace/libscap/scap_bpf.h
+++ b/userspace/libscap/scap_bpf.h
@@ -39,6 +39,7 @@ int32_t scap_bpf_stop_capture(scap_t *handle);
 int32_t scap_bpf_close(scap_t *handle);
 int32_t scap_bpf_set_snaplen(scap_t* handle, uint32_t snaplen);
 int32_t scap_bpf_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, uint16_t range_end);
+int32_t scap_bpf_set_statsd_port(scap_t* handle, uint16_t port);
 int32_t scap_bpf_enable_dynamic_snaplen(scap_t* handle);
 int32_t scap_bpf_disable_dynamic_snaplen(scap_t* handle);
 int32_t scap_bpf_enable_page_faults(scap_t* handle);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -900,6 +900,8 @@ public:
 
 	void set_fullcapture_port_range(uint16_t range_start, uint16_t range_end);
 
+	void set_statsd_port(uint16_t port);
+
 	void set_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
 
@@ -1133,6 +1135,8 @@ public:
 		uint16_t range_start;
 		uint16_t range_end;
 	} m_increased_snaplen_port_range;
+
+	int32_t m_statsd_port;
 
 	//
 	// Some thread table limits


### PR DESCRIPTION
This change introduces a new `ioctl` for the sysdig probe ---
`PPM_IOCTL_SET_STATSD_PORT` --- and associated API wrappers to enable
userspace to change the port on which the kernel supports an expanded
snaplen for statsd metrics.  This change also makes a similar change to
the eBPF probe settings object to support the same behavior.