### PR TITLE
Get CRI resource limits from cgroups

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -134,11 +134,13 @@ endif()
 
 if(NOT WIN32 AND NOT APPLE)
 list(APPEND SINSP_SOURCES
-	grpc_channel_registry.cpp
+	cgroup_limits.cpp
 	cri.cpp
 	container_engine/cri.cpp
 	${CMAKE_CURRENT_BINARY_DIR}/cri.grpc.pb.cc
-	${CMAKE_CURRENT_BINARY_DIR}/cri.pb.cc)
+	${CMAKE_CURRENT_BINARY_DIR}/cri.pb.cc
+	grpc_channel_registry.cpp
+)
 endif()
 
 add_library(sinsp STATIC ${SINSP_SOURCES})

--- a/userspace/libsinsp/cgroup_limits.cpp
+++ b/userspace/libsinsp/cgroup_limits.cpp
@@ -1,0 +1,89 @@
+#include "cgroup_limits.h"
+
+#include <fstream>
+#include "sinsp.h"
+
+namespace {
+// to prevent 32-bit number of kilobytes from overflowing, ignore values larger than 4 TiB.
+// This reports extremely large values (e.g. almost-but-not-quite 9EiB as set by k8s) as unlimited.
+// Note: we use the same maximum value for cpu shares/quotas as well; the typical values are much lower
+// and so should never exceed CGROUP_VAL_MAX either
+constexpr const int64_t CGROUP_VAL_MAX = (1UL << 42u) - 1;
+
+/**
+ * \brief Read a single int64_t value from cgroupfs
+ * @param subsys path to the specific cgroup subsystem, e.g. /sys/fs/cgroup/cpu
+ * @param cgroup cgroup path within the cgroup mountpoint (like in /proc/pid/cgroup)
+ * @param filename the filename within the cgroup directory, e.g. cpu.shares
+ * @param out reference to the output value
+ * @return true if we successfully read the value and it's within reasonable range,
+ *          reasonable being [0; CGROUP_VAL_MAX)
+ */
+bool read_cgroup_val(std::shared_ptr<std::string>& subsys,
+	const std::string& cgroup, const std::string& filename, int64_t& out)
+{
+	std::string path = *subsys.get() + "/" + cgroup + "/" + filename;
+	std::ifstream cg_val(path);
+
+	int64_t val = -1;
+	cg_val >> val;
+
+	if(val <= 0 || val > CGROUP_VAL_MAX)
+	{
+		g_logger.format(sinsp_logger::SEV_DEBUG, "(cgroup-limits) value of %s (%lld) out of range, ignoring",
+			path.c_str(), val);
+		return false;
+	}
+	out = val;
+	return true;
+}
+}
+
+namespace libsinsp {
+namespace cgroup_limits {
+
+bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_value& value, bool report_no_cgroup)
+{
+	bool found_all = true;
+	auto no_cg_log_level = report_no_cgroup
+		? sinsp_logger::SEV_INFO
+		: sinsp_logger::SEV_DEBUG;
+
+	std::shared_ptr<std::string> memcg_root = sinsp::lookup_cgroup_dir("memory");
+	if(key.m_mem_cgroup.find(key.m_container_id) == std::string::npos)
+	{
+		g_logger.format(no_cg_log_level, "(cgroup-limits) mem cgroup for container [%s]: %s/%s -- no per-container memory cgroup, ignoring",
+			key.m_container_id.c_str(), memcg_root->c_str(), key.m_mem_cgroup.c_str());
+	}
+	else
+	{
+		g_logger.format(sinsp_logger::SEV_DEBUG, "(cgroup-limits) mem cgroup for container [%s]: %s/%s",
+			key.m_container_id.c_str(), memcg_root->c_str(), key.m_mem_cgroup.c_str());
+		found_all = read_cgroup_val(memcg_root, key.m_mem_cgroup, "memory.limit_in_bytes", value.m_memory_limit) && found_all;
+	}
+
+	std::shared_ptr<std::string> cpucg_root = sinsp::lookup_cgroup_dir("cpu");
+	if(key.m_cpu_cgroup.find(key.m_container_id) == std::string::npos)
+	{
+		g_logger.format(no_cg_log_level, "(cgroup-limits) cpu cgroup for container [%s]: %s/%s -- no per-container CPU cgroup, ignoring",
+				key.m_container_id.c_str(), cpucg_root->c_str(), key.m_cpu_cgroup.c_str());
+	}
+	else
+	{
+		g_logger.format(sinsp_logger::SEV_DEBUG, "(cgroup-limits) cpu cgroup for container [%s]: %s/%s",
+				key.m_container_id.c_str(), cpucg_root->c_str(), key.m_cpu_cgroup.c_str());
+		found_all = read_cgroup_val(cpucg_root, key.m_cpu_cgroup, "cpu.shares", value.m_cpu_shares) && found_all;
+		found_all = read_cgroup_val(cpucg_root, key.m_cpu_cgroup, "cpu.cfs_quota_us", value.m_cpu_quota) && found_all;
+		found_all = read_cgroup_val(cpucg_root, key.m_cpu_cgroup, "cpu.cfs_period_us", value.m_cpu_period) && found_all;
+	}
+
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+		"(cgroup-limits) Got cgroup limits for container [%s]: "
+		"mem_limit=%ld, cpu_shares=%ld cpu_quota=%ld cpu_period=%ld",
+		key.m_container_id.c_str(),
+		value.m_memory_limit, value.m_cpu_shares, value.m_cpu_quota, value.m_cpu_period);
+
+	return found_all;
+}
+}
+}

