### PR TITLE
[SMAGENT-2076] docker engine changes to retrieve rw size

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -556,10 +556,19 @@ void sinsp_container_manager::create_engines()
 void sinsp_container_manager::update_container_with_size(sinsp_container_type type,
 							 const std::string& container_id)
 {
+	auto found = m_container_engine_by_type.find(type);
+	if(found == m_container_engine_by_type.end())
+	{
+		g_logger.format(sinsp_logger::SEV_ERROR,
+				"Container type %d not found when requesting size for %s",
+				type,
+				container_id.c_str());
+	}
+
 	g_logger.format(sinsp_logger::SEV_DEBUG,
 			"Request size for %s",
 			container_id.c_str());
-	m_container_engine_by_type[type]->update_with_size(container_id);
+	found->second->update_with_size(container_id);
 }
 
 void sinsp_container_manager::cleanup()

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -517,6 +517,26 @@ void sinsp_container_manager::create_engines()
 #endif
 }
 
+void sinsp_container_manager::update_container_with_size(sinsp_container_type type,
+							 const std::string& container_id)
+{
+	for(auto& eng : m_container_engines)
+	{
+		if(!eng->supports(type))
+		{
+			continue;
+		}
+
+		g_logger.format(sinsp_logger::SEV_INFO,//sinsp_logger::SEV_DEBUG,
+				"Request size for %s",
+				container_id.c_str());
+		eng->update_with_size(container_id);
+	}
+	g_logger.format(sinsp_logger::SEV_ERROR,
+			"Invalid size request for %s with type %d",
+			container_id.c_str(), type);
+}
+
 void sinsp_container_manager::cleanup()
 {
 	for(auto &eng : m_container_engines)

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include <functional>
 #include <memory>
+#include <unordered_map>
 
 #include "scap.h"
 
@@ -67,7 +68,7 @@ public:
 	 *
 	 * @param container_info shared_ptr owning the updated container_info
 	 */
-	void replace_container(const sinsp_container_info::ptr_t& container_info);
+	void replace_container(const sinsp_container_info::ptr_t& container_info) override;
 
 	/**
 	 * @brief Get a container_info by container id
@@ -124,6 +125,14 @@ public:
 	void subscribe_on_remove_container(remove_container_cb callback);
 
 	void create_engines();
+
+	/**
+	 * Update the container_info associated with the given type and container_id
+	 * to include the size of the container layer. This is not filled in the
+	 * initial request because it can easily take seconds.
+	 */
+	void update_container_with_size(sinsp_container_type type,
+					const std::string& container_id);
 	void cleanup();
 
 	void set_docker_socket_path(std::string socket_path);

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -36,6 +36,7 @@ limitations under the License.
 
 #include "container_engine/container_cache_interface.h"
 #include "container_engine/container_engine_base.h"
+#include "container_engine/sinsp_container_type.h"
 #include "mutex.h"
 
 class sinsp_container_manager : public libsinsp::container_engine::container_cache_interface
@@ -185,7 +186,8 @@ private:
 	bool container_to_sinsp_event(const std::string& json, sinsp_evt* evt, std::shared_ptr<sinsp_threadinfo> tinfo);
 	std::string get_docker_env(const Json::Value &env_vars, const std::string &mti);
 
-	std::list<std::unique_ptr<libsinsp::container_engine::container_engine_base>> m_container_engines;
+	std::list<std::shared_ptr<libsinsp::container_engine::container_engine_base>> m_container_engines;
+	std::map<sinsp_container_type, std::shared_ptr<libsinsp::container_engine::container_engine_base>> m_container_engine_by_type;
 
 	sinsp* m_inspector;
 	libsinsp::Mutex<std::unordered_map<std::string, std::shared_ptr<const sinsp_container_info>>> m_containers;

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -39,7 +39,8 @@ limitations under the License.
 #include "container_engine/sinsp_container_type.h"
 #include "mutex.h"
 
-class sinsp_container_manager : public libsinsp::container_engine::container_cache_interface
+class sinsp_container_manager :
+	public libsinsp::container_engine::container_cache_interface
 {
 public:
 	using map_ptr_t = libsinsp::ConstMutexGuard<std::unordered_map<std::string, sinsp_container_info::ptr_t>>;

--- a/userspace/libsinsp/container_engine/bpm.h
+++ b/userspace/libsinsp/container_engine/bpm.h
@@ -23,12 +23,21 @@ class sinsp_container_info;
 class sinsp_threadinfo;
 
 #include "container_engine/container_engine_base.h"
+#include "container_engine/sinsp_container_type.h"
 
 namespace libsinsp {
 namespace container_engine {
+
 class bpm : public container_engine_base
 {
 public:
+	bpm() = default;
+
+	bool supports(sinsp_container_type type) override
+	{
+		return CT_BPM == type;
+	}
+
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 };
 }

--- a/userspace/libsinsp/container_engine/bpm.h
+++ b/userspace/libsinsp/container_engine/bpm.h
@@ -33,11 +33,6 @@ class bpm : public container_engine_base
 public:
 	bpm() = default;
 
-	bool supports(sinsp_container_type type) override
-	{
-		return CT_BPM == type;
-	}
-
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 };
 }

--- a/userspace/libsinsp/container_engine/container_cache_interface.h
+++ b/userspace/libsinsp/container_engine/container_cache_interface.h
@@ -51,6 +51,11 @@ public:
 	virtual void add_container(const sinsp_container_info::ptr_t& container_info, sinsp_threadinfo *thread) = 0;
 
 	/**
+	 * Update a container by replacing its entry with a new one
+	 */
+	virtual void replace_container(const sinsp_container_info::ptr_t& container_info) = 0;
+
+	/**
 	 * Return whether the container exists in the cache.
 	 */
 	virtual bool container_exists(const std::string& container_id) const = 0;

--- a/userspace/libsinsp/container_engine/container_engine_base.cpp
+++ b/userspace/libsinsp/container_engine/container_engine_base.cpp
@@ -19,8 +19,20 @@ limitations under the License.
 
 #include "container_engine/container_engine_base.h"
 
-using namespace libsinsp::container_engine;
+namespace libsinsp
+{
+
+namespace container_engine
+{
+
+void container_engine_base::update_with_size(const std::string &container_id)
+{
+	g_logger.debug("Updating container size not supported for this container type.");
+}
 
 void container_engine_base::cleanup()
 {
+}
+
+}
 }

--- a/userspace/libsinsp/container_engine/container_engine_base.cpp
+++ b/userspace/libsinsp/container_engine/container_engine_base.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 */
 
 #include "container_engine/container_engine_base.h"
+#include "logger.h"
 
 namespace libsinsp
 {
@@ -27,7 +28,7 @@ namespace container_engine
 
 void container_engine_base::update_with_size(const std::string &container_id)
 {
-	g_logger.debug("Updating container size not supported for this container type.");
+	SINSP_DEBUG("Updating container size not supported for this container type.");
 }
 
 void container_engine_base::cleanup()

--- a/userspace/libsinsp/container_engine/container_engine_base.h
+++ b/userspace/libsinsp/container_engine/container_engine_base.h
@@ -35,11 +35,6 @@ public:
 	virtual ~container_engine_base() = default;
 
 	/**
-	 * Return whether this engine supports the given container type.
-	 */
-	virtual bool supports(sinsp_container_type type) = 0;
-
-	/**
 	 * Find a container associated with the given tinfo and add it to the
 	 * cache.
 	 */

--- a/userspace/libsinsp/container_engine/container_engine_base.h
+++ b/userspace/libsinsp/container_engine/container_engine_base.h
@@ -35,12 +35,24 @@ public:
 	virtual ~container_engine_base() = default;
 
 	/**
+	 * Return whether this engine supports the given container type.
+	 */
+	virtual bool supports(sinsp_container_type type) = 0;
+
+	/**
 	 * Find a container associated with the given tinfo and add it to the
 	 * cache.
 	 */
 	virtual bool resolve(container_cache_interface* cache,
 			     sinsp_threadinfo* tinfo,
 			     bool query_os_for_missing_info) = 0;
+
+	/**
+	 * Update an existing container with the size of the container layer.
+	 * The size is not requested as the part of the initial request (in resolve)
+	 * because determining the size can take seconds.
+	 */
+	virtual void update_with_size(const std::string& container_id);
 
 	virtual void cleanup();
 };

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -80,11 +80,6 @@ class cri : public container_engine_base
 {
 public:
 	cri();
-	virtual bool supports(sinsp_container_type type) override
-	{
-		return CT_CRI == type || CT_CRIO == type || CT_CONTAINERD == type;
-	}
-
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 	void cleanup() override;
 	static void set_cri_socket_path(const std::string& path);

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -26,6 +26,7 @@ class sinsp_threadinfo;
 
 #include "cgroup_limits.h"
 #include "container_engine/container_engine_base.h"
+#include "container_engine/sinsp_container_type.h"
 #include "container_info.h"
 #include <cri.h>
 
@@ -79,6 +80,10 @@ class cri : public container_engine_base
 {
 public:
 	cri();
+	virtual bool supports(sinsp_container_type type) override
+	{
+		return CT_CRI == type || CT_CRIO == type || CT_CONTAINERD == type;
+	}
 
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 	void cleanup() override;

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -1,4 +1,5 @@
 /*
+
 Copyright (C) 2013-2019 Draios Inc dba Sysdig.
 
 This file is part of sysdig.
@@ -38,6 +39,7 @@ limitations under the License.
 #include "container_info.h"
 
 #include "container_engine/container_engine_base.h"
+#include "container_engine/sinsp_container_type.h"
 #include "container_engine/wmi_handle_source.h"
 
 class sinsp;
@@ -46,7 +48,39 @@ class sinsp_threadinfo;
 namespace libsinsp {
 namespace container_engine {
 
-class docker_async_source : public sysdig::async_key_value_source<std::string, sinsp_container_info>
+struct docker_async_instruction
+{
+	docker_async_instruction() :
+		request_rw_size(false)
+	{}
+
+	docker_async_instruction(const std::string container_id_value,
+				 bool rw_size_value) :
+		container_id(container_id_value),
+		request_rw_size(rw_size_value)
+	{}
+
+	bool operator<(const docker_async_instruction& rhs) const
+	{
+		if(container_id < rhs.container_id)
+		{
+			return true;
+		}
+
+		return request_rw_size < rhs.request_rw_size;
+	}
+
+	bool operator==(const docker_async_instruction& rhs) const
+	{
+		return container_id == rhs.container_id &&
+		       request_rw_size == rhs.request_rw_size;
+	}
+
+	std::string container_id;
+	bool request_rw_size;
+};
+
+class docker_async_source : public sysdig::async_key_value_source<docker_async_instruction, sinsp_container_info>
 {
 	enum docker_response
 	{
@@ -75,7 +109,7 @@ private:
 	std::string build_request(const std::string& url);
 	docker_response get_docker(const std::string& url, std::string &json);
 
-	bool parse_docker(std::string &container_id, sinsp_container_info &container);
+	bool parse_docker(const docker_async_instruction& instruction, sinsp_container_info& container);
 
 	// Look for a pod specification in this container's labels and
 	// if found set spec to the pod spec.
@@ -133,10 +167,10 @@ public:
 #ifdef _WIN32
 	docker(const wmi_handle_source&);
 #else
-	docker() = default;
+	docker() :
+	   m_cache(nullptr)
+	{}
 #endif
-
-	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 	void cleanup() override;
 	static void parse_json_mounts(const Json::Value &mnt_obj, std::vector<sinsp_container_info::container_mount_info> &mounts);
 
@@ -160,6 +194,17 @@ protected:
 #else
 	static std::string m_docker_sock;
 #endif
+
+private:
+	// implement container_engine_base
+	bool supports(sinsp_container_type type) override
+	{
+		return CT_DOCKER == type;
+	}
+	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	void update_with_size(const std::string& container_id) override;
+
+	container_cache_interface *m_cache;
 };
 }
 }

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -1,5 +1,4 @@
 /*
-
 Copyright (C) 2013-2019 Draios Inc dba Sysdig.
 
 This file is part of sysdig.

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -196,10 +196,6 @@ protected:
 
 private:
 	// implement container_engine_base
-	bool supports(sinsp_container_type type) override
-	{
-		return CT_DOCKER == type;
-	}
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 	void update_with_size(const std::string& container_id) override;
 

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -720,7 +720,9 @@ bool docker_async_source::parse_docker(const docker_async_instruction& instructi
 					instruction.container_id.c_str(),
 					secondary_container_id.c_str());
 
-			if(parse_docker(docker_async_instruction(secondary_container_id, instruction.request_rw_size), pcnt))
+			if(parse_docker(docker_async_instruction(secondary_container_id,
+								 false /*don't request size since we just need the IP*/),
+					pcnt))
 			{
 				g_logger.format(sinsp_logger::SEV_DEBUG,
 						"docker_async (%s), secondary (%s): Secondary fetch successful",

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -59,21 +59,22 @@ docker_async_source::~docker_async_source()
 
 void docker_async_source::run_impl()
 {
-	std::string container_id;
+	docker_async_instruction instruction;
 
-	while (dequeue_next_key(container_id))
+	while (dequeue_next_key(instruction))
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG,
-				"docker_async (%s): Source dequeued key",
-				container_id.c_str());
+				"docker_async (%s : %s): Source dequeued key",
+				instruction.container_id.c_str(),
+				instruction.request_rw_size ? "true" : "false");
 
 		sinsp_container_info res;
 
 		res.m_lookup_state = sinsp_container_lookup_state::SUCCESSFUL;
 		res.m_type = CT_DOCKER;
-		res.m_id = container_id;
+		res.m_id = instruction.container_id;
 
-		if(!parse_docker(container_id, res))
+		if(!parse_docker(instruction, res))
 		{
 			// This is not always an error e.g. when using
 			// containerd as the runtime. Since the cgroup
@@ -82,17 +83,17 @@ void docker_async_source::run_impl()
 			// fetch both.
 			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"docker_async (%s): Failed to get Docker metadata, returning successful=false",
-					container_id.c_str());
+					instruction.container_id.c_str());
 			res.m_lookup_state = sinsp_container_lookup_state::FAILED;
 		}
 
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker_async (%s): Parse successful, storing value",
-				container_id.c_str());
+				instruction.container_id.c_str());
 
 		// Return a result object either way, to ensure any
 		// new container callbacks are called.
