### PR TITLE
Add google test to sysdig repo

### DIFF
--- a/.travis-scripts/osx/build.sh
+++ b/.travis-scripts/osx/build.sh
@@ -21,4 +21,5 @@ mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DUSE_BUNDLED_LUAJIT=OFF -DUSE_BUNDLED_ZLIB=OFF
 make install
+make run-unit-tests
 ../test/sysdig_trace_regression.sh $(which sysdig) ./userspace/sysdig/chisels $TRAVIS_BRANCH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,7 @@ if(NOT WIN32)
 	option(USE_BUNDLED_GTEST "Enable building of the bundled gtest" ${USE_BUNDLED_DEPS})
 	if(NOT USE_BUNDLED_GTEST)
 		find_path(GTEST_INCLUDE_DIR NAMES gtest.h)
+		find_library(GTEST_MAIN_LIB NAMES gtest_main)
 	else()
 		# https://github.com/google/googletest/tree/master/googletest#incorporating-into-an-existing-cmake-project
 		# Download and unpack googletest at configure time
@@ -557,6 +558,7 @@ if(NOT WIN32)
 		                 EXCLUDE_FROM_ALL)
 
 		set(GTEST_INCLUDE_DIR "${gtest_SOURCE_DIR}/include/gtest")
+		set(GTEST_MAIN_LIB "gtest_main")
 	endif()
 endif() # NOT WIN32 AND NOT APPLE
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,7 +529,8 @@ if(NOT WIN32 AND NOT APPLE)
 	endif()
 endif() # NOT WIN32 AND NOT APPLE
 
-if(NOT WIN32)
+option(CREATE_TEST_TARGETS "Enable make-targets for unit testing" ON)
+if(CREATE_TEST_TARGETS AND NOT WIN32)
 	option(USE_BUNDLED_GTEST "Enable building of the bundled gtest" ${USE_BUNDLED_DEPS})
 	if(NOT USE_BUNDLED_GTEST)
 		find_path(GTEST_INCLUDE_DIR NAMES gtest.h)
@@ -566,7 +567,7 @@ add_subdirectory(userspace/sysdig)
 add_subdirectory(userspace/libscap)
 add_subdirectory(userspace/libsinsp)
 
-if(NOT WIN32)
+if(CREATE_TEST_TARGETS AND NOT WIN32)
 		# Add unit test directories
 		add_subdirectory(userspace/libsinsp/test)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -568,7 +568,9 @@ if(NOT WIN32)
 		# Add unit test directories
 		add_subdirectory(userspace/libsinsp/test)
 
-		# Add command to run all unit tests at once via the make system
+		# Add command to run all unit tests at once via the make system.
+		# This is preferred vs using ctest's add_test because it will build
+		# the code and output to stdout.
 		add_custom_target(run-unit-tests
 			COMMAND $(MAKE) run-unit-test-libsinsp
 		)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,11 +527,52 @@ if(NOT WIN32 AND NOT APPLE)
 		PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && wget https://download.sysdig.com/dependencies/grpc-1.8.1-Makefile.patch && patch < grpc-1.8.1-Makefile.patch
 		INSTALL_COMMAND "")
 	endif()
-endif()
+endif() # NOT WIN32 AND NOT APPLE
+
+if(NOT WIN32)
+	option(USE_BUNDLED_GTEST "Enable building of the bundled gtest" ${USE_BUNDLED_DEPS})
+	if(NOT USE_BUNDLED_GTEST)
+		find_path(GTEST_INCLUDE_DIR NAMES gtest.h)
+	else()
+		# https://github.com/google/googletest/tree/master/googletest#incorporating-into-an-existing-cmake-project
+		# Download and unpack googletest at configure time
+		configure_file(CMakeListsGtestInclude.cmake googletest-download/CMakeLists.txt)
+		execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+			RESULT_VARIABLE result
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+		if(result)
+			message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+		endif()
+		execute_process(COMMAND ${CMAKE_COMMAND} --build .
+			RESULT_VARIABLE result
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+		if(result)
+			message(FATAL_ERROR "Build step for googletest failed: ${result}")
+		endif()
+
+		# Add googletest directly to our build. This defines
+		# the gtest and gtest_main targets.
+		add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+		                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+		                 EXCLUDE_FROM_ALL)
+
+		set(GTEST_INCLUDE_DIR "${gtest_SOURCE_DIR}/include/gtest")
+	endif()
+endif() # NOT WIN32 AND NOT APPLE
 
 add_subdirectory(userspace/sysdig)
 add_subdirectory(userspace/libscap)
 add_subdirectory(userspace/libsinsp)
