### PR TITLE
Don't pass raw pointers to sinsp_container_info around

### DIFF
--- a/userspace/libsinsp/chisel_api.cpp
+++ b/userspace/libsinsp/chisel_api.cpp
@@ -1142,7 +1142,7 @@ int lua_cbacks::get_container_table(lua_State *ls)
 	//
 	// Retrieve the container list
 	//
-	const unordered_map<string, sinsp_container_info>* ctable  = ch->m_inspector->m_container_manager.get_containers();
+	const sinsp_container_manager::map_ptr_t ctable = ch->m_inspector->m_container_manager.get_containers();
 
 	ASSERT(ctable != NULL);
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -74,7 +74,7 @@ bool sinsp_container_manager::remove_inactive_containers()
 			return true;
 		});
 
-		for(unordered_map<string, sinsp_container_info>::iterator it = m_containers.begin(); it != m_containers.end();)
+		for(auto it = m_containers.begin(); it != m_containers.end();)
 		{
 			if(containers_in_use.find(it->first) == containers_in_use.end())
 			{
@@ -94,7 +94,7 @@ bool sinsp_container_manager::remove_inactive_containers()
 	return res;
 }
 
-sinsp_container_info* sinsp_container_manager::get_container(const string& container_id)
+sinsp_container_manager::entry_ptr_t sinsp_container_manager::get_container(const string& container_id)
 {
 	auto it = m_containers.find(container_id);
 	if(it != m_containers.end())
@@ -273,7 +273,7 @@ bool sinsp_container_manager::container_to_sinsp_event(const string& json, sinsp
 	return true;
 }
 
-const unordered_map<string, sinsp_container_info>* sinsp_container_manager::get_containers()
+sinsp_container_manager::map_ptr_t sinsp_container_manager::get_containers()
 {
 	return &m_containers;
 }
@@ -314,10 +314,10 @@ void sinsp_container_manager::notify_new_container(const sinsp_container_info& c
 
 void sinsp_container_manager::dump_containers(scap_dumper_t* dumper)
 {
-	for(unordered_map<string, sinsp_container_info>::const_iterator it = m_containers.begin(); it != m_containers.end(); ++it)
+	for(const auto& it : m_containers)
 	{
 		sinsp_evt evt;
-		if(container_to_sinsp_event(container_to_json(it->second), &evt, it->second.get_tinfo(m_inspector)))
+		if(container_to_sinsp_event(container_to_json(it.second), &evt, it.second.get_tinfo(m_inspector)))
 		{
 			int32_t res = scap_dump(m_inspector->m_h, dumper, evt.m_pevt, evt.m_cpuid, 0);
 			if(res != SCAP_SUCCESS)
@@ -338,7 +338,7 @@ string sinsp_container_manager::get_container_name(sinsp_threadinfo* tinfo)
 	}
 	else
 	{
-		const sinsp_container_info *container_info = get_container(tinfo->m_container_id);
+		const sinsp_container_manager::entry_ptr_t container_info = get_container(tinfo->m_container_id);
 
 		if(!container_info)
 		{
@@ -363,7 +363,7 @@ void sinsp_container_manager::identify_category(sinsp_threadinfo *tinfo)
 		return;
 	}
 
-	sinsp_container_info *cinfo = get_container(tinfo->m_container_id);
+	sinsp_container_manager::entry_ptr_t cinfo = get_container(tinfo->m_container_id);
 
 	if(!cinfo)
 	{

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -34,13 +34,16 @@ limitations under the License.
 class sinsp_container_manager
 {
 public:
+	using map_ptr_t = const std::unordered_map<std::string, sinsp_container_info>*;
+	using entry_ptr_t = sinsp_container_info*;
+
 	sinsp_container_manager(sinsp* inspector);
 	virtual ~sinsp_container_manager();
 
-	const unordered_map<string, sinsp_container_info>* get_containers();
+	map_ptr_t get_containers();
 	bool remove_inactive_containers();
 	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread);
-	sinsp_container_info * get_container(const string &id);
+	entry_ptr_t get_container(const string &id);
 	void notify_new_container(const sinsp_container_info& container_info);
 	template<typename E> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	template<typename E1, typename E2, typename... Args> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
@@ -79,7 +82,7 @@ private:
 	std::list<std::unique_ptr<libsinsp::container_engine::resolver>> m_container_engines;
 
 	sinsp* m_inspector;
-	unordered_map<string, sinsp_container_info> m_containers;
+	std::unordered_map<std::string, sinsp_container_info> m_containers;
 	uint64_t m_last_flush_time_ns;
 	list<new_container_cb> m_new_callbacks;
 	list<remove_container_cb> m_remove_callbacks;

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -56,7 +56,7 @@ bool parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, 
 		return false;
 	}
 
-	parse_cri_env(root, container);
+	parse_cri_env(root, *container);
 	parse_cri_json_image(root, container);
 	parse_cri_runtime_spec(root, container);
 

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -40,7 +40,7 @@ using namespace libsinsp::container_engine;
 using namespace libsinsp::runc;
 
 namespace {
-bool parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, sinsp_container_info *container, sinsp_threadinfo *tinfo)
+bool parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, sinsp_container_info &container, sinsp_threadinfo *tinfo)
 {
 	const auto &info_it = status.info().find("info");
 	if(info_it == status.info().end())
@@ -56,14 +56,14 @@ bool parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, 
 		return false;
 	}
 
-	parse_cri_env(root, *container);
-	parse_cri_json_image(root, *container);
-	parse_cri_runtime_spec(root, *container);
+	parse_cri_env(root, container);
+	parse_cri_json_image(root, container);
+	parse_cri_runtime_spec(root, container);
 
 	if(root.isMember("sandboxID") && root["sandboxID"].isString())
 	{
 		const auto pod_sandbox_id = root["sandboxID"].asString();
-		container->m_container_ip = ntohl(get_pod_sandbox_ip(pod_sandbox_id));
+		container.m_container_ip = ntohl(get_pod_sandbox_ip(pod_sandbox_id));
 	}
 
 	return true;
@@ -126,7 +126,7 @@ bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container
 	parse_cri_image(resp_container, *container);
 	parse_cri_mounts(resp_container, *container);
 
-	if(parse_containerd(resp, container, tinfo))
+	if(parse_containerd(resp, *container, tinfo))
 	{
 		return true;
 	}

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -124,7 +124,7 @@ bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container
 	}
 
 	parse_cri_image(resp_container, *container);
-	parse_cri_mounts(resp_container, container);
+	parse_cri_mounts(resp_container, *container);
 
 	if(parse_containerd(resp, container, tinfo))
 	{

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -57,7 +57,7 @@ bool parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, 
 	}
 
 	parse_cri_env(root, *container);
-	parse_cri_json_image(root, container);
+	parse_cri_json_image(root, *container);
 	parse_cri_runtime_spec(root, container);
 
 	if(root.isMember("sandboxID") && root["sandboxID"].isString())

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -69,7 +69,7 @@ bool parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, 
 	return true;
 }
 
-bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container, sinsp_threadinfo *tinfo)
+bool parse_cri(sinsp_container_info *container, sinsp_threadinfo *tinfo)
 {
 	if(!s_cri)
 	{
@@ -230,7 +230,7 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 					"cri (%s): Performing lookup",
 					container_info.m_id.c_str());
 
-			if (!parse_cri(manager, &container_info, tinfo))
+			if (!parse_cri(&container_info, tinfo))
 			{
 				g_logger.format(sinsp_logger::SEV_DEBUG, "cri (%s): Failed to get CRI metadata for container",
 						container_info.m_id.c_str());

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -242,7 +242,7 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 			container_info.m_type = s_cri_runtime_type;
 
 		}
-		if (mesos::set_mesos_task_id(&container_info, tinfo))
+		if (mesos::set_mesos_task_id(container_info, tinfo))
 		{
 			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"cri (%s) Mesos CRI container, Mesos task ID: [%s]",

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -58,7 +58,7 @@ bool parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, 
 
 	parse_cri_env(root, *container);
 	parse_cri_json_image(root, *container);
-	parse_cri_runtime_spec(root, container);
+	parse_cri_runtime_spec(root, *container);
 
 	if(root.isMember("sandboxID") && root["sandboxID"].isString())
 	{

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -123,7 +123,7 @@ bool parse_cri(sinsp_container_manager *manager, sinsp_container_info *container
 		container->m_labels[pair.first] = pair.second;
 	}
 
-	parse_cri_image(resp_container, container);
+	parse_cri_image(resp_container, *container);
 	parse_cri_mounts(resp_container, container);
 
 	if(parse_containerd(resp, container, tinfo))

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -101,7 +101,7 @@ private:
 	// Parse all healthchecks/liveness probes/readiness probes out
 	// of the provided object, updating the container info as required.
 	void parse_health_probes(const Json::Value &config_obj,
-				 sinsp_container_info *container);
+				 sinsp_container_info &container);
 
 	sinsp *m_inspector;
 

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -89,7 +89,7 @@ private:
 	// Parse a healthcheck out of the provided healthcheck object,
 	// updating the container info with any healthcheck found.
 	void parse_healthcheck(const Json::Value &healthcheck_obj,
-			       sinsp_container_info *container);
+			       sinsp_container_info &container);
 
 	// Parse either a readiness or liveness probe out of the
 	// provided object, updating the container info with any probe

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -96,7 +96,7 @@ private:
 	// found.
 	bool parse_liveness_readiness_probe(const Json::Value &probe_obj,
 					    sinsp_container_info::container_health_probe::probe_type ptype,
-					    sinsp_container_info *container);
+					    sinsp_container_info &container);
 
 	// Parse all healthchecks/liveness probes/readiness probes out
 	// of the provided object, updating the container info as required.

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -77,7 +77,7 @@ private:
 	std::string build_request(const std::string& url);
 	docker_response get_docker(const std::string& url, std::string &json);
 
-	bool parse_docker(std::string &container_id, sinsp_container_info *container);
+	bool parse_docker(std::string &container_id, sinsp_container_info &container);
 
 	// Look for a pod specification in this container's labels and
 	// if found set spec to the pod spec.

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -256,7 +256,7 @@ void docker_async_source::parse_healthcheck(const Json::Value &healthcheck_obj,
 
 bool docker_async_source::parse_liveness_readiness_probe(const Json::Value &probe_obj,
 							 sinsp_container_info::container_health_probe::probe_type ptype,
-							 sinsp_container_info *container)
+							 sinsp_container_info &container)
 {
 	if(probe_obj.isNull() ||
 	   !probe_obj.isMember("exec") ||
@@ -282,11 +282,11 @@ bool docker_async_source::parse_liveness_readiness_probe(const Json::Value &prob
 
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker (%s): Setting %s exe=%s nargs=%d",
-				container->m_id.c_str(),
+				container.m_id.c_str(),
 				sinsp_container_info::container_health_probe::probe_type_names[ptype].c_str(),
 				exe.c_str(), args.size());
 
-		container->m_health_probes.emplace_back(ptype, std::move(exe), std::move(args));
+		container.m_health_probes.emplace_back(ptype, std::move(exe), std::move(args));
 	}
 
 	return true;
@@ -306,7 +306,7 @@ void docker_async_source::parse_health_probes(const Json::Value &config_obj,
 		{
 			if(parse_liveness_readiness_probe(spec["livenessProbe"],
 							  sinsp_container_info::container_health_probe::PT_LIVENESS_PROBE,
-							  container))
+							  *container))
 			{
 				liveness_readiness_added = true;
 			}
@@ -315,7 +315,7 @@ void docker_async_source::parse_health_probes(const Json::Value &config_obj,
 		{
 			if(parse_liveness_readiness_probe(spec["readinessProbe"],
 							  sinsp_container_info::container_health_probe::PT_READINESS_PROBE,
-							  container))
+							  *container))
 			{
 				liveness_readiness_added = true;
 			}

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -171,11 +171,11 @@ std::string docker_async_source::normalize_arg(const std::string &arg)
 }
 
 void docker_async_source::parse_healthcheck(const Json::Value &healthcheck_obj,
-					    sinsp_container_info *container)
+					    sinsp_container_info &container)
 {
 	g_logger.format(sinsp_logger::SEV_DEBUG,
 			"docker (%s): Trying to parse healthcheck from %s",
-			container->m_id.c_str(), Json::FastWriter().write(healthcheck_obj).c_str());
+			container.m_id.c_str(), Json::FastWriter().write(healthcheck_obj).c_str());
 
 	if(healthcheck_obj.isNull())
 	{
@@ -224,9 +224,9 @@ void docker_async_source::parse_healthcheck(const Json::Value &healthcheck_obj,
 
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker (%s): Setting PT_HEALTHCHECK exe=%s nargs=%d",
-				container->m_id.c_str(), exe.c_str(), args.size());
+				container.m_id.c_str(), exe.c_str(), args.size());
 
-		container->m_health_probes.emplace_back(sinsp_container_info::container_health_probe::PT_HEALTHCHECK,
+		container.m_health_probes.emplace_back(sinsp_container_info::container_health_probe::PT_HEALTHCHECK,
 							std::move(exe),
 							std::move(args));
 	}
@@ -240,9 +240,9 @@ void docker_async_source::parse_healthcheck(const Json::Value &healthcheck_obj,
 
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker (%s): Setting PT_HEALTHCHECK exe=%s nargs=%d",
-				container->m_id.c_str(), exe.c_str(), args.size());
+				container.m_id.c_str(), exe.c_str(), args.size());
 
