### PR TITLE
fix(cmake): look for pkg-config when building grpc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,6 +499,11 @@ if(NOT WIN32 AND NOT APPLE)
 			message(FATAL_ERROR "System grpc_cpp_plugin not found")
 		endif()
 	else()
+		find_package(PkgConfig)
+		if(NOT PKG_CONFIG_FOUND)
+			message(FATAL_ERROR "pkg-config binary not found")
+		endif()
+		message(STATUS "Found pkg-config executable: ${PKG_CONFIG_EXECUTABLE}")
 		set(GRPC_SRC "${PROJECT_BINARY_DIR}/grpc-prefix/src/grpc")
 		message(STATUS "Using bundled grpc in '${GRPC_SRC}'")
 		set(GRPC_INCLUDE "${GRPC_SRC}/include")
@@ -514,7 +519,7 @@ if(NOT WIN32 AND NOT APPLE)
 		URL_MD5 "2fc42c182a0ed1b48ad77397f76bb3bc"
 		CONFIGURE_COMMAND ""
 		# TODO what if using system openssl, protobuf or cares?
-		BUILD_COMMAND CFLAGS=-Wno-implicit-fallthrough HAS_SYSTEM_ZLIB=false LDFLAGS=-static PATH=${PROTOC_DIR}:$ENV{PATH} PKG_CONFIG_PATH=${OPENSSL_BUNDLE_DIR}:${PROTOBUF_SRC}:${CARES_SRC} make grpc_cpp_plugin static_cxx static_c
+		BUILD_COMMAND CFLAGS=-Wno-implicit-fallthrough HAS_SYSTEM_ZLIB=false LDFLAGS=-static PATH=${PROTOC_DIR}:$ENV{PATH} PKG_CONFIG_PATH=${OPENSSL_BUNDLE_DIR}:${PROTOBUF_SRC}:${CARES_SRC} PKG_CONFIG=${PKG_CONFIG_EXECUTABLE} make grpc_cpp_plugin static_cxx static_c
 		BUILD_IN_SOURCE 1
 		BUILD_BYPRODUCTS ${GRPC_LIB} ${GRPCPP_LIB}
 		# TODO s390x support


### PR DESCRIPTION
Find pkg-config sooner than later, to avoid people to stumble into this error:

```
[ 40%] Performing patch step for 'grpc'
--2019-08-06 22:19:23--  https://download.sysdig.com/dependencies/grpc-1.8.1-Makefile.patch
Resolving download.sysdig.com (download.sysdig.com)... 54.230.117.108, 54.230.117.175, 54.230.117.33, ...
Connecting to download.sysdig.com (download.sysdig.com)|54.230.117.108|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 673 [binary/octet-stream]
Saving to: 'grpc-1.8.1-Makefile.patch'

grpc-1.8.1-Makefile.patch  100%[======================================>]     673  --.-KB/s    in 0s

2019-08-06 22:19:24 (59.0 MB/s) - 'grpc-1.8.1-Makefile.patch' saved [673/673]

patching file Makefile
[ 40%] No update step for 'grpc'
[ 40%] No configure step for 'grpc'
[ 41%] Performing build step for 'grpc'

DEPENDENCY ERROR

The target you are trying to run requires protobuf 3.0.0+
Your system doesn't have it, and neither does the third_party directory.

Please consult INSTALL to get more information.

If you need information about why these tests failed, run:

  make run_dep_checks
```

Signed-off-by: Lorenzo Fontana <lo@linux.com>