-		store_value(container_id, res);
+		store_value(instruction, res);
 	}
 }
 
@@ -468,11 +469,13 @@ bool docker::resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, 
 
 void docker::parse_docker_async(const string& container_id, container_cache_interface *cache)
 {
-	auto cb = [cache](const std::string& container_id, const sinsp_container_info& res)
-        {
+	m_cache = cache;
+
+	auto cb = [cache](const docker_async_instruction& instruction, const sinsp_container_info& res)
+	{
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker_async (%s): Source callback result=%d",
-				container_id.c_str(),
+				instruction.container_id.c_str(),
 				res.m_lookup_state);
 
 		cache->notify_new_container(res);
@@ -480,10 +483,11 @@ void docker::parse_docker_async(const string& container_id, container_cache_inte
 
         sinsp_container_info result;
 
-	if (m_docker_info_source->lookup(container_id, result, cb))
+	docker_async_instruction instruction(container_id, false /*don't request size*/);
+	if(m_docker_info_source->lookup(instruction, result, cb))
 	{
 		// if a previous lookup call already found the metadata, process it now
-		cb(container_id, result);
+		cb(instruction, result);
 
 		// This should *never* happen, as ttl is 0 (never wait)
 		g_logger.format(sinsp_logger::SEV_ERROR,
@@ -492,24 +496,31 @@ void docker::parse_docker_async(const string& container_id, container_cache_inte
 	}
 }
 
-bool docker_async_source::parse_docker(std::string &container_id, sinsp_container_info &container)
+bool docker_async_source::parse_docker(const docker_async_instruction& instruction, sinsp_container_info& container)
 {
 	string json;
 
 	g_logger.format(sinsp_logger::SEV_DEBUG,
 			"docker_async (%s): Looking up info for container",
-			container_id.c_str());
+			instruction.container_id.c_str());
 
-	docker_response resp = get_docker(build_request("/containers/" + container_id + "/json"), json);
+	std::string request = build_request("/containers/" + instruction.container_id + "/json");
+	if(instruction.request_rw_size)
+	{
+		request += "?size=true";
+	}
+
+	docker_response resp = get_docker(request, json);
+
 	switch(resp) {
 		case docker_response::RESP_BAD_REQUEST:
 			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"docker_async (%s): Initial url fetch failed, trying w/o api version",
-					container_id.c_str());
+					instruction.container_id.c_str());
 
 			m_api_version = "";
 			json = "";
-			resp = get_docker(build_request("/containers/" + container_id + "/json"), json);
+			resp = get_docker(build_request("/containers/" + instruction.container_id + "/json"), json);
 			if (resp == docker_response::RESP_OK)
 			{
 				break;
@@ -518,7 +529,7 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 		case docker_response::RESP_ERROR:
 			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"docker_async (%s): Url fetch failed, returning false",
-					container_id.c_str());
+					instruction.container_id.c_str());
 
 			return false;
 
@@ -528,7 +539,7 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 
 	g_logger.format(sinsp_logger::SEV_DEBUG,
 			"docker_async (%s): Parsing containers response \"%s\"",
-			container_id.c_str(),
+			instruction.container_id.c_str(),
 			json.c_str());
 
 	Json::Value root;
@@ -538,7 +549,7 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 	{
 		g_logger.format(sinsp_logger::SEV_ERROR,
 				"docker_async (%s): Could not parse json \"%s\", returning false",
-				container_id.c_str(),
+				instruction.container_id.c_str(),
 				json.c_str());
 
 		ASSERT(false);
@@ -584,15 +595,21 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker_async (%s) image (%s): Fetching image info",
-				container_id.c_str(),
+				instruction.container_id.c_str(),
 				container.m_imageid.c_str());
 
 		string img_json;
-		if(get_docker(build_request("/images/" + container.m_imageid + "/json?digests=1"), img_json) == docker_response::RESP_OK)
+		std::string url = "/images/" + container.m_imageid + "/json?digests=1";
+
+		g_logger.format(sinsp_logger::SEV_DEBUG,
+				"docker_async url: %s",
+				url.c_str());
+
+		if(get_docker(build_request(url), img_json) == docker_response::RESP_OK)
 		{
 			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"docker_async (%s) image (%s): Image info fetch returned \"%s\"",
-					container_id.c_str(),
+					instruction.container_id.c_str(),
 					container.m_imageid.c_str(),
 					img_json.c_str());
 
@@ -649,7 +666,7 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 			{
 				g_logger.format(sinsp_logger::SEV_ERROR,
 						"docker_async (%s) image (%s): Could not parse json image info \"%s\"",
-						container_id.c_str(),
+						instruction.container_id.c_str(),
 						container.m_imageid.c_str(),
 						img_json.c_str());
 			}
@@ -658,7 +675,7 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 		{
 			g_logger.format(sinsp_logger::SEV_ERROR,
 					"docker_async (%s) image (%s): Could not fetch image info",
-					container_id.c_str(),
+					instruction.container_id.c_str(),
 					container.m_imageid.c_str());
 		}
 
@@ -700,14 +717,14 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 			// separate thread so this is ok.
 			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"docker_async (%s), secondary (%s): Doing blocking fetch of secondary container",
-					container_id.c_str(),
+					instruction.container_id.c_str(),
 					secondary_container_id.c_str());
 
-			if (parse_docker(secondary_container_id, pcnt))
+			if(parse_docker(docker_async_instruction(secondary_container_id, instruction.request_rw_size), pcnt))
 			{
 				g_logger.format(sinsp_logger::SEV_DEBUG,
 						"docker_async (%s), secondary (%s): Secondary fetch successful",
-						container_id.c_str(),
+						instruction.container_id.c_str(),
 						secondary_container_id.c_str());
 				container.m_container_ip = pcnt.m_container_ip;
 			}
@@ -715,7 +732,7 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 			{
 				g_logger.format(sinsp_logger::SEV_ERROR,
 						"docker_async (%s), secondary (%s): Secondary fetch failed",
-						container_id.c_str(),
+						instruction.container_id.c_str(),
 						secondary_container_id.c_str());
 			}
 		}
