### PR TITLE
Fix driver build for RHEL 7.7/4.13+ w/CONFIG_VIRT_CPU_ACCOUNTING_GEN

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -58,6 +58,7 @@ set(DRIVER_SOURCES
 	syscall_table.c
 	ppm_cputime.c
 	ppm_compat_unistd_32.h
+	ppm_version.h
 )
 
 foreach(FILENAME IN LISTS DRIVER_SOURCES)

--- a/driver/ppm_cputime.c
+++ b/driver/ppm_cputime.c
@@ -34,6 +34,7 @@ or GPL2.txt for full copies of the license.
 #include "ppm_events_public.h"
 #include "ppm_events.h"
 #include "ppm.h"
+#include "ppm_version.h"
 
 #if (defined CONFIG_VIRT_CPU_ACCOUNTING_NATIVE) || (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 30))
 void ppm_task_cputime_adjusted(struct task_struct *p, cputime_t *ut, cputime_t *st)
@@ -48,15 +49,26 @@ void ppm_task_cputime_adjusted(struct task_struct *p, cputime_t *ut, cputime_t *
 #endif
 
 #ifdef CONFIG_VIRT_CPU_ACCOUNTING_GEN
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)) || (PPM_RHEL_RELEASE_CODE > 0 && PPM_RHEL_RELEASE_CODE >= PPM_RHEL_RELEASE_VERSION(7, 7))
+#define ppm_vtime_starttime(tsk) ((tsk)->vtime.starttime)
+#define ppm_vtime_seqlock(tsk) (&(tsk)->vtime.seqlock)
+#define ppm_vtime_state(tsk) ((tsk)->vtime.state)
+#else
+#define ppm_vtime_starttime(tsk) ((tsk)->vtime_snap)
+#define ppm_vtime_seqlock(tsk) (&(tsk)->vtime_seqlock)
+#define ppm_vtime_state(tsk) ((tsk)->vtime_snap_whence)
+#endif
+
 static unsigned long long vtime_delta(struct task_struct *tsk)
 {
 	unsigned long long clock;
 
 	clock = local_clock();
-	if (clock < tsk->vtime_snap)
+	if (clock < ppm_vtime_starttime(tsk))
 		return 0;
 
-	return clock - tsk->vtime_snap;
+	return clock - ppm_vtime_starttime(tsk);
 }
 
 static void
@@ -72,7 +84,7 @@ fetch_task_cputime(struct task_struct *t,
 		*udelta = 0;
 		*sdelta = 0;
 
-		seq = read_seqbegin(&t->vtime_seqlock);
+		seq = read_seqbegin(ppm_vtime_seqlock(t));
 
 		if (u_dst)
 			*u_dst = *u_src;
@@ -80,7 +92,7 @@ fetch_task_cputime(struct task_struct *t,
 			*s_dst = *s_src;
 
 		/* Task is sleeping, nothing to add */
-		if (t->vtime_snap_whence == VTIME_SLEEPING ||
+		if (t->vtime.state == VTIME_SLEEPING ||
 		    is_idle_task(t))
 			continue;
 
@@ -90,13 +102,13 @@ fetch_task_cputime(struct task_struct *t,
 		 * Task runs either in user or kernel space, add pending nohz time to
 		 * the right place.
 		 */
-		if (t->vtime_snap_whence == VTIME_USER || t->flags & PF_VCPU) {
+		if (t->vtime.state == VTIME_USER || t->flags & PF_VCPU) {
 			*udelta = delta;
 		} else {
-			if (t->vtime_snap_whence == VTIME_SYS)
+			if (t->vtime.state == VTIME_SYS)
 				*sdelta = delta;
 		}
-	} while (read_seqretry(&t->vtime_seqlock, seq));
+	} while (read_seqretry(ppm_vtime_seqlock(t), seq));
 }
 
 void task_cputime(struct task_struct *t, cputime_t *utime, cputime_t *stime)

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -38,6 +38,7 @@ or GPL2.txt for full copies of the license.
 #include "ppm_events.h"
 #include "ppm.h"
 #include "ppm_flag_helpers.h"
+#include "ppm_version.h"
 
 /*
  * The kernel patched with grsecurity makes the default access_ok trigger a
@@ -46,10 +47,10 @@ or GPL2.txt for full copies of the license.
 #ifdef access_ok_noprefault
 #define ppm_access_ok access_ok_noprefault
 #else
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
-#define ppm_access_ok(type, addr, size)	access_ok(type, addr, size)
-#else
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)) || (PPM_RHEL_RELEASE_CODE > 0 && PPM_RHEL_RELEASE_CODE >= PPM_RHEL_RELEASE_VERSION(8, 1))
 #define ppm_access_ok(type, addr, size)	access_ok(addr, size)
+#else
+#define ppm_access_ok(type, addr, size)	access_ok(type, addr, size)
 #endif
 #endif
 

--- a/driver/ppm_version.h
+++ b/driver/ppm_version.h
@@ -1,0 +1,18 @@
+#include <linux/version.h>
+
+/**
+ * for RHEL kernels, export the release code (which is equal to e.g.
+ * RHEL_RELEASE_CODE(8, 1)) under our own name.
+ * For other kernels, just use zeros.
+ *
+ * We need macros that are always defined to use in preprocessor directives
+ * to express the required kernel version in a single expression, without
+ * a multiline #ifdef soup.
+ */
+#ifdef RHEL_RELEASE_CODE
+#define PPM_RHEL_RELEASE_CODE RHEL_RELEASE_CODE
+#define PPM_RHEL_RELEASE_VERSION(x,y) RHEL_RELEASE_VERSION(x,y)
+#else
+#define PPM_RHEL_RELEASE_CODE 0
+#define PPM_RHEL_RELEASE_VERSION(x,y) 0
+#endif


### PR DESCRIPTION
Kernel commits 60a9ce57e7c5ac1df3a39fb941022bbfa40c0862
and bac5b6b6b11560f323e71d0ebac4061cfe5f56c0 move the vtime_* fields
from task_struct to a nested struct vtime.

RHEL 7.7 is the first kernel where we hit this but the changes landed
in upstream kernel 4.13.

To hit this bug, CONFIG_VIRT_CPU_ACCOUNTING_GEN has to be set.