--- a/userspace/libsinsp/cgroup_limits.h
+++ b/userspace/libsinsp/cgroup_limits.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <string>
+#include <utility>
+#include "async_key_value_source.h"
+
+namespace libsinsp {
+namespace cgroup_limits {
+
+/**
+ * \brief The key for cgroup value lookup
+ *
+ * It's effectively a (container_id, cpu_cgroup, mem_cgroup) tuple
+ */
+struct cgroup_limits_key {
+	cgroup_limits_key() :
+		m_container_id(""),
+		m_cpu_cgroup(""),
+		m_mem_cgroup("") {}
+
+	cgroup_limits_key(std::string container_id, std::string cpu_cgroup_dir, std::string mem_cgroup_dir) :
+		m_container_id(std::move(container_id)),
+		m_cpu_cgroup(std::move(cpu_cgroup_dir)),
+		m_mem_cgroup(std::move(mem_cgroup_dir)) {}
+
+	explicit operator const std::string&() const
+	{
+		return m_container_id;
+	}
+
+	std::string m_container_id;
+	std::string m_cpu_cgroup;
+	std::string m_mem_cgroup;
+};
+
+/**
+ * \brief The result of an asynchronous cgroup lookup
+ *
+ * This contains all the cgroup values we read during the asynchronous lookup
+ */
+struct cgroup_limits_value {
+	cgroup_limits_value() :
+		m_cpu_shares(0),
+		m_cpu_quota(0),
+		m_cpu_period(0),
+		m_memory_limit(0) {}
+
+	int64_t m_cpu_shares;
+	int64_t m_cpu_quota;
+	int64_t m_cpu_period;
+	int64_t m_memory_limit;
+};
+
+/**
+ * \brief Read resource limits from cgroups
+ * @param key the container to read limits for
+ * @param value output value. when the return value is false, specific fields
+ *         may or may not have been modified
+ * @param report_no_cgroup if true, log a message when the container doesn't
+ *         use its own cgroups for mem/cpu and we ignore the values.
+ *         We want to log this only once since the cgroups will stay the same
+ *         during subsequent lookups
+ * @return true when all values have been successfully read, false otherwise
+ *
+ * Note: reading a zero/negative/very large value is considered a failure,
+ * because it might mean that resource limits haven't yet been set. Essentially,
+ * `false` means "there's real chance the limits could conceivably change
+ * in the future", while `true` means we really don't expect them to change
+ * any more.
+ */
+bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_value& value, bool report_no_cgroup = true);
+
+}
+}

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -28,6 +28,7 @@ limitations under the License.
 #include "cri.pb.h"
 #include "cri.grpc.pb.h"
 
+#include "cgroup_limits.h"
 #include "runc.h"
 #include "container_engine/mesos.h"
 #include "grpc_channel_registry.h"
@@ -128,6 +129,18 @@ bool cri::parse_cri(sinsp_container_info &container, sinsp_threadinfo *tinfo)
 	{
 		return true;
 	}
+
+	libsinsp::cgroup_limits::cgroup_limits_key key(
+		container.m_id,
+		tinfo->get_cgroup("cpu"),
+		tinfo->get_cgroup("memory"));
+	libsinsp::cgroup_limits::cgroup_limits_value limits;
+	libsinsp::cgroup_limits::get_cgroup_resource_limits(key, limits);
+
+	container.m_memory_limit = limits.m_memory_limit;
+	container.m_cpu_shares = limits.m_cpu_shares;
+	container.m_cpu_quota = limits.m_cpu_quota;
+	container.m_cpu_period = limits.m_cpu_period;
 
 	if(s_cri_extra_queries)
 	{

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -24,8 +24,15 @@ limitations under the License.
 
 class sinsp_container_manager;
 class sinsp_threadinfo;
+class sinsp_container_info;
 
 #include "container_engine/container_engine.h"
+
+namespace runtime {
+namespace v1alpha2 {
+class ContainerStatusResponse;
+}
+}
 
 namespace libsinsp {
 namespace container_engine {
@@ -39,6 +46,10 @@ public:
 	static void set_cri_socket_path(const std::string& path);
 	static void set_cri_timeout(int64_t timeout_ms);
 	static void set_extra_queries(bool extra_queries);
+
+private:
+	bool parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, sinsp_container_info &container, sinsp_threadinfo *tinfo);
+	bool parse_cri(sinsp_container_info &container, sinsp_threadinfo *tinfo);
 };
 }
 }

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -42,6 +42,7 @@ limitations under the License.
 #include "k8s_api_handler.h"
 #ifdef HAS_CAPTURE
 #include <curl/curl.h>
