### PR TITLE
Defer machine-readable formatting of user events to callbacks

### DIFF
--- a/userspace/libsinsp/json_error_log.cpp
+++ b/userspace/libsinsp/json_error_log.cpp
@@ -74,7 +74,6 @@ void json_error_log::log(const std::string &json, const std::string &errstr,
 
 	if(bucket.claim(1, ts_ns))
 	{
-		sinsp_user_event evt;
 		sinsp_user_event::tag_map_t tags;
 		tags["source"] = "json_parser";
 		tags["uri"] = uri;
@@ -89,15 +88,16 @@ void json_error_log::log(const std::string &json, const std::string &errstr,
 		}
 
 		// Also emit a custom event noting the json parse failure.
-		std::string evtstr = sinsp_user_event::to_string(now,
-								 std::move(event_name),
-								 std::move(desc),
-								 std::move(scope),
-								 std::move(tags));
+		auto evt = sinsp_user_event(now,
+					       std::move(event_name),
+					       std::move(desc),
+					       std::move(scope.get_ref()),
+					       std::move(tags),
+					       user_event_logger::SEV_EVT_WARNING);
 
-		g_logger.log("Logging user event: " + evtstr, sinsp_logger::SEV_DEBUG);
+		g_logger.log("Logging user event: " + evt.to_string(), sinsp_logger::SEV_DEBUG);
 
-		user_event_logger::log(evtstr, user_event_logger::SEV_EVT_WARNING);
+		user_event_logger::log(evt, user_event_logger::SEV_EVT_WARNING);
 	}
 }
 

--- a/userspace/libsinsp/k8s_component.cpp
+++ b/userspace/libsinsp/k8s_component.cpp
@@ -909,12 +909,15 @@ bool k8s_event_t::update(const Json::Value& item, k8s_state_t& state)
 	}
 
 	tags["source"] = "kubernetes";
-	user_event_logger::log(sinsp_user_event::to_string(epoch_time_evt_s,
-	                                                   std::move(event_name),
-	                                                   std::move(description),
-	                                                   std::move(scope),
-	                                                   std::move(tags)),
-	                       severity);
+
+	auto evt = sinsp_user_event(epoch_time_evt_s,
+				    std::move(event_name),
+				    std::move(description),
+				    std::move(scope.get_ref()),
+				    std::move(tags),
+				    severity);
+
+	user_event_logger::log(evt, severity);
 
 	// TODO: sysdig capture?
 #endif // _WIN32

--- a/userspace/libsinsp/user_event.cpp
+++ b/userspace/libsinsp/user_event.cpp
@@ -392,38 +392,28 @@ sinsp_user_event& sinsp_user_event::operator=(sinsp_user_event&& other)
 	return *this;
 }
 
-std::string sinsp_user_event::to_string(uint64_t timestamp,
-										std::string&& name,
-										std::string&& description,
-										event_scope&& scope,
-										tag_map_t&& tags,
-										uint32_t sev)
+std::string sinsp_user_event::to_string()
 {
-	const std::string from("\"");
-	const std::string to("\\\"");
-
 	std::ostringstream ostr;
-	ostr << "timestamp: " << timestamp << '\n' <<
-			"name: \"" << replace_in_place(name, from, to) << "\"\n"
-			"description: \"" << replace_in_place(description, from, to) << "\"\n"
-			"scope: \"" << replace_in_place(scope.get_ref(), from, to) << "\"\n";
+	ostr << "timestamp: " << m_epoch_time_s << '\n' <<
+			"name: " << m_name << "\n"
+			"description: " << m_description << "\"\n"
+			"scope: " << m_scope << "\"\n";
 
-	if(sev != UNKNOWN_SEVERITY)
+	if(m_severity != UNKNOWN_SEVERITY)
 	{
-		ostr << "priority: " << sev << '\n';
+		ostr << "priority: " << m_severity << '\n';
 	}
 
-	if(tags.size())
+	if(m_tags.size())
 	{
 		ostr << "tags:";
-		for(auto& tag : tags)
+		for(auto& tag : m_tags)
 		{
-			ostr << "\n  \"" << replace(tag.first, from, to) << "\": \""
-				<< replace_in_place(tag.second, from, to) << '"';
+			ostr << "\n  " << tag.first << ": " << tag.second;
 		}
 	}
 	ostr << std::flush;
-	g_logger.log(ostr.str(), sinsp_logger::SEV_DEBUG);
 	return ostr.str();
 }
 
