### PR TITLE
Fix build on ppc64le when built with -DBUILD_BPF=ON

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -931,6 +931,9 @@ static __always_inline int bpf_val_to_ring_type(struct filler_data *data,
 
 static __always_inline bool bpf_in_ia32_syscall()
 {
+#ifdef __ppc64__
+	return 0;
+#else
 	struct task_struct *task;
 	u32 status;
 
@@ -947,6 +950,7 @@ static __always_inline bool bpf_in_ia32_syscall()
 #endif
 
 	return status & TS_COMPAT;
+#endif
 }
 
 #endif

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -950,7 +950,7 @@ static __always_inline bool bpf_in_ia32_syscall()
 #endif
 
 	return status & TS_COMPAT;
-#endif
+#endif // #ifdef __ppc64__
 }
 
 #endif


### PR DESCRIPTION
In the function static bpf_in_ia32_syscall()  if the platform is ppc64le then return a 0.

sysdig-CLA-1.0-contributing-entity: IBM
sysdig-CLA-1.0-signed-off-by: Amit Shirodkar amit.shirodkar@ibm.com