### PR TITLE
[SMAGENT-2075] installer removes older sysdig-probes before loading newly built probe

### DIFF
--- a/scripts/install-sysdig.in
+++ b/scripts/install-sysdig.in
@@ -196,3 +196,5 @@ elif [ -f /etc/system-release-cpe ]; then
 else
 	unsupported
 fi
+
+modprobe -r _COMPONENT__probe

--- a/scripts/install-sysdig.in
+++ b/scripts/install-sysdig.in
@@ -197,4 +197,4 @@ else
 	unsupported
 fi
 
-modprobe _COMPONENT__probe
+modprobe -r _COMPONENT__probe

--- a/scripts/install-sysdig.in
+++ b/scripts/install-sysdig.in
@@ -197,4 +197,4 @@ else
 	unsupported
 fi
 
-modprobe -r _COMPONENT__probe
+modprobe _COMPONENT__probe


### PR DESCRIPTION
Added modprobe line to load newly built probe in sysdig install script