### PR TITLE
Add set operator "intersects"

### DIFF
--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -38,7 +38,8 @@ enum cmpop {
 	CO_STARTSWITH = 11,
 	CO_GLOB = 12,
 	CO_PMATCH = 13,
-	CO_ENDSWITH = 14
+	CO_ENDSWITH = 14,
+	CO_INTERSECTS = 15,
 };
 
 enum boolop

--- a/userspace/libsinsp/lua_parser_api.cpp
+++ b/userspace/libsinsp/lua_parser_api.cpp
@@ -79,6 +79,10 @@ static cmpop string_to_cmpop(const char* str)
 	{
 		return CO_IN;
 	}
+	else if(strcmp(str, "intersects") == 0)
+	{
+		return CO_INTERSECTS;
+	}
 	else if(strcmp(str, "pmatch") == 0)
 	{
 		return CO_PMATCH;
@@ -253,7 +257,9 @@ int lua_parser_cbacks::rel_expr(lua_State *ls)
 		// "exists" is the only unary comparison op
 		if(strcmp(cmpop, "exists"))
 		{
-			if (strcmp(cmpop, "in") == 0 || strcmp(cmpop, "pmatch") == 0)
+			if (strcmp(cmpop, "in") == 0 ||
+			    strcmp(cmpop, "intersects") == 0 ||
+			    strcmp(cmpop, "pmatch") == 0)
 			{
 				if (!lua_istable(ls, 4))
 				{

--- a/userspace/libsinsp/prefix_search.cpp
+++ b/userspace/libsinsp/prefix_search.cpp
@@ -43,6 +43,12 @@ void path_prefix_search::add_search_path(const filter_value_t &path)
 	return path_prefix_map<bool>::add_search_path(path, dummy);
 }
 
+void path_prefix_search::add_search_path(const std::string &str)
+{
+	bool dummy = true;
+	return path_prefix_map<bool>::add_search_path(str, dummy);
+}
+
 bool path_prefix_search::match(const char *path)
 {
 	const bool *val = path_prefix_map<bool>::match(path);

--- a/userspace/libsinsp/prefix_search.h
+++ b/userspace/libsinsp/prefix_search.h
@@ -63,6 +63,12 @@ public:
 	void add_search_path(const char *path, Value &v);
 	void add_search_path(const filter_value_t &path, Value &v);
 
+	// With the above methods the pointers in the char */uint8_t *
+	// above point to memory not owned by this object. The below
+	// method passes a string which is copied into the object,
+	// holding its own memory.
+	void add_search_path(const std::string &str, Value &v);
+
 	// Similar to add_search_path, but takes a path already split
 	// into a list of components. This allows for custom splitting
 	// of paths other than on '/' boundaries.
@@ -102,6 +108,8 @@ private:
 		std::pair<path_prefix_map *, Value *>,
 		g_hash_membuf,
 		g_equal_to_membuf> m_dirs;
+
+	std::list<std::string> m_strvals;
 };
 
 template<class Value>
@@ -125,6 +133,14 @@ void path_prefix_map<Value>::add_search_path(const char *path, Value &v)
 {
 	filter_value_t mem((uint8_t *) path, (uint32_t) strlen(path));
 	return add_search_path(mem, v);
+}
+
+template<class Value>
+void path_prefix_map<Value>::add_search_path(const std::string &str, Value &v)
+{
+	m_strvals.push_back(str);
+
+	return add_search_path(m_strvals.back().c_str(), v);
 }
 
 template<class Value>
@@ -316,6 +332,7 @@ public:
 
 	void add_search_path(const char *path);
 	void add_search_path(const filter_value_t &path);
+	void add_search_path(const std::string &str);
 
 	// If non-NULL, Value is not allocated. It points to memory
 	// held within this path_prefix_map() and is only valid as


### PR DESCRIPTION
Add filtercheck operator "intersects"/CO_INTERSECTS that allows testing a group of extracted values against a set of provided values, looking for any overlap.

It differs from CO_IN because (a,b,c) in (a,b) is false while (a,b,c) intersects (a,b) is true.

For syscall events, there is no difference between "in" and "intersects". When a filtercheck can extract multiple values, as it can for falco + k8s audit events, "intersects" has a distinct meaning, looking for overlaps instead of being a subset.

Also make a change to path prefix match that allows for using local storage instead of externally-provided memory.