### PR TITLE
Fix memcpy call in syscall_get_arguments_deprecated for 5.1+

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -69,7 +69,7 @@ static inline struct inode *file_inode(struct file *f)
 	do { \
 		unsigned long _sga_args[6] = {}; \
 		syscall_get_arguments(_task, _reg, _sga_args); \
-		memcpy(_args, &_sga_args[_start], _len); \
+		memcpy(_args, &_sga_args[_start], _len * sizeof(unsigned long)); \
 	} while(0)
 #endif
 


### PR DESCRIPTION
This fixes the dr_pf events for 5.1+, at least for me.