### PR TITLE
Remove some circular dependencies on container engine

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -41,7 +41,7 @@ set(SINSP_SOURCES
 	chisel.cpp
 	chisel_api.cpp
 	container.cpp
-	container_engine/container_engine.cpp
+	container_engine/container_engine_base.cpp
 	container_engine/docker_common.cpp
 	container_info.cpp
 	ctext.cpp

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -502,8 +502,10 @@ void sinsp_container_manager::subscribe_on_remove_container(remove_container_cb 
 
 void sinsp_container_manager::create_engines()
 {
+#ifdef CYGWING_AGENT
+	m_container_engines.emplace_back(new container_engine::docker(m_inspector /*wmi source*/));
+#else
 	m_container_engines.emplace_back(new container_engine::docker());
-#ifndef CYGWING_AGENT
 #if defined(HAS_CAPTURE)
 	m_container_engines.emplace_back(new container_engine::cri());
 #endif

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -33,7 +33,7 @@ limitations under the License.
 #include <curl/multi.h>
 #endif
 
-#include "container_engine/container_engine.h"
+#include "container_engine/container_engine_base.h"
 #include "mutex.h"
 
 class sinsp_container_manager
@@ -175,7 +175,7 @@ private:
 	bool container_to_sinsp_event(const std::string& json, sinsp_evt* evt, std::shared_ptr<sinsp_threadinfo> tinfo);
 	std::string get_docker_env(const Json::Value &env_vars, const std::string &mti);
 
-	std::list<std::unique_ptr<libsinsp::container_engine::resolver>> m_container_engines;
+	std::list<std::unique_ptr<libsinsp::container_engine::container_engine_base>> m_container_engines;
 
 	sinsp* m_inspector;
 	libsinsp::Mutex<std::unordered_map<std::string, std::shared_ptr<const sinsp_container_info>>> m_containers;

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -33,10 +33,11 @@ limitations under the License.
 #include <curl/multi.h>
 #endif
 
+#include "container_engine/container_cache_interface.h"
 #include "container_engine/container_engine_base.h"
 #include "mutex.h"
 
-class sinsp_container_manager
+class sinsp_container_manager : public libsinsp::container_engine::container_cache_interface
 {
 public:
 	using map_ptr_t = libsinsp::ConstMutexGuard<std::unordered_map<std::string, sinsp_container_info::ptr_t>>;
@@ -57,7 +58,7 @@ public:
 	 * @param container_info shared_ptr owning the container_info to add/update
 	 * @param thread a thread in the container, only passed to callbacks
 	 */
-	void add_container(const sinsp_container_info::ptr_t& container_info, sinsp_threadinfo *thread);
+	void add_container(const sinsp_container_info::ptr_t& container_info, sinsp_threadinfo *thread) override;
 
 	/**
 	 * @brief Update a container by replacing its entry with a new one
@@ -77,7 +78,7 @@ public:
 	 * the container, get a new shared_ptr<sinsp_container_info> and pass it
 	 * to replace_container()
 	 */
-	sinsp_container_info::ptr_t get_container(const std::string &id) const;
+	sinsp_container_info::ptr_t get_container(const std::string &id) const override;
 
 	/**
 	 * @brief Generate container JSON event from a new container
@@ -86,7 +87,7 @@ public:
 	 * Note: this is unrelated to on_new_container callbacks even though
 	 * both happen during container creation
 	 */
-	void notify_new_container(const sinsp_container_info& container_info);
+	void notify_new_container(const sinsp_container_info& container_info) override;
 
 	/**
 	 * @brief Detect container engine for a thread
@@ -111,7 +112,7 @@ public:
 	// across execs e.g. "sh -c /bin/true" execing /bin/true.
 	void identify_category(sinsp_threadinfo *tinfo);
 
-	bool container_exists(const std::string& container_id) const {
+	bool container_exists(const std::string& container_id) const override{
 		auto containers = m_containers.lock();
 		return containers->find(container_id) != containers->end() ||
 			m_lookups.find(container_id) != m_lookups.end();
@@ -145,7 +146,7 @@ public:
 	 * state of the lookup via this method and call should_lookup() before
 	 * starting a new lookup.
 	 */
-	void set_lookup_status(const std::string& container_id, sinsp_container_type ctype, sinsp_container_lookup_state state)
+	void set_lookup_status(const std::string& container_id, sinsp_container_type ctype, sinsp_container_lookup_state state) override
 	{
 		m_lookups[container_id][ctype] = state;
 	}
@@ -160,7 +161,7 @@ public:
 	 * This method effectively checks if m_lookups[container_id][ctype]
 	 * exists, without creating unnecessary map entries along the way.
 	 */
-	bool should_lookup(const std::string& container_id, sinsp_container_type ctype)
+	bool should_lookup(const std::string& container_id, sinsp_container_type ctype) override
 	{
 		auto container_lookups = m_lookups.find(container_id);
 		if(container_lookups == m_lookups.end())

--- a/userspace/libsinsp/container_engine/bpm.cpp
+++ b/userspace/libsinsp/container_engine/bpm.cpp
@@ -21,7 +21,7 @@ limitations under the License.
 
 using namespace libsinsp::container_engine;
 
-bool bpm::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
+bool bpm::resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 {
 	sinsp_container_info container_info;
 	bool matches = false;
@@ -59,12 +59,12 @@ bool bpm::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 	}
 
 	tinfo->m_container_id = container_info.m_id;
-	if (manager->should_lookup(container_info.m_id, CT_BPM))
+	if(cache->should_lookup(container_info.m_id, CT_BPM))
 	{
 		container_info.m_name = container_info.m_id;
 		auto container = std::make_shared<sinsp_container_info>(container_info);
-		manager->add_container(container, tinfo);
-		manager->notify_new_container(container_info);
+		cache->add_container(container, tinfo);
+		cache->notify_new_container(container_info);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/bpm.h
+++ b/userspace/libsinsp/container_engine/bpm.h
@@ -19,7 +19,6 @@ limitations under the License.
 
 #pragma once
 
-class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
@@ -30,7 +29,7 @@ namespace container_engine {
 class bpm : public container_engine_base
 {
 public:
-	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;
+	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 };
 }
 }

--- a/userspace/libsinsp/container_engine/bpm.h
+++ b/userspace/libsinsp/container_engine/bpm.h
@@ -23,11 +23,11 @@ class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
-#include "container_engine/container_engine.h"
+#include "container_engine/container_engine_base.h"
 
 namespace libsinsp {
 namespace container_engine {
-class bpm : public resolver
+class bpm : public container_engine_base
 {
 public:
 	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;

--- a/userspace/libsinsp/container_engine/container_cache_interface.h
+++ b/userspace/libsinsp/container_engine/container_cache_interface.h
@@ -1,0 +1,60 @@
+/*
+Copyright (C) 2013-2018 Draios Inc dba Sysdig.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include "container_info.h"
+
+namespace libsinsp
+{
+namespace container_engine
+{
+
+/**
+ * Interface for a container cache for container engines.
+ */
+class container_cache_interface
+{
+public:
+	virtual ~container_cache_interface() = default;
+
+	virtual void notify_new_container(const sinsp_container_info& container_info) = 0;
+
+	virtual bool should_lookup(const std::string& container_id, sinsp_container_type ctype) = 0;
+
+	virtual void set_lookup_status(const std::string& container_id, sinsp_container_type ctype, sinsp_container_lookup_state state) = 0;
+
+	/**
+	 * Get a container from the cache.
+	 */
+	virtual sinsp_container_info::ptr_t get_container(const std::string& id) const = 0;
+
+	/**
+	 * Add a new container to the cache.
+	 */
+	virtual void add_container(const sinsp_container_info::ptr_t& container_info, sinsp_threadinfo *thread) = 0;
+
+	/**
+	 * Return whether the container exists in the cache.
+	 */
+	virtual bool container_exists(const std::string& container_id) const = 0;
+};
+
+}
+}

--- a/userspace/libsinsp/container_engine/container_engine_base.cpp
+++ b/userspace/libsinsp/container_engine/container_engine_base.cpp
@@ -17,10 +17,10 @@ limitations under the License.
 
 */
 
-#include "container_engine/container_engine.h"
+#include "container_engine/container_engine_base.h"
 
 using namespace libsinsp::container_engine;
 
-void resolver::cleanup()
+void container_engine_base::cleanup()
 {
 }

--- a/userspace/libsinsp/container_engine/container_engine_base.h
+++ b/userspace/libsinsp/container_engine/container_engine_base.h
@@ -25,9 +25,13 @@ class sinsp_threadinfo;
 namespace libsinsp {
 namespace container_engine {
 
-class resolver {
+/**
+ * Base class for container engine. This provided the interfaces to
+ * associate a container with a thread.
+ */
+class container_engine_base {
 public:
-	virtual ~resolver() = default;
+	virtual ~container_engine_base() = default;
 
 	virtual bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) = 0;
 

--- a/userspace/libsinsp/container_engine/container_engine_base.h
+++ b/userspace/libsinsp/container_engine/container_engine_base.h
@@ -19,7 +19,8 @@ limitations under the License.
 
 #pragma once
 
-class sinsp_container_manager;
+#include "container_engine/container_cache_interface.h"
+
 class sinsp_threadinfo;
 
 namespace libsinsp {
@@ -33,7 +34,13 @@ class container_engine_base {
 public:
 	virtual ~container_engine_base() = default;
 
-	virtual bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) = 0;
+	/**
+	 * Find a container associated with the given tinfo and add it to the
+	 * cache.
+	 */
+	virtual bool resolve(container_cache_interface* cache,
+			     sinsp_threadinfo* tinfo,
+			     bool query_os_for_missing_info) = 0;
 
 	virtual void cleanup();
 };

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -26,7 +26,7 @@ class sinsp_container_manager;
 class sinsp_threadinfo;
 
 #include "cgroup_limits.h"
-#include "container_engine/container_engine.h"
+#include "container_engine/container_engine_base.h"
 #include "container_info.h"
 #include <cri.h>
 
@@ -76,7 +76,7 @@ private:
 	::libsinsp::cri::cri_interface *m_cri;
 };
 
-class cri : public resolver
+class cri : public container_engine_base
 {
 public:
 	cri();

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -22,7 +22,6 @@ limitations under the License.
 #include <string>
 #include <stdint.h>
 
-class sinsp_container_manager;
 class sinsp_threadinfo;
 
 #include "cgroup_limits.h"
@@ -53,9 +52,9 @@ class cri_async_source : public sysdig::async_key_value_source<
         sinsp_container_info>
 {
 public:
-	explicit cri_async_source(sinsp_container_manager* manager, ::libsinsp::cri::cri_interface* cri, uint64_t ttl_ms) :
+	explicit cri_async_source(container_cache_interface *cache, ::libsinsp::cri::cri_interface *cri, uint64_t ttl_ms) :
 		async_key_value_source(NO_WAIT_LOOKUP, ttl_ms),
-		m_container_manager(manager),
+		m_cache(cache),
 		m_cri(cri)
 	{
 	}
@@ -72,7 +71,7 @@ private:
 	bool parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, sinsp_container_info& container);
 	void run_impl() override;
 
-	sinsp_container_manager* m_container_manager;
+	container_cache_interface *m_cache;
 	::libsinsp::cri::cri_interface *m_cri;
 };
 
@@ -81,7 +80,7 @@ class cri : public container_engine_base
 public:
 	cri();
 
-	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;
+	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 	void cleanup() override;
 	static void set_cri_socket_path(const std::string& path);
 	static void set_cri_timeout(int64_t timeout_ms);

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -38,6 +38,7 @@ limitations under the License.
 #include "container_info.h"
 
 #include "container_engine/container_engine_base.h"
+#include "container_engine/wmi_handle_source.h"
 
 class sinsp;
 class sinsp_threadinfo;
@@ -56,9 +57,9 @@ class docker_async_source : public sysdig::async_key_value_source<std::string, s
 
 public:
 #ifdef _WIN32
-	docker_async_source(uint64_t max_wait_ms, uint64_t ttl_ms, sinsp *inspector);
+	docker_async_source(uint64_t max_wait_ms, uint64_t ttl_ms, container_cache_interface *cache);
 #else
-	docker_async_source(uint64_t max_wait_ms, uint64_t ttl_ms, sinsp *inspector, std::string socket_path);
+	docker_async_source(uint64_t max_wait_ms, uint64_t ttl_ms, container_cache_interface *cache, std::string socket_path);
 #endif
 	virtual ~docker_async_source();
 
@@ -112,7 +113,7 @@ private:
 	void parse_health_probes(const Json::Value &config_obj,
 				 sinsp_container_info &container);
 
-	sinsp *m_inspector;
+	container_cache_interface *m_cache;
 
 	std::string m_api_version;
 
@@ -128,9 +129,14 @@ private:
 class docker : public container_engine_base
 {
 public:
-	docker();
 
-	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;
+#ifdef _WIN32
+	docker(const wmi_handle_source&);
+#else
+	docker() = default;
+#endif
+
+	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 	void cleanup() override;
 	static void parse_json_mounts(const Json::Value &mnt_obj, std::vector<sinsp_container_info::container_mount_info> &mounts);
 
@@ -142,13 +148,16 @@ public:
 		m_docker_sock = std::move(docker_sock);
 	}
 #endif
+
 protected:
-	void parse_docker_async(const std::string& container_id, sinsp_container_manager *manager);
+	void parse_docker_async(const std::string& container_id, container_cache_interface *cache);
 
 	std::unique_ptr<docker_async_source> m_docker_info_source;
 
 	static std::string s_incomplete_info_name;
-#ifndef _WIN32
+#ifdef _WIN32
+	const wmi_handle_source& m_wmi_handle_source;
+#else
 	static std::string m_docker_sock;
 #endif
 };

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -37,7 +37,7 @@ limitations under the License.
 #include "container.h"
 #include "container_info.h"
 
-#include "container_engine/container_engine.h"
+#include "container_engine/container_engine_base.h"
 
 class sinsp;
 class sinsp_threadinfo;
@@ -125,7 +125,7 @@ private:
 	static bool m_query_image_info;
 };
 
-class docker : public resolver
+class docker : public container_engine_base
 {
 public:
 	docker();

--- a/userspace/libsinsp/container_engine/docker_linux.cpp
+++ b/userspace/libsinsp/container_engine/docker_linux.cpp
@@ -45,10 +45,6 @@ constexpr const cgroup_layout DOCKER_CGROUP_LAYOUT[] = {
 
 std::string docker::m_docker_sock = "/var/run/docker.sock";
 
-docker::docker()
-{
-}
-
 void docker::cleanup()
 {
 	m_docker_info_source.reset(NULL);

--- a/userspace/libsinsp/container_engine/docker_win.cpp
+++ b/userspace/libsinsp/container_engine/docker_win.cpp
@@ -24,7 +24,8 @@ limitations under the License.
 
 using namespace libsinsp::container_engine;
 
-docker::docker()
+docker::docker(const wmi_handle_source& wmi_source)
+   : m_wmi_handle_source(wmi_source)
 {
 }
 
@@ -48,7 +49,7 @@ std::string docker_async_source::build_request(const std::string &url)
 
 bool docker::detect_docker(sinsp_threadinfo *tinfo, std::string &container_id, std::string &container_name)
 {
-	wh_docker_container_info wcinfo = wh_docker_resolve_pid(manager->get_inspector()->get_wmi_handle(), tinfo->m_pid);
+	wh_docker_container_info wcinfo = wh_docker_resolve_pid(m_wmi_handle_source.get_wmi_handle(), tinfo->m_pid);
 	if(!wcinfo.m_res)
 	{
 		return false;

--- a/userspace/libsinsp/container_engine/libvirt_lxc.cpp
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.cpp
@@ -73,7 +73,7 @@ bool libvirt_lxc::match(sinsp_threadinfo* tinfo, sinsp_container_info &container
 	return false;
 }
 
-bool libvirt_lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
+bool libvirt_lxc::resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 {
 	auto container = std::make_shared<sinsp_container_info>();
 
@@ -83,11 +83,11 @@ bool libvirt_lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* ti
 	}
 
 	tinfo->m_container_id = container->m_id;
-	if (manager->should_lookup(container->m_id, CT_LIBVIRT_LXC))
+	if(cache->should_lookup(container->m_id, CT_LIBVIRT_LXC))
 	{
 		container->m_name = container->m_id;
-		manager->add_container(container, tinfo);
-		manager->notify_new_container(*container);
+		cache->add_container(container, tinfo);
+		cache->notify_new_container(*container);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/libvirt_lxc.h
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.h
@@ -19,7 +19,6 @@ limitations under the License.
 
 #pragma once
 
-class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
@@ -30,7 +29,7 @@ namespace container_engine {
 class libvirt_lxc : public container_engine_base
 {
 public:
-	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;
+	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 protected:
 	bool match(sinsp_threadinfo* tinfo, sinsp_container_info &container_info);
 };

--- a/userspace/libsinsp/container_engine/libvirt_lxc.h
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.h
@@ -23,11 +23,11 @@ class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
-#include "container_engine/container_engine.h"
+#include "container_engine/container_engine_base.h"
 
 namespace libsinsp {
 namespace container_engine {
-class libvirt_lxc : public resolver
+class libvirt_lxc : public container_engine_base
 {
 public:
 	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;

--- a/userspace/libsinsp/container_engine/lxc.cpp
+++ b/userspace/libsinsp/container_engine/lxc.cpp
@@ -22,7 +22,7 @@ limitations under the License.
 
 using namespace libsinsp::container_engine;
 
-bool lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
+bool lxc::resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 {
 	auto container = std::make_shared<sinsp_container_info>();
 	bool matches = false;
@@ -62,11 +62,11 @@ bool lxc::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, boo
 	}
 
 	tinfo->m_container_id = container->m_id;
-	if (manager->should_lookup(container->m_id, CT_LXC))
+	if (cache->should_lookup(container->m_id, CT_LXC))
 	{
 		container->m_name = container->m_id;
-		manager->add_container(container, tinfo);
-		manager->notify_new_container(*container);
+		cache->add_container(container, tinfo);
+		cache->notify_new_container(*container);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/lxc.h
+++ b/userspace/libsinsp/container_engine/lxc.h
@@ -23,11 +23,11 @@ class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
-#include "container_engine/container_engine.h"
+#include "container_engine/container_engine_base.h"
 
 namespace libsinsp {
 namespace container_engine {
-class lxc : public resolver
+class lxc : public container_engine_base
 {
 public:
 	bool resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;

--- a/userspace/libsinsp/container_engine/mesos.cpp
+++ b/userspace/libsinsp/container_engine/mesos.cpp
@@ -52,7 +52,7 @@ bool libsinsp::container_engine::mesos::match(sinsp_threadinfo* tinfo, sinsp_con
 	return false;
 }
 
-bool libsinsp::container_engine::mesos::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
+bool libsinsp::container_engine::mesos::resolve(container_cache_interface *cache, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 {
 	auto container = std::make_shared<sinsp_container_info>();
 
@@ -60,11 +60,11 @@ bool libsinsp::container_engine::mesos::resolve(sinsp_container_manager* manager
 		return false;
 
 	tinfo->m_container_id = container->m_id;
-	if (manager->should_lookup(container->m_id, CT_MESOS))
+	if(cache->should_lookup(container->m_id, CT_MESOS))
 	{
 		container->m_name = container->m_id;
-		manager->add_container(container, tinfo);
-		manager->notify_new_container(*container);
+		cache->add_container(container, tinfo);
+		cache->notify_new_container(*container);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/mesos.h
+++ b/userspace/libsinsp/container_engine/mesos.h
@@ -25,18 +25,19 @@ class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
-#include "container_engine/container_engine.h"
+#include "container_engine/container_engine_base.h"
 
 namespace libsinsp {
 namespace container_engine {
-class mesos : public resolver {
+class mesos : public container_engine_base
+{
 public:
 	bool resolve(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
-	static bool set_mesos_task_id(sinsp_container_info &container, sinsp_threadinfo *tinfo);
+	static bool set_mesos_task_id(sinsp_container_info& container, sinsp_threadinfo *tinfo);
 
 protected:
-	bool match(sinsp_threadinfo *tinfo, sinsp_container_info &container_info);
+	bool match(sinsp_threadinfo *tinfo, sinsp_container_info& container_info);
 
 	static std::string get_env_mesos_task_id(sinsp_threadinfo *tinfo);
 };

--- a/userspace/libsinsp/container_engine/mesos.h
+++ b/userspace/libsinsp/container_engine/mesos.h
@@ -21,7 +21,6 @@ limitations under the License.
 
 #include <string>
 
-class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
@@ -32,7 +31,7 @@ namespace container_engine {
 class mesos : public container_engine_base
 {
 public:
-	bool resolve(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
 	static bool set_mesos_task_id(sinsp_container_info& container, sinsp_threadinfo *tinfo);
 

--- a/userspace/libsinsp/container_engine/rkt.cpp
+++ b/userspace/libsinsp/container_engine/rkt.cpp
@@ -26,7 +26,7 @@ limitations under the License.
 
 using namespace libsinsp::container_engine;
 
-bool rkt::match(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, sinsp_container_info &container_info, string &rkt_podid, string &rkt_appname, bool query_os_for_missing_info)
+bool rkt::match(container_cache_interface *cache, sinsp_threadinfo *tinfo, sinsp_container_info& container_info, string& rkt_podid, string& rkt_appname, bool query_os_for_missing_info)
 {
 	for(auto it = tinfo->m_cgroups.begin(); it != tinfo->m_cgroups.end(); ++it)
 	{
@@ -72,7 +72,7 @@ bool rkt::match(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, sinsp
 				// First lookup if the container exists in our table, otherwise only if we are live check if it has
 				// an entry in /var/lib/rkt. In capture mode only the former will be used.
 				// In live mode former will be used only if we already hit that container
-				bool is_rkt_pod_id_valid = manager->container_exists(rkt_podid + ":" + rkt_appname); // if it's already on our table
+				bool is_rkt_pod_id_valid = cache->container_exists(rkt_podid + ":" + rkt_appname); // if it's already on our table
 #ifdef HAS_CAPTURE
 				if(!is_rkt_pod_id_valid && query_os_for_missing_info)
 				{
@@ -165,18 +165,18 @@ bool rkt::match(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, sinsp
 	return false;
 }
 
-bool rkt::rkt::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
+bool rkt::rkt::resolve(container_cache_interface *cache, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 {
 	auto container = std::make_shared<sinsp_container_info>();
 	string rkt_podid, rkt_appname;
 
-	if (!match(manager, tinfo, *container, rkt_podid, rkt_appname, query_os_for_missing_info))
+	if (!match(cache, tinfo, *container, rkt_podid, rkt_appname, query_os_for_missing_info))
 	{
 		return false;
 	}
 
 	tinfo->m_container_id = container->m_id;
-	if (!query_os_for_missing_info || !manager->should_lookup(container->m_id, CT_RKT))
+	if (!query_os_for_missing_info || !cache->should_lookup(container->m_id, CT_RKT))
 	{
 		return true;
 	}
@@ -189,8 +189,8 @@ bool rkt::rkt::resolve(sinsp_container_manager* manager, sinsp_threadinfo* tinfo
 
 	if (have_rkt)
 	{
-		manager->add_container(container, tinfo);
-		manager->notify_new_container(*container);
+		cache->add_container(container, tinfo);
+		cache->notify_new_container(*container);
 		return true;
 	}
 	else

--- a/userspace/libsinsp/container_engine/rkt.h
+++ b/userspace/libsinsp/container_engine/rkt.h
@@ -21,7 +21,6 @@ limitations under the License.
 
 #include <string>
 
-class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
@@ -32,10 +31,10 @@ namespace container_engine {
 class rkt : public container_engine_base
 {
 public:
-	bool resolve(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
 protected:
-	bool match(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, sinsp_container_info& container_info,
+	bool match(container_cache_interface *cache, sinsp_threadinfo *tinfo, sinsp_container_info& container_info,
 		   std::string& rkt_podid, std::string& rkt_appname, bool query_os_for_missing_info);
 
 	bool parse_rkt(sinsp_container_info& container, const std::string& podid, const std::string& appname);

--- a/userspace/libsinsp/container_engine/rkt.h
+++ b/userspace/libsinsp/container_engine/rkt.h
@@ -25,19 +25,20 @@ class sinsp_container_manager;
 class sinsp_container_info;
 class sinsp_threadinfo;
 
-#include "container_engine/container_engine.h"
+#include "container_engine/container_engine_base.h"
 
 namespace libsinsp {
 namespace container_engine {
-class rkt : public resolver {
+class rkt : public container_engine_base
+{
 public:
 	bool resolve(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
 protected:
-	bool match(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, sinsp_container_info &container_info,
-		   std::string &rkt_podid, std::string &rkt_appname, bool query_os_for_missing_info);
+	bool match(sinsp_container_manager *manager, sinsp_threadinfo *tinfo, sinsp_container_info& container_info,
+		   std::string& rkt_podid, std::string& rkt_appname, bool query_os_for_missing_info);
 
-	bool parse_rkt(sinsp_container_info &container, const std::string &podid, const std::string &appname);
+	bool parse_rkt(sinsp_container_info& container, const std::string& podid, const std::string& appname);
 };
 }
 }

--- a/userspace/libsinsp/container_engine/sinsp_container_type.h
+++ b/userspace/libsinsp/container_engine/sinsp_container_type.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2013-2019 Draios Inc dba Sysdig.
+Copyright (C) 2019 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
 
@@ -19,17 +19,16 @@ limitations under the License.
 
 #pragma once
 
-class sinsp_container_info;
-class sinsp_threadinfo;
-
-#include "container_engine/container_engine_base.h"
-
-namespace libsinsp {
-namespace container_engine {
-class lxc : public container_engine_base
+enum sinsp_container_type
 {
-public:
-	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	CT_DOCKER = 0,
+	CT_LXC = 1,
+	CT_LIBVIRT_LXC = 2,
+	CT_MESOS = 3,
+	CT_RKT = 4,
+	CT_CUSTOM = 5,
+	CT_CRI = 6,
+	CT_CONTAINERD = 7,
+	CT_CRIO = 8,
+	CT_BPM = 9,
 };
-}
-}

--- a/userspace/libsinsp/container_engine/wmi_handle_source.h
+++ b/userspace/libsinsp/container_engine/wmi_handle_source.h
@@ -1,0 +1,48 @@
+/*
+Copyright (C) 2019 Sysdig Inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+#pragma once
+
+typedef struct wh_t wh_t;
+
+/**
+ * Interface to an object that can provide a Windows Management
+ * Instrumentation (WHI) handle. This is needed for windows support.
+ *
+ * This class does nothing for non-windows to enable simpler
+ * cross-compilation.
+ *
+ * Note that the intention here is to apply the Interface Segregation
+ * Principle (ISP) to class sinsp.  Some clients of sinsp need only the
+ * get_capture_stats() API, and this interface exposes only that API.  Do
+ * not add additional APIs here.  If some client of sinsp needs a different
+ * set of APIs, introduce a new interface.
+ */
+class SINSP_PUBLIC wmi_handle_source
+{
+public:
+	virtual ~wmi_handle_source() = default;
+
+
+#ifdef CYGWING_AGENT
+	/**
+	 * Return a wmi handle
+	 */
+	virtual wh_t* get_wmi_handle() = 0;
+#endif
+};

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -25,25 +25,11 @@ limitations under the License.
 #include <list>
 #include <string>
 #include <vector>
-
+#include "container_engine/sinsp_container_type.h"
 #include "json/json.h"
 
 class sinsp;
 class sinsp_threadinfo;
-
-enum sinsp_container_type
-{
-	CT_DOCKER = 0,
-	CT_LXC = 1,
-	CT_LIBVIRT_LXC = 2,
-	CT_MESOS = 3,
-	CT_RKT = 4,
-	CT_CUSTOM = 5,
-	CT_CRI = 6,
-	CT_CONTAINERD = 7,
-	CT_CRIO = 8,
-	CT_BPM = 9,
-};
 
 namespace std {
 template<> struct hash<sinsp_container_type> {

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -44,6 +44,7 @@ limitations under the License.
 #pragma once
 
 #include "capture_stats_source.h"
+#include "container_engine/wmi_handle_source.h"
 
 #ifdef _WIN32
 #pragma warning(disable: 4251 4200 4221 4190)
@@ -186,7 +187,7 @@ public:
   - event retrieval
   - setting capture filters
 */
-class SINSP_PUBLIC sinsp : public capture_stats_source
+class SINSP_PUBLIC sinsp : public capture_stats_source, public wmi_handle_source
 {
 public:
 	typedef std::shared_ptr<sinsp> ptr;
@@ -827,7 +828,7 @@ public:
 	static std::shared_ptr<std::string> lookup_cgroup_dir(const std::string& subsys);
 #endif
 #ifdef CYGWING_AGENT
-	wh_t* get_wmi_handle()
+	wh_t* get_wmi_handle() override
 	{
 		return scap_get_wmi_handle(m_h);
 	}


### PR DESCRIPTION
This is the start of some work to get a cleaner interface to the container engines. This'll lead to being able to call back into the container engine to get the size of the container layer (overlay2). I also plan to mock the container cache for unit testing soonish, though that won't help this repo until we get gtest added.

More specifically, this PR gets rid of the direct dependency on container_manager and sinsp.

@gnosek I'd appreciate if you could help me write the doxy on container_cache_interface