### PR TITLE
use configured value for cpuset data

### DIFF
--- a/userspace/libsinsp/cgroup_limits.cpp
+++ b/userspace/libsinsp/cgroup_limits.cpp
@@ -125,7 +125,7 @@ bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_valu
 				key.m_container_id.c_str(), cpuset_root->c_str(), key.m_cpuset_cgroup.c_str());
 		found_all = read_cgroup_list_count(*cpuset_root,
 						   key.m_cpuset_cgroup,
-						   "cpuset.effective_cpus",
+						   "cpuset.cpus",
 						   value.m_cpuset_cpu_count) && found_all;
 	}
 


### PR DESCRIPTION
Early versions of cpuset configs didn't use `cpuset.effective_cpus`. So use the configured value instead.