### PR TITLE
bash-completion: use the correct installation directory

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -19,7 +19,7 @@ configure_file(debian/postinst.in debian/postinst)
 configure_file(debian/prerm.in debian/prerm)
 
 install(FILES completions/bash/sysdig
-	DESTINATION "${DIR_ETC}/bash_completion.d")
+	DESTINATION "share/bash-completion/completions")
 
 install(FILES completions/zsh/_sysdig
 	DESTINATION share/zsh/vendor-completions)


### PR DESCRIPTION
Installing completions to /etc/bash_completion.d is the legacy method from bash-completion 1.x which became obsolete in 2011.

Any remotely recent system expects completions to be installed in /usr/share/bash-completion/completions, and dynamically loaded into the bash shell only when the user first attempts to complete the command.

It no longer makes sense, if it ever did, to use the extremely ancient compat dir (which is always reloaded every time the shell is started, whether sysdig gets used or not). No Debian or Ubuntu release (the usual cause of outdated standards) still uses a bash-completion package that old, and the very first upload of sysdig to the Debian repositories included a modification to override the CMakeLists.txt and install the completion file to /usr/share.

No one is using /etc/bash_completion.d anymore, and good riddance to things that slow down the user's shell.