### PR TITLE
Update two links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ sysdig
 
 Where to start?
 ---
-If this is your first time hearing about sysdig, we recommend you [start with the website](http://www.sysdig.com).  
+If this is your first time hearing about sysdig, we recommend you [start with the website](http://www.sysdig.org).  
   
 What does sysdig do and why should I use it?
 ---

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ sysdig
 
 Where to start?
 ---
-If this is your first time hearing about sysdig, we recommend you [start with the website](http://www.sysdig.org).  
+If this is your first time hearing about sysdig, we recommend you [start with the website](http://www.sysdig.com).  
   
 What does sysdig do and why should I use it?
 ---
@@ -90,7 +90,7 @@ Use a real name of a natural person who is an authorized representative of the c
 
 Sysdig Cloud
 ---
-Interested in a fully supported, fully distributed version of sysdig? Check out [Sysdig Monitor](https://sysdig.com/product)!
+Interested in a fully supported, fully distributed version of sysdig? Check out [Sysdig Monitor](https://sysdig.com/products/monitor/)!
 
 Open source sysdig is proudly supported by [Sysdig Inc](https://sysdig.com/company/).  
 


### PR DESCRIPTION
Proposing updating two links in the README:

```diff
- http://www.sysdig.org
+ http://www.sysdig.com
```
Looks like .org redirects to .com, might as well directly link to it here.

```diff
- [Sysdig Monitor](https://sysdig.com/product)
+ [Sysdig Monitor](https://sysdig.com/products/monitor/)
```
Directly linking to the Sysdig Monitor product page.