@@ -442,10 +432,14 @@ void sinsp_user_event::emit_event_overflow(const std::string& component,
 		scope.append("host.mac=").append(machine_id);
 	}
 	tag_map_t tags{{"source", source}};
-	user_event_logger::log(sinsp_user_event::to_string(get_epoch_utc_seconds_now(),
-	                                                   std::move(event_name),
-	                                                   description.str(),
-	                                                   std::move(scope),
-	                                                   std::move(tags)),
-	                       user_event_logger::SEV_EVT_WARNING);
+
+	auto evt = sinsp_user_event(
+		get_epoch_utc_seconds_now(),
+		std::move(event_name),
+		description.str(),
+		std::move(scope),
+		std::move(tags),
+		user_event_logger::SEV_EVT_WARNING);
+
+	user_event_logger::log(evt, user_event_logger::SEV_EVT_WARNING);
 }

--- a/userspace/libsinsp/user_event.h
+++ b/userspace/libsinsp/user_event.h
@@ -280,12 +280,15 @@ public:
 	const std::string& scope() const;
 	const tag_map_t& tags() const;
 
-	static std::string to_string(uint64_t timestamp,
-								std::string&& name,
-								std::string&& description,
-								event_scope&& scope,
-								tag_map_t&& tags,
-								uint32_t sev = UNKNOWN_SEVERITY);
+	/**
+	 * \brief Format the event as a YAML-like human readable string
+	 * @return the formatted string
+	 *
+	 * Note: While the format looks superficially similar to YAML, it's not.
+	 * This method does not generate valid YAML, especially when characters
+	 * like quotes, backslashes or newlines are found in any of the fields
+	 */
+	std::string to_string();
 
 	static void emit_event_overflow(const std::string& component,
 									const std::string& machine_id,

--- a/userspace/libsinsp/user_event_logger.cpp
+++ b/userspace/libsinsp/user_event_logger.cpp
@@ -29,7 +29,7 @@ namespace
 class null_callback : public user_event_logger::callback
 {
 public:
-	void log(std::string&& str,
+	void log(const sinsp_user_event& evt,
 	         const user_event_logger::severity severity) override
 	{ }
 
@@ -41,10 +41,10 @@ user_event_logger::callback::ptr_t s_callback = std::make_shared<null_callback>(
 
 } // end namespace
 
-void user_event_logger::log(std::string msg,
+void user_event_logger::log(const sinsp_user_event& evt,
                             const user_event_logger::severity severity)
 {
-	s_callback->log(std::move(msg), severity);
+	s_callback->log(evt, severity);
 }
 
 void user_event_logger::register_callback(callback::ptr_t callback)

--- a/userspace/libsinsp/user_event_logger.h
+++ b/userspace/libsinsp/user_event_logger.h
@@ -18,6 +18,7 @@ limitations under the License.
 */
 #pragma once
 #include <memory>
+#include "user_event.h"
 
 /**
  * This namespace exposes an API for logging user events.
@@ -53,7 +54,7 @@ public:
 	/**
 	 * Write the given log str with the given severity.
 	 */
-	virtual void log(std::string&& str, user_event_logger::severity sev) = 0;
+	virtual void log(const sinsp_user_event& evt, user_event_logger::severity sev) = 0;
 
 	/**
 	 * We use the "Null Object Pattern" with this interface; this will
@@ -66,7 +67,7 @@ public:
  * Write the given user event log message with the given severity to the
  * registered callback.
  */
-void log(std::string msg, user_event_logger::severity sev);
+void log(const sinsp_user_event& evt, user_event_logger::severity sev);
 
 /**
  * Register the given callback.  If a callback is already registered, it will


### PR DESCRIPTION
The YAML serializer in user_event.cpp was incomplete and libsinsp effectively uses it only to format user-visible log messages so forget about trying to make it valid YAML (would need to add
an extra dependency).

Registered log callbacks now take the unformatted event object and can serialize it however they want.