@@ -809,6 +826,9 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 
 	docker::parse_json_mounts(root["Mounts"], container.m_mounts);
 
+	container.m_size_rw_bytes = root["SizeRw"].asInt64();
+	container.m_size_root_fs_bytes = root["SizeRootFs"].asInt64();
+
 #ifdef HAS_ANALYZER
 	sinsp_utils::find_env(container.m_sysdig_agent_conf, container.get_env(), "SYSDIG_AGENT_CONF");
 	// container.m_sysdig_agent_conf = get_docker_env(env_vars, "SYSDIG_AGENT_CONF");
@@ -816,7 +836,30 @@ bool docker_async_source::parse_docker(std::string &container_id, sinsp_containe
 
 	g_logger.format(sinsp_logger::SEV_DEBUG,
 			"docker_async (%s): parse_docker returning true",
-			container_id.c_str());
+			instruction.container_id.c_str());
 	return true;
+}
+
+void docker::update_with_size(const std::string &container_id)
+{
+	ASSERT(m_cache != nullptr);
+
+	auto cb = [this](const docker_async_instruction& instruction, const sinsp_container_info& res) {
+		g_logger.format(sinsp_logger::SEV_DEBUG,
+				"docker_async (%s): with size callback result=%d",
+				instruction.container_id.c_str(),
+				res.m_lookup_state);
+
+		sinsp_container_info::ptr_t updated = make_shared<sinsp_container_info>(res);
+		m_cache->replace_container(updated);
+	};
+
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"docker_async size request (%s)",
+			container_id.c_str());
+
+	sinsp_container_info result;
+	docker_async_instruction instruction(container_id, true /*request rw size*/);
+	(void)m_docker_info_source->lookup(instruction, result, cb);
 }
 

