### PR TITLE
Immediately recycle reused pids coming from a clone event

### DIFF
--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -165,6 +165,7 @@ or GPL2.txt for full copies of the license.
 #define PPM_CL_CLONE_NEWCGROUP (1 << 28)
 #define PPM_CL_CHILD_IN_PIDNS (1<<29)			/* true if the thread created by clone() is *not*
 									in the init pid namespace */
+#define PPM_CL_FROM_PROC (1<<30)			/* thread found via /proc scan or lookup, not via clone event */
 
 /*
  * Futex Operations

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1014,7 +1014,26 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 		//
 		if(evt->m_tinfo && evt->m_tinfo->m_clone_ts != 0)
 		{
-			if(evt->get_ts() - evt->m_tinfo->m_clone_ts > CLONE_STALE_TIME_NS)
+			// has the original thread lived long enough to assume
+			// it can't possibly be the same thread and we must have lost
+			// the exit event?
+			bool long_lived = evt->get_ts() - evt->m_tinfo->m_clone_ts > CLONE_STALE_TIME_NS;
+
+			// if the old thread appeared in response to a clone event,
+			// we know it's a different one, so we can unconditionally
+			// replace it (we've rolled over all pids in the CLONE_STALE_TIME_NS
+			// interval)
+			bool from_proc = evt->m_tinfo->m_flags & PPM_CL_FROM_PROC;
+
+			// XXX: we probably want to treat threads that have already exited
+			// as stale, but we cannot rely 100% on the event ordering
+			// Otherwise, a clone event would always signal the existing
+			// entry is stale; AIUI, we can receive other events from
+			// a freshly cloned thread before we see its clone event
+//			bool already_closed = evt->m_tinfo->m_flags & PPM_CL_CLOSED;
+//			bool stale = already_closed || !from_proc;
+			bool stale = !from_proc;
+			if(long_lived || stale)
 			{
 				m_inspector->remove_thread(tid, true);
 				evt->m_tinfo = NULL;

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -409,7 +409,7 @@ void sinsp_threadinfo::init(scap_threadinfo* pi)
 		set_cwd(pi->cwd, (uint32_t)strlen(pi->cwd));
 	}
 	m_flags |= pi->flags;
-	m_flags |= PPM_CL_ACTIVE; // Assume that all the threads coming from /proc are real, active threads
+	m_flags |= PPM_CL_ACTIVE | PPM_CL_FROM_PROC; // Assume that all the threads coming from /proc are real, active threads
 	m_fdtable.clear();
 	m_fdlimit = pi->fdlimit;
 	m_uid = pi->uid;


### PR DESCRIPTION
If we learn of both old and new threads from their clone events, it can't possibly the same thread, even if the old one was created recently (pid wraparound under 2 seconds is entirely possible)