+#include <mntent.h>
 #endif
 #endif
 
@@ -2544,3 +2545,56 @@ bool sinsp_thread_manager::remove_inactive_threads()
 
 	return res;
 }
+
+#ifdef HAS_CAPTURE
+std::shared_ptr<std::string> sinsp::lookup_cgroup_dir(const string& subsys)
+{
+	shared_ptr<string> cgroup_dir;
+	static std::unordered_map<std::string, std::shared_ptr<std::string>> cgroup_dir_cache;
+
+	const auto& it = cgroup_dir_cache.find(subsys);
+	if(it != cgroup_dir_cache.end())
+	{
+		return it->second;
+	}
+
+	// Look for mount point of cgroup filesystem
+	// It should be already mounted on the host or by
+	// our docker-entrypoint.sh script
+	if(strcmp(scap_get_host_root(), "") != 0)
+	{
+		// We are inside our container, so we should use the directory
+		// mounted by it
+		auto cgroup = std::string(scap_get_host_root()) + "/cgroup/" + subsys;
+		cgroup_dir = std::make_shared<std::string>(cgroup);
+	}
+	else
+	{
+		struct mntent mntent_buf = {};
+		char mntent_string_buf[4096];
+		FILE* fp = setmntent("/proc/mounts", "r");
+		struct mntent* entry = getmntent_r(fp, &mntent_buf,
+			mntent_string_buf, sizeof(mntent_string_buf));
+		while(entry != nullptr)
+		{
+			if(strcmp(entry->mnt_type, "cgroup") == 0 &&
+			   hasmntopt(entry, subsys.c_str()) != NULL)
+			{
+				cgroup_dir = std::make_shared<std::string>(entry->mnt_dir);
+				break;
+			}
+			entry = getmntent(fp);
+		}
+		endmntent(fp);
+	}
+	if(!cgroup_dir)
+	{
+		return std::make_shared<std::string>();
+	}
+	else
+	{
+		cgroup_dir_cache[subsys] = cgroup_dir;
+		return cgroup_dir;
+	}
+}
+#endif

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -867,6 +867,10 @@ public:
 	bool is_bpf_enabled();
 
 	static unsigned num_possible_cpus();
+
+#ifdef HAS_CAPTURE
+	static std::shared_ptr<std::string> lookup_cgroup_dir(const std::string& subsys);
+#endif
 #ifdef CYGWING_AGENT
 	wh_t* get_wmi_handle()
 	{

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -893,6 +893,21 @@ uint64_t sinsp_threadinfo::get_fd_limit()
 	return get_main_thread()->m_fdlimit;
 }
 
+const std::string& sinsp_threadinfo::get_cgroup(const std::string& subsys) const
+{
+	static const std::string notfound = "/";
+
+	for(const auto& it : m_cgroups)
+	{
+		if(it.first == subsys)
+		{
+			return it.second;
+		}
+	}
+
+	return notfound;
+}
+
 void sinsp_threadinfo::traverse_parent_state(visitor_func_t &visitor)
 {
 	// Use two pointers starting at this, traversing the parent

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -226,6 +226,11 @@ public:
 	*/
 	uint64_t get_fd_limit();
 
+	/*!
+	  \brief Return the cgroup name for a specific subsystem
+	 */
+	 const std::string& get_cgroup(const std::string& subsys) const;
+
 	//
 	// Walk up the parent process hierarchy, calling the provided
 	// function for each node. If the function returns false, the


### PR DESCRIPTION
If the CRI runtime is _not_ containerd, we need to find the resource limit values ourselves directly from cgroups.

Note: Values smaller than zero and larger than an arbitrary "too large" value are ignored. "too large" is defined as (4 TiB, to avoid overflow when converting to a 32-bit number of kilobytes)

Note: CRI-o apparently sets up cgroups *after* creating the container, so we may find that the values aren't set up yet. Currently this will result in missing limit values, but it will be fixed by the next PR that makes CRI lookup asynchronous (and delayed a little bit).

Note: It seems that CRI-o sets up cgroup *limits* only when *requests* are set as well, so we want at least a message in this case.