### PR TITLE
Asynchronous CRI v2

### DIFF
--- a/userspace/libsinsp/cgroup_limits.h
+++ b/userspace/libsinsp/cgroup_limits.h
@@ -4,6 +4,25 @@
 #include <utility>
 #include "async_key_value_source.h"
 
+namespace {
+bool less_than(const std::string& lhs, const std::string& rhs, bool if_equal=false)
+{
+	int cmp = lhs.compare(rhs);
+	if(cmp < 0)
+	{
+		return true;
+	}
+	else if(cmp > 0)
+	{
+		return false;
+	}
+	else
+	{
+		return if_equal;
+	}
+}
+}
+
 namespace libsinsp {
 namespace cgroup_limits {
 
@@ -11,6 +30,7 @@ namespace cgroup_limits {
  * \brief The key for cgroup value lookup
  *
  * It's effectively a (container_id, cpu_cgroup, mem_cgroup) tuple
+ * that can be used as a hash key.
  */
 struct cgroup_limits_key {
 	cgroup_limits_key() :
@@ -22,6 +42,20 @@ struct cgroup_limits_key {
 		m_container_id(std::move(container_id)),
 		m_cpu_cgroup(std::move(cpu_cgroup_dir)),
 		m_mem_cgroup(std::move(mem_cgroup_dir)) {}
+
+	bool operator<(const cgroup_limits_key& rhs) const
+	{
+		return less_than(m_container_id, rhs.m_container_id,
+				 less_than(m_cpu_cgroup, rhs.m_cpu_cgroup,
+					   less_than(m_mem_cgroup, rhs.m_mem_cgroup)));
+	}
+
+	bool operator==(const cgroup_limits_key& rhs) const
+	{
+		return m_container_id == rhs.m_container_id &&
+		       m_cpu_cgroup == rhs.m_cpu_cgroup &&
+		       m_mem_cgroup == rhs.m_mem_cgroup;
+	}
 
 	explicit operator const std::string&() const
 	{
@@ -71,4 +105,20 @@ struct cgroup_limits_value {
 bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_value& value, bool report_no_cgroup = true);
 
 }
+}
+
+namespace std {
+/**
+ * \brief Specialization of std::hash for cgroup_limits_key
+ *
+ * It allows `cgroup_limits_key` instances to be used as `unordered_map` keys
+ */
+template<> struct hash<libsinsp::cgroup_limits::cgroup_limits_key> {
+	std::size_t operator()(const libsinsp::cgroup_limits::cgroup_limits_key& h) const {
+		size_t h1 = ::std::hash<std::string>{}(h.m_container_id);
+		size_t h2 = ::std::hash<std::string>{}(h.m_cpu_cgroup);
+		size_t h3 = ::std::hash<std::string>{}(h.m_mem_cgroup);
+		return h1 ^ (h2 << 1u) ^ (h3 << 2u);
+	}
+};
 }

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -554,3 +554,10 @@ void sinsp_container_manager::set_cri_async(bool async)
 	libsinsp::container_engine::cri::set_async(async);
 #endif
 }
+
+void sinsp_container_manager::set_cri_delay(uint64_t delay_ms)
+{
+#if defined(HAS_CAPTURE)
+	libsinsp::container_engine::cri::set_cri_delay(delay_ms);
+#endif
+}

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -547,3 +547,10 @@ void sinsp_container_manager::set_cri_timeout(int64_t timeout_ms)
 	libsinsp::container_engine::cri::set_cri_timeout(timeout_ms);
 #endif
 }
+
+void sinsp_container_manager::set_cri_async(bool async)
+{
+#if defined(HAS_CAPTURE)
+	libsinsp::container_engine::cri::set_async(async);
+#endif
+}

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -129,6 +129,7 @@ public:
 	void set_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
 	void set_cri_async(bool async);
+	void set_cri_delay(uint64_t delay_ms);
 	sinsp* get_inspector() { return m_inspector; }
 
 	/**

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -128,6 +128,7 @@ public:
 	void set_cri_extra_queries(bool extra_queries);
 	void set_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
+	void set_cri_async(bool async);
 	sinsp* get_inspector() { return m_inspector; }
 
 	/**

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -84,6 +84,7 @@ public:
 	static void set_cri_timeout(int64_t timeout_ms);
 	static void set_extra_queries(bool extra_queries);
 	static void set_async(bool async_limits);
+	static void set_cri_delay(uint64_t delay_ms);
 
 private:
 	std::unique_ptr<cri_async_source> m_async_source;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1627,6 +1627,11 @@ void sinsp::set_cri_async(bool async)
 	m_container_manager.set_cri_async(async);
 }
 
+void sinsp::set_cri_delay(uint64_t delay_ms)
+{
+	m_container_manager.set_cri_delay(delay_ms);
+}
+
 void sinsp::set_snaplen(uint32_t snaplen)
 {
 	//

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1622,6 +1622,11 @@ void sinsp::set_cri_timeout(int64_t timeout_ms)
 	m_container_manager.set_cri_timeout(timeout_ms);
 }
 
+void sinsp::set_cri_async(bool async)
+{
+	m_container_manager.set_cri_async(async);
+}
+
 void sinsp::set_snaplen(uint32_t snaplen)
 {
 	//

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -910,6 +910,7 @@ public:
 	void set_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
 	void set_cri_async(bool async);
+	void set_cri_delay(uint64_t delay_ms);
 
 VISIBILITY_PROTECTED
 	bool add_thread(const sinsp_threadinfo *ptinfo);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -909,6 +909,7 @@ public:
 
 	void set_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
+	void set_cri_async(bool async);
 
 VISIBILITY_PROTECTED
 	bool add_thread(const sinsp_threadinfo *ptinfo);


### PR DESCRIPTION
The one interesting thing is that we delay the lookup by 500 ms (by default) as apparently CRI-o might not respond with the details of a freshly created container immediately.