### PR TITLE
Modify amzn linux2 mirrorlist

### DIFF
--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -244,14 +244,16 @@ for repo_release, release_type in amazon_linux_builder:
     })
 repos['AmazonLinux'] = amazon_repos
 
+amazon_linux_2 = ['2.0', 'latest']
 amazon_linux2 = []
-amazon_linux2.append({
-    "root": "http://amazonlinux.us-east-1.amazonaws.com/2/core/2.0/x86_64/mirror.list",
-    "discovery_pattern": "SELECT * FROM packages WHERE name LIKE 'kernel%'",
-    "subdirs": [""],
-    "page_pattern": "",
-    "exclude_patterns": ["doc", "tools", "headers"]
-})
+for amzn_repos in amazon_linux_2:
+    amazon_linux2.append({
+        "root": "http://amazonlinux.us-east-1.amazonaws.com/2/core/" + amzn_repos + "/x86_64/mirror.list",
+        "discovery_pattern": "SELECT * FROM packages WHERE name LIKE 'kernel%'",
+        "subdirs": [""],
+        "page_pattern": "",
+        "exclude_patterns": ["doc", "tools", "headers"]
+    })
 
 repos['AmazonLinux2'] = amazon_linux2
 

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -244,11 +244,7 @@ for repo_release, release_type in amazon_linux_builder:
     })
 repos['AmazonLinux'] = amazon_repos
 
-prev_months = 24
-now = time.localtime()
-check_months = [time.localtime(time.mktime((now.tm_year, now.tm_mon - n, 1, 0, 0, 0, 0, 0, 0)))[:2] for n in range(prev_months)]
 amazon_linux2 = []
-#for year, month in check_months[:-1]:
 amazon_linux2.append({
     "root": "http://amazonlinux.us-east-1.amazonaws.com/2/core/2.0/x86_64/mirror.list",
     "discovery_pattern": "SELECT * FROM packages WHERE name LIKE 'kernel%'",

--- a/scripts/kernel-crawler.py
+++ b/scripts/kernel-crawler.py
@@ -248,14 +248,14 @@ prev_months = 24
 now = time.localtime()
 check_months = [time.localtime(time.mktime((now.tm_year, now.tm_mon - n, 1, 0, 0, 0, 0, 0, 0)))[:2] for n in range(prev_months)]
 amazon_linux2 = []
-for year, month in check_months[:-1]:
-    amazon_linux2.append({
-        "root": "http://amazonlinux.us-east-1.amazonaws.com/" + str(year) + "." + str(month).zfill(2) + "/core/latest/x86_64/mirror.list",
-        "discovery_pattern": "SELECT * FROM packages WHERE name LIKE 'kernel%'",
-        "subdirs": [""],
-        "page_pattern": "",
-        "exclude_patterns": ["doc", "tools", "headers"]
-        })
+#for year, month in check_months[:-1]:
+amazon_linux2.append({
+    "root": "http://amazonlinux.us-east-1.amazonaws.com/2/core/2.0/x86_64/mirror.list",
+    "discovery_pattern": "SELECT * FROM packages WHERE name LIKE 'kernel%'",
+    "subdirs": [""],
+    "page_pattern": "",
+    "exclude_patterns": ["doc", "tools", "headers"]
+})
 
 repos['AmazonLinux2'] = amazon_linux2
 


### PR DESCRIPTION
Amazon Linux 2 mirrorlist moved and this caused the kernel-crawler script to not find any Amazon Linux 2 kernel rpms. This change fixes that. 

A longer term fix/PR would hopefully throw an error when a particular kernel flavour doesn't return any urls. 