### PR TITLE
Keep `shared_ptr`s in container_manager's container map

### DIFF
--- a/userspace/libsinsp/chisel_api.cpp
+++ b/userspace/libsinsp/chisel_api.cpp
@@ -1156,49 +1156,49 @@ int lua_cbacks::get_container_table(lua_State *ls)
 	{
 		lua_newtable(ls);
 		lua_pushliteral(ls, "id");
-		lua_pushstring(ls, it->second.m_id.c_str());
+		lua_pushstring(ls, it->second->m_id.c_str());
 		lua_settable(ls, -3);
 		lua_pushliteral(ls, "name");
-		lua_pushstring(ls, it->second.m_name.c_str());
+		lua_pushstring(ls, it->second->m_name.c_str());
 		lua_settable(ls, -3);
 		lua_pushliteral(ls, "image");
-		lua_pushstring(ls, it->second.m_image.c_str());
+		lua_pushstring(ls, it->second->m_image.c_str());
 		lua_settable(ls, -3);
 
 		lua_pushliteral(ls, "type");
-		if(it->second.m_type == CT_DOCKER)
+		if(it->second->m_type == CT_DOCKER)
 		{
 			lua_pushstring(ls, "docker");
 		}
-		else if(it->second.m_type == CT_LXC)
+		else if(it->second->m_type == CT_LXC)
 		{
 			lua_pushstring(ls, "lxc");
 		}
-		else if(it->second.m_type == CT_LIBVIRT_LXC)
+		else if(it->second->m_type == CT_LIBVIRT_LXC)
 		{
 			lua_pushstring(ls, "libvirt_lxc");
 		}
-		else if(it->second.m_type == CT_MESOS)
+		else if(it->second->m_type == CT_MESOS)
 		{
 			lua_pushstring(ls, "mesos");
 		}
-		else if(it->second.m_type == CT_RKT)
+		else if(it->second->m_type == CT_RKT)
 		{
 			lua_pushstring(ls, "rkt");
 		}
-		else if(it->second.m_type == CT_CRI)
+		else if(it->second->m_type == CT_CRI)
 		{
 			lua_pushstring(ls, "cri");
 		}
-		else if(it->second.m_type == CT_CONTAINERD)
+		else if(it->second->m_type == CT_CONTAINERD)
 		{
 			lua_pushstring(ls, "containerd");
 		}
-		else if(it->second.m_type == CT_CRIO)
+		else if(it->second->m_type == CT_CRIO)
 		{
 			lua_pushstring(ls, "cri-o");
 		}
-		else if(it->second.m_type == CT_BPM)
+		else if(it->second->m_type == CT_BPM)
 		{
 			lua_pushstring(ls, "bpm");
 		}

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -279,14 +279,13 @@ sinsp_container_manager::map_ptr_t sinsp_container_manager::get_containers()
 	return &m_containers;
 }
 
-void sinsp_container_manager::add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread_info)
+void sinsp_container_manager::add_container(const sinsp_container_info::ptr_t& container_info, sinsp_threadinfo *thread)
 {
-	auto new_entry = std::make_shared<sinsp_container_info>(container_info);
-	m_containers[container_info.m_id] = new_entry;
+	m_containers[container_info->m_id] = container_info;
 
 	for(const auto &new_cb : m_new_callbacks)
 	{
-		new_cb(*m_containers[container_info.m_id], thread_info);
+		new_cb(*container_info, thread);
 	}
 }
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -289,6 +289,12 @@ void sinsp_container_manager::add_container(const sinsp_container_info::ptr_t& c
 	}
 }
 
+void sinsp_container_manager::replace_container(const sinsp_container_info::ptr_t& container_info)
+{
+	ASSERT(m_containers.find(container_info->m_id) != m_containers.end());
+	m_containers[container_info->m_id] = container_info;
+}
+
 void sinsp_container_manager::notify_new_container(const sinsp_container_info& container_info)
 {
 	sinsp_evt *evt = new sinsp_evt();

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -95,7 +95,7 @@ bool sinsp_container_manager::remove_inactive_containers()
 	return res;
 }
 
