### PR TITLE
Allow skipping cgroup path check for container resource limits

### DIFF
--- a/userspace/libsinsp/cgroup_limits.cpp
+++ b/userspace/libsinsp/cgroup_limits.cpp
@@ -42,17 +42,13 @@ bool read_cgroup_val(std::shared_ptr<std::string>& subsys,
 namespace libsinsp {
 namespace cgroup_limits {
 
-bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_value& value, bool report_no_cgroup)
+bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_value& value, bool name_check)
 {
 	bool found_all = true;
-	auto no_cg_log_level = report_no_cgroup
-		? sinsp_logger::SEV_INFO
-		: sinsp_logger::SEV_DEBUG;
-
 	std::shared_ptr<std::string> memcg_root = sinsp::lookup_cgroup_dir("memory");
-	if(key.m_mem_cgroup.find(key.m_container_id) == std::string::npos)
+	if(name_check && key.m_mem_cgroup.find(key.m_container_id) == std::string::npos)
 	{
-		g_logger.format(no_cg_log_level, "(cgroup-limits) mem cgroup for container [%s]: %s/%s -- no per-container memory cgroup, ignoring",
+		g_logger.format(sinsp_logger::SEV_INFO, "(cgroup-limits) mem cgroup for container [%s]: %s/%s -- no per-container memory cgroup, ignoring",
 			key.m_container_id.c_str(), memcg_root->c_str(), key.m_mem_cgroup.c_str());
 	}
 	else
@@ -63,9 +59,9 @@ bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_valu
 	}
 
 	std::shared_ptr<std::string> cpucg_root = sinsp::lookup_cgroup_dir("cpu");
-	if(key.m_cpu_cgroup.find(key.m_container_id) == std::string::npos)
+	if(name_check && key.m_cpu_cgroup.find(key.m_container_id) == std::string::npos)
 	{
-		g_logger.format(no_cg_log_level, "(cgroup-limits) cpu cgroup for container [%s]: %s/%s -- no per-container CPU cgroup, ignoring",
+		g_logger.format(sinsp_logger::SEV_INFO, "(cgroup-limits) cpu cgroup for container [%s]: %s/%s -- no per-container CPU cgroup, ignoring",
 				key.m_container_id.c_str(), cpucg_root->c_str(), key.m_cpu_cgroup.c_str());
 	}
 	else

--- a/userspace/libsinsp/cgroup_limits.h
+++ b/userspace/libsinsp/cgroup_limits.h
@@ -56,10 +56,10 @@ struct cgroup_limits_value {
  * @param key the container to read limits for
  * @param value output value. when the return value is false, specific fields
  *         may or may not have been modified
- * @param report_no_cgroup if true, log a message when the container doesn't
- *         use its own cgroups for mem/cpu and we ignore the values.
- *         We want to log this only once since the cgroups will stay the same
- *         during subsequent lookups
+ * @param name_check if true and the container doesn't use its own cgroups
+ *         for mem/cpu, we log a message and we ignore the values.
+ *         "Use its own cgroups" means the container id is present in the cgroup
+ *         path, which may not be true for all container engines.
  * @return true when all values have been successfully read, false otherwise
  *
  * Note: reading a zero/negative/very large value is considered a failure,
@@ -68,7 +68,7 @@ struct cgroup_limits_value {
  * in the future", while `true` means we really don't expect them to change
  * any more.
  */
-bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_value& value, bool report_no_cgroup = true);
+bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_value& value, bool name_check = true);
 
 }
 }


### PR DESCRIPTION
Usually the container ID is present in cgroup paths and the code that reads resource limits from cgroups checks that to avoid treating e.g. root cgroup settings as per-container values.

In some cases we want to skip the check and read the limits even if the cgroup path does not contain the container ID.