### PR TITLE
Fix cos version detection in probe loader script

### DIFF
--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -43,7 +43,7 @@ cos_version_greater()
 	# Test the first component
 	if [[ $a -gt $d ]]; then
 		return 1
-	elif [[ $d -gt $d ]]; then
+	elif [[ $d -gt $a ]]; then
 		return 0
 	fi
 


### PR DESCRIPTION
A recent fix (#1431) to the eBPF probe for COS required improvements to COS version detection in the probe loader script in order to pass appropriate probe build flags. A typo prevented the version detection from working correctly. 