-sinsp_container_info::ptr_t sinsp_container_manager::get_container(const string& container_id)
+sinsp_container_info::ptr_t sinsp_container_manager::get_container(const string& container_id) const
 {
 	auto it = m_containers.find(container_id);
 	if(it != m_containers.end())
@@ -274,7 +274,7 @@ bool sinsp_container_manager::container_to_sinsp_event(const string& json, sinsp
 	return true;
 }
 
-sinsp_container_manager::map_ptr_t sinsp_container_manager::get_containers()
+sinsp_container_manager::map_ptr_t sinsp_container_manager::get_containers() const
 {
 	return &m_containers;
 }
@@ -335,7 +335,7 @@ void sinsp_container_manager::dump_containers(scap_dumper_t* dumper)
 	}
 }
 
-string sinsp_container_manager::get_container_name(sinsp_threadinfo* tinfo)
+string sinsp_container_manager::get_container_name(sinsp_threadinfo* tinfo) const
 {
 	string res;
 

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -45,7 +45,7 @@ public:
 
 	map_ptr_t get_containers();
 	bool remove_inactive_containers();
-	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread);
+	void add_container(const sinsp_container_info::ptr_t& container_info, sinsp_threadinfo *thread);
 	sinsp_container_info::ptr_t get_container(const std::string &id);
 	void notify_new_container(const sinsp_container_info& container_info);
 	template<typename E> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -38,7 +38,7 @@ limitations under the License.
 class sinsp_container_manager
 {
 public:
-	using map_ptr_t = const std::unordered_map<std::string, std::shared_ptr<sinsp_container_info>>*;
+	using map_ptr_t = const std::unordered_map<std::string, std::shared_ptr<const sinsp_container_info>>*;
 
 	sinsp_container_manager(sinsp* inspector);
 	virtual ~sinsp_container_manager();
@@ -46,6 +46,7 @@ public:
 	map_ptr_t get_containers();
 	bool remove_inactive_containers();
 	void add_container(const sinsp_container_info::ptr_t& container_info, sinsp_threadinfo *thread);
+	void replace_container(const sinsp_container_info::ptr_t& container_info);
 	sinsp_container_info::ptr_t get_container(const std::string &id);
 	void notify_new_container(const sinsp_container_info& container_info);
 	template<typename E> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
@@ -85,7 +86,7 @@ private:
 	std::list<std::unique_ptr<libsinsp::container_engine::resolver>> m_container_engines;
 
 	sinsp* m_inspector;
-	std::unordered_map<std::string, std::shared_ptr<sinsp_container_info>> m_containers;
+	std::unordered_map<std::string, std::shared_ptr<const sinsp_container_info>> m_containers;
 	uint64_t m_last_flush_time_ns;
 	std::list<new_container_cb> m_new_callbacks;
 	std::list<remove_container_cb> m_remove_callbacks;

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -38,8 +38,7 @@ limitations under the License.
 class sinsp_container_manager
 {
 public:
-	using map_ptr_t = const std::unordered_map<std::string, sinsp_container_info>*;
-	using entry_ptr_t = sinsp_container_info*;
+	using map_ptr_t = const std::unordered_map<std::string, std::shared_ptr<sinsp_container_info>>*;
 
 	sinsp_container_manager(sinsp* inspector);
 	virtual ~sinsp_container_manager();
@@ -47,7 +46,7 @@ public:
 	map_ptr_t get_containers();
 	bool remove_inactive_containers();
 	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread);
-	entry_ptr_t get_container(const std::string &id);
+	sinsp_container_info::ptr_t get_container(const std::string &id);
 	void notify_new_container(const sinsp_container_info& container_info);
 	template<typename E> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	template<typename E1, typename E2, typename... Args> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
@@ -86,7 +85,7 @@ private:
 	std::list<std::unique_ptr<libsinsp::container_engine::resolver>> m_container_engines;
 
 	sinsp* m_inspector;
-	std::unordered_map<std::string, sinsp_container_info> m_containers;
+	std::unordered_map<std::string, std::shared_ptr<sinsp_container_info>> m_containers;
 	uint64_t m_last_flush_time_ns;
 	std::list<new_container_cb> m_new_callbacks;
 	std::list<remove_container_cb> m_remove_callbacks;

--- a/userspace/libsinsp/container_engine/bpm.cpp
+++ b/userspace/libsinsp/container_engine/bpm.cpp
@@ -62,7 +62,8 @@ bool bpm::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 	if (!manager->container_exists(container_info.m_id))
 	{
 		container_info.m_name = container_info.m_id;
-		manager->add_container(container_info, tinfo);
+		auto container = std::make_shared<sinsp_container_info>(container_info);
+		manager->add_container(container, tinfo);
 		manager->notify_new_container(container_info);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -211,7 +211,6 @@ void cri::set_extra_queries(bool extra_queries) {
 bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 {
 	sinsp_container_info container_info;
-	sinsp_container_info::ptr_t existing_container_info;
 
 	if(!matches_runc_cgroups(tinfo, CRI_CGROUP_LAYOUT, container_info.m_id))
 	{
@@ -219,7 +218,7 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 	}
 	tinfo->m_container_id = container_info.m_id;
 
-	existing_container_info = manager->get_container(container_info.m_id);
+	sinsp_container_info::ptr_t existing_container_info = manager->get_container(container_info.m_id);
 
 	if (!existing_container_info ||
 	    existing_container_info->m_metadata_complete == false)

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -248,7 +248,8 @@ bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 					"cri (%s) Mesos CRI container, Mesos task ID: [%s]",
 					container_info.m_id.c_str(), container_info.m_mesos_task_id.c_str());
 		}
-		manager->add_container(container_info, tinfo);
+		auto container = std::make_shared<sinsp_container_info>(container_info);
+		manager->add_container(container, tinfo);
 		manager->notify_new_container(container_info);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -211,7 +211,7 @@ void cri::set_extra_queries(bool extra_queries) {
 bool cri::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 {
 	sinsp_container_info container_info;
-	sinsp_container_info *existing_container_info;
+	sinsp_container_info::ptr_t existing_container_info;
 
 	if(!matches_runc_cgroups(tinfo, CRI_CGROUP_LAYOUT, container_info.m_id))
 	{

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -345,7 +345,7 @@ std::string docker::s_incomplete_info_name = "incomplete";
 bool docker::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 {
 	std::string container_id, container_name;
-	sinsp_container_info *existing_container_info;
+	sinsp_container_info::ptr_t existing_container_info;
 
 	if(!detect_docker(tinfo, container_id, container_name))
 	{

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -370,23 +370,24 @@ bool docker::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, 
 		// container id, (possibly) name, and a container
 		// image = incomplete is filled in. This may be
 		// overidden later once parse_docker_async completes.
-		container_info = std::make_shared<sinsp_container_info>();
+		auto new_container_info = std::make_shared<sinsp_container_info>();
 
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker_async (%s): No existing container info, creating initial stub info",
 				container_id.c_str());
 
-		container_info->m_type = CT_DOCKER;
-		container_info->m_id = container_id;
-		container_info->m_name = container_name;
-		container_info->m_image = s_incomplete_info_name;
-		container_info->m_imageid = s_incomplete_info_name;
-		container_info->m_imagerepo = s_incomplete_info_name;
-		container_info->m_imagetag = s_incomplete_info_name;
-		container_info->m_imagedigest = s_incomplete_info_name;
-		container_info->m_metadata_complete = false;
+		new_container_info->m_type = CT_DOCKER;
+		new_container_info->m_id = container_id;
+		new_container_info->m_name = container_name;
+		new_container_info->m_image = s_incomplete_info_name;
+		new_container_info->m_imageid = s_incomplete_info_name;
+		new_container_info->m_imagerepo = s_incomplete_info_name;
+		new_container_info->m_imagetag = s_incomplete_info_name;
+		new_container_info->m_imagedigest = s_incomplete_info_name;
+		new_container_info->m_metadata_complete = false;
 
-		manager->add_container(container_info, tinfo);
+		manager->add_container(new_container_info, tinfo);
+		container_info = new_container_info;
 	}
 
 #ifdef HAS_CAPTURE

--- a/userspace/libsinsp/container_engine/libvirt_lxc.cpp
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.cpp
@@ -86,7 +86,8 @@ bool libvirt_lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* ti
 	if (!manager->container_exists(container_info.m_id))
 	{
 		container_info.m_name = container_info.m_id;
-		manager->add_container(container_info, tinfo);
+		auto container = std::make_shared<sinsp_container_info>(container_info);
+		manager->add_container(container, tinfo);
 		manager->notify_new_container(container_info);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/libvirt_lxc.cpp
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.cpp
@@ -75,20 +75,19 @@ bool libvirt_lxc::match(sinsp_threadinfo* tinfo, sinsp_container_info &container
 
 bool libvirt_lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 {
-	sinsp_container_info container_info;
+	auto container = std::make_shared<sinsp_container_info>();
 
-	if (!match(tinfo, container_info))
+	if (!match(tinfo, *container))
 	{
 		return false;
 	}
 
-	tinfo->m_container_id = container_info.m_id;
-	if (!manager->container_exists(container_info.m_id))
+	tinfo->m_container_id = container->m_id;
+	if (!manager->container_exists(container->m_id))
 	{
-		container_info.m_name = container_info.m_id;
-		auto container = std::make_shared<sinsp_container_info>(container_info);
+		container->m_name = container->m_id;
 		manager->add_container(container, tinfo);
-		manager->notify_new_container(container_info);
+		manager->notify_new_container(*container);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/lxc.cpp
+++ b/userspace/libsinsp/container_engine/lxc.cpp
@@ -24,7 +24,7 @@ using namespace libsinsp::container_engine;
 
 bool lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 {
-	sinsp_container_info container_info;
+	auto container = std::make_shared<sinsp_container_info>();
 	bool matches = false;
 
 	for(const auto& it : tinfo->m_cgroups)
@@ -38,8 +38,8 @@ bool lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 		{
 			auto id_start = pos + sizeof("/lxc/") - 1;
 			auto id_end = cgroup.find('/', id_start);
-			container_info.m_type = CT_LXC;
-			container_info.m_id = cgroup.substr(id_start, id_end - id_start);
+			container->m_type = CT_LXC;
+			container->m_id = cgroup.substr(id_start, id_end - id_start);
 			matches = true;
 			break;
 		}
@@ -49,8 +49,8 @@ bool lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 		{
 			auto id_start = pos + sizeof("/lxc.payload/") - 1;
 			auto id_end = cgroup.find('/', id_start);
-			container_info.m_type = CT_LXC;
-			container_info.m_id = cgroup.substr(id_start, id_end - id_start);
+			container->m_type = CT_LXC;
+			container->m_id = cgroup.substr(id_start, id_end - id_start);
 			matches = true;
 			break;
 		}
@@ -61,13 +61,12 @@ bool lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 		return false;
 	}
 
-	tinfo->m_container_id = container_info.m_id;
-	if (!manager->container_exists(container_info.m_id))
+	tinfo->m_container_id = container->m_id;
+	if (!manager->container_exists(container->m_id))
 	{
-		container_info.m_name = container_info.m_id;
-		auto container = std::make_shared<sinsp_container_info>(container_info);
+		container->m_name = container->m_id;
 		manager->add_container(container, tinfo);
-		manager->notify_new_container(container_info);
+		manager->notify_new_container(*container);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/lxc.cpp
+++ b/userspace/libsinsp/container_engine/lxc.cpp
@@ -65,7 +65,8 @@ bool lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 	if (!manager->container_exists(container_info.m_id))
 	{
 		container_info.m_name = container_info.m_id;
-		manager->add_container(container_info, tinfo);
+		auto container = std::make_shared<sinsp_container_info>(container_info);
+		manager->add_container(container, tinfo);
 		manager->notify_new_container(container_info);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/mesos.cpp
+++ b/userspace/libsinsp/container_engine/mesos.cpp
@@ -54,18 +54,17 @@ bool libsinsp::container_engine::mesos::match(sinsp_threadinfo* tinfo, sinsp_con
 
 bool libsinsp::container_engine::mesos::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 {
-	sinsp_container_info container_info;
+	auto container = std::make_shared<sinsp_container_info>();
 
-	if (!match(tinfo, container_info))
+	if (!match(tinfo, *container))
 		return false;
 
-	tinfo->m_container_id = container_info.m_id;
-	if (!manager->container_exists(container_info.m_id))
+	tinfo->m_container_id = container->m_id;
+	if (!manager->container_exists(container->m_id))
 	{
-		container_info.m_name = container_info.m_id;
-		auto container = std::make_shared<sinsp_container_info>(container_info);
+		container->m_name = container->m_id;
 		manager->add_container(container, tinfo);
-		manager->notify_new_container(container_info);
+		manager->notify_new_container(*container);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/mesos.cpp
+++ b/userspace/libsinsp/container_engine/mesos.cpp
@@ -63,7 +63,8 @@ bool libsinsp::container_engine::mesos::resolve(sinsp_container_manager* manager
 	if (!manager->container_exists(container_info.m_id))
 	{
 		container_info.m_name = container_info.m_id;
-		manager->add_container(container_info, tinfo);
+		auto container = std::make_shared<sinsp_container_info>(container_info);
+		manager->add_container(container, tinfo);
 		manager->notify_new_container(container_info);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/rkt.cpp
+++ b/userspace/libsinsp/container_engine/rkt.cpp
@@ -167,31 +167,30 @@ bool rkt::match(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, sinsp
 
 bool rkt::rkt::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 {
-	sinsp_container_info container_info;
+	auto container = std::make_shared<sinsp_container_info>();
 	string rkt_podid, rkt_appname;
 
-	if (!match(manager, tinfo, container_info, rkt_podid, rkt_appname, query_os_for_missing_info))
+	if (!match(manager, tinfo, *container, rkt_podid, rkt_appname, query_os_for_missing_info))
 	{
 		return false;
 	}
 
-	tinfo->m_container_id = container_info.m_id;
-	if (!query_os_for_missing_info || manager->container_exists(container_info.m_id))
+	tinfo->m_container_id = container->m_id;
+	if (!query_os_for_missing_info || manager->container_exists(container->m_id))
 	{
 		return true;
 	}
 
 #ifndef _WIN32
-	bool have_rkt = parse_rkt(container_info, rkt_podid, rkt_appname);
+	bool have_rkt = parse_rkt(*container, rkt_podid, rkt_appname);
 #else
 	bool have_rkt = true;
 #endif
 
 	if (have_rkt)
 	{
-		auto container = std::make_shared<sinsp_container_info>(container_info);
 		manager->add_container(container, tinfo);
-		manager->notify_new_container(container_info);
+		manager->notify_new_container(*container);
 		return true;
 	}
 	else

--- a/userspace/libsinsp/container_engine/rkt.cpp
+++ b/userspace/libsinsp/container_engine/rkt.cpp
@@ -189,7 +189,8 @@ bool rkt::rkt::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo
 
 	if (have_rkt)
 	{
-		manager->add_container(container_info, tinfo);
+		auto container = std::make_shared<sinsp_container_info>(container_info);
+		manager->add_container(container, tinfo);
 		manager->notify_new_container(container_info);
 		return true;
 	}

--- a/userspace/libsinsp/container_info.cpp
+++ b/userspace/libsinsp/container_info.cpp
@@ -159,13 +159,13 @@ std::shared_ptr<sinsp_threadinfo> sinsp_container_info::get_tinfo(sinsp* inspect
 	return tinfo;
 }
 
-sinsp_container_info::container_health_probe::probe_type sinsp_container_info::match_health_probe(sinsp_threadinfo *tinfo)
+sinsp_container_info::container_health_probe::probe_type sinsp_container_info::match_health_probe(sinsp_threadinfo *tinfo) const
 {
 	g_logger.format(sinsp_logger::SEV_DEBUG,
 			"match_health_probe (%s): %u health probes to consider",
 			m_id.c_str(), m_health_probes.size());
 
-	auto pred = [&] (container_health_probe &p) {
+	auto pred = [&] (const container_health_probe &p) {
                 g_logger.format(sinsp_logger::SEV_DEBUG,
 				"match_health_probe (%s): Matching tinfo %s %d against %s %d",
 				m_id.c_str(),

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -59,7 +59,7 @@ static inline bool is_docker_compatible(sinsp_container_type t)
 class sinsp_container_info
 {
 public:
-	using ptr_t = std::shared_ptr<sinsp_container_info>;
+	using ptr_t = std::shared_ptr<const sinsp_container_info>;
 
 	class container_port_mapping
 	{

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -203,7 +203,7 @@ public:
 	std::shared_ptr<sinsp_threadinfo> get_tinfo(sinsp* inspector) const;
 
 	// Match a process against the set of health probes
-	container_health_probe::probe_type match_health_probe(sinsp_threadinfo *tinfo);
+	container_health_probe::probe_type match_health_probe(sinsp_threadinfo *tinfo) const;
 
 	std::string m_id;
 	sinsp_container_type m_type;

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -59,6 +59,7 @@ static inline bool is_docker_compatible(sinsp_container_type t)
 class sinsp_container_info
 {
 public:
+	using ptr_t = std::shared_ptr<sinsp_container_info>;
 
 	class container_port_mapping
 	{

--- a/userspace/libsinsp/cursesui.cpp
+++ b/userspace/libsinsp/cursesui.cpp
@@ -155,7 +155,7 @@ void json_spy_renderer::process_event_spy(sinsp_evt* evt, int32_t next_res)
 
 		if(!tinfo->m_container_id.empty())
 		{
-			const sinsp_container_manager::entry_ptr_t container_info =
+			const sinsp_container_info::ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(container_info)
 			{

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -6111,7 +6111,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_manager::entry_ptr_t container_info =
+			const sinsp_container_info::ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6134,7 +6134,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_manager::entry_ptr_t container_info =
+			const sinsp_container_info::ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6160,7 +6160,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_manager::entry_ptr_t container_info =
+			const sinsp_container_info::ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6202,7 +6202,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_manager::entry_ptr_t container_info =
+			const sinsp_container_info::ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6250,7 +6250,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_manager::entry_ptr_t container_info =
+			const sinsp_container_info::ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6277,7 +6277,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_manager::entry_ptr_t container_info =
+			const sinsp_container_info::ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6312,7 +6312,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		else
 		{
 
-			const sinsp_container_manager::entry_ptr_t container_info =
+			const sinsp_container_info::ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6355,7 +6355,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		else
 		{
 
-			const sinsp_container_manager::entry_ptr_t container_info =
+			const sinsp_container_info::ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -6416,7 +6416,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 		}
 		else
 		{
-			const sinsp_container_manager::entry_ptr_t container_info =
+			const sinsp_container_info::ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info)
 			{
@@ -7767,7 +7767,7 @@ mesos_task::ptr_t sinsp_filter_check_mesos::find_task_for_thread(const sinsp_thr
 
 		if(m_inspector && m_inspector->m_mesos_client)
 		{
-			const sinsp_container_manager::entry_ptr_t container_info =
+			const sinsp_container_info::ptr_t container_info =
 				m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 			if(!container_info || container_info->m_mesos_task_id.empty())
 			{

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -225,7 +225,7 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 {
 	if(!tinfo->m_container_id.empty())
 	{
-		const sinsp_container_manager::entry_ptr_t container_info =
+		const sinsp_container_info::ptr_t container_info =
 			m_inspector->m_container_manager.get_container(tinfo->m_container_id);
 
 		//
@@ -263,13 +263,13 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 
 				for(const auto it : *clist)
 				{
-					if(!it.second.m_metadata_complete)
+					if(!it.second->m_metadata_complete)
 					{
 						g_logger.format(sinsp_logger::SEV_DEBUG, "Checking IP address of container %s with incomplete metadata (in context of %s)",
-								it.second.m_id.c_str(), tinfo->m_container_id.c_str());
+								it.second->m_id.c_str(), tinfo->m_container_id.c_str());
 					}
 
-					if(htonl(it.second.m_container_ip) == addr)
+					if(htonl(it.second->m_container_ip) == addr)
 					{
 						return true;
 					}

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4753,22 +4753,21 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 void sinsp_parser::parse_container_evt(sinsp_evt *evt)
 {
 	sinsp_evt_param *parinfo;
-	sinsp_container_info container_info;
+	auto container = std::make_shared<sinsp_container_info>();
 
 	parinfo = evt->get_param(0);
-	container_info.m_id = parinfo->m_val;
+	container->m_id = parinfo->m_val;
 
 	parinfo = evt->get_param(1);
 	ASSERT(parinfo->m_len == sizeof(uint32_t));
-	container_info.m_type = (sinsp_container_type) *(uint32_t *)parinfo->m_val;
+	container->m_type = (sinsp_container_type) *(uint32_t *)parinfo->m_val;
 
 	parinfo = evt->get_param(2);
-	container_info.m_name = parinfo->m_val;
+	container->m_name = parinfo->m_val;
 
 	parinfo = evt->get_param(3);
-	container_info.m_image = parinfo->m_val;
+	container->m_image = parinfo->m_val;
 
-	auto container = std::make_shared<sinsp_container_info>(container_info);
 	m_inspector->m_container_manager.add_container(container, evt->get_thread_info(true));
 }
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4563,64 +4563,64 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 	Json::Value root;
 	if(Json::Reader().parse(json, root))
 	{
-		sinsp_container_info container_info;
+		auto container_info = std::make_shared<sinsp_container_info>();
 		const Json::Value& container = root["container"];
 		const Json::Value& id = container["id"];
 		if(check_json_val_is_convertible(id, Json::stringValue, "id"))
 		{
-			container_info.m_id = id.asString();
+			container_info->m_id = id.asString();
 		}
 		const Json::Value& type = container["type"];
 		if(check_json_val_is_convertible(type, Json::uintValue, "type"))
 		{
-			container_info.m_type = static_cast<sinsp_container_type>(type.asUInt());
+			container_info->m_type = static_cast<sinsp_container_type>(type.asUInt());
 		}
 		const Json::Value& name = container["name"];
 		if(check_json_val_is_convertible(name, Json::stringValue, "name"))
 		{
-			container_info.m_name = name.asString();
+			container_info->m_name = name.asString();
 		}
 
 		const Json::Value& is_pod_sandbox = container["is_pod_sandbox"];
 		if(check_json_val_is_convertible(is_pod_sandbox, Json::booleanValue, "is_pod_sandbox"))
 		{
-			container_info.m_is_pod_sandbox = is_pod_sandbox.asBool();
+			container_info->m_is_pod_sandbox = is_pod_sandbox.asBool();
 		}
 
 		const Json::Value& image = container["image"];
 		if(check_json_val_is_convertible(image, Json::stringValue, "image"))
 		{
-			container_info.m_image = image.asString();
+			container_info->m_image = image.asString();
 		}
 		const Json::Value& imageid = container["imageid"];
 		if(check_json_val_is_convertible(imageid, Json::stringValue, "imageid"))
 		{
-			container_info.m_imageid = imageid.asString();
+			container_info->m_imageid = imageid.asString();
 		}
 		const Json::Value& imagerepo = container["imagerepo"];
 		if(check_json_val_is_convertible(imagerepo, Json::stringValue, "imagerepo"))
 		{
-			container_info.m_imagerepo = imagerepo.asString();
+			container_info->m_imagerepo = imagerepo.asString();
 		}
 		const Json::Value& imagetag = container["imagetag"];
 		if(check_json_val_is_convertible(imagetag, Json::stringValue, "imagetag"))
 		{
-			container_info.m_imagetag = imagetag.asString();
+			container_info->m_imagetag = imagetag.asString();
 		}
 		const Json::Value& imagedigest = container["imagedigest"];
 		if(check_json_val_is_convertible(imagedigest, Json::stringValue, "imagedigest"))
 		{
-			container_info.m_imagedigest = imagedigest.asString();
+			container_info->m_imagedigest = imagedigest.asString();
 		}
 		const Json::Value& privileged = container["privileged"];
 		if(check_json_val_is_convertible(privileged, Json::booleanValue, "privileged"))
 		{
-			container_info.m_privileged = privileged.asBool();
+			container_info->m_privileged = privileged.asBool();
 		}
 
-		libsinsp::container_engine::docker::parse_json_mounts(container["Mounts"], container_info.m_mounts);
+		libsinsp::container_engine::docker::parse_json_mounts(container["Mounts"], container_info->m_mounts);
 
-		sinsp_container_info::container_health_probe::parse_health_probes(container, container_info.m_health_probes);
+		sinsp_container_info::container_health_probe::parse_health_probes(container, container_info->m_health_probes);
 
 		const Json::Value& contip = container["ip"];
 		if(check_json_val_is_convertible(contip, Json::stringValue, "ip"))
@@ -4632,7 +4632,7 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 				throw sinsp_exception("Invalid 'ip' field while parsing container info: " + json);
 			}
 
-			container_info.m_container_ip = ntohl(ip);
+			container_info->m_container_ip = ntohl(ip);
 		}
 
 		const Json::Value &port_mappings = container["port_mappings"];
@@ -4657,7 +4657,7 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 				if(check_json_val_is_convertible(container_port, Json::intValue, "ContainerPort", true)) {
 					map.m_container_port = (uint16_t) container_port.asInt();
 				}
-				container_info.m_port_mappings.push_back(map);
+				container_info->m_port_mappings.push_back(map);
 			}
 		}
 
@@ -4665,7 +4665,7 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		for(vector<string>::const_iterator it = labels.begin(); it != labels.end(); ++it)
 		{
 			string val = container["labels"][*it].asString();
-			container_info.m_labels[*it] = val;
+			container_info->m_labels[*it] = val;
 		}
 
 		const Json::Value& env_vars = container["env"];
@@ -4674,50 +4674,50 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		{
 			if(env_var.isString())
 			{
-				container_info.m_env.emplace_back(env_var.asString());
+				container_info->m_env.emplace_back(env_var.asString());
 			}
 		}
 
 		const Json::Value& memory_limit = container["memory_limit"];
 		if(check_int64_json_is_convertible(memory_limit, "memory_limit"))
 		{
-			container_info.m_memory_limit = memory_limit.asInt64();
+			container_info->m_memory_limit = memory_limit.asInt64();
 		}
 
 		const Json::Value& swap_limit = container["swap_limit"];
 		if(check_int64_json_is_convertible(swap_limit, "swap_limit"))
 		{
-			container_info.m_swap_limit = swap_limit.asInt64();
+			container_info->m_swap_limit = swap_limit.asInt64();
 		}
 
 		const Json::Value& cpu_shares = container["cpu_shares"];
 		if(check_int64_json_is_convertible(cpu_shares, "cpu_shares"))
 		{
-			container_info.m_cpu_shares = cpu_shares.asInt64();
+			container_info->m_cpu_shares = cpu_shares.asInt64();
 		}
 
 		const Json::Value& cpu_quota = container["cpu_quota"];
 		if(check_int64_json_is_convertible(cpu_quota, "cpu_quota"))
 		{
-			container_info.m_cpu_quota = cpu_quota.asInt64();
+			container_info->m_cpu_quota = cpu_quota.asInt64();
 		}
 
 		const Json::Value& cpu_period = container["cpu_period"];
 		if(check_int64_json_is_convertible(cpu_period, "cpu_period"))
 		{
-			container_info.m_cpu_period = cpu_period.asInt64();
+			container_info->m_cpu_period = cpu_period.asInt64();
 		}
 
 		const Json::Value& cpuset_cpu_count = container["cpuset_cpu_count"];
 		if(check_json_val_is_convertible(cpuset_cpu_count, Json::intValue, "cpuset_cpu_count"))
 		{
-			container_info.m_cpuset_cpu_count = cpuset_cpu_count.asInt();
+			container_info->m_cpuset_cpu_count = cpuset_cpu_count.asInt();
 		}
 
 		const Json::Value& mesos_task_id = container["mesos_task_id"];
 		if(check_json_val_is_convertible(mesos_task_id, Json::stringValue, "mesos_task_id"))
 		{
-			container_info.m_mesos_task_id = mesos_task_id.asString();
+			container_info->m_mesos_task_id = mesos_task_id.asString();
 		}
 
 		const Json::Value& metadata_deadline = container["metadata_deadline"];
@@ -4725,13 +4725,13 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		{
 			// isConvertibleTo doesn't seem to work on large 64 bit numbers
 			if(metadata_deadline.isUInt64()) {
-				container_info.m_metadata_deadline = metadata_deadline.asUInt64();
+				container_info->m_metadata_deadline = metadata_deadline.asUInt64();
 			} else {
 				SINSP_DEBUG("Unable to convert json value for field: %s", "metadata_deadline");
 			}
 		}
 
-		evt->m_tinfo_ref = container_info.get_tinfo(m_inspector);
+		evt->m_tinfo_ref = container_info->get_tinfo(m_inspector);
 		evt->m_tinfo = evt->m_tinfo_ref.get();
 		m_inspector->m_container_manager.add_container(container_info, evt->get_thread_info(true));
 		/*
@@ -4768,7 +4768,8 @@ void sinsp_parser::parse_container_evt(sinsp_evt *evt)
 	parinfo = evt->get_param(3);
 	container_info.m_image = parinfo->m_val;
 
-	m_inspector->m_container_manager.add_container(container_info, evt->get_thread_info(true));
+	auto container = std::make_shared<sinsp_container_info>(container_info);
+	m_inspector->m_container_manager.add_container(container, evt->get_thread_info(true));
 }
 
 void sinsp_parser::parse_cpu_hotplug_enter(sinsp_evt *evt)


### PR DESCRIPTION
This makes it safer to hold onto container references across threads