### PR TITLE
Fix crash when `scap_get_threadlist` is called before the first actual event

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1009,10 +1009,6 @@ void schedule_next_threadinfo_evt(sinsp* _this, void* data)
 
 			_this->add_meta_event(&mei->m_pievt);
 		}
-		else if(mei->m_cur_procinfo_evt == (int32_t)mei->m_n_procinfo_evts)
-		{
-			_this->add_meta_event(mei->m_next_evt);
-		}
 
 		break;
 	}
@@ -1168,7 +1164,6 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 						m_meinfo.m_cur_procinfo_evt = -1;
 
 						m_meinfo.m_piscapevt->ts = m_next_flush_time_ns - (ONE_SECOND_IN_NS + 1);
-						m_meinfo.m_next_evt = &m_evt;
 						add_meta_event_callback(&schedule_next_threadinfo_evt, &m_meinfo);
 						schedule_next_threadinfo_evt(this, &m_meinfo);
 					}

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -216,7 +216,6 @@ public:
 	uint64_t m_n_procinfo_evts;
 	int64_t m_cur_procinfo_evt;
 	ppm_proclist_info* m_pli;
-	sinsp_evt* m_next_evt;
 };
 
 /** @defgroup inspector Main library


### PR DESCRIPTION
The last synthetic event is actually m_evt (the real event from the driver)
so if we call scap_get_threadlist (and process the resulting synthetic
events) before a real event happens, m_evt is still uninitialized.

This is pretty hard to hit as we explicitly skip the first time when
the function should be called (`if (m_next_flush_time_ns != 0)`),
so it happens only when the setup (/proc scan, container detection)
takes long enough and/or the stars align just right.

Removing the check and getting the thread list even the first time
around crashes sysdig reliably and this patch fixes it.

The patch basically stops scheduling the actual event as a synthetic
event (we don't read data from the driver for synthetic events
so if it's the first event ever, it contains bogus data).