-		container->m_health_probes.emplace_back(sinsp_container_info::container_health_probe::PT_HEALTHCHECK,
+		container.m_health_probes.emplace_back(sinsp_container_info::container_health_probe::PT_HEALTHCHECK,
 							std::move(exe),
 							std::move(args));
 	}
@@ -327,7 +327,7 @@ void docker_async_source::parse_health_probes(const Json::Value &config_obj,
 	// consider a healthcheck if no liveness/readiness was added.
 	if(!liveness_readiness_added && config_obj.isMember("Healthcheck"))
 	{
-		parse_healthcheck(config_obj["Healthcheck"], container);
+		parse_healthcheck(config_obj["Healthcheck"], *container);
 	}
 }
 

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -293,7 +293,7 @@ bool docker_async_source::parse_liveness_readiness_probe(const Json::Value &prob
 }
 
 void docker_async_source::parse_health_probes(const Json::Value &config_obj,
-					      sinsp_container_info *container)
+					      sinsp_container_info &container)
 {
 	Json::Value spec;
 	bool liveness_readiness_added = false;
@@ -306,7 +306,7 @@ void docker_async_source::parse_health_probes(const Json::Value &config_obj,
 		{
 			if(parse_liveness_readiness_probe(spec["livenessProbe"],
 							  sinsp_container_info::container_health_probe::PT_LIVENESS_PROBE,
-							  *container))
+							  container))
 			{
 				liveness_readiness_added = true;
 			}
@@ -315,7 +315,7 @@ void docker_async_source::parse_health_probes(const Json::Value &config_obj,
 		{
 			if(parse_liveness_readiness_probe(spec["readinessProbe"],
 							  sinsp_container_info::container_health_probe::PT_READINESS_PROBE,
-							  *container))
+							  container))
 			{
 				liveness_readiness_added = true;
 			}
@@ -327,7 +327,7 @@ void docker_async_source::parse_health_probes(const Json::Value &config_obj,
 	// consider a healthcheck if no liveness/readiness was added.
 	if(!liveness_readiness_added && config_obj.isMember("Healthcheck"))
 	{
-		parse_healthcheck(config_obj["Healthcheck"], *container);
+		parse_healthcheck(config_obj["Healthcheck"], container);
 	}
 }
 
@@ -501,7 +501,7 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 		container->m_imageid = imgstr.substr(cpos + 1);
 	}
 