+
+if(NOT WIN32)
+		# Add unit test directories
+		add_subdirectory(userspace/libsinsp/test)
+
+		# Add command to run all unit tests at once via the make system
+		add_custom_target(run-unit-tests
+			COMMAND $(MAKE) run-unit-test-libsinsp
+		)
+endif()
 
 set(CPACK_PACKAGE_NAME "${PACKAGE_NAME}")
 set(CPACK_PACKAGE_VENDOR "Sysdig Inc.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,7 +560,7 @@ if(NOT WIN32)
 		set(GTEST_INCLUDE_DIR "${gtest_SOURCE_DIR}/include/gtest")
 		set(GTEST_MAIN_LIB "gtest_main")
 	endif()
-endif() # NOT WIN32 AND NOT APPLE
+endif() # NOT WIN32
 
 add_subdirectory(userspace/sysdig)
 add_subdirectory(userspace/libscap)

--- a/CMakeListsGtestInclude.cmake
+++ b/CMakeListsGtestInclude.cmake
@@ -1,6 +1,5 @@
-#!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
+# Copyright (C) 2019 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #
@@ -16,21 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-set -e
-export CC="gcc-4.8"
-export CXX="g++-4.8"
-wget https://s3.amazonaws.com/download.draios.com/dependencies/cmake-3.3.2.tar.gz
-tar -xzf cmake-3.3.2.tar.gz
-cd cmake-3.3.2
-./bootstrap --prefix=/usr
-make
-sudo make install
-cd ..
-mkdir build
-cd build
-cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-make VERBOSE=1
-make package
-make run-unit-tests
-cd ..
-test/sysdig_trace_regression.sh build/userspace/sysdig/sysdig build/userspace/sysdig/chisels $TRAVIS_BRANCH
+
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/CMakeListsGtestInclude.cmake
+++ b/CMakeListsGtestInclude.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 Draios Inc dba Sysdig.
+# Copyright (C) 2019 Sysdig Inc.
 #
 # This file is part of sysdig .
 #

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -1,6 +1,5 @@
-#!/bin/bash
 #
-# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
+# Copyright (C) 2019 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #
@@ -16,21 +15,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-set -e
-export CC="gcc-4.8"
-export CXX="g++-4.8"
-wget https://s3.amazonaws.com/download.draios.com/dependencies/cmake-3.3.2.tar.gz
-tar -xzf cmake-3.3.2.tar.gz
-cd cmake-3.3.2
-./bootstrap --prefix=/usr
-make
-sudo make install
-cd ..
-mkdir build
-cd build
-cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-make VERBOSE=1
-make package
-make run-unit-tests
-cd ..
-test/sysdig_trace_regression.sh build/userspace/sysdig/sysdig build/userspace/sysdig/chisels $TRAVIS_BRANCH
+
+include_directories("${GTEST_INCLUDE_DIR}")
+
+add_executable(unit-test-libsinsp
+	testy_test_face.ut.cpp
+)
+
+target_link_libraries(unit-test-libsinsp
+	gtest_main
+)
+
+add_custom_target(run-unit-test-libsinsp
+	DEPENDS unit-test-libsinsp
+	COMMAND unit-test-libsinsp
+)

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 Draios Inc dba Sysdig.
+# Copyright (C) 2019 Sysdig Inc.
 #
 # This file is part of sysdig .
 #

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(unit-test-libsinsp
 )
 
 target_link_libraries(unit-test-libsinsp
-	gtest_main
+	"${GTEST_MAIN_LIB}"
 )
 
 add_custom_target(run-unit-test-libsinsp

--- a/userspace/libsinsp/test/testy_test_face.ut.cpp
+++ b/userspace/libsinsp/test/testy_test_face.ut.cpp
@@ -1,0 +1,28 @@
+/*
+Copyright (C) 2019 Sysdig Inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <gtest.h>
+
+/**
+ * Ensure that tests are being tested
+ */
+TEST(testy_test_face_test, basic)
+{
+	ASSERT_TRUE(true);
+}


### PR DESCRIPTION
Add google test to the sysdig repo with a simple no-op test. Tests will be added in future changes.

```
bryan@bryan-server:/draios/sysdig/build$ make run-unit-tests
[ 33%] Built target gtest
[ 66%] Built target gtest_main
[100%] Built target unit-test-libsinsp
Running main() from /draios/sysdig/build/googletest-src/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from testy_test_face_test
[ RUN      ] testy_test_face_test.basic
[       OK ] testy_test_face_test.basic (0 ms)
[----------] 1 test from testy_test_face_test (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
[100%] Built target run-unit-test-libsinsp
Built target run-unit-tests
```