--- a/userspace/libsinsp/container_engine/docker_win.cpp
+++ b/userspace/libsinsp/container_engine/docker_win.cpp
@@ -25,7 +25,8 @@ limitations under the License.
 using namespace libsinsp::container_engine;
 
 docker::docker(const wmi_handle_source& wmi_source)
-   : m_wmi_handle_source(wmi_source)
+   : m_wmi_handle_source(wmi_source),
+     m_cache(nullptr)
 {
 }
 

--- a/userspace/libsinsp/container_engine/libvirt_lxc.h
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.h
@@ -23,12 +23,17 @@ class sinsp_container_info;
 class sinsp_threadinfo;
 
 #include "container_engine/container_engine_base.h"
+#include "container_engine/sinsp_container_type.h"
 
 namespace libsinsp {
 namespace container_engine {
 class libvirt_lxc : public container_engine_base
 {
 public:
+	bool supports(sinsp_container_type type) override
+	{
+		return CT_LIBVIRT_LXC == type;
+	}
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 protected:
 	bool match(sinsp_threadinfo* tinfo, sinsp_container_info &container_info);

--- a/userspace/libsinsp/container_engine/libvirt_lxc.h
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.h
@@ -30,10 +30,6 @@ namespace container_engine {
 class libvirt_lxc : public container_engine_base
 {
 public:
-	bool supports(sinsp_container_type type) override
-	{
-		return CT_LIBVIRT_LXC == type;
-	}
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 protected:
 	bool match(sinsp_threadinfo* tinfo, sinsp_container_info &container_info);

--- a/userspace/libsinsp/container_engine/lxc.h
+++ b/userspace/libsinsp/container_engine/lxc.h
@@ -23,12 +23,17 @@ class sinsp_container_info;
 class sinsp_threadinfo;
 
 #include "container_engine/container_engine_base.h"
+#include "container_engine/sinsp_container_type.h"
 
 namespace libsinsp {
 namespace container_engine {
 class lxc : public container_engine_base
 {
 public:
+	bool supports(sinsp_container_type type) override
+	{
+		return CT_LXC == type;
+	}
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 };
 }

--- a/userspace/libsinsp/container_engine/lxc.h
+++ b/userspace/libsinsp/container_engine/lxc.h
@@ -30,10 +30,6 @@ namespace container_engine {
 class lxc : public container_engine_base
 {
 public:
-	bool supports(sinsp_container_type type) override
-	{
-		return CT_LXC == type;
-	}
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 };
 }

--- a/userspace/libsinsp/container_engine/mesos.h
+++ b/userspace/libsinsp/container_engine/mesos.h
@@ -25,12 +25,17 @@ class sinsp_container_info;
 class sinsp_threadinfo;
 
 #include "container_engine/container_engine_base.h"
+#include "container_engine/sinsp_container_type.h"
 
 namespace libsinsp {
 namespace container_engine {
 class mesos : public container_engine_base
 {
 public:
+	bool supports(sinsp_container_type type) override
+	{
+		return CT_MESOS == type;
+	}
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
 	static bool set_mesos_task_id(sinsp_container_info& container, sinsp_threadinfo *tinfo);

--- a/userspace/libsinsp/container_engine/mesos.h
+++ b/userspace/libsinsp/container_engine/mesos.h
@@ -32,10 +32,6 @@ namespace container_engine {
 class mesos : public container_engine_base
 {
 public:
-	bool supports(sinsp_container_type type) override
-	{
-		return CT_MESOS == type;
-	}
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
 	static bool set_mesos_task_id(sinsp_container_info& container, sinsp_threadinfo *tinfo);

--- a/userspace/libsinsp/container_engine/rkt.h
+++ b/userspace/libsinsp/container_engine/rkt.h
@@ -32,10 +32,6 @@ namespace container_engine {
 class rkt : public container_engine_base
 {
 public:
-	bool supports(sinsp_container_type type) override
-	{
-		return CT_RKT == type;
-	}
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
 protected:

--- a/userspace/libsinsp/container_engine/rkt.h
+++ b/userspace/libsinsp/container_engine/rkt.h
@@ -25,12 +25,17 @@ class sinsp_container_info;
 class sinsp_threadinfo;
 
 #include "container_engine/container_engine_base.h"
+#include "sinsp_container_type.h"
 
 namespace libsinsp {
 namespace container_engine {
 class rkt : public container_engine_base
 {
 public:
+	bool supports(sinsp_container_type type) override
+	{
+		return CT_RKT == type;
+	}
 	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
 protected:

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -199,8 +199,8 @@ public:
 		m_is_pod_sandbox(false),
 		m_lookup_state(sinsp_container_lookup_state::SUCCESSFUL),
 		m_metadata_deadline(0),
-		m_size_rw_bytes(0),
-		m_size_root_fs_bytes(0)
+		m_size_rw_bytes(-1),
+		m_size_root_fs_bytes(-1)
 	{
 	}
 

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -198,7 +198,9 @@ public:
 		m_cpuset_cpu_count(0),
 		m_is_pod_sandbox(false),
 		m_lookup_state(sinsp_container_lookup_state::SUCCESSFUL),
-		m_metadata_deadline(0)
+		m_metadata_deadline(0),
+		m_size_rw_bytes(0),
+		m_size_root_fs_bytes(0)
 	{
 	}
 
@@ -251,4 +253,16 @@ public:
 	std::string m_sysdig_agent_conf;
 #endif
 	uint64_t m_metadata_deadline;
+
+	/**
+	 * The size of files that have been created or changed by this container.
+	 * This is not filled by default.
+	 */
+	int64_t m_size_rw_bytes;
+
+	/**
+	 * The total size of all the files in this container. This is not filled by
+	 * default.
+	 */
+	int64_t m_size_root_fs_bytes;
 };


### PR DESCRIPTION
For docker, perform the request with the extra "size=true" parameter. This is relevant when running overlay2 and gives the size of the container layer.

The size request isn't done during the initial request because determining the size can easily take seconds.