### PR TITLE
Partial liveness/readiness k8s probe parsing

### DIFF
--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -90,10 +90,22 @@ private:
 
 	// Parse either a readiness or liveness probe out of the
 	// provided object, updating the container info with any probe
-	// found.
+	// found. Returns true if the healthcheck/livenesss/readiness
+	// probe info was found and could be parsed.
 	bool parse_liveness_readiness_probe(const Json::Value &probe_obj,
 					    sinsp_container_info::container_health_probe::probe_type ptype,
 					    sinsp_container_info &container);
+
+	// See if this config has a io.kubernetes.sandbox.id label
+	// referring to a different container. (NOTE: this is not the
+	// same as docker's sandbox id, which refers to networks.) If
+	// it does, try to copy the health checks from that container
+	// to the provided container_info pointer. Returns true if a
+	// sandbox container id was found, the corresponding container
+	// was found, and if the health checks could be copied from
+	// that container.
+	bool get_sandbox_liveness_readiness_probes(const Json::Value &config_obj,
+						   sinsp_container_info *container);
 
 	// Parse all healthchecks/liveness probes/readiness probes out
 	// of the provided object, updating the container info as required.

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -105,7 +105,7 @@ private:
 	// was found, and if the health checks could be copied from
 	// that container.
 	bool get_sandbox_liveness_readiness_probes(const Json::Value &config_obj,
-						   sinsp_container_info *container);
+						   sinsp_container_manager::entry_ptr_t container);
 
 	// Parse all healthchecks/liveness probes/readiness probes out
 	// of the provided object, updating the container info as required.

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -105,7 +105,7 @@ private:
 	// was found, and if the health checks could be copied from
 	// that container.
 	bool get_sandbox_liveness_readiness_probes(const Json::Value &config_obj,
-						   sinsp_container_manager::entry_ptr_t container);
+						   sinsp_container_info &container);
 
 	// Parse all healthchecks/liveness probes/readiness probes out
 	// of the provided object, updating the container info as required.

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -297,7 +297,7 @@ bool docker_async_source::parse_liveness_readiness_probe(const Json::Value &prob
 }
 
 bool docker_async_source::get_sandbox_liveness_readiness_probes(const Json::Value &config_obj,
-								sinsp_container_info *container)
+								sinsp_container_manager::entry_ptr_t container)
 {
 	std::string sandbox_container_id;
 	std::string sandbox_label = "io.kubernetes.sandbox.id";
@@ -319,7 +319,7 @@ bool docker_async_source::get_sandbox_liveness_readiness_probes(const Json::Valu
 		sandbox_container_id.resize(12);
 	}
 
-	sinsp_container_info *sandbox_container = m_inspector->m_container_manager.get_container(sandbox_container_id);
+	sinsp_container_manager::entry_ptr_t sandbox_container = m_inspector->m_container_manager.get_container(sandbox_container_id);
 
 	if(!sandbox_container)
 	{

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -297,7 +297,7 @@ bool docker_async_source::parse_liveness_readiness_probe(const Json::Value &prob
 }
 
 bool docker_async_source::get_sandbox_liveness_readiness_probes(const Json::Value &config_obj,
-								sinsp_container_manager::entry_ptr_t container)
+								sinsp_container_info &container)
 {
 	std::string sandbox_container_id;
 	std::string sandbox_label = "io.kubernetes.sandbox.id";
@@ -308,7 +308,7 @@ bool docker_async_source::get_sandbox_liveness_readiness_probes(const Json::Valu
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker (%s): No sandbox label found, not copying liveness/readiness probes",
-				container->m_id.c_str());
+				container.m_id.c_str());
 		return false;
 	}
 
@@ -319,13 +319,13 @@ bool docker_async_source::get_sandbox_liveness_readiness_probes(const Json::Valu
 		sandbox_container_id.resize(12);
 	}
 
-	sinsp_container_manager::entry_ptr_t sandbox_container = m_inspector->m_container_manager.get_container(sandbox_container_id);
+	sinsp_container_info::ptr_t sandbox_container = m_inspector->m_container_manager.get_container(sandbox_container_id);
 
 	if(!sandbox_container)
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker (%s): Sandbox container %s doesn't exist, not copying liveness/readiness probes",
-				container->m_id.c_str(), sandbox_container_id.c_str());
+				container.m_id.c_str(), sandbox_container_id.c_str());
 		return false;
 	}
 
