### PR TITLE
[SMAGENT-2078] Disable minikube prebuilt probes

### DIFF
--- a/scripts/build-probe-binaries
+++ b/scripts/build-probe-binaries
@@ -725,13 +725,13 @@ if [ -z "$KERNEL_TYPE" ]; then
 	#
 	# Minikube build
 	#
-	echo Building Minikube
-	VERSIONS=$(curl https://api.github.com/repos/kubernetes/minikube/releases | jq -r '.[].name' | head -10)
+	#echo Building Minikube
+	#VERSIONS=$(curl https://api.github.com/repos/kubernetes/minikube/releases | jq -r '.[].name' | head -10)
 
-	for VERSION in $VERSIONS
-	do
-	        minikube_build $VERSION
-	done
+	#for VERSION in $VERSIONS
+	#do
+	#        minikube_build $VERSION
+	#done
 
 	#
 	# Upload modules


### PR DESCRIPTION
minikube recently changed their config format, making it more difficult to find the kernel version and automatically build probes. This change is causing the probe-builder job to fail and probes for other OSes to not get built. Disable minikube builds for now in order to build other OSes.