### PR TITLE
Adding power support to Travis builds

### DIFF
--- a/.travis-scripts/linux/build.sh
+++ b/.travis-scripts/linux/build.sh
@@ -17,8 +17,13 @@
 # limitations under the License.
 #
 set -e
-export CC="gcc-4.8"
-export CXX="g++-4.8"
+if [[ $(uname -i) == "ppc64le" ]]; then
+	export CC="gcc-7"
+	export CXX="g++-7"
+else
+	export CC="gcc-4.8"
+	export CXX="g++-4.8"
+fi
 wget https://s3.amazonaws.com/download.draios.com/dependencies/cmake-3.3.2.tar.gz
 tar -xzf cmake-3.3.2.tar.gz
 cd cmake-3.3.2

--- a/.travis-scripts/linux/install.sh
+++ b/.travis-scripts/linux/install.sh
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sudo apt-get --force-yes install g++-4.8
+if [[ $(uname -i) != "ppc64le" ]]; then
+	sudo apt-get --force-yes install g++-4.8
+fi
 sudo apt-get install rpm linux-headers-$(uname -r) libelf-dev
 sudo apt-get purge cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,26 @@
 # limitations under the License.
 #
 language: c
-os:
-    - linux
-    - osx
-env:
-    - BUILD_TYPE=Debug
-    - BUILD_TYPE=Release
+
+matrix:
+  include:
+    - env: BUILD_TYPE=Debug
+      os: linux
+    - env: BUILD_TYPE=Release
+      os: linux
+    - env: BUILD_TYPE=Debug
+      os: osx
+    - env: BUILD_TYPE=Release
+      os: osx
+    - env: BUILD_TYPE=Debug
+      os: linux
+      arch: ppc64le
+      dist: bionic
+    - env: BUILD_TYPE=Release
+      os: linux
+      arch: ppc64le
+      dist: bionic
+
 sudo: required
 services:
     - docker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,17 @@ else()
 	set(LUAJIT_INCLUDE "${LUAJIT_SRC}")
 	if(NOT WIN32)
 		set(LUAJIT_LIB "${LUAJIT_SRC}/libluajit.a")
+ 		if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+		ExternalProject_Add(luajit
+			GIT_REPOSITORY "https://github.com/moonjit/moonjit"
+			GIT_TAG "2.1.2"
+			PATCH_COMMAND sed -i "s/luaL_reg/luaL_Reg/g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/chisel.cpp && sed -i "s/luaL_reg/luaL_Reg/g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/lua_parser.cpp && sed -i "s/luaL_getn/lua_objlen /g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/lua_parser_api.cpp
+			CONFIGURE_COMMAND ""
+			BUILD_COMMAND ${CMD_MAKE}
+			BUILD_IN_SOURCE 1
+			BUILD_BYPRODUCTS ${LUAJIT_LIB}
+			INSTALL_COMMAND "")
+		else()
 		ExternalProject_Add(luajit
 			URL "http://download.draios.com/dependencies/LuaJIT-2.0.3.tar.gz"
 			URL_MD5 "f14e9104be513913810cd59c8c658dc0"
@@ -168,6 +179,7 @@ else()
 			BUILD_IN_SOURCE 1
 			BUILD_BYPRODUCTS ${LUAJIT_LIB}
 			INSTALL_COMMAND "")
+		endif()
 	else()
 		set(LUAJIT_LIB "${LUAJIT_SRC}/lua51.lib")
 		ExternalProject_Add(luajit


### PR DESCRIPTION
As we all know Travis officially supports multiple arch's now - https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z .
Adding support for "ppc64le" arch for this repo with below changes ..

1. Installing moonjit in place of luajit for power
2. Using gcc-7, g++-7 compiler as default during builds for power
3. Avoiding installing gcc-4.8 for power
4. Adding power support in travis.yml

sysdig-CLA-1.0-contributing-entity: IBM
sysdig-CLA-1.0-signed-off-by: Amit Ghatwal ghatwala@us.ibm.com