### PR TITLE
[SMAGENT-2097] modify logger to short-circuit and return more quickly if sev is too low

### DIFF
--- a/userspace/libsinsp/logger.cpp
+++ b/userspace/libsinsp/logger.cpp
@@ -206,7 +206,7 @@ void sinsp_logger::log(std::string msg, const severity sev)
 	}
 }
 
-const char* sinsp_logger::format(const severity sev, const char* const fmt, ...)
+void sinsp_logger::format(const severity sev, const char* const fmt, ...)
 {
 	if(sev > m_sev)
 	{
@@ -220,17 +220,21 @@ const char* sinsp_logger::format(const severity sev, const char* const fmt, ...)
 	va_end(ap);
 
 	log(s_tbuf, sev);
-
-	return s_tbuf;
 }
 
-const char* sinsp_logger::format(const char* const fmt, ...)
+void sinsp_logger::format(const char* const fmt, ...)
 {
-	if(sev > m_sev)
-	{
-		return;
-	}
+	va_list ap;
 
+	va_start(ap, fmt);
+	vsnprintf(s_tbuf, sizeof s_tbuf, fmt, ap);
+	va_end(ap);
+
+	log(s_tbuf, SEV_INFO);
+}
+
+const char* sinsp_logger::format_and_return(const severity sev, const char* const fmt, ...)
+{
 	va_list ap;
 
 	va_start(ap, fmt);

--- a/userspace/libsinsp/logger.cpp
+++ b/userspace/libsinsp/logger.cpp
@@ -208,6 +208,11 @@ void sinsp_logger::log(std::string msg, const severity sev)
 
 const char* sinsp_logger::format(const severity sev, const char* const fmt, ...)
 {
+	if(sev > m_sev)
+	{
+		return;
+	}
+
 	va_list ap;
 
 	va_start(ap, fmt);
@@ -221,6 +226,11 @@ const char* sinsp_logger::format(const severity sev, const char* const fmt, ...)
 
 const char* sinsp_logger::format(const char* const fmt, ...)
 {
+	if(sev > m_sev)
+	{
+		return;
+	}
+
 	va_list ap;
 
 	va_start(ap, fmt);

--- a/userspace/libsinsp/logger.h
+++ b/userspace/libsinsp/logger.h
@@ -130,20 +130,23 @@ public:
 	/**
 	 * Write the given printf-style log message of the given severity
 	 * with the given format to the configured log sink.
-	 *
-	 * @returns a pointer to static thread-local storage containing the
-	 *          formatted log message.
 	 */
-	const char* format(severity sev, const char* fmt, ...);
+	void format(severity sev, const char* fmt, ...);
 
 	/**
-	 * Write the given printf-style log message of SEV_INFO severity
+	 * Write the given printf-style log message of the given severity
 	 * with the given format to the configured log sink.
 	 *
 	 * @returns a pointer to static thread-local storage containing the
 	 *          formatted log message.
 	 */
-	const char* format(const char* fmt, ...);
+	const char* format_and_return(severity sev, const char* fmt, ...);
+
+	/**
+	 * Write the given printf-style log message of SEV_INFO severity
+	 * with the given format to the configured log sink.
+	 */
+	void format(const char* fmt, ...);
 
 	/** Sets `sev` to the decoded severity or SEV_MAX+1 for errors.
 	 *  Returns the length of the severity string on success


### PR DESCRIPTION
previously format would call vnsprintf before checking the severity. This is an expensive operation which we can skip if we aren't going to log anyway.