### PR TITLE
Clean up container.h include

### DIFF
--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -20,7 +20,11 @@ limitations under the License.
 #pragma once
 
 #include <functional>
+#include <memory>
 
+#include "scap.h"
+
+#include "event.h"
 #include "container_info.h"
 
 #if !defined(_WIN32) && !defined(CYGWING_AGENT) && defined(HAS_CAPTURE)
@@ -43,13 +47,13 @@ public:
 	map_ptr_t get_containers();
 	bool remove_inactive_containers();
 	void add_container(const sinsp_container_info& container_info, sinsp_threadinfo *thread);
-	entry_ptr_t get_container(const string &id);
+	entry_ptr_t get_container(const std::string &id);
 	void notify_new_container(const sinsp_container_info& container_info);
 	template<typename E> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	template<typename E1, typename E2, typename... Args> bool resolve_container_impl(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	bool resolve_container(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
 	void dump_containers(scap_dumper_t* dumper);
-	string get_container_name(sinsp_threadinfo* tinfo);
+	std::string get_container_name(sinsp_threadinfo* tinfo);
 
 	// Set tinfo's m_category based on the container context.  It
 	// will *not* change any category to NONE, so a threadinfo
@@ -57,7 +61,7 @@ public:
 	// across execs e.g. "sh -c /bin/true" execing /bin/true.
 	void identify_category(sinsp_threadinfo *tinfo);
 
-	bool container_exists(const string& container_id) const {
+	bool container_exists(const std::string& container_id) const {
 		return m_containers.find(container_id) != m_containers.end();
 	}
 
@@ -75,17 +79,17 @@ public:
 	void set_cri_timeout(int64_t timeout_ms);
 	sinsp* get_inspector() { return m_inspector; }
 private:
-	string container_to_json(const sinsp_container_info& container_info);
-	bool container_to_sinsp_event(const string& json, sinsp_evt* evt, shared_ptr<sinsp_threadinfo> tinfo);
-	string get_docker_env(const Json::Value &env_vars, const string &mti);
+	std::string container_to_json(const sinsp_container_info& container_info);
+	bool container_to_sinsp_event(const std::string& json, sinsp_evt* evt, std::shared_ptr<sinsp_threadinfo> tinfo);
+	std::string get_docker_env(const Json::Value &env_vars, const std::string &mti);
 
 	std::list<std::unique_ptr<libsinsp::container_engine::resolver>> m_container_engines;
 
 	sinsp* m_inspector;
 	std::unordered_map<std::string, sinsp_container_info> m_containers;
 	uint64_t m_last_flush_time_ns;
-	list<new_container_cb> m_new_callbacks;
-	list<remove_container_cb> m_remove_callbacks;
+	std::list<new_container_cb> m_new_callbacks;
+	std::list<remove_container_cb> m_remove_callbacks;
 
 	friend class test_helper;
 };

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -34,13 +34,12 @@ limitations under the License.
 
 #include "async_key_value_source.h"
 
+#include "container.h"
 #include "container_info.h"
 
 #include "container_engine/container_engine.h"
 
 class sinsp;
-class sinsp_container_manager;
-class sinsp_container_info;
 class sinsp_threadinfo;
 
 namespace libsinsp {


### PR DESCRIPTION
Clean up container.h include so it can be included on it own:

 - Add std:: namespace to missing stl objects
 - Add includes for scap.h (scap_dumper) and event.h (sinsp_evt).