### PR TITLE
Only query container runtimes once per engine

### DIFF
--- a/userspace/libsinsp/async_container.h
+++ b/userspace/libsinsp/async_container.h
@@ -62,7 +62,19 @@ void async_container_source<key_type>::lookup_container(const key_type& key, sin
 				static_cast<const std::string&>(key).c_str(),
 				(res.m_successful ? "true" : "false"));
 
-		manager->notify_new_container(res);
+		// store the container metadata in container_manager regardless of the result
+		// this ensures that we don't get stuck with incomplete containers
+		// when all async lookups fail
+		//
+		// the manager will ignore any lookup results reported after the first
+		// successful one and return false
+		//
+		// if we did use the metadata and the lookup succeeded,
+		// generate a container event for libsinsp consumers
+		if(manager->update_container(res) && res.m_successful)
+		{
+			manager->notify_new_container(res);
+		}
 	};
 
 	sinsp_container_info result;

--- a/userspace/libsinsp/async_container.h
+++ b/userspace/libsinsp/async_container.h
@@ -1,0 +1,82 @@
+/*
+Copyright (C) 2019 Draios Inc dba Sysdig.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include "async_key_value_source.h"
+#include "container_info.h"
+#include "container.h"
+
+namespace sysdig {
+/**
+ * \brief Base class for async container metadata sources
+ * @tparam key_type lookup key (container id plus optionally other data)
+ *
+ * The result type is hardcoded as sinsp_container_info.
+ */
+template<typename key_type>
+class async_container_source : public async_key_value_source<key_type, sinsp_container_info>
+{
+public:
+	using async_key_value_source<key_type, sinsp_container_info>::async_key_value_source;
+
+	/**
+	 * \brief Start async lookup of container metadata
+	 * @param key the container lookup key
+	 * @param manager the instance of sinsp_container_manager to store
+	 * the metadata found
+	 */
+	void lookup_container(const key_type& key, sinsp_container_manager *manager);
+
+	/**
+	 * \brief Wait for all pending lookups to complete
+	 */
+	void quiesce() {
+		this->stop();
+	}
+};
+
+template<typename key_type>
+void async_container_source<key_type>::lookup_container(const key_type& key, sinsp_container_manager *manager)
+{
+	auto cb = [manager](const key_type& key, const sinsp_container_info &res)
+	{
+		g_logger.format(sinsp_logger::SEV_DEBUG,
+				"async_container_source (%s): Source callback result successful=%s",
+				static_cast<const std::string&>(key).c_str(),
+				(res.m_successful ? "true" : "false"));
+
+		manager->notify_new_container(res);
+	};
+
+	sinsp_container_info result;
+
+	if (this->lookup(key, result, cb))
+	{
+		// if a previous lookup call already found the metadata, process it now
+		cb(key, result);
+
+		// This should *never* happen, as ttl is 0 (never wait)
+		g_logger.format(sinsp_logger::SEV_ERROR,
+				"async_container_source (%s): Unexpected immediate return from lookup()",
+				static_cast<const std::string&>(key).c_str());
+	}
+
+}
+}

--- a/userspace/libsinsp/chisel_api.cpp
+++ b/userspace/libsinsp/chisel_api.cpp
@@ -1141,9 +1141,7 @@ int lua_cbacks::get_container_table(lua_State *ls)
 	//
 	// Retrieve the container list
 	//
-	const unordered_map<string, sinsp_container_info>* ctable  = ch->m_inspector->m_container_manager.get_containers();
-
-	ASSERT(ctable != NULL);
+	const auto ctable  = ch->m_inspector->m_container_manager.get_containers();
 
 	lua_newtable(ls);
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -138,6 +138,7 @@ sinsp_container_info* sinsp_container_manager::get_or_create_container(
 	container_info.m_imagetag = s_incomplete_info_name;
 	container_info.m_imagedigest = s_incomplete_info_name;
 	container_info.m_metadata_complete = false;
+	container_info.m_successful = false;
 
 	add_container(container_info, tinfo, containers);
 	return &(*containers)[id];
@@ -264,6 +265,13 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 	}
 
 	container["metadata_deadline"] = (Json::Value::UInt64) container_info.m_metadata_deadline;
+
+	// Allow the container engine to report failed lookups as well.
+	// These will not overwrite any successful lookups that may have
+	// happened (e.g. with a different container engine, as Docker/CRI
+	// cgroups overlap) but they will overwrite any incomplete containers.
+	container["successful"] = (Json::Value::UInt64) container_info.m_successful;
+
 	return Json::FastWriter().write(obj);
 }
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -74,15 +74,16 @@ bool sinsp_container_manager::remove_inactive_containers()
 			return true;
 		});
 
