### PR TITLE
Fixed gcc-6 dependency by adding libmpx2

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
 	llvm-7 \
 	procps \
 	xz-utils \
+	libmpx2 \
  && rm -rf /var/lib/apt/lists/*
 
 # gcc 6 is no longer included in debian unstable, but we need it to

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
 	llvm-7 \
 	procps \
 	xz-utils \
+	libmpx2 \
  && rm -rf /var/lib/apt/lists/*
 
 # gcc 6 is no longer included in debian unstable, but we need it to

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
 	llvm-7 \
 	procps \
 	xz-utils \
+	libmpx2 \
  && rm -rf /var/lib/apt/lists/*
 
 # gcc 6 is no longer included in debian unstable, but we need it to


### PR DESCRIPTION
Builds of docker images on docker hub have been failing. I don't seem to have access to the build logs on docker hub but I strongly suspect they're failing for the exact same reason our agent builds have been failing:

`dpkg: dependency problems prevent configuration of libgcc-6-dev:amd64:
 libgcc-6-dev:amd64 depends on libmpx2 (>= 6.3.0-18); however:
  Package libmpx2 is not installed.`

Adding libmpx2