### PR TITLE
Set container_id before doing a synchronous CRI lookup

### DIFF
--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -145,6 +145,7 @@ bool cri_async_source::parse_cri(sinsp_container_info *container, const libsinsp
 		return false;
 	}
 
+	container->m_id = key.m_container_id;
 	container->m_name = "";
 	container->m_image = "";
 	container->m_imageid = "";


### PR DESCRIPTION
For asynchronous lookups, this was masked by setting the id in
get_or_create_container(), but synchronous lookups were broken
as they tried to request empty container ids from the CRI API.