@@ -333,14 +333,14 @@ bool docker_async_source::get_sandbox_liveness_readiness_probes(const Json::Valu
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker (%s): Sandbox container %s has no liveness/readiness probes, not copying",
-				container->m_id.c_str(), sandbox_container_id.c_str());
+				container.m_id.c_str(), sandbox_container_id.c_str());
 		return false;
 	}
 
 	g_logger.format(sinsp_logger::SEV_DEBUG,
 			"docker (%s): Copying liveness/readiness probes from sandbox container %s",
-			container->m_id.c_str(), sandbox_container_id.c_str());
-	container->m_health_probes = sandbox_container->m_health_probes;
+			container.m_id.c_str(), sandbox_container_id.c_str());
+	container.m_health_probes = sandbox_container->m_health_probes;
 
 	return true;
 }
@@ -357,7 +357,7 @@ void docker_async_source::parse_health_probes(const Json::Value &config_obj,
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker (%s): Parsing liveness/readiness probes from pod spec",
-				container->m_id.c_str());
+				container.m_id.c_str());
 
 		if(spec.isMember("livenessProbe"))
 		{
@@ -387,7 +387,7 @@ void docker_async_source::parse_health_probes(const Json::Value &config_obj,
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker (%s): No liveness/readiness probes found",
-				container->m_id.c_str());
+				container.m_id.c_str());
 	}
 
 	// To avoid any confusion about containers that both refer to

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -306,9 +306,8 @@ bool docker_async_source::get_sandbox_liveness_readiness_probes(const Json::Valu
 	   !config_obj.isMember("Labels") ||
 	   !config_obj["Labels"].isMember(sandbox_label))
 	{
-		g_logger.format(sinsp_logger::SEV_DEBUG,
-				"docker (%s): No sandbox label found, not copying liveness/readiness probes",
-				container.m_id.c_str());
+		SINSP_DEBUG("docker (%s): No sandbox label found, not copying liveness/readiness probes",
+			    container.m_id.c_str());
 		return false;
 	}
 
@@ -323,23 +322,20 @@ bool docker_async_source::get_sandbox_liveness_readiness_probes(const Json::Valu
 
 	if(!sandbox_container)
 	{
-		g_logger.format(sinsp_logger::SEV_DEBUG,
-				"docker (%s): Sandbox container %s doesn't exist, not copying liveness/readiness probes",
-				container.m_id.c_str(), sandbox_container_id.c_str());
+		SINSP_DEBUG("docker (%s): Sandbox container %s doesn't exist, not copying liveness/readiness probes",
+			    container.m_id.c_str(), sandbox_container_id.c_str());
 		return false;
 	}
 
 	if(sandbox_container->m_health_probes.size() == 0)
 	{
-		g_logger.format(sinsp_logger::SEV_DEBUG,
-				"docker (%s): Sandbox container %s has no liveness/readiness probes, not copying",
-				container.m_id.c_str(), sandbox_container_id.c_str());
+		SINSP_DEBUG("docker (%s): Sandbox container %s has no liveness/readiness probes, not copying",
+			    container.m_id.c_str(), sandbox_container_id.c_str());
 		return false;
 	}
 
-	g_logger.format(sinsp_logger::SEV_DEBUG,
-			"docker (%s): Copying liveness/readiness probes from sandbox container %s",
-			container.m_id.c_str(), sandbox_container_id.c_str());
+	SINSP_DEBUG("docker (%s): Copying liveness/readiness probes from sandbox container %s",
+		    container.m_id.c_str(), sandbox_container_id.c_str());
 	container.m_health_probes = sandbox_container->m_health_probes;
 
 	return true;


### PR DESCRIPTION
Add the ability to fetch liveness/readiness probe information from
related containers when not available in the container info labels.

When starting k8s deployments, a pod contains a long-lived "pause"
container and shorter-lived containers that are restarted as the
container process exits, is restarted, etc. Only the pause container has
the necessary ..../last-applied-configuration label that contains the
pod's liveness/readiness probes. The shorter-lived container does have a
reference to the pause container, though, via a io.kubernetes.sandbox.id
label.

So when the container doesn't have a .../last-applied-configuration
label, see if it has a io.kubernetes.sandbox.id label, try to look up
that container, and if it has liveness/readiness probes, copy the probes
from that container.