### PR TITLE
Improve error message for probe loader

### DIFF
--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -202,8 +202,8 @@ load_kernel_probe() {
 		if [[ "$curl_out" =~ "404 Not Found" ]]; then
 			# The curl output throws a "curl: (22) The requested URL returned error: 404 Not Found" - but that is because the probe doesn't exist in the repo.
 			echo "Download of ${PROBE_NAME} for version ${SYSDIG_VERSION} failed. This is because the probe for this particular version does not exist in the repo."
-			if [ "${PROBE_NAME}" == "sysdigcloud-probe" ]; then
-				echo "Have you tried to upgrade the Sysdig agent version ? If that also does not work, please contact support@sysdig.com with the output of uname -r"
+			if [ ! -z "${KERNEL_ERR_MESSAGE}" ]; then
+				echo "${KERNEL_ERR_MESSAGE}"
 			else
 				echo "Consider compiling your own ${PROBE_NAME} and loading it or getting in touch with the sysdig community"
 			fi
@@ -386,8 +386,9 @@ else
 fi
 
 MAX_RMMOD_WAIT=60
+KERNEL_ERR_MESSAGE=""
 if [[ $# -ge 1 ]]; then
-	MAX_RMMOD_WAIT=$1
+	KERNEL_ERR_MESSAGE="$1"
 fi
 
 if [ -z "${SYSDIG_REPOSITORY}" ]; then

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -192,12 +192,24 @@ load_kernel_probe() {
 	URL=$(echo "${SYSDIG_PROBE_URL}/${SYSDIG_REPOSITORY}/sysdig-probe-binaries/${SYSDIG_PROBE_FILENAME}" | sed s/+/%2B/g)
 
 	echo "* Trying to download precompiled module from ${URL}"
-	if curl --create-dirs "${SYSDIG_PROBE_CURL_OPTIONS}" -o "${HOME}/.sysdig/${SYSDIG_PROBE_FILENAME}" "${URL}"; then
+
+	curl_out=$(curl --create-dirs "${SYSDIG_PROBE_CURL_OPTIONS}" -o "${HOME}/.sysdig/${SYSDIG_PROBE_FILENAME}" "${URL}" 2>&1)
+	if [ "$?" = "0" ]; then
 		echo "Download succeeded, loading module"
 		insmod "${HOME}/.sysdig/${SYSDIG_PROBE_FILENAME}"
 		exit $?
 	else
-		echo "Download failed, consider compiling your own ${PROBE_NAME} and loading it or getting in touch with the sysdig community"
+		if [[ "$curl_out" =~ "404 Not Found" ]]; then
+			# The curl output throws a "curl: (22) The requested URL returned error: 404 Not Found" - but that is because the probe doesn't exist in the repo.
+			echo "Download of ${PROBE_NAME} for version ${SYSDIG_VERSION} failed. This is because the probe for this particular version does not exist in the repo."
+			if [ "${PROBE_NAME}" == "sysdigcloud-probe" ]; then
+				echo "Have you tried to upgrade the Sysdig agent version ? If that also does not work, please contact support@sysdig.com with the output of uname -r"
+			else
+				echo "Consider compiling your own ${PROBE_NAME} and loading it or getting in touch with the sysdig community"
+			fi
+		else
+			echo "$curl_out"
+		fi
 		exit 1
 	fi
 }


### PR DESCRIPTION
The error message for the `sysdigcloud-probe` loader is improved in order to provide customers with an easier understanding of the issue and possible next steps. 

Sample error message: 

```
Download of sysdigcloud-probe for version 0.93.0 failed. This is because the probe for this particular version does not exist in the repo.
Have you tried to upgrade the Sysdig agent version ? If that also does not work, please contact support@sysdig.com with the output of uname -r
```
