### PR TITLE
free variables in the thread case to avoid memory leaks

### DIFF
--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -1017,6 +1017,7 @@ int32_t scap_fd_handle_socket(scap_t *handle, char *fname, scap_threadinfo *tinf
 			if(uth_status != SCAP_SUCCESS)
 			{
 				snprintf(error, SCAP_LASTERR_SIZE, "socket list allocation error");
+				free(sockets);
 				return SCAP_FAILURE;
 			}
 
@@ -1183,6 +1184,7 @@ int32_t scap_fd_read_unix_sockets_from_proc_fs(scap_t *handle, const char* filen
 		{
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unix socket allocation error");
 			fclose(f);
+			free(fdinfo);
 			return SCAP_FAILURE;
 		}
 	}
@@ -1498,6 +1500,7 @@ int32_t scap_fd_read_ipv4_sockets_from_proc_fs(scap_t *handle, const char *dir, 
 			{
 				uth_status = SCAP_FAILURE;
 				snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "ipv4 socket allocation error");
+				free(fdinfo);
 				break;
 			}
 

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -1327,6 +1327,7 @@ int32_t scap_fd_read_netlink_sockets_from_proc_fs(scap_t *handle, const char* fi
 		{
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "netlink socket allocation error");
 			fclose(f);
+			free(fdinfo);
 			return SCAP_FAILURE;
 		}
 	}

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -925,6 +925,11 @@ int32_t scap_proc_read_thread(scap_t* handle, char* procdirname, uint64_t tid, s
 		snprintf(error, SCAP_LASTERR_SIZE, "cannot add proc tid = %"PRIu64", dirname = %s, error=%s", tid, procdirname, add_error);
 	}
 
+	if(sockets_by_ns != NULL && sockets_by_ns != (void*)-1)
+	{
+		scap_fd_free_ns_sockets_list(handle, &sockets_by_ns);
+	}
+
 	return res;
 }
 

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -874,6 +874,7 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, char* procd
 			if(uth_status != SCAP_SUCCESS)
 			{
 				snprintf(error, SCAP_LASTERR_SIZE, "process table allocation error (2)");
+				free(tinfo);
 				return SCAP_FAILURE;
 			}
 		}

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -1396,6 +1396,7 @@ int32_t scap_update_suppressed(scap_t *handle,
 		if(uth_status != SCAP_SUCCESS)
 		{
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't add tid to suppressed hash table");
+			free(stid);
 			return SCAP_FAILURE;
 		}
 		*suppressed = true;

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -1160,6 +1160,7 @@ struct scap_threadinfo* scap_proc_get(scap_t* handle, int64_t tid, bool scan_soc
 	snprintf(filename, sizeof(filename), "%s/proc", scap_get_host_root());
 	if(scap_proc_read_thread(handle, filename, tid, &tinfo, handle->m_lasterr, scan_sockets) != SCAP_SUCCESS)
 	{
+		free(tinfo);
 		return NULL;
 	}
 


### PR DESCRIPTION
Co-authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

This PR frees:
- `sockets_by_ns` variable in the thread case
- thread info `tinfo` variable when an errors occurs inserting it into the hashmap `andle->m_proclist` 
- `fdinfo` variable when an errors occurs inserting it into the hashmap `*sockets`
- `procinfo` variable

It is an attempt to fix a memory leak an user [reported in Falco](https://github.com/falcosecurity/falco/issues/740).