### PR TITLE
Exit properly on one-item Test Json arrays

### DIFF
--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -206,8 +206,8 @@ void docker_async_source::parse_healthcheck(const Json::Value &healthcheck_obj,
 		{
 			g_logger.format(sinsp_logger::SEV_WARNING, "Could not parse health check from %s (Expected NONE for single-element Test array)",
 					Json::FastWriter().write(healthcheck_obj).c_str());
-			return;
 		}
+		return;
 	}
 
 	if(test_obj[0].asString() == "CMD")


### PR DESCRIPTION
If the value of Test actually is a single-item array,
parse_healthcheck() should return regardless of whether the single item
is NONE or not. (It will log a warning if it is anything other than
NONE).

This fixes https://sysdig.atlassian.net/browse/SMAGENT-1791.