### PR TITLE
add curl include to unit test build

### DIFF
--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -19,6 +19,7 @@
 include_directories("${GTEST_INCLUDE_DIR}")
 include_directories("${JSONCPP_INCLUDE}")
 include_directories("${TBB_INCLUDE_DIR}")
+include_directories("${CURL_INCLUDE_DIR}")
 
 include_directories("..")
 include_directories("../../libscap")


### PR DESCRIPTION
```
[ 98%] Building CXX object userspace/libsinsp/test/CMakeFiles/unit-test-libsinsp.dir/sinsp.ut.cpp.o
In file included from /draios/sysdig/userspace/libsinsp/test/../sinsp.h:80:0,
                 from /draios/sysdig/userspace/libsinsp/test/sinsp.ut.cpp:20:
/draios/sysdig/userspace/libsinsp/test/../container.h:32:10: fatal error: curl/curl.h: No such file or directory
 #include <curl/curl.h>
          ^~~~~~~~~~~~~
compilation terminated.
userspace/libsinsp/test/CMakeFiles/unit-test-libsinsp.dir/build.make:86: recipe for target 'userspace/libsinsp/test/CMakeFiles/unit-test-libsinsp.dir/sinsp.ut.cpp.o' failed
```