-	parse_health_probes(config_obj, container);
+	parse_health_probes(config_obj, *container);
 
 	// containers can be spawned using just the imageID as image name,
 	// with or without the hash prefix (e.g. sha256:)

--- a/userspace/libsinsp/container_engine/libvirt_lxc.cpp
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.cpp
@@ -22,7 +22,7 @@ limitations under the License.
 
 using namespace libsinsp::container_engine;
 
-bool libvirt_lxc::match(sinsp_threadinfo* tinfo, sinsp_container_info* container_info)
+bool libvirt_lxc::match(sinsp_threadinfo* tinfo, sinsp_container_info &container_info)
 {
 	for(const auto& it : tinfo->m_cgroups)
 	{
@@ -37,8 +37,8 @@ bool libvirt_lxc::match(sinsp_threadinfo* tinfo, sinsp_container_info* container
 			size_t pos2 = cgroup.find_last_of("/");
 			if(pos2 != std::string::npos)
 			{
-				container_info->m_type = CT_LIBVIRT_LXC;
-				container_info->m_id = cgroup.substr(pos2 + 1, pos - pos2 - 1);
+				container_info.m_type = CT_LIBVIRT_LXC;
+				container_info.m_id = cgroup.substr(pos2 + 1, pos - pos2 - 1);
 				return true;
 			}
 		}
@@ -53,8 +53,8 @@ bool libvirt_lxc::match(sinsp_threadinfo* tinfo, sinsp_container_info* container
 			if(pos2 != std::string::npos &&
 			   pos2 == cgroup.length() - sizeof(".scope") + 1)
 			{
-				container_info->m_type = CT_LIBVIRT_LXC;
-				container_info->m_id = cgroup.substr(pos + sizeof("-lxc\\x2"), pos2 - pos - sizeof("-lxc\\x2"));
+				container_info.m_type = CT_LIBVIRT_LXC;
+				container_info.m_id = cgroup.substr(pos + sizeof("-lxc\\x2"), pos2 - pos - sizeof("-lxc\\x2"));
 				return true;
 			}
 		}
@@ -65,8 +65,8 @@ bool libvirt_lxc::match(sinsp_threadinfo* tinfo, sinsp_container_info* container
 		pos = cgroup.find("/libvirt/lxc/");
 		if(pos != std::string::npos)
 		{
-			container_info->m_type = CT_LIBVIRT_LXC;
-			container_info->m_id = cgroup.substr(pos + sizeof("/libvirt/lxc/") - 1);
+			container_info.m_type = CT_LIBVIRT_LXC;
+			container_info.m_id = cgroup.substr(pos + sizeof("/libvirt/lxc/") - 1);
 			return true;
 		}
 	}
@@ -77,7 +77,7 @@ bool libvirt_lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* ti
 {
 	sinsp_container_info container_info;
 
-	if (!match(tinfo, &container_info))
+	if (!match(tinfo, container_info))
 	{
 		return false;
 	}

--- a/userspace/libsinsp/container_engine/libvirt_lxc.h
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.h
@@ -32,7 +32,7 @@ class libvirt_lxc : public resolver
 public:
 	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;
 protected:
-	bool match(sinsp_threadinfo* tinfo, sinsp_container_info* container_info);
+	bool match(sinsp_threadinfo* tinfo, sinsp_container_info &container_info);
 };
 }
 }

