### PR TITLE
[SMAGENT-2181] CRIO support for bytes used

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -149,6 +149,7 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 	Json::Value obj;
 	Json::Value& container = obj["container"];
 	container["id"] = container_info.m_id;
+	container["full_id"] = container_info.m_full_id;
 	container["type"] = container_info.m_type;
 	container["name"] = container_info.m_name;
 	container["image"] = container_info.m_image;

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -130,7 +130,7 @@ bool sinsp_container_manager::resolve_container(sinsp_threadinfo* tinfo, bool qu
 
 	for(auto &eng : m_container_engines)
 	{
-		matches = matches || eng->resolve(this, tinfo, query_os_for_missing_info);
+		matches = matches || eng->resolve(tinfo, query_os_for_missing_info);
 
 		if(matches)
 		{
@@ -504,20 +504,20 @@ void sinsp_container_manager::create_engines()
 {
 #ifdef CYGWING_AGENT
 	{
-		auto docker_engine = std::make_shared<container_engine::docker>(m_inspector /*wmi source*/);
+		auto docker_engine = std::make_shared<container_engine::docker>(*this, m_inspector /*wmi source*/);
 		m_container_engines.push_back(docker_engine);
 		m_container_engine_by_type[CT_DOCKER] = docker_engine;
 	}
 #else
 	{
-		auto docker_engine = std::make_shared<container_engine::docker>();
+		auto docker_engine = std::make_shared<container_engine::docker>(*this);
 		m_container_engines.push_back(docker_engine);
 		m_container_engine_by_type[CT_DOCKER] = docker_engine;
 	}
 
 #if defined(HAS_CAPTURE)
 	{
-		auto cri_engine = std::make_shared<container_engine::cri>();
+		auto cri_engine = std::make_shared<container_engine::cri>(*this);
 		m_container_engines.push_back(cri_engine);
 		m_container_engine_by_type[CT_CRI] = cri_engine;
 		m_container_engine_by_type[CT_CRIO] = cri_engine;
@@ -525,28 +525,28 @@ void sinsp_container_manager::create_engines()
 	}
 #endif
 	{
-		auto lxc_engine = std::make_shared<container_engine::lxc>();
+		auto lxc_engine = std::make_shared<container_engine::lxc>(*this);
 		m_container_engines.push_back(lxc_engine);
 		m_container_engine_by_type[CT_LXC] = lxc_engine;
 	}
 	{
-		auto libvirt_lxc_engine = std::make_shared<container_engine::libvirt_lxc>();
+		auto libvirt_lxc_engine = std::make_shared<container_engine::libvirt_lxc>(*this);
 		m_container_engines.push_back(libvirt_lxc_engine);
 		m_container_engine_by_type[CT_LIBVIRT_LXC] = libvirt_lxc_engine;
 	}
 
 	{
-		auto mesos_engine = std::make_shared<container_engine::mesos>();
+		auto mesos_engine = std::make_shared<container_engine::mesos>(*this);
 		m_container_engines.push_back(mesos_engine);
 		m_container_engine_by_type[CT_MESOS] = mesos_engine;
 	}
 	{
-		auto rkt_engine = std::make_shared<container_engine::rkt>();
+		auto rkt_engine = std::make_shared<container_engine::rkt>(*this);
 		m_container_engines.push_back(rkt_engine);
 		m_container_engine_by_type[CT_RKT] = rkt_engine;
 	}
 	{
-		auto bpm_engine = std::make_shared<container_engine::bpm>();
+		auto bpm_engine = std::make_shared<container_engine::bpm>(*this);
 		m_container_engines.push_back(bpm_engine);
 		m_container_engine_by_type[CT_BPM] = bpm_engine;
 	}

--- a/userspace/libsinsp/container_engine/bpm.cpp
+++ b/userspace/libsinsp/container_engine/bpm.cpp
@@ -21,7 +21,7 @@ limitations under the License.
 
 using namespace libsinsp::container_engine;
 
-bool bpm::resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
+bool bpm::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 {
 	sinsp_container_info container_info;
 	bool matches = false;
@@ -59,12 +59,12 @@ bool bpm::resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, boo
 	}
 
 	tinfo->m_container_id = container_info.m_id;
-	if(cache->should_lookup(container_info.m_id, CT_BPM))
+	if(container_cache().should_lookup(container_info.m_id, CT_BPM))
 	{
 		container_info.m_name = container_info.m_id;
 		auto container = std::make_shared<sinsp_container_info>(container_info);
-		cache->add_container(container, tinfo);
-		cache->notify_new_container(container_info);
+		container_cache().add_container(container, tinfo);
+		container_cache().notify_new_container(container_info);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/bpm.h
+++ b/userspace/libsinsp/container_engine/bpm.h
@@ -31,9 +31,10 @@ namespace container_engine {
 class bpm : public container_engine_base
 {
 public:
-	bpm() = default;
+	bpm(container_cache_interface& cache) : container_engine_base(cache)
+	{}
 
-	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	bool resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 };
 }
 }

--- a/userspace/libsinsp/container_engine/container_engine_base.cpp
+++ b/userspace/libsinsp/container_engine/container_engine_base.cpp
@@ -26,6 +26,11 @@ namespace libsinsp
 namespace container_engine
 {
 
+container_engine_base::container_engine_base(container_cache_interface &cache) :
+   m_cache(cache)
+{
+}
+
 void container_engine_base::update_with_size(const std::string &container_id)
 {
 	SINSP_DEBUG("Updating container size not supported for this container type.");

--- a/userspace/libsinsp/container_engine/container_engine_base.h
+++ b/userspace/libsinsp/container_engine/container_engine_base.h
@@ -28,7 +28,7 @@ namespace container_engine {
 
 /**
  * Base class for container engine. This provides the interfaces to
- * associate a create a sinsp_container_info.
+ * create a sinsp_container_info.
  */
 class container_engine_base {
 public:

--- a/userspace/libsinsp/container_engine/container_engine_base.h
+++ b/userspace/libsinsp/container_engine/container_engine_base.h
@@ -27,19 +27,20 @@ namespace libsinsp {
 namespace container_engine {
 
 /**
- * Base class for container engine. This provided the interfaces to
- * associate a container with a thread.
+ * Base class for container engine. This provides the interfaces to
+ * associate a create a sinsp_container_info.
  */
 class container_engine_base {
 public:
+	container_engine_base(container_cache_interface &cache);
+
 	virtual ~container_engine_base() = default;
 
 	/**
 	 * Find a container associated with the given tinfo and add it to the
 	 * cache.
 	 */
-	virtual bool resolve(container_cache_interface* cache,
-			     sinsp_threadinfo* tinfo,
+	virtual bool resolve(sinsp_threadinfo* tinfo,
 			     bool query_os_for_missing_info) = 0;
 
 	/**
@@ -50,6 +51,18 @@ public:
 	virtual void update_with_size(const std::string& container_id);
 
 	virtual void cleanup();
+
+protected:
+	/**
+	 * Derived class accessor to the cache
+	 */
+	container_cache_interface& container_cache()
+	{
+		return m_cache;
+	}
+
+private:
+	container_cache_interface& m_cache;
 };
 }
 }

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -196,7 +196,7 @@ bool cri_async_source::lookup_sync(const libsinsp::cgroup_limits::cgroup_limits_
 	return true;
 }
 
-cri::cri()
+cri::cri(container_cache_interface &cache) : container_engine_base(cache)
 {
 	if(s_cri_unix_socket_path.empty()) {
 		return;
@@ -248,8 +248,9 @@ void cri::set_cri_delay(uint64_t delay_ms)
 	s_cri_lookup_delay_ms = delay_ms;
 }
 
-bool cri::resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
+bool cri::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 {
+	container_cache_interface *cache = &container_cache();
 	std::string container_id;
 
 	if(!matches_runc_cgroups(tinfo, CRI_CGROUP_LAYOUT, container_id))

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -81,6 +81,7 @@ class cri : public container_engine_base
 public:
 	cri(container_cache_interface &cache);
 	bool resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	void update_with_size(const std::string& container_id) override;
 	void cleanup() override;
 	static void set_cri_socket_path(const std::string& path);
 	static void set_cri_timeout(int64_t timeout_ms);

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -79,8 +79,8 @@ private:
 class cri : public container_engine_base
 {
 public:
-	cri();
-	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	cri(container_cache_interface &cache);
+	bool resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 	void cleanup() override;
 	static void set_cri_socket_path(const std::string& path);
 	static void set_cri_timeout(int64_t timeout_ms);

--- a/userspace/libsinsp/container_engine/docker.h
+++ b/userspace/libsinsp/container_engine/docker.h
@@ -164,10 +164,9 @@ class docker : public container_engine_base
 public:
 
 #ifdef _WIN32
-	docker(const wmi_handle_source&);
+	docker(container_cache_interface &cache, const wmi_handle_source&);
 #else
-	docker() :
-	   m_cache(nullptr)
+	docker(container_cache_interface &cache) : container_engine_base(cache)
 	{}
 #endif
 	void cleanup() override;
@@ -196,10 +195,8 @@ protected:
 
 private:
 	// implement container_engine_base
-	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	bool resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 	void update_with_size(const std::string& container_id) override;
-
-	container_cache_interface *m_cache;
 };
 }
 }

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -684,6 +684,7 @@ bool docker_async_source::parse_docker(const docker_async_instruction& instructi
 		container.m_imagetag = "latest";
 	}
 
+	container.m_full_id = root["Id"].asString();
 	container.m_name = root["Name"].asString();
 	// k8s Docker container names could have '/' as the first character.
 	if(!container.m_name.empty() && container.m_name[0] == '/')
@@ -828,7 +829,6 @@ bool docker_async_source::parse_docker(const docker_async_instruction& instructi
 	docker::parse_json_mounts(root["Mounts"], container.m_mounts);
 
 	container.m_size_rw_bytes = root["SizeRw"].asInt64();
-	container.m_size_root_fs_bytes = root["SizeRootFs"].asInt64();
 
 #ifdef HAS_ANALYZER
 	sinsp_utils::find_env(container.m_sysdig_agent_conf, container.get_env(), "SYSDIG_AGENT_CONF");

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -409,9 +409,10 @@ void docker_async_source::set_query_image_info(bool query_image_info)
 
 std::string docker::s_incomplete_info_name = "incomplete";
 
-bool docker::resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
+bool docker::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 {
 	std::string container_id, container_name;
+	container_cache_interface *cache = &container_cache();
 
 	if(!detect_docker(tinfo, container_id, container_name))
 	{
@@ -469,8 +470,6 @@ bool docker::resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, 
 
 void docker::parse_docker_async(const string& container_id, container_cache_interface *cache)
 {
-	m_cache = cache;
-
 	auto cb = [cache](const docker_async_instruction& instruction, const sinsp_container_info& res)
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG,
@@ -844,8 +843,6 @@ bool docker_async_source::parse_docker(const docker_async_instruction& instructi
 
 void docker::update_with_size(const std::string &container_id)
 {
-	ASSERT(m_cache != nullptr);
-
 	auto cb = [this](const docker_async_instruction& instruction, const sinsp_container_info& res) {
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker_async (%s): with size callback result=%d",
@@ -853,7 +850,7 @@ void docker::update_with_size(const std::string &container_id)
 				res.m_lookup_state);
 
 		sinsp_container_info::ptr_t updated = make_shared<sinsp_container_info>(res);
-		m_cache->replace_container(updated);
+		container_cache().replace_container(updated);
 	};
 
 	g_logger.format(sinsp_logger::SEV_DEBUG,

--- a/userspace/libsinsp/container_engine/docker_win.cpp
+++ b/userspace/libsinsp/container_engine/docker_win.cpp
@@ -24,9 +24,9 @@ limitations under the License.
 
 using namespace libsinsp::container_engine;
 
-docker::docker(const wmi_handle_source& wmi_source)
-   : m_wmi_handle_source(wmi_source),
-     m_cache(nullptr)
+docker::docker(container_cache_interface& cache, const wmi_handle_source& wmi_source) :
+   container_engine_base(cache),
+   m_wmi_handle_source(wmi_source)
 {
 }
 

--- a/userspace/libsinsp/container_engine/libvirt_lxc.cpp
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.cpp
@@ -73,7 +73,7 @@ bool libvirt_lxc::match(sinsp_threadinfo* tinfo, sinsp_container_info &container
 	return false;
 }
 
-bool libvirt_lxc::resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
+bool libvirt_lxc::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 {
 	auto container = std::make_shared<sinsp_container_info>();
 
@@ -83,11 +83,11 @@ bool libvirt_lxc::resolve(container_cache_interface *cache, sinsp_threadinfo *ti
 	}
 
 	tinfo->m_container_id = container->m_id;
-	if(cache->should_lookup(container->m_id, CT_LIBVIRT_LXC))
+	if(container_cache().should_lookup(container->m_id, CT_LIBVIRT_LXC))
 	{
 		container->m_name = container->m_id;
-		cache->add_container(container, tinfo);
-		cache->notify_new_container(*container);
+		container_cache().add_container(container, tinfo);
+		container_cache().notify_new_container(*container);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/libvirt_lxc.h
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.h
@@ -30,7 +30,10 @@ namespace container_engine {
 class libvirt_lxc : public container_engine_base
 {
 public:
-	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	libvirt_lxc(container_cache_interface &cache) : container_engine_base(cache)
+	{}
+
+	bool resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 protected:
 	bool match(sinsp_threadinfo* tinfo, sinsp_container_info &container_info);
 };

--- a/userspace/libsinsp/container_engine/lxc.cpp
+++ b/userspace/libsinsp/container_engine/lxc.cpp
@@ -22,7 +22,7 @@ limitations under the License.
 
 using namespace libsinsp::container_engine;
 
-bool lxc::resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
+bool lxc::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 {
 	auto container = std::make_shared<sinsp_container_info>();
 	bool matches = false;
@@ -62,11 +62,11 @@ bool lxc::resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, boo
 	}
 
 	tinfo->m_container_id = container->m_id;
-	if (cache->should_lookup(container->m_id, CT_LXC))
+	if (container_cache().should_lookup(container->m_id, CT_LXC))
 	{
 		container->m_name = container->m_id;
-		cache->add_container(container, tinfo);
-		cache->notify_new_container(*container);
+		container_cache().add_container(container, tinfo);
+		container_cache().notify_new_container(*container);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/lxc.h
+++ b/userspace/libsinsp/container_engine/lxc.h
@@ -30,7 +30,10 @@ namespace container_engine {
 class lxc : public container_engine_base
 {
 public:
-	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	lxc(container_cache_interface &cache) : container_engine_base(cache)
+	{}
+
+	bool resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 };
 }
 }

--- a/userspace/libsinsp/container_engine/mesos.cpp
+++ b/userspace/libsinsp/container_engine/mesos.cpp
@@ -52,7 +52,7 @@ bool libsinsp::container_engine::mesos::match(sinsp_threadinfo* tinfo, sinsp_con
 	return false;
 }
 
-bool libsinsp::container_engine::mesos::resolve(container_cache_interface *cache, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
+bool libsinsp::container_engine::mesos::resolve(sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 {
 	auto container = std::make_shared<sinsp_container_info>();
 
@@ -60,11 +60,11 @@ bool libsinsp::container_engine::mesos::resolve(container_cache_interface *cache
 		return false;
 
 	tinfo->m_container_id = container->m_id;
-	if(cache->should_lookup(container->m_id, CT_MESOS))
+	if(container_cache().should_lookup(container->m_id, CT_MESOS))
 	{
 		container->m_name = container->m_id;
-		cache->add_container(container, tinfo);
-		cache->notify_new_container(*container);
+		container_cache().add_container(container, tinfo);
+		container_cache().notify_new_container(*container);
 	}
 	return true;
 }

--- a/userspace/libsinsp/container_engine/mesos.h
+++ b/userspace/libsinsp/container_engine/mesos.h
@@ -32,7 +32,10 @@ namespace container_engine {
 class mesos : public container_engine_base
 {
 public:
-	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	mesos(container_cache_interface& cache) : container_engine_base(cache)
+	{}
+
+	bool resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
 	static bool set_mesos_task_id(sinsp_container_info& container, sinsp_threadinfo *tinfo);
 

--- a/userspace/libsinsp/container_engine/rkt.cpp
+++ b/userspace/libsinsp/container_engine/rkt.cpp
@@ -165,8 +165,10 @@ bool rkt::match(container_cache_interface *cache, sinsp_threadinfo *tinfo, sinsp
 	return false;
 }
 
-bool rkt::rkt::resolve(container_cache_interface *cache, sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
+bool rkt::rkt::resolve(sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 {
+	container_cache_interface *cache = &container_cache();
+
 	auto container = std::make_shared<sinsp_container_info>();
 	string rkt_podid, rkt_appname;
 

--- a/userspace/libsinsp/container_engine/rkt.h
+++ b/userspace/libsinsp/container_engine/rkt.h
@@ -32,7 +32,10 @@ namespace container_engine {
 class rkt : public container_engine_base
 {
 public:
-	bool resolve(container_cache_interface *cache, sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	rkt(container_cache_interface& cache) : container_engine_base(cache)
+	{}
+
+	bool resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 
 protected:
 	bool match(container_cache_interface *cache, sinsp_threadinfo *tinfo, sinsp_container_info& container_info,

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -199,8 +199,7 @@ public:
 		m_is_pod_sandbox(false),
 		m_lookup_state(sinsp_container_lookup_state::SUCCESSFUL),
 		m_metadata_deadline(0),
-		m_size_rw_bytes(-1),
-		m_size_root_fs_bytes(-1)
+		m_size_rw_bytes(-1)
 	{
 	}
 
@@ -224,6 +223,7 @@ public:
 	container_health_probe::probe_type match_health_probe(sinsp_threadinfo *tinfo) const;
 
 	std::string m_id;
+	std::string m_full_id;
 	sinsp_container_type m_type;
 	std::string m_name;
 	std::string m_image;
@@ -259,10 +259,4 @@ public:
 	 * This is not filled by default.
 	 */
 	int64_t m_size_rw_bytes;
-
-	/**
-	 * The total size of all the files in this container. This is not filled by
-	 * default.
-	 */
-	int64_t m_size_root_fs_bytes;
 };

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -103,7 +103,6 @@ grpc::Status cri_interface::get_container_stats(const std::string& container_id,
 {
 	runtime::v1alpha2::ContainerStatsRequest req;
 	req.set_container_id(container_id);
-	//req.set_verbose(true);
 	grpc::ClientContext context;
 	auto deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(s_cri_timeout);
 	context.set_deadline(deadline);

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -99,6 +99,17 @@ grpc::Status cri_interface::get_container_status(const std::string& container_id
 	return m_cri->ContainerStatus(&context, req, &resp);
 }
 
+grpc::Status cri_interface::get_container_stats(const std::string& container_id, runtime::v1alpha2::ContainerStatsResponse& resp)
+{
+	runtime::v1alpha2::ContainerStatsRequest req;
+	req.set_container_id(container_id);
+	//req.set_verbose(true);
+	grpc::ClientContext context;
+	auto deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(s_cri_timeout);
+	context.set_deadline(deadline);
+	return m_cri->ContainerStats(&context, req, &resp);
+}
+
 bool cri_interface::parse_cri_image(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info &container)
 {
 	// image_ref may be one of two forms:

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -37,6 +37,7 @@ namespace libsinsp {
 namespace cri {
 std::string s_cri_unix_socket_path = "/run/containerd/containerd.sock";
 int64_t s_cri_timeout = 1000;
+int64_t s_cri_size_timeout = 10000;
 sinsp_container_type s_cri_runtime_type = CT_CRI;
 bool s_cri_extra_queries = true;
 
@@ -104,7 +105,7 @@ grpc::Status cri_interface::get_container_stats(const std::string& container_id,
 	runtime::v1alpha2::ContainerStatsRequest req;
 	req.set_container_id(container_id);
 	grpc::ClientContext context;
-	auto deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(s_cri_timeout);
+	auto deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(s_cri_size_timeout);
 	context.set_deadline(deadline);
 	return m_cri->ContainerStats(&context, req, &resp);
 }

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -71,7 +71,12 @@ public:
 	 */
 	grpc::Status get_container_status(const std::string& container_id, runtime::v1alpha2::ContainerStatusResponse& resp);
 
-
+	/**
+	 * @brief thin wrapper around CRI gRPC ContainerStats call
+	 * @param container_id container ID
+	 * @param resp reference to the response (if the RPC is successful, it will be filled out)
+	 * @return status of the gRPC call
+	 */
 	grpc::Status get_container_stats(const std::string& container_id, runtime::v1alpha2::ContainerStatsResponse& resp);
 
 	/**

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -71,6 +71,9 @@ public:
 	 */
 	grpc::Status get_container_status(const std::string& container_id, runtime::v1alpha2::ContainerStatusResponse& resp);
 
+
+	grpc::Status get_container_stats(const std::string& container_id, runtime::v1alpha2::ContainerStatsResponse& resp);
+
 	/**
 	 * @brief fill out container image information based on CRI response
 	 * @param status `status` field of the ContainerStatusResponse

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4602,6 +4602,11 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		{
 			container_info->m_id = id.asString();
 		}
+		const Json::Value& full_id = container["full_id"];
+		if(check_json_val_is_convertible(full_id, Json::stringValue, "full_id"))
+		{
+			container_info->m_full_id = full_id.asString();
+		}
 		const Json::Value& type = container["type"];
 		if(check_json_val_is_convertible(type, Json::uintValue, "type"))
 		{


### PR DESCRIPTION
Important part of this review is the sync call to update the size in `cri::update_with_size`

Several other small-ish changes that add up:
1. Delete m_size_root_fs_bytes since it can't be provided for CRI and doesn't add a lot of value
2. Save the full loooong container id in container_info
3. Make the container_cache_interface stored in the base class so the callers don't have to pass it every time.

