### PR TITLE
Prevent double-definition of ASSERT macro

### DIFF
--- a/userspace/libsinsp/sinsp_int.h
+++ b/userspace/libsinsp/sinsp_int.h
@@ -63,18 +63,20 @@ using namespace std;
 // ASSERT implementation
 //
 #ifdef _DEBUG
+#ifndef ASSERT
 #ifdef ASSERT_TO_LOG
 #define ASSERT(X) \
 	if(!(X)) \
 	{ \
 		g_logger.format(sinsp_logger::SEV_ERROR, "ASSERTION %s at %s:%d", #X , __FILE__, __LINE__); \
 		assert(X); \
-	} 
+	}
 #else
 #define ASSERT(X) assert(X)
 #endif // ASSERT_TO_LOG
 #else // _DEBUG
 #define ASSERT(X)
+#endif // !ASSERT
 #endif // _DEBUG
 
 //

--- a/userspace/libsinsp/sinsp_int.h
+++ b/userspace/libsinsp/sinsp_int.h
@@ -63,7 +63,7 @@ using namespace std;
 // ASSERT implementation
 //
 #ifdef _DEBUG
-#ifndef ASSERT
+#undef ASSERT
 #ifdef ASSERT_TO_LOG
 #define ASSERT(X) \
 	if(!(X)) \
@@ -76,7 +76,6 @@ using namespace std;
 #endif // ASSERT_TO_LOG
 #else // _DEBUG
 #define ASSERT(X)
-#endif // !ASSERT
 #endif // _DEBUG
 
 //


### PR DESCRIPTION
In case the sinsp library is used inside a codebase that already defines
its own ASSERT.