### PR TITLE
fix: include makedev definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ cmake_minimum_required(VERSION 2.8.2)
 
 project(sysdig)
 
+# Add path for custom CMake modules.
+list(APPEND CMAKE_MODULE_PATH
+	"${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+
 if(NOT DEFINED SYSDIG_VERSION)
 	set(SYSDIG_VERSION "0.1.1dev")
 endif()
@@ -91,17 +95,6 @@ if(NOT WIN32)
 
 		if(NOT DEFINED PROBE_DEVICE_NAME)
 			set(PROBE_DEVICE_NAME "sysdig")
-		endif()
-
-		include(${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)
-		check_include_file("sys/mkdev.h" HAVE_SYS_MKDEV_H)
-		check_include_file("sys/sysmacros.h" HAVE_SYS_SYSMACROS_H)
-
-		if (HAVE_SYS_MKDEV_H)
-			add_definitions(-DHAVE_SYS_MKDEV_H)
-		endif()
-		if (HAVE_SYS_SYSMACROS_H)
-			add_definitions(-DHAVE_SYS_SYSMACROS_H)
 		endif()
 
 		add_subdirectory(driver)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,17 @@ if(NOT WIN32)
 			set(PROBE_DEVICE_NAME "sysdig")
 		endif()
 
+		include(${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)
+		check_include_file("sys/mkdev.h" HAVE_SYS_MKDEV_H)
+		check_include_file("sys/sysmacros.h" HAVE_SYS_SYSMACROS_H)
+
+		if (HAVE_SYS_MKDEV_H)
+			add_definitions(-DHAVE_SYS_MKDEV_H)
+		endif()
+		if (HAVE_SYS_SYSMACROS_H)
+			add_definitions(-DHAVE_SYS_SYSMACROS_H)
+		endif()
+
 		add_subdirectory(driver)
 		add_definitions(-DHAS_CAPTURE)
 	endif()

--- a/cmake/modules/FindMakedev.cmake
+++ b/cmake/modules/FindMakedev.cmake
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2013-2019 Draios Inc dba Sysdig.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This module is used to understand where the makedev function
+# is defined in the glibc in use.
+# see 'man 3 makedev'
+# Usage:
+#  In your CMakeLists.txt
+#    include(FindMakedev)
+#
+#  In your source code:
+#
+#    #if HAVE_SYS_MKDEV_H
+#    #include <sys/mkdev.h>
+#    #endif
+#    #ifdef HAVE_SYS_SYSMACROS_H
+#    #include <sys/sysmacros.h>
+#    #endif
+#
+include(${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)
+
+check_include_file("sys/mkdev.h" HAVE_SYS_MKDEV_H)
+check_include_file("sys/sysmacros.h" HAVE_SYS_SYSMACROS_H)
+
+if (HAVE_SYS_MKDEV_H)
+    add_definitions(-DHAVE_SYS_MKDEV_H)
+endif()
+if (HAVE_SYS_SYSMACROS_H)
+    add_definitions(-DHAVE_SYS_SYSMACROS_H)
+endif()

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -81,4 +81,6 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         add_subdirectory(examples/01-open)
         add_subdirectory(examples/02-validatebuffer)
     endif()
+
+	include(FindMakedev)
 endif()

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -49,6 +49,7 @@ limitations under the License.
 #include <errno.h>
 #include <netinet/tcp.h>
 #if defined(__linux__)
+#include <sys/sysmacros.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 //#include <linux/sock_diag.h>

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -49,7 +49,12 @@ limitations under the License.
 #include <errno.h>
 #include <netinet/tcp.h>
 #if defined(__linux__)
+#if HAVE_SYS_MKDEV_H
+#include <sys/mkdev.h>
+#endif
+#ifdef HAVE_SYS_SYSMACROS_H
 #include <sys/sysmacros.h>
+#endif
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 //#include <linux/sock_diag.h>


### PR DESCRIPTION
This PR fixes the missing definition of `makedev` function into libscap.

