### PR TITLE
improve /dev/<pid>/sstat parsing

### DIFF
--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -258,11 +258,15 @@ int32_t scap_proc_fill_info_from_stats(scap_t *handle, char* procdirname, struct
 		return SCAP_FAILURE;
 	}
 
-	uint32_t slpos = 0;
-	while(fgets(line + slpos, sizeof(line) - slpos, f) != NULL)
+	size_t ssres = fread(line, 1, sizeof(line) - 1, f);
+	if(ssres < 0)
 	{
-		slpos = strlen(line);
+		fclose(f);
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Could not read from stat file %s (%s)",	
+				filename, scap_strerror(handle, errno));	
+		return SCAP_FAILURE;
 	}
+	line[ssres] = 0;
 
 	s = strrchr(line, ')');
 	if(s == NULL)

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -259,7 +259,7 @@ int32_t scap_proc_fill_info_from_stats(scap_t *handle, char* procdirname, struct
 	}
 
 	size_t ssres = fread(line, 1, sizeof(line) - 1, f);
-	if(ssres < 0)
+	if(ssres == 0)
 	{
 		ASSERT(false);
 		fclose(f);

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -258,13 +258,10 @@ int32_t scap_proc_fill_info_from_stats(scap_t *handle, char* procdirname, struct
 		return SCAP_FAILURE;
 	}
 
-	if(fgets(line, sizeof(line), f) == NULL)
+	uint32_t slpos = 0;
+	while(fgets(line + slpos, sizeof(line) - slpos, f) != NULL)
 	{
-		ASSERT(false);
-		fclose(f);
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Could not read from stat file %s (%s)",
-			 filename, scap_strerror(handle, errno));
-		return SCAP_FAILURE;
+		slpos = strlen(line);
 	}
 
 	s = strrchr(line, ')');
@@ -272,7 +269,7 @@ int32_t scap_proc_fill_info_from_stats(scap_t *handle, char* procdirname, struct
 	{
 		ASSERT(false);
 		fclose(f);
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Could not find closng parens in stat file %s",
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Could not find closing bracket in stat file %s",
 			 filename);
 		return SCAP_FAILURE;
 	}

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -261,9 +261,10 @@ int32_t scap_proc_fill_info_from_stats(scap_t *handle, char* procdirname, struct
 	size_t ssres = fread(line, 1, sizeof(line) - 1, f);
 	if(ssres < 0)
 	{
+		ASSERT(false);
 		fclose(f);
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Could not read from stat file %s (%s)",	
-				filename, scap_strerror(handle, errno));	
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Could not read from stat file %s (%s)",
+			 filename, scap_strerror(handle, errno));
 		return SCAP_FAILURE;
 	}
 	line[ssres] = 0;


### PR DESCRIPTION
this PR makes the parsing of the sttats file more solid with regards to processes that have end of line characters in their name.