### PR TITLE
[SMAGENT-1713] Add an RHEL build that pulls rpms from artifactory

### DIFF
--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -223,7 +223,6 @@ function coreos_build_new {
 		LOOPDEV=$(sudo kpartx -asv coreos_developer_container.bin | cut -d\  -f 3)
 		sudo mkdir /tmp/loop || true
 		sudo mount /dev/mapper/$LOOPDEV /tmp/loop
-
 		# Copy kernel headers
 		cp -r /tmp/loop/lib/modules .
 
@@ -393,7 +392,7 @@ function rhel_build {
 	# We need two rpms (devel and core) to get what we need
 	if [ $NUM_RPM -eq 2 ]; then
 
-		echo Building $KERNEL_RELEASE
+		#echo Building $KERNEL_RELEASE
 
 		if [ -f boot/config-$KERNEL_RELEASE ]; then
 			HASH=$(md5sum boot/config-$KERNEL_RELEASE | cut -d' ' -f1)
@@ -598,7 +597,6 @@ if [ -z "$KERNEL_TYPE" ]; then
 	echo Building Fedora Atomic
 	DIR=$(dirname $(readlink -f $0))
 	URLS="$($DIR/kernel-crawler.py Fedora-Atomic)"
-
 	for URL in $URLS
 	do
 		rhel_build $URL
@@ -753,10 +751,10 @@ elif [ "RHEL" = "$KERNEL_TYPE" ]; then
 
 	echo Building RHEL from Stored Sources
 
-	# We're using aql to query for all of the objects in the repo then
-	# using jq to part the json
+	# We're using aql to query for all of the objects in the repo
 	JSON_RESULT=$(curl -H 'Content-Type: text/plain' -H "X-JFrog-Art-Api:$INTERNAL_ARTIFACTORY_API_KEY" -X POST -d 'items.find({"repo":"redhat-sources"})' https:///artifactory.internal.sysdig.com/artifactory/api/search/aql)
 
+	# Use jq to parse the json to get the rpms
 	URLS=$(echo "$JSON_RESULT"| jq -r '.results[].name as $o | $o | select(endswith(".rpm")) | "https://artifactory.internal.sysdig.com/artifactory/redhat-sources/" + $o')
 
 	for URL in $URLS

--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -28,13 +28,20 @@ PROBE_NAME=$1
 PROBE_VERSION=$2
 REPOSITORY_NAME=$3
 KERNEL_TYPE=
+INTERNAL_ARTIFACTORY_API_KEY=
 BASEDIR=$(pwd)
 ARCH=$(uname -m)
 URL_TIMEOUT=300
 RETRY=10
 
-if [ $# -eq 4 ]; then
+if [ $# -ge 4 ]; then
 	KERNEL_TYPE=$4
+
+	echo KERNEL TYPE is $KERNEL_TYPE
+
+	if [ "RHEL" = "$KERNEL_TYPE" ]; then
+		INTERNAL_ARTIFACTORY_API_KEY=$5
+	fi
 fi
 
 if [ ! -d $BASEDIR/output ]; then
@@ -216,7 +223,7 @@ function coreos_build_new {
 		LOOPDEV=$(sudo kpartx -asv coreos_developer_container.bin | cut -d\  -f 3)
 		sudo mkdir /tmp/loop || true
 		sudo mount /dev/mapper/$LOOPDEV /tmp/loop
-		
+
 		# Copy kernel headers
 		cp -r /tmp/loop/lib/modules .
 
@@ -272,10 +279,10 @@ function boot2docker_build {
 		cd $DIR_NAME
 		make distclean
 		git clone -b "$AUFS_BRANCH" "$AUFS_REPO" aufs-standalone
-		cd aufs-standalone 
+		cd aufs-standalone
 		git checkout -q "$AUFS_COMMIT"
 		cd ..
-		cp -r aufs-standalone/Documentation . 
+		cp -r aufs-standalone/Documentation .
 		cp -r aufs-standalone/fs .
 		cp -r aufs-standalone/include/uapi/linux/aufs_type.h include/uapi/linux/
 		set -e && for patch in \
@@ -357,6 +364,10 @@ function rhel_build {
 
 	# Get all the parameters needed
 	URL=$1
+
+	# Optionally take an artifactory api key.
+	ARTIFACTORY_API_KEY="${2:-""}"
+
 	RPM=$(echo $URL | grep -o '[^/]*$')
 	KERNEL_RELEASE=$(echo $RPM | awk 'match($0, /[^kernel\-(uek\-)?(core\-|devel\-)?].*[^(\.rpm)]/){ print substr($0, RSTART, RLENGTH) }')
 
@@ -368,15 +379,21 @@ function rhel_build {
 
 	if [ ! -f $RPM ]; then
 		echo Downloading $RPM [RHEL and CentOS]
-		wget -nv --timeout=${URL_TIMEOUT} --tries=${RETRY} $URL
+
+		if [ -z "$ARTIFACTORY_API_KEY" ]; then
+			wget -nv --timeout=${URL_TIMEOUT} --tries=${RETRY} $URL
+		else
+			curl -H "X-JFrog-Art-Api:$ARTIFACTORY_API_KEY" -O $URL
+		fi
 		rpm2cpio $RPM | cpio -idm
 	fi
 
 	NUM_RPM=$(ls kernel-*.rpm -1 | wc -l)
 
+	# We need two rpms (devel and core) to get what we need
 	if [ $NUM_RPM -eq 2 ]; then
 
-		#echo Building $KERNEL_RELEASE
+		echo Building $KERNEL_RELEASE
 
 		if [ -f boot/config-$KERNEL_RELEASE ]; then
 			HASH=$(md5sum boot/config-$KERNEL_RELEASE | cut -d' ' -f1)
@@ -550,10 +567,10 @@ if [ -z "$KERNEL_TYPE" ]; then
 	done
 
 	#
-	# RHEL build
+	# RHEL build through CentOS
 	#
 
-	echo Building RHEL
+	echo Building CentOS
 	DIR=$(dirname $(readlink -f $0))
 	URLS="$($DIR/kernel-crawler.py CentOS)"
 
@@ -581,7 +598,7 @@ if [ -z "$KERNEL_TYPE" ]; then
 	echo Building Fedora Atomic
 	DIR=$(dirname $(readlink -f $0))
 	URLS="$($DIR/kernel-crawler.py Fedora-Atomic)"
-	
+
 	for URL in $URLS
 	do
 		rhel_build $URL
@@ -725,6 +742,27 @@ if [ -z "$KERNEL_TYPE" ]; then
 	#fi
 
 	echo "Success."
+
+
+elif [ "RHEL" = "$KERNEL_TYPE" ]; then
+	#
+	# RHEL build from Stored Sources
+	#
+
+        checkout_sysdig
+
+	echo Building RHEL from Stored Sources
+
+	# We're using aql to query for all of the objects in the repo then
+	# using jq to part the json
+	JSON_RESULT=$(curl -H 'Content-Type: text/plain' -H "X-JFrog-Art-Api:$INTERNAL_ARTIFACTORY_API_KEY" -X POST -d 'items.find({"repo":"redhat-sources"})' https:///artifactory.internal.sysdig.com/artifactory/api/search/aql)
+
+	URLS=$(echo "$JSON_RESULT"| jq -r '.results[].name as $o | $o | select(endswith(".rpm")) | "https://artifactory.internal.sysdig.com/artifactory/redhat-sources/" + $o')
+
+	for URL in $URLS
+	do
+		rhel_build $URL $INTERNAL_ARTIFACTORY_API_KEY
+	done
 
 elif [ "OL6-UEK" = "$KERNEL_TYPE" ]; then
 	# This should only run in the ol6-builder container context


### PR DESCRIPTION
I manually added the Red Hat rpms to artifactory and updated the script to pull those instead of pulling from the internet. I purposely kept it as a separate script call.

This is because we can't do the just-in-time probe build on RedHat CoreOS in Openshift4. We are talking to RedHat people so hopefully this is just a stopgap until we get a better solution.

```
bryan@bryan-build:~/test$ /draios/sysdig/scripts/build-probe-binaries sysdigcloud-probe 0.90.3 X RHEL <API-KEY>
KERNEL TYPE is RHEL
Cloning into 'sysdig'...
Enter passphrase for key '/home/bryan/.ssh/id_rsa':
remote: Enumerating objects: 165, done.
remote: Counting objects: 100% (165/165), done.
remote: Compressing objects: 100% (73/73), done.
remote: Total 33249 (delta 107), reused 127 (delta 91), pack-reused 33084
Receiving objects: 100% (33249/33249), 14.76 MiB | 7.60 MiB/s, done.
Resolving deltas: 100% (25676/25676), done.
Note: checking out 'agent/0.90.3'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at 17cf0a8c Merge branch 'dev' into agent-master-3
Building RHEL from Stored Sources
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1154    0  1117  100    37   4899    162 --:--:-- --:--:-- --:--:--  5039
Downloading kernel-core-4.18.0-80.1.2.el8_0.x86_64.rpm [RHEL and CentOS]
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 23.6M  100 23.6M    0     0  8001k      0  0:00:03  0:00:03 --:--:-- 8004k
52922 blocks
Downloading kernel-devel-4.18.0-80.1.2.el8_0.x86_64.rpm [RHEL and CentOS]
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12.2M  100 12.2M    0     0  7607k      0  0:00:01  0:00:01 --:--:-- 7602k
99272 blocks
Building 4.18.0-80.1.2.el8_0.x86_64
Building sysdigcloud-probe-0.90.3-x86_64-4.18.0-80.1.2.el8_0.x86_64-3a23dd0bd9b99585050853784f5495b6.ko [rhel_build]
HEAD is now at 17cf0a8c Merge branch 'dev' into agent-master-3
-- The C compiler identification is GNU 7.4.0
-- The CXX compiler identification is GNU 7.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using bundled LuaJIT in '/home/bryan/test/sysdig/build/luajit-prefix/src/luajit/src'
-- Using bundled jsoncpp in '/home/bryan/test/sysdig/userspace/libsinsp/third-party/jsoncpp'
-- Using bundled zlib in '/home/bryan/test/sysdig/build/zlib-prefix/src/zlib'
-- Using bundled tbb in '/home/bryan/test/sysdig/build/tbb-prefix/src/tbb'
-- Using bundled jq in '/home/bryan/test/sysdig/build/jq-prefix/src/jq'
-- Using bundled ncurses in '/home/bryan/test/sysdig/build/ncurses-prefix/src/ncurses'
-- Using bundled b64 in '/home/bryan/test/sysdig/build/b64-prefix/src/b64'
-- Using bundled openssl in '/home/bryan/test/sysdig/build/openssl-prefix/src/openssl'
-- Using bundled curl in '/home/bryan/test/sysdig/build/curl-prefix/src/curl'
-- Using SSL for curl in '--with-ssl=/home/bryan/test/sysdig/build/openssl-prefix/src/openssl/target'
-- Using bundled c-ares in '/home/bryan/test/sysdig/build/c-ares-prefix/src/c-ares'
-- Using bundled protobuf in '/home/bryan/test/sysdig/build/protobuf-prefix/src/protobuf'
-- Using bundled grpc in '/home/bryan/test/sysdig/build/grpc-prefix/src/grpc'
-- Configuring done
-- Generating done
-- Build files have been written to: /home/bryan/test/sysdig/build
Scanning dependencies of target driver
Built target driver
bryan@bryan-build:~/test$ ls output/
sysdigcloud-probe-0.90.3-x86_64-4.18.0-80.1.2.el8_0.x86_64-3a23dd0bd9b99585050853784f5495b6.ko
```