### PR TITLE
fix: avoid ASSERT macro redefinition

### DIFF
--- a/userspace/libsinsp/sinsp_public.h
+++ b/userspace/libsinsp/sinsp_public.h
@@ -24,7 +24,9 @@ limitations under the License.
 #define SINSP_PUBLIC
 #endif
 
+#ifndef ASSERT
 #ifdef _DEBUG
+
 #ifdef ASSERT_TO_LOG
 #define ASSERT(X) \
         if(!(X)) \
@@ -38,3 +40,4 @@ limitations under the License.
 #else // _DEBUG
 #define ASSERT(X)
 #endif // _DEBUG
+#endif // ASSERT

--- a/userspace/sysdig/sysdig.h
+++ b/userspace/sysdig/sysdig.h
@@ -27,12 +27,13 @@ limitations under the License.
 //
 // ASSERT implementation
 //
+#ifndef ASSERT
 #ifdef _DEBUG
 #define ASSERT(X) assert(X)
 #else // _DEBUG
 #define ASSERT(X)
 #endif // _DEBUG
-
+#endif // ASSERT
 //
 // Capture results
 //


### PR DESCRIPTION
The `ASSERT` macro redefinition as defined in #1568  causes compiler errors when compiling the debug target.
Signed-off-by: Lorenzo Fontana <lo@linux.com>