### PR TITLE
Fix for kernels < 3.11 and the pidns check

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -73,6 +73,15 @@ static inline struct inode *file_inode(struct file *f)
 	} while(0)
 #endif
 
+static inline struct pid_namespace *pid_ns_for_children(struct task_struct *task)
+{
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0))
+	return task->nsproxy->pid_ns;
+#else
+	return task->nsproxy->pid_ns_for_children;
+#endif
+}
+
 int f_sys_generic(struct event_filler_arguments *args)
 {
 	int res;
@@ -949,7 +958,7 @@ cgroups_error:
 			val = 0;
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)
-		if(pidns != &init_pid_ns || current->nsproxy->pid_ns_for_children != pidns)
+		if(pidns != &init_pid_ns || pid_ns_for_children(current) != pidns)
 			in_pidns = PPM_CL_CHILD_IN_PIDNS;
 #endif
 		res = val_to_ring(args, (uint64_t)clone_flags_to_scap(val) | in_pidns, 0, false, 0);


### PR DESCRIPTION
Commit c2b1df2eb42978073ec27c99cc199d20ae48b849 renamed nsproxy->pid_ns to nsproxy->pid_ns_for_children so we need to use the old name for kernels < 3.11