-		for(unordered_map<string, sinsp_container_info>::iterator it = m_containers.begin(); it != m_containers.end();)
+		auto containers = m_containers.lock();
+		for(auto it = containers->begin(); it != containers->end();)
 		{
 			if(containers_in_use.find(it->first) == containers_in_use.end())
 			{
 				for(const auto &remove_cb : m_remove_callbacks)
 				{
-					remove_cb(m_containers[it->first]);
+					remove_cb((*containers)[it->first]);
 				}
-				m_containers.erase(it++);
+				containers->erase(it++);
 			}
 			else
 			{
@@ -96,8 +97,9 @@ bool sinsp_container_manager::remove_inactive_containers()
 
 sinsp_container_info* sinsp_container_manager::get_container(const string& container_id)
 {
-	auto it = m_containers.find(container_id);
-	if(it != m_containers.end())
+	auto containers = m_containers.lock();
+	auto it = containers->find(container_id);
+	if(it != containers->end())
 	{
 		return &it->second;
 	}
@@ -272,18 +274,25 @@ bool sinsp_container_manager::container_to_sinsp_event(const string& json, sinsp
 	return true;
 }
 
-const unordered_map<string, sinsp_container_info>* sinsp_container_manager::get_containers()
+ConstMutexGuard<unordered_map<string, sinsp_container_info>> sinsp_container_manager::get_containers()
 {
-	return &m_containers;
+	return m_containers.lock();
 }
 
 void sinsp_container_manager::add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread_info)
 {
-	m_containers[container_info.m_id] = container_info;
+	auto containers = m_containers.lock();
+	add_container(container_info, thread_info, containers);
+}
+
+void sinsp_container_manager::add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread_info,
+	libsinsp::MutexGuard<std::unordered_map<std::string, sinsp_container_info>>& containers)
+{
+	(*containers)[container_info.m_id] = container_info;
 
 	for(const auto &new_cb : m_new_callbacks)
 	{
-		new_cb(m_containers[container_info.m_id], thread_info);
+		new_cb((*containers)[container_info.m_id], thread_info);
 	}
 }
 
@@ -313,10 +322,10 @@ void sinsp_container_manager::notify_new_container(const sinsp_container_info& c
 
 void sinsp_container_manager::dump_containers(scap_dumper_t* dumper)
 {
-	for(unordered_map<string, sinsp_container_info>::const_iterator it = m_containers.begin(); it != m_containers.end(); ++it)
+	for(const auto& it : (*m_containers.lock()))
 	{
 		sinsp_evt evt;
-		if(container_to_sinsp_event(container_to_json(it->second), &evt, it->second.get_tinfo(m_inspector)))
+		if(container_to_sinsp_event(container_to_json(it.second), &evt, it.second.get_tinfo(m_inspector)))
 		{
 			int32_t res = scap_dump(m_inspector->m_h, dumper, evt.m_pevt, evt.m_cpuid, 0);
 			if(res != SCAP_SUCCESS)

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -569,6 +569,13 @@ void sinsp_container_manager::cleanup()
 	}
 }
 
+void sinsp_container_manager::set_docker_socket_path(std::string socket_path)
+{
+#if defined(HAS_CAPTURE)
+	libsinsp::container_engine::docker::set_docker_sock(std::move(socket_path));
+#endif
+}
+
 void sinsp_container_manager::set_query_docker_image_info(bool query_image_info)
 {
 	libsinsp::container_engine::docker_async_source::set_query_image_info(query_image_info);

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <string>
 #include <unordered_map>
 
+#include "mutex.h"
 #include "container_info.h"
 
 #if !defined(_WIN32) && !defined(CYGWING_AGENT) && defined(HAS_CAPTURE)
@@ -44,9 +45,10 @@ public:
 	sinsp_container_manager(sinsp* inspector);
 	virtual ~sinsp_container_manager();
 
-	const std::unordered_map<std::string, sinsp_container_info>* get_containers();
+	libsinsp::ConstMutexGuard<std::unordered_map<std::string, sinsp_container_info>> get_containers();
 	bool remove_inactive_containers();
 	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread);
+	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread, libsinsp::MutexGuard<std::unordered_map<std::string, sinsp_container_info>>& containers);
 	sinsp_container_info * get_container(const std::string &id);
 	void notify_new_container(const sinsp_container_info& container_info);
 	template<typename E> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
@@ -62,7 +64,8 @@ public:
 	void identify_category(sinsp_threadinfo *tinfo);
 
 	bool container_exists(const std::string& container_id) const {
-		return m_containers.find(container_id) != m_containers.end();
+		const auto containers = m_containers.lock();
+		return containers->find(container_id) != containers->end();
 	}
 
 	typedef std::function<void(const sinsp_container_info&, sinsp_threadinfo *)> new_container_cb;
@@ -86,7 +89,7 @@ private:
 	std::list<std::unique_ptr<libsinsp::container_engine::resolver>> m_container_engines;
 
 	sinsp* m_inspector;
-	std::unordered_map<std::string, sinsp_container_info> m_containers;
+	libsinsp::Mutex<std::unordered_map<std::string, sinsp_container_info>> m_containers;
 	uint64_t m_last_flush_time_ns;
 	std::list<new_container_cb> m_new_callbacks;
 	std::list<remove_container_cb> m_remove_callbacks;

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -49,6 +49,7 @@ public:
 	bool remove_inactive_containers();
 	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread);
 	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread, libsinsp::MutexGuard<std::unordered_map<std::string, sinsp_container_info>>& containers);
