### PR TITLE
Add autoconf for driver_config.h in order to fix builds of just the BPF probe

### DIFF
--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -5,6 +5,8 @@
 # MIT.txt or GPL.txt for full copies of the license.
 #
 
+configure_file(../driver_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/../driver_config.h)
+
 option(BUILD_BPF "Build the BPF driver on Linux" OFF)
 
 if(BUILD_BPF)


### PR DESCRIPTION
When attempting to build just the BPF probe (EG: `docker run falcosecurity/falco-builder make bpf`) it fails because `driver_config.h.in` in the parent directory is never processed into `driver_config.h`. This resolves the issue by ensuring the `driver_config.h` file is generated every time a build of the BPF probe is run.

Relates to https://github.com/falcosecurity/falco/issues/900