--- a/userspace/libsinsp/container_engine/mesos.cpp
+++ b/userspace/libsinsp/container_engine/mesos.cpp
@@ -24,7 +24,7 @@ limitations under the License.
 #include "sinsp.h"
 #include "sinsp_int.h"
 
-bool libsinsp::container_engine::mesos::match(sinsp_threadinfo* tinfo, sinsp_container_info* container_info)
+bool libsinsp::container_engine::mesos::match(sinsp_threadinfo* tinfo, sinsp_container_info &container_info)
 {
 	for(auto it = tinfo->m_cgroups.begin(); it != tinfo->m_cgroups.end(); ++it)
 	{
@@ -38,14 +38,14 @@ bool libsinsp::container_engine::mesos::match(sinsp_threadinfo* tinfo, sinsp_con
 			auto id = cgroup.substr(pos + sizeof("/mesos/") - 1);
 			if(id.size() == 36 && id.find_first_not_of("0123456789abcdefABCDEF-") == string::npos)
 			{
-				container_info->m_type = CT_MESOS;
-				container_info->m_id = move(id);
+				container_info.m_type = CT_MESOS;
+				container_info.m_id = move(id);
 				// Consider a mesos container valid only if we find the mesos_task_id
 				// this will exclude from the container itself the mesos-executor
 				// but makes sure that we have task_id parsed properly. Otherwise what happens
 				// is that we'll create a mesos container struct without a mesos_task_id
 				// and for all other processes we'll use it
-				return set_mesos_task_id(*container_info, tinfo);
+				return set_mesos_task_id(container_info, tinfo);
 			}
 		}
 	}
@@ -56,7 +56,7 @@ bool libsinsp::container_engine::mesos::resolve(sinsp_container_manager* manager
 {
 	sinsp_container_info container_info;
 
-	if (!match(tinfo, &container_info))
+	if (!match(tinfo, container_info))
 		return false;
 
 	tinfo->m_container_id = container_info.m_id;

--- a/userspace/libsinsp/container_engine/mesos.cpp
+++ b/userspace/libsinsp/container_engine/mesos.cpp
@@ -45,7 +45,7 @@ bool libsinsp::container_engine::mesos::match(sinsp_threadinfo* tinfo, sinsp_con
 				// but makes sure that we have task_id parsed properly. Otherwise what happens
 				// is that we'll create a mesos container struct without a mesos_task_id
 				// and for all other processes we'll use it
-				return set_mesos_task_id(container_info, tinfo);
+				return set_mesos_task_id(*container_info, tinfo);
 			}
 		}
 	}
@@ -98,9 +98,8 @@ string libsinsp::container_engine::mesos::get_env_mesos_task_id(sinsp_threadinfo
 	return mtid;
 }
 
-bool libsinsp::container_engine::mesos::set_mesos_task_id(sinsp_container_info* container, sinsp_threadinfo* tinfo)
+bool libsinsp::container_engine::mesos::set_mesos_task_id(sinsp_container_info &container, sinsp_threadinfo* tinfo)
 {
-	ASSERT(container);
 	ASSERT(tinfo);
 
 	// there are applications that do not share their environment in /proc/[PID]/environ
@@ -112,9 +111,9 @@ bool libsinsp::container_engine::mesos::set_mesos_task_id(sinsp_container_info* 
 	//   get_env_mesos_task_id(sinsp_threadinfo*) implementation) environment variable, so we
 	//   peek into the parent process environment to discover it
 
-	if(container && tinfo)
+	if(tinfo)
 	{
-		string& mtid = container->m_mesos_task_id;
+		string& mtid = container.m_mesos_task_id;
 		if(mtid.empty())
 		{
 			mtid = get_env_mesos_task_id(tinfo);
@@ -125,12 +124,12 @@ bool libsinsp::container_engine::mesos::set_mesos_task_id(sinsp_container_info* 
 			if(!mtid.empty() && mtid.length()>=3 &&
 			   (mtid.find_first_of("._") != std::string::npos))
 			{
-				g_logger.log("Mesos native container: [" + container->m_id + "], Mesos task ID: " + mtid, sinsp_logger::SEV_DEBUG);
+				g_logger.log("Mesos native container: [" + container.m_id + "], Mesos task ID: " + mtid, sinsp_logger::SEV_DEBUG);
 				return true;
 			}
 			else
 			{
-				g_logger.log("Mesos container [" + container->m_id + "],"
+				g_logger.log("Mesos container [" + container.m_id + "],"
 										     "thread [" + std::to_string(tinfo->m_tid) +
 					     "], has likely malformed mesos task id [" + mtid + "], ignoring", sinsp_logger::SEV_DEBUG);
 			}

--- a/userspace/libsinsp/container_engine/mesos.h
+++ b/userspace/libsinsp/container_engine/mesos.h
@@ -33,7 +33,7 @@ class mesos : public resolver {
 public:
 	bool resolve(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
-	static bool set_mesos_task_id(sinsp_container_info *container, sinsp_threadinfo *tinfo);
+	static bool set_mesos_task_id(sinsp_container_info &container, sinsp_threadinfo *tinfo);
 
 protected:
 	bool match(sinsp_threadinfo *tinfo, sinsp_container_info *container_info);

--- a/userspace/libsinsp/container_engine/mesos.h
+++ b/userspace/libsinsp/container_engine/mesos.h
@@ -36,7 +36,7 @@ public:
 	static bool set_mesos_task_id(sinsp_container_info &container, sinsp_threadinfo *tinfo);
 
 protected:
-	bool match(sinsp_threadinfo *tinfo, sinsp_container_info *container_info);
+	bool match(sinsp_threadinfo *tinfo, sinsp_container_info &container_info);
 
 	static std::string get_env_mesos_task_id(sinsp_threadinfo *tinfo);
 };

--- a/userspace/libsinsp/container_engine/rkt.cpp
+++ b/userspace/libsinsp/container_engine/rkt.cpp
@@ -182,7 +182,7 @@ bool rkt::rkt::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo
 	}
 
 #ifndef _WIN32
-	bool have_rkt = parse_rkt(&container_info, rkt_podid, rkt_appname);
+	bool have_rkt = parse_rkt(container_info, rkt_podid, rkt_appname);
 #else
 	bool have_rkt = true;
 #endif
@@ -199,7 +199,7 @@ bool rkt::rkt::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo
 	}
 }
 
-bool rkt::rkt::parse_rkt(sinsp_container_info *container, const string &podid, const string &appname)
+bool rkt::rkt::parse_rkt(sinsp_container_info &container, const string &podid, const string &appname)
 {
 	bool ret = false;
 	Json::Reader reader;
@@ -210,15 +210,15 @@ bool rkt::rkt::parse_rkt(sinsp_container_info *container, const string &podid, c
 	ifstream image_manifest(image_manifest_path);
 	if(reader.parse(image_manifest, jroot))
 	{
-		container->m_image = jroot["name"].asString();
+		container.m_image = jroot["name"].asString();
 		for(const auto& label_entry : jroot["labels"])
 		{
-			container->m_labels.emplace(label_entry["name"].asString(), label_entry["value"].asString());
+			container.m_labels.emplace(label_entry["name"].asString(), label_entry["value"].asString());
 		}
-		auto version_label_it = container->m_labels.find("version");
-		if(version_label_it != container->m_labels.end())
+		auto version_label_it = container.m_labels.find("version");
+		if(version_label_it != container.m_labels.end())
 		{
-			container->m_image += ":" + version_label_it->second;
+			container.m_image += ":" + version_label_it->second;
 		}
 		ret = true;
 	}
@@ -229,11 +229,11 @@ bool rkt::rkt::parse_rkt(sinsp_container_info *container, const string &podid, c
 	if(reader.parse(net_info, jroot) && jroot.size() > 0)
 	{
 		const auto& first_net = jroot[0];
-		if(inet_pton(AF_INET, first_net["ip"].asCString(), &container->m_container_ip) == -1)
+		if(inet_pton(AF_INET, first_net["ip"].asCString(), &container.m_container_ip) == -1)
 		{
 			ASSERT(false);
 		}
-		container->m_container_ip = ntohl(container->m_container_ip);
+		container.m_container_ip = ntohl(container.m_container_ip);
 	}
 
 	char pod_manifest_path[SCAP_MAX_PATH_SIZE];
@@ -262,7 +262,7 @@ bool rkt::rkt::parse_rkt(sinsp_container_info *container, const string &podid, c
 				sinsp_container_info::container_port_mapping port_mapping;
 				port_mapping.m_host_port = host_port;
 				port_mapping.m_container_port = container_port_it->second;
-				container->m_port_mappings.emplace_back(move(port_mapping));
+				container.m_port_mappings.emplace_back(move(port_mapping));
 			}
 		}
 	}

--- a/userspace/libsinsp/container_engine/rkt.cpp
+++ b/userspace/libsinsp/container_engine/rkt.cpp
@@ -26,7 +26,7 @@ limitations under the License.
 
 using namespace libsinsp::container_engine;
 
-bool rkt::match(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, sinsp_container_info* container_info, string& rkt_podid, string& rkt_appname, bool query_os_for_missing_info)
+bool rkt::match(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, sinsp_container_info &container_info, string &rkt_podid, string &rkt_appname, bool query_os_for_missing_info)
 {
 	for(auto it = tinfo->m_cgroups.begin(); it != tinfo->m_cgroups.end(); ++it)
 	{
@@ -81,9 +81,9 @@ bool rkt::match(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, sinsp
 #endif
 				if(is_rkt_pod_id_valid)
 				{
-					container_info->m_type = CT_RKT;
-					container_info->m_id = rkt_podid + ":" + rkt_appname;
-					container_info->m_name = rkt_appname;
+					container_info.m_type = CT_RKT;
+					container_info.m_id = rkt_podid + ":" + rkt_appname;
+					container_info.m_name = rkt_appname;
 					return true;
 				}
 			}
@@ -116,9 +116,9 @@ bool rkt::match(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, sinsp
 					if(container_uuid_pos == 0)
 					{
 						rkt_podid = env_var.substr(COREOS_PODID_VAR.size());
-						container_info->m_type = CT_RKT;
-						container_info->m_id = rkt_podid + ":" + rkt_appname;
-						container_info->m_name = rkt_appname;
+						container_info.m_type = CT_RKT;
+						container_info.m_id = rkt_podid + ":" + rkt_appname;
+						container_info.m_name = rkt_appname;
 						valid_id = true;
 						return false;
 					}
@@ -154,9 +154,9 @@ bool rkt::match(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, sinsp
 				{
 					rkt_appname = tinfo->m_root.substr(podid_suffix + FLY_PODID_SUFFIX.size(),
 									   appname_suffix-podid_suffix-FLY_PODID_SUFFIX.size());
-					container_info->m_type = CT_RKT;
-					container_info->m_id = rkt_podid + ":" + rkt_appname;
-					container_info->m_name = rkt_appname;
+					container_info.m_type = CT_RKT;
+					container_info.m_id = rkt_podid + ":" + rkt_appname;
+					container_info.m_name = rkt_appname;
 					return true;
 				}
 			}
@@ -170,7 +170,7 @@ bool rkt::rkt::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo
 	sinsp_container_info container_info;
 	string rkt_podid, rkt_appname;
 
-	if (!match(manager, tinfo, &container_info, rkt_podid, rkt_appname, query_os_for_missing_info))
+	if (!match(manager, tinfo, container_info, rkt_podid, rkt_appname, query_os_for_missing_info))
 	{
 		return false;
 	}

--- a/userspace/libsinsp/container_engine/rkt.h
+++ b/userspace/libsinsp/container_engine/rkt.h
@@ -34,7 +34,7 @@ public:
 	bool resolve(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
 protected:
-	bool match(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, sinsp_container_info *container_info,
+	bool match(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, sinsp_container_info &container_info,
 		   std::string &rkt_podid, std::string &rkt_appname, bool query_os_for_missing_info);
 
 	bool parse_rkt(sinsp_container_info *container, const std::string &podid, const std::string &appname);

--- a/userspace/libsinsp/container_engine/rkt.h
+++ b/userspace/libsinsp/container_engine/rkt.h
@@ -37,7 +37,7 @@ protected:
 	bool match(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, sinsp_container_info &container_info,
 		   std::string &rkt_podid, std::string &rkt_appname, bool query_os_for_missing_info);
 
-	bool parse_rkt(sinsp_container_info *container, const std::string &podid, const std::string &appname);
+	bool parse_rkt(sinsp_container_info &container, const std::string &podid, const std::string &appname);
 };
 }
 }

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -102,7 +102,7 @@ bool parse_cri_image(const runtime::v1alpha2::ContainerStatus &status, sinsp_con
 	return true;
 }
 
-bool parse_cri_mounts(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info *container)
+bool parse_cri_mounts(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info &container)
 {
 	for(const auto &mount : status.mounts())
 	{
@@ -122,7 +122,7 @@ bool parse_cri_mounts(const runtime::v1alpha2::ContainerStatus &status, sinsp_co
 			propagation = "unknown";
 			break;
 		}
-		container->m_mounts.emplace_back(
+		container.m_mounts.emplace_back(
 			mount.host_path(),
 			mount.container_path(),
 			"",

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -214,7 +214,7 @@ bool parse_cri_json_image(const Json::Value &info, sinsp_container_info &contain
 	return true;
 }
 
-bool parse_cri_runtime_spec(const Json::Value &info, sinsp_container_info *container)
+bool parse_cri_runtime_spec(const Json::Value &info, sinsp_container_info &container)
 {
 	const Json::Value *linux = nullptr;
 	if(!walk_down_json(info, &linux, "runtimeSpec", "linux") || !linux->isObject())
@@ -225,22 +225,22 @@ bool parse_cri_runtime_spec(const Json::Value &info, sinsp_container_info *conta
 	const Json::Value *memory = nullptr;
 	if(walk_down_json(*linux, &memory, "resources", "memory"))
 	{
-		set_numeric(*memory, "limit", container->m_memory_limit);
-		container->m_swap_limit = container->m_memory_limit;
+		set_numeric(*memory, "limit", container.m_memory_limit);
+		container.m_swap_limit = container.m_memory_limit;
 	}
 
 	const Json::Value *cpu = nullptr;
 	if(walk_down_json(*linux, &cpu, "resources", "cpu") && cpu->isObject())
 	{
-		set_numeric(*cpu, "shares", container->m_cpu_shares);
-		set_numeric(*cpu, "quota", container->m_cpu_quota);
-		set_numeric(*cpu, "period", container->m_cpu_period);
+		set_numeric(*cpu, "shares", container.m_cpu_shares);
+		set_numeric(*cpu, "quota", container.m_cpu_quota);
+		set_numeric(*cpu, "period", container.m_cpu_period);
 	}
 
 	const Json::Value *privileged;
 	if(walk_down_json(*linux, &privileged, "security_context", "privileged") && privileged->isBool())
 	{
-		container->m_privileged = privileged->asBool();
+		container.m_privileged = privileged->asBool();
 	}
 
 	return true;

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -60,7 +60,7 @@ sinsp_container_type get_cri_runtime_type(const std::string &runtime_name)
 	}
 }
 
-bool parse_cri_image(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info *container)
+bool parse_cri_image(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info &container)
 {
 	// image_ref may be one of two forms:
 	// host/image@sha256:digest
@@ -84,20 +84,20 @@ bool parse_cri_image(const runtime::v1alpha2::ContainerStatus &status, sinsp_con
 	sinsp_utils::split_container_image(status.image().image(),
 					   hostname,
 					   port,
-					   container->m_imagerepo,
-					   container->m_imagetag,
+					   container.m_imagerepo,
+					   container.m_imagetag,
 					   digest,
 					   false);
-	container->m_image = status.image().image();
+	container.m_image = status.image().image();
 
 
 	if(have_digest)
 	{
-		container->m_imagedigest = image_ref.substr(digest_start);
+		container.m_imagedigest = image_ref.substr(digest_start);
 	}
 	else
 	{
-		container->m_imagedigest = digest;
+		container.m_imagedigest = digest;
 	}
 	return true;
 }

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -168,7 +168,7 @@ bool set_numeric(const Json::Value &dict, const std::string &key, int64_t &val)
 	return true;
 }
 
-bool parse_cri_env(const Json::Value &info, sinsp_container_info *container)
+bool parse_cri_env(const Json::Value &info, sinsp_container_info &container)
 {
 	const Json::Value *envs;
 	if(!walk_down_json(info, &envs, "config", "envs") || !envs->isArray())
@@ -186,7 +186,7 @@ bool parse_cri_env(const Json::Value &info, sinsp_container_info *container)
 			auto var = key.asString();
 			var += '=';
 			var += value.asString();
-			container->m_env.emplace_back(var);
+			container.m_env.emplace_back(var);
 		}
 	}
 

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -193,7 +193,7 @@ bool parse_cri_env(const Json::Value &info, sinsp_container_info &container)
 	return true;
 }
 
-bool parse_cri_json_image(const Json::Value &info, sinsp_container_info *container)
+bool parse_cri_json_image(const Json::Value &info, sinsp_container_info &container)
 {
 	const Json::Value *image;
 	if(!walk_down_json(info, &image, "config", "image", "image") || !image->isString())
@@ -205,10 +205,10 @@ bool parse_cri_json_image(const Json::Value &info, sinsp_container_info *contain
 	auto pos = image_str.find(':');
 	if(pos == string::npos)
 	{
-		container->m_imageid = move(image_str);
+		container.m_imageid = move(image_str);
 	} else
 	{
-		container->m_imageid = image_str.substr(pos + 1);
+		container.m_imageid = image_str.substr(pos + 1);
 	}
 
 	return true;

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -38,7 +38,7 @@ extern bool s_cri_extra_queries;
 
 sinsp_container_type get_cri_runtime_type(const std::string &runtime_name);
 
-bool parse_cri_image(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info *container);
+bool parse_cri_image(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info &container);
 
 bool parse_cri_mounts(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info *container);
 

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -42,7 +42,7 @@ bool parse_cri_image(const runtime::v1alpha2::ContainerStatus &status, sinsp_con
 
 bool parse_cri_mounts(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info &container);
 
-bool parse_cri_env(const Json::Value &info, sinsp_container_info *container);
+bool parse_cri_env(const Json::Value &info, sinsp_container_info &container);
 
 bool parse_cri_json_image(const Json::Value &info, sinsp_container_info *container);
 

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -46,7 +46,7 @@ bool parse_cri_env(const Json::Value &info, sinsp_container_info &container);
 
 bool parse_cri_json_image(const Json::Value &info, sinsp_container_info &container);
 
-bool parse_cri_runtime_spec(const Json::Value &info, sinsp_container_info *container);
+bool parse_cri_runtime_spec(const Json::Value &info, sinsp_container_info &container);
 
 bool is_pod_sandbox(const std::string &container_id);
 

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -40,7 +40,7 @@ sinsp_container_type get_cri_runtime_type(const std::string &runtime_name);
 
 bool parse_cri_image(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info &container);
 
-bool parse_cri_mounts(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info *container);
+bool parse_cri_mounts(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info &container);
 
 bool parse_cri_env(const Json::Value &info, sinsp_container_info *container);
 

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -44,7 +44,7 @@ bool parse_cri_mounts(const runtime::v1alpha2::ContainerStatus &status, sinsp_co
 
 bool parse_cri_env(const Json::Value &info, sinsp_container_info &container);
 
-bool parse_cri_json_image(const Json::Value &info, sinsp_container_info *container);
+bool parse_cri_json_image(const Json::Value &info, sinsp_container_info &container);
 
 bool parse_cri_runtime_spec(const Json::Value &info, sinsp_container_info *container);
 

--- a/userspace/libsinsp/cursesui.cpp
+++ b/userspace/libsinsp/cursesui.cpp
@@ -155,7 +155,7 @@ void json_spy_renderer::process_event_spy(sinsp_evt* evt, int32_t next_res)
 
 		if(!tinfo->m_container_id.empty())
 		{
-			const sinsp_container_info *container_info =
+			const sinsp_container_manager::entry_ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(container_info)
 			{

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -6111,7 +6111,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_info *container_info =
+			const sinsp_container_manager::entry_ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6134,7 +6134,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_info *container_info =
+			const sinsp_container_manager::entry_ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6160,7 +6160,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_info *container_info =
+			const sinsp_container_manager::entry_ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6202,7 +6202,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_info *container_info =
+			const sinsp_container_manager::entry_ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6250,7 +6250,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_info *container_info =
+			const sinsp_container_manager::entry_ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6277,7 +6277,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_info *container_info =
+			const sinsp_container_manager::entry_ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6312,7 +6312,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		else
 		{
 
-			const sinsp_container_info *container_info =
+			const sinsp_container_manager::entry_ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6355,7 +6355,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		else
 		{
 
-			const sinsp_container_info *container_info =
+			const sinsp_container_manager::entry_ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6416,7 +6416,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_info *container_info =
+			const sinsp_container_manager::entry_ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -7767,7 +7767,7 @@ mesos_task::ptr_t sinsp_filter_check_mesos::find_task_for_thread(const sinsp_thr
 
 		if(m_inspector && m_inspector->m_mesos_client)
 		{
-			const sinsp_container_info *container_info =
+			const sinsp_container_manager::entry_ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info || container_info->m_mesos_task_id.empty())
 			{

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -225,7 +225,7 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 {
 	if(!tinfo->m_container_id.empty())
 	{
-		const sinsp_container_info * container_info =
+		const sinsp_container_manager::entry_ptr_t container_info =
 			m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 
 		//
@@ -259,17 +259,17 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 						tinfo->m_container_id.c_str());
 				}
 
-				const unordered_map<string, sinsp_container_info>* clist = m_inspector->m_container_manager.get_containers();
+				const sinsp_container_manager::map_ptr_t clist = m_inspector->m_container_manager.get_containers();
 
-				for(auto it = clist->begin(); it != clist->end(); ++it)
+				for(const auto it : *clist)
 				{
-					if(!it->second.m_metadata_complete)
+					if(!it.second.m_metadata_complete)
 					{
 						g_logger.format(sinsp_logger::SEV_DEBUG, "Checking IP address of container %s with incomplete metadata (in context of %s)",
-								it->second.m_id.c_str(), tinfo->m_container_id.c_str());
+								it.second.m_id.c_str(), tinfo->m_container_id.c_str());
 					}
 
-					if(htonl(it->second.m_container_ip) == addr)
+					if(htonl(it.second.m_container_ip) == addr)
 					{
 						return true;
 					}


### PR DESCRIPTION
Switch to references instead. Mechanical change only, shouldn't affect behavior in any way

We still hand out raw pointers from container_manager's get_container, that will be handled by a separate PR.