### PR TITLE
Fix k8s events handling to accommodate changes from v1beta1 API [SMAGENT-2020]

### DIFF
--- a/userspace/libsinsp/k8s_event_handler.cpp
+++ b/userspace/libsinsp/k8s_event_handler.cpp
@@ -118,7 +118,6 @@ bool k8s_event_handler::handle_component(const Json::Value& json, const msg_data
 						bool is_aggregate = (get_json_string(json , "message").find("events with common reason combined") != std::string::npos);
 						time_t last_ts = 0;
 						time_t now_ts = get_epoch_utc_seconds_now();
-						g_logger.log("K8s EVENT JSON STRING: " + Json::FastWriter().write(json), sinsp_logger::SEV_DEBUG);
 						// So we first are going to check for "eventTime"
 						// If that is empty, we will check for "lastTimestamp"
 						// If that is also empty, use current timestamp and log it. 

--- a/userspace/libsinsp/k8s_event_handler.cpp
+++ b/userspace/libsinsp/k8s_event_handler.cpp
@@ -121,7 +121,7 @@ bool k8s_event_handler::handle_component(const Json::Value& json, const msg_data
 						// So we first are going to check for "eventTime"
 						// If that is empty, we will check for "lastTimestamp"
 						// If that is also empty, use current timestamp and log it. 
-						// This change is necessiated because in v1beta1/events, "EventTime" is
+						// This change is necessitated because in v1beta1/events, "EventTime" is
 						// the main field that holds timestamp and `lastTimestamp` is deprecated.
 						// This change is addressed towards that. 
 						std::string evtTime = get_json_string(json, "eventTime");

--- a/userspace/libsinsp/k8s_event_handler.cpp
+++ b/userspace/libsinsp/k8s_event_handler.cpp
@@ -137,7 +137,7 @@ bool k8s_event_handler::handle_component(const Json::Value& json, const msg_data
 						else
 						{
 							// Ideally we should NEVER hit this case. But log it if we do, so we know.
-							g_logger.log("K8s EVENT: both eventTime and lastTimestamp are null, using current timestamp", sinsp_logger::SEV_INFO);
+							g_logger.log("K8s EVENT: both eventTime and lastTimestamp are null, using current timestamp. Event Json : " + Json::FastWriter().write(json) , sinsp_logger::SEV_INFO);
 							last_ts = now_ts;
 						}
 						g_logger.log("K8s EVENT: lastTimestamp=" + std::to_string(last_ts) + ", now_ts=" + std::to_string(now_ts),

--- a/userspace/libsinsp/k8s_event_handler.cpp
+++ b/userspace/libsinsp/k8s_event_handler.cpp
@@ -116,8 +116,9 @@ bool k8s_event_handler::handle_component(const Json::Value& json, const msg_data
 					if(!involved_object.isNull())
 					{
 						bool is_aggregate = (get_json_string(json , "message").find("events with common reason combined") != std::string::npos);
-						g_logger.log("K8s EVENT JSON STRING: " + Json::FastWriter().write(json), sinsp_logger::SEV_DEBUG);
+						time_t last_ts = 0;
 						time_t now_ts = get_epoch_utc_seconds_now();
+						g_logger.log("K8s EVENT JSON STRING: " + Json::FastWriter().write(json), sinsp_logger::SEV_DEBUG);
 						// So we first are going to check for "eventTime"
 						// If that is empty, we will check for "lastTimestamp"
 						// If that is also empty, use current timestamp and log it. 
@@ -126,7 +127,6 @@ bool k8s_event_handler::handle_component(const Json::Value& json, const msg_data
 						// This change is addressed towards that. 
 						std::string evtTime = get_json_string(json, "eventTime");
 						std::string ts = get_json_string(json , "lastTimestamp");
-						time_t last_ts = 0;
 						if(!evtTime.empty())
 						{
 							last_ts	= get_epoch_utc_seconds(evtTime);


### PR DESCRIPTION
The k8s event API in v1beta1/events deprecates the field `lastTimestamp` and instead populates timestamp in `eventTime` field. Incorporate this into the k8s event timestamp logic. 

This change is needed to fully support k8s v1.16 . This fixes an error due to the lastTimestamp sometimes being null. 