+	bool update_container(const sinsp_container_info& container_info);
 	sinsp_container_info * get_container(const std::string &id);
 	sinsp_container_info * get_or_create_container(sinsp_container_type type, const std::string &id, const std::string& name, sinsp_threadinfo* tinfo);
 	void notify_new_container(const sinsp_container_info& container_info);

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -50,6 +50,7 @@ public:
 	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread);
 	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread, libsinsp::MutexGuard<std::unordered_map<std::string, sinsp_container_info>>& containers);
 	sinsp_container_info * get_container(const std::string &id);
+	sinsp_container_info * get_or_create_container(sinsp_container_type type, const std::string &id, const std::string& name, sinsp_threadinfo* tinfo);
 	void notify_new_container(const sinsp_container_info& container_info);
 	template<typename E> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	template<typename E1, typename E2, typename... Args> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
@@ -93,6 +94,8 @@ private:
 	uint64_t m_last_flush_time_ns;
 	std::list<new_container_cb> m_new_callbacks;
 	std::list<remove_container_cb> m_remove_callbacks;
+
+	static std::string s_incomplete_info_name;
 
 	friend class test_helper;
 };

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -20,6 +20,10 @@ limitations under the License.
 #pragma once
 
 #include <functional>
+#include <list>
+#include <memory>
+#include <string>
+#include <unordered_map>
 
 #include "container_info.h"
 
@@ -31,22 +35,25 @@ limitations under the License.
 
 #include "container_engine/container_engine.h"
 
+struct scap_dumper;
+class sinsp_evt;
+
 class sinsp_container_manager
 {
 public:
 	sinsp_container_manager(sinsp* inspector);
 	virtual ~sinsp_container_manager();
 
-	const unordered_map<string, sinsp_container_info>* get_containers();
+	const std::unordered_map<std::string, sinsp_container_info>* get_containers();
 	bool remove_inactive_containers();
 	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread);
-	sinsp_container_info * get_container(const string &id);
+	sinsp_container_info * get_container(const std::string &id);
 	void notify_new_container(const sinsp_container_info& container_info);
 	template<typename E> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	template<typename E1, typename E2, typename... Args> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	bool resolve_container(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
-	void dump_containers(scap_dumper_t* dumper);
-	string get_container_name(sinsp_threadinfo* tinfo);
+	void dump_containers(struct scap_dumper* dumper);
+	std::string get_container_name(sinsp_threadinfo* tinfo);
 
 	// Set tinfo's m_category based on the container context.  It
 	// will *not* change any category to NONE, so a threadinfo
@@ -54,7 +61,7 @@ public:
 	// across execs e.g. "sh -c /bin/true" execing /bin/true.
 	void identify_category(sinsp_threadinfo *tinfo);
 
-	bool container_exists(const string& container_id) const {
+	bool container_exists(const std::string& container_id) const {
 		return m_containers.find(container_id) != m_containers.end();
 	}
 
@@ -72,17 +79,17 @@ public:
 	void set_cri_timeout(int64_t timeout_ms);
 	sinsp* get_inspector() { return m_inspector; }
 private:
-	string container_to_json(const sinsp_container_info& container_info);
-	bool container_to_sinsp_event(const string& json, sinsp_evt* evt, shared_ptr<sinsp_threadinfo> tinfo);
-	string get_docker_env(const Json::Value &env_vars, const string &mti);
+	std::string container_to_json(const sinsp_container_info& container_info);
+	bool container_to_sinsp_event(const std::string& json, sinsp_evt* evt, std::shared_ptr<sinsp_threadinfo> tinfo);
+	std::string get_docker_env(const Json::Value &env_vars, const std::string &mti);
 
 	std::list<std::unique_ptr<libsinsp::container_engine::resolver>> m_container_engines;
 
 	sinsp* m_inspector;
-	unordered_map<string, sinsp_container_info> m_containers;
+	std::unordered_map<std::string, sinsp_container_info> m_containers;
 	uint64_t m_last_flush_time_ns;
-	list<new_container_cb> m_new_callbacks;
-	list<remove_container_cb> m_remove_callbacks;
+	std::list<new_container_cb> m_new_callbacks;
+	std::list<remove_container_cb> m_remove_callbacks;
 
 	friend class test_helper;
 };

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -78,6 +78,7 @@ public:
 	void create_engines();
 	void cleanup();
 
+	void set_docker_socket_path(std::string socket_path);
 	void set_query_docker_image_info(bool query_image_info);
 	void set_cri_extra_queries(bool extra_queries);
 	void set_cri_socket_path(const std::string& path);

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -83,6 +83,13 @@ bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container
 		return false;
 	}
 
+	container->m_name = "";
+	container->m_image = "";
+	container->m_imageid = "";
+	container->m_imagerepo = "";
+	container->m_imagetag = "";
+	container->m_imagedigest = "";
+
 	runtime::v1alpha2::ContainerStatusRequest req;
 	runtime::v1alpha2::ContainerStatusResponse resp;
 	req.set_container_id(container->m_id);
@@ -222,7 +229,7 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 	existing_container_info = manager->get_container(container_info.m_id);
 
 	if (!existing_container_info ||
-	    existing_container_info->m_metadata_complete == false)
+	    existing_container_info->query_anyway(s_cri_runtime_type))
 	{
 		if (query_os_for_missing_info)
 		{
@@ -230,7 +237,8 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 					"cri (%s): Performing lookup",
 					container_info.m_id.c_str());
 
-			if (!parse_cri(manager, &container_info, tinfo))
+			container_info.m_successful = parse_cri(manager, &container_info, tinfo);
+			if (!container_info.m_successful)
 			{
 				g_logger.format(sinsp_logger::SEV_DEBUG, "cri (%s): Failed to get CRI metadata for container",
 						container_info.m_id.c_str());

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -256,8 +256,10 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 					"cri (%s) Mesos CRI container, Mesos task ID: [%s]",
 					container_info.m_id.c_str(), container_info.m_mesos_task_id.c_str());
 		}
-		manager->add_container(container_info, tinfo);
-		manager->notify_new_container(container_info);
+		if (manager->update_container(container_info) && container_info.m_successful)
+		{
+			manager->notify_new_container(container_info);
+		}
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -32,10 +32,8 @@ limitations under the License.
 
 #include "json/json.h"
 
-#include "async_key_value_source.h"
-
+#include "async_container.h"
 #include "container_info.h"
-
 #include "container_engine/container_engine.h"
 
 class sinsp;
@@ -46,13 +44,7 @@ class sinsp_threadinfo;
 namespace libsinsp {
 namespace container_engine {
 
-struct container_lookup_result
-{
-	bool m_successful;
-	sinsp_container_info m_container_info;
-};
-
-class docker_async_source : public sysdig::async_key_value_source<std::string, container_lookup_result>
+class docker_async_source : public sysdig::async_container_source<std::string>
 {
 	enum docker_response
 	{
@@ -128,8 +120,6 @@ public:
 	// Container name only set for windows. For linux name must be fetched via lookup
 	static bool detect_docker(const sinsp_threadinfo* tinfo, std::string& container_id, std::string &container_name);
 protected:
-	void parse_docker_async(sinsp *inspector, std::string &container_id, sinsp_container_manager *manager);
-
 	std::unique_ptr<docker_async_source> m_docker_info_source;
 };
 }

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -131,8 +131,6 @@ protected:
 	void parse_docker_async(sinsp *inspector, std::string &container_id, sinsp_container_manager *manager);
 
 	std::unique_ptr<docker_async_source> m_docker_info_source;
-
-	static std::string s_incomplete_info_name;
 };
 }
 }

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -54,7 +54,11 @@ class docker_async_source : public sysdig::async_container_source<std::string>
 	};
 
 public:
+#ifdef _WIN32
 	docker_async_source(uint64_t max_wait_ms, uint64_t ttl_ms, sinsp *inspector);
+#else
+	docker_async_source(uint64_t max_wait_ms, uint64_t ttl_ms, sinsp *inspector, std::string socket_path);
+#endif
 	virtual ~docker_async_source();
 
 	static void set_query_image_info(bool query_image_info);
@@ -97,10 +101,10 @@ private:
 
 	sinsp *m_inspector;
 
-	std::string m_docker_unix_socket_path;
 	std::string m_api_version;
 
 #ifndef _WIN32
+	std::string m_docker_unix_socket_path;
 	CURLM *m_curlm;
 	CURL *m_curl;
 #endif
@@ -119,8 +123,17 @@ public:
 
 	// Container name only set for windows. For linux name must be fetched via lookup
 	static bool detect_docker(const sinsp_threadinfo* tinfo, std::string& container_id, std::string &container_name);
+
+#ifndef _WIN32
+	static void set_docker_sock(std::string docker_sock) {
+		m_docker_sock = std::move(docker_sock);
+	}
+#endif
 protected:
 	std::unique_ptr<docker_async_source> m_docker_info_source;
+#ifndef _WIN32
+	static std::string m_docker_sock;
+#endif
 };
 }
 }

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -358,15 +358,18 @@ bool docker::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, 
 	}
 
 	tinfo->m_container_id = container_id;
-	container_info = manager->get_or_create_container(CT_DOCKER, container_id, container_name, tinfo);
+	container_info = manager->get_container(container_id);
 
 #ifdef HAS_CAPTURE
 	// Possibly start a lookup for this container info
-	if(!container_info->m_metadata_complete &&
-	    query_os_for_missing_info)
+	if(container_info == nullptr || container_info->query_anyway(CT_DOCKER))
 	{
-		// give docker a chance to return metadata for this container
-		m_docker_info_source->lookup_container(container_id, manager);
+		container_info = manager->get_or_create_container(CT_DOCKER, container_id, container_name, tinfo);
+		if (query_os_for_missing_info)
+		{
+			// give docker a chance to return metadata for this container
+			m_docker_info_source->lookup_container(container_id, manager);
+		}
 	}
 #endif
 

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -27,7 +27,7 @@ limitations under the License.
 using namespace libsinsp::container_engine;
 
 docker_async_source::docker_async_source(uint64_t max_wait_ms, uint64_t ttl_ms, sinsp *inspector)
-	: async_key_value_source(max_wait_ms, ttl_ms),
+	: sysdig::async_container_source<std::string>(max_wait_ms, ttl_ms),
 	  m_inspector(inspector),
 	  m_docker_unix_socket_path("/var/run/docker.sock"),
 #ifdef _WIN32
@@ -59,13 +59,13 @@ void docker_async_source::run_impl()
 				"docker_async (%s): Source dequeued key",
 				container_id.c_str());
 
-		container_lookup_result res;
+		sinsp_container_info res;
 
 		res.m_successful = true;
-		res.m_container_info.m_type = CT_DOCKER;
-		res.m_container_info.m_id = container_id;
+		res.m_type = CT_DOCKER;
+		res.m_id = container_id;
 
-		if(!parse_docker(container_id, &res.m_container_info))
+		if(!parse_docker(container_id, &res))
 		{
 			// This is not always an error e.g. when using
 			// containerd as the runtime. Since the cgroup
@@ -366,7 +366,7 @@ bool docker::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, 
 	    query_os_for_missing_info)
 	{
 		// give docker a chance to return metadata for this container
-		parse_docker_async(manager->get_inspector(), container_id, manager);
+		m_docker_info_source->lookup_container(container_id, manager);
 	}
 #endif
 
@@ -374,35 +374,6 @@ bool docker::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, 
 	// trying to resolve the container, so only return true if we
 	// have complete metadata.
 	return container_info->m_metadata_complete;
-}
-
-void docker::parse_docker_async(sinsp *inspector, std::string &container_id, sinsp_container_manager *manager)
-{
-	auto cb = [manager](const std::string &container_id, const container_lookup_result &res)
-        {
-		g_logger.format(sinsp_logger::SEV_DEBUG,
-				"docker_async (%s): Source callback result successful=%s",
-				container_id.c_str(),
-				(res.m_successful ? "true" : "false"));
-
-		if(res.m_successful)
-		{
-			manager->notify_new_container(res.m_container_info);
-		}
-	};
-
-        container_lookup_result result;
-
-	if (m_docker_info_source->lookup(container_id, result, cb))
-	{
-		// if a previous lookup call already found the metadata, process it now
-		cb(container_id, result);
-
-		// This should *never* happen, as ttl is 0 (never wait)
-		g_logger.format(sinsp_logger::SEV_ERROR,
-				"docker_async (%s): Unexpected immediate return from docker_info_source.lookup()",
-				container_id.c_str());
-	}
 }
 
 bool docker_async_source::parse_docker(std::string &container_id, sinsp_container_info *container)

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -26,14 +26,19 @@ limitations under the License.
 
 using namespace libsinsp::container_engine;
 
-docker_async_source::docker_async_source(uint64_t max_wait_ms, uint64_t ttl_ms, sinsp *inspector)
+docker_async_source::docker_async_source(uint64_t max_wait_ms, uint64_t ttl_ms,
+	sinsp *inspector
+#ifndef _WIN32
+	, std::string socket_path
+#endif
+	)
 	: sysdig::async_container_source<std::string>(max_wait_ms, ttl_ms),
 	  m_inspector(inspector),
-	  m_docker_unix_socket_path("/var/run/docker.sock"),
 #ifdef _WIN32
 	  m_api_version("/v1.30"),
 #else
 	  m_api_version("/v1.24"),
+	  m_docker_unix_socket_path(std::move(socket_path)),
 	  m_curlm(NULL),
 	  m_curl(NULL)
 #endif
@@ -353,7 +358,11 @@ bool docker::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, 
 		g_logger.log("docker_async: Creating docker async source",
 			     sinsp_logger::SEV_DEBUG);
 		uint64_t max_wait_ms = 10000;
+#ifdef _WIN32
 		docker_async_source *src = new docker_async_source(docker_async_source::NO_WAIT_LOOKUP, max_wait_ms, manager->get_inspector());
+#else
+		docker_async_source *src = new docker_async_source(docker_async_source::NO_WAIT_LOOKUP, max_wait_ms, manager->get_inspector(), m_docker_sock);
+#endif
 		m_docker_info_source.reset(src);
 	}
 

--- a/userspace/libsinsp/container_engine/docker_linux.cpp
+++ b/userspace/libsinsp/container_engine/docker_linux.cpp
@@ -215,7 +215,7 @@ bool docker::detect_docker(const sinsp_threadinfo *tinfo, std::string &container
 	if(matches_runc_cgroups(tinfo, DOCKER_CGROUP_LAYOUT, container_id))
 	{
 		// The container name is only available in windows
-		container_name = s_incomplete_info_name;
+		container_name = "";
 
 		return true;
 	}

--- a/userspace/libsinsp/container_engine/docker_linux.cpp
+++ b/userspace/libsinsp/container_engine/docker_linux.cpp
@@ -49,6 +49,10 @@ docker::docker()
 
 void docker::cleanup()
 {
+	if (m_docker_info_source)
+	{
+		m_docker_info_source->quiesce();
+	}
 	m_docker_info_source.reset(NULL);
 }
 

--- a/userspace/libsinsp/container_engine/docker_linux.cpp
+++ b/userspace/libsinsp/container_engine/docker_linux.cpp
@@ -43,6 +43,8 @@ constexpr const cgroup_layout DOCKER_CGROUP_LAYOUT[] = {
 };
 }
 
+std::string docker::m_docker_sock = "/var/run/docker.sock";
+
 docker::docker()
 {
 }

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -199,6 +199,13 @@ public:
 		return m_is_pod_sandbox;
 	}
 
+	// should we start a query for this container id but with type `type`?
+	// yes, if the container as we know it is of another type
+	// and it's either in flight (i.e. may yet fail) or unsuccessful
+	bool query_anyway(sinsp_container_type type) const {
+		return m_type != type && (!m_successful || !m_metadata_complete);
+	}
+
 	std::shared_ptr<sinsp_threadinfo> get_tinfo(sinsp* inspector) const;
 
 	// Match a process against the set of health probes

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -184,6 +184,7 @@ public:
 		m_cpu_period(100000),
 		m_is_pod_sandbox(false),
 		m_metadata_complete(true),
+		m_successful(true),
 		m_metadata_deadline(0)
 	{
 	}
@@ -231,6 +232,9 @@ public:
 	// container that will be filled in later as a result of an
 	// async fetch of container info.
 	bool m_metadata_complete;
+
+	// if false, the lookup finished unsuccessfully
+	bool m_successful;
 #ifdef HAS_ANALYZER
 	std::string m_sysdig_agent_conf;
 #endif

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -363,16 +363,20 @@ private:
 
 	const char* get_param_value_str(const char* name, OUT const char** resolved_str, param_fmt fmt = PF_NORMAL);
 
-	inline void init()
+	inline void init_keep_threadinfo()
 	{
 		m_flags = EF_NONE;
 		m_info = &(m_event_info_table[m_pevt->type]);
-		m_tinfo_ref.reset();
-		m_tinfo = NULL;
 		m_fdinfo = NULL;
 		m_fdinfo_name_changed = false;
 		m_iosize = 0;
 		m_poriginal_evt = NULL;
+	}
+	inline void init()
+	{
+		init_keep_threadinfo();
+		m_tinfo_ref.reset();
+		m_tinfo = NULL;
 	}
 	inline void init(uint8_t* evdata, uint16_t cpuid)
 	{

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -259,7 +259,7 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 						tinfo->m_container_id.c_str());
 				}
 
-				const unordered_map<string, sinsp_container_info>* clist = m_inspector->m_container_manager.get_containers();
+				const auto clist = m_inspector->m_container_manager.get_containers();
 
 				for(auto it = clist->begin(); it != clist->end(); ++it)
 				{

--- a/userspace/libsinsp/mutex.h
+++ b/userspace/libsinsp/mutex.h
@@ -1,0 +1,166 @@
+/*
+Copyright (C) 2019 Draios Inc dba Sysdig.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <mutex>
+#include <thread>
+
+namespace libsinsp {
+template<typename T>
+class ConstMutexGuard;
+
+/**
+ * \brief A wrapper to allow synchronized access to a value owned by a Mutex<T>
+ *
+ * @tparam T type of the value protected by the mutex
+ *
+ * It works by simply holding a `std::unique_lock` object that keeps the mutex
+ * locked while it exists and unlocks it upon destruction
+ */
+template<typename T>
+class MutexGuard {
+public:
+	MutexGuard(std::unique_lock<std::mutex> lock, T *inner) : m_lock(std::move(lock)), m_inner(inner) {}
+
+	// we cannot copy a MutexGuard, only move
+	MutexGuard(MutexGuard &rhs) = delete;
+	MutexGuard& operator=(MutexGuard &rhs) = delete;
+	MutexGuard(MutexGuard &&rhs) noexcept : m_lock(std::move(rhs.m_lock)),
+						m_inner(rhs.m_inner) {}
+
+	T *operator->()
+	{
+		return m_inner;
+	}
+
+	T &operator*()
+	{
+		return *m_inner;
+	}
+
+private:
+	std::unique_lock<std::mutex> m_lock;
+	T *m_inner;
+
+	friend class ConstMutexGuard<T>;
+};
+
+/**
+ * \brief A wrapper to allow synchronized const access to a value owned by a Mutex<T>
+ *
+ * @tparam T type of the value protected by the mutex
+ *
+ * It works by simply holding a `std::unique_lock` object that keeps the mutex
+ * locked while it exists and unlocks it upon destruction
+ */
+template<typename T>
+class ConstMutexGuard {
+public:
+	ConstMutexGuard(std::unique_lock<std::mutex> lock, const T *inner) : m_lock(std::move(lock)),
+									     m_inner(inner) {
+	}
+
+	// we cannot copy a ConstMutexGuard, only move
+	ConstMutexGuard(ConstMutexGuard &rhs) = delete;
+	ConstMutexGuard& operator=(ConstMutexGuard &rhs) = delete;
+	ConstMutexGuard(ConstMutexGuard &&rhs) noexcept : m_lock(std::move(rhs.m_lock)),
+							  m_inner(rhs.m_inner) {}
+
+	// a writable guard can be demoted to a read-only one, but *not* the other way around
+	ConstMutexGuard(MutexGuard<T> &&rhs) noexcept : m_lock(std::move(rhs.m_lock)),
+	                                                m_inner(rhs.m_inner) // NOLINT(google-explicit-constructor)
+	{}
+
+	const T *operator->() const
+	{
+		return m_inner;
+	}
+
+	const T &operator*() const
+	{
+		return *m_inner;
+	}
+
+private:
+	std::unique_lock<std::mutex> m_lock;
+	const T *m_inner;
+};
+
+/**
+ * \brief Wrap a value of type T, enforcing synchronized access
+ *
+ * @tparam T type of the wrapped value
+ *
+ * The class owns a value of type T and a mutex. The only way to access the T inside
+ * is via the lock() method, which returns a guard object that unlocks the mutex
+ * once it falls out of scope
+ *
+ * To protect an object with a mutex, declare a variable of type `Mutex<T>`, e.g.
+ *
+ * Mutex<std::vector<int>> m_locked_vector;
+ *
+ * Then, to access the variable, call .lock() on the Mutex object:
+ *
+ * MutexGuard<std::vector<int>> locked = m_locked_vector.lock();
+ *
+ * Now you can call the inner object's methods directly on the guard object,
+ * which behaves like a smart pointer to the inner object:
+ *
+ * size_t num_elts = locked->size();
+ *
+ */
+template<typename T>
+class Mutex {
+public:
+	Mutex() = default;
+
+	Mutex(T inner) : m_inner(std::move(inner)) {}
+
+	/**
+	 * \brief Lock the mutex, allowing access to the stored object
+	 *
+	 * The returned guard object allows access to the protected data
+	 * via operator * or -> and ensures the lock is held as long as
+	 * the guard object exists
+	 */
+	MutexGuard<T> lock()
+	{
+		return MutexGuard<T>(std::unique_lock<std::mutex>(m_lock), &m_inner);
+	}
+
+	/**
+	 * \brief Lock the mutex, allowing access to the stored object
+	 *
+	 * The returned guard object allows access to the protected data
+	 * via operator * or -> and ensures the lock is held as long as
+	 * the guard object exists
+	 *
+	 * `const Mutex<T>` only allows read-only access to the protected object
+	 */
+	ConstMutexGuard<T> lock() const
+	{
+		return ConstMutexGuard<T>(std::unique_lock<std::mutex>(m_lock), &m_inner);
+	}
+
+private:
+	mutable std::mutex m_lock;
+	T m_inner;
+};
+}

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4719,6 +4719,26 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 				SINSP_DEBUG("Unable to convert json value for field: %s", "metadata_deadline");
 			}
 		}
+		const Json::Value& successful = container["successful"];
+		if(!successful.isNull()) // otherwise, the default is `true`, which is fine
+		{
+			if(successful.isUInt64()) {
+				container_info.m_successful = successful.asUInt64();
+			} else {
+				SINSP_DEBUG("Unable to convert json value for field: %s", "successful");
+			}
+		}
+
+		if(!container_info.m_successful)
+		{
+			auto existing_container = m_inspector->m_container_manager.get_container(container_info.m_id);
+			if(existing_container && existing_container->m_successful)
+			{
+				SINSP_DEBUG("Ignoring failed metadata for container %s, successful metadata already present (got: %s)",
+					container_info.m_id.c_str(), json.c_str());
+				return;
+			}
+		}
 
 		evt->m_tinfo_ref = container_info.get_tinfo(m_inspector);
 		evt->m_tinfo = evt->m_tinfo_ref.get();

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1589,6 +1589,11 @@ void sinsp::add_suppressed_comms(scap_open_args &oargs)
 	oargs.suppressed_comms[i++] = NULL;
 }
 
+void sinsp::set_docker_socket_path(std::string socket_path)
+{
+	m_container_manager.set_docker_socket_path(std::move(socket_path));
+}
+
 void sinsp::set_query_docker_image_info(bool query_image_info)
 {
 	m_container_manager.set_query_docker_image_info(query_image_info);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -894,6 +894,7 @@ public:
 
 	bool check_suppressed(int64_t tid);
 
+	void set_docker_socket_path(std::string socket_path);
 	void set_query_docker_image_info(bool query_image_info);
 
 	void set_cri_extra_queries(bool extra_queries);


### PR DESCRIPTION
(this applies only to Docker ATM but async CRI is coming soon)

This PR decouples the two meanings of `!m_metadata_complete`:
• an async lookup is still in progress
• an async lookup finished and reported a failure

To avoid getting stuck with `incomplete` containers, we update container metadata even when the lookup fails. We generate container JSON events only if we haven't yet seen a successful lookup from a different engine (to avoid races between successful Docker lookups and failed CRI ones, or vice versa).

It also moves some Docker-specific code to generic infrastructure to be shared across async container engines.