### PR TITLE
expose max used buf size through sinsp API

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1188,6 +1188,7 @@ static int32_t scap_next_nodriver(scap_t* handle, OUT scap_evt** pevent, OUT uin
 
 uint64_t scap_max_buf_used(scap_t* handle)
 {
+#if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT)
 	uint64_t i;
 	uint64_t max = 0;
 
@@ -1198,6 +1199,9 @@ uint64_t scap_max_buf_used(scap_t* handle)
 	}
 
 	return max;
+#else
+	return 0;
+#endif
 }
 
 int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid)

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1014,20 +1014,6 @@ static bool are_buffers_empty(scap_t* handle)
 	return true;
 }
 
-uint64_t scap_max_buf_used(scap_t* handle)
-{
-	uint64_t i;
-	uint64_t max = 0;
-
-	for(i = 0; i < handle->m_ndevs; i++)
-	{
-		uint64_t size = buf_size_used(handle, i);
-		max = size > max ? size : max;
-	}
-
-	return max;
-}
-
 int32_t refill_read_buffers(scap_t* handle)
 {
 	uint32_t j;
@@ -1199,6 +1185,20 @@ static int32_t scap_next_nodriver(scap_t* handle, OUT scap_evt** pevent, OUT uin
 	return SCAP_SUCCESS;
 }
 #endif // _WIN32
+
+uint64_t scap_max_buf_used(scap_t* handle)
+{
+	uint64_t i;
+	uint64_t max = 0;
+
+	for(i = 0; i < handle->m_ndevs; i++)
+	{
+		uint64_t size = buf_size_used(handle, i);
+		max = size > max ? size : max;
+	}
+
+	return max;
+}
 
 int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
 {

--- a/userspace/libscap/scap.def
+++ b/userspace/libscap/scap.def
@@ -9,6 +9,7 @@ EXPORTS
 		scap_get_os_platform
 		scap_get_ndevs
 		scap_getlasterr
+		scap_max_buf_used
 		scap_next
 		scap_event_getlen
 		scap_event_get_ts
@@ -51,4 +52,3 @@ EXPORTS
 		scap_get_host_root
 		scap_ftell
 		scap_fseek
-		scap_max_buf_used

--- a/userspace/libscap/scap.def
+++ b/userspace/libscap/scap.def
@@ -51,3 +51,4 @@ EXPORTS
 		scap_get_host_root
 		scap_ftell
 		scap_fseek
+		scap_max_buf_used

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -606,6 +606,11 @@ scap_os_platform scap_get_os_platform(scap_t* handle);
 const char* scap_getlasterr(scap_t* handle);
 
 /*!
+ * \brief returns the maximum amount of memory used by any driver queue
+ */
+uint64_t scap_max_buf_used(scap_t* handle);
+
+/*!
   \brief Get the next event from the from the given capture instance
 
   \param handle Handle to the capture instance.

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1027,6 +1027,18 @@ void sinsp::restart_capture_at_filepos(uint64_t filepos)
 	}
 }
 
+uint64_t sinsp::max_buf_used()
+{
+	if(m_h)
+	{
+		return scap_max_buf_used(m_h);
+	}
+	else
+	{
+		return 0;
+	}
+}
+
 int32_t sinsp::next(OUT sinsp_evt **puevt)
 {
 	sinsp_evt* evt;

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -254,6 +254,11 @@ public:
 	virtual int32_t next(OUT sinsp_evt **evt);
 
 	/*!
+	  \brief Get the maximum number of bytes currently in use by any CPU buffer
+     */
+	uint64_t max_buf_used();
+
+	/*!
 	  \brief Get the number of events that have been captured and processed
 	   since the call to \ref open()
 


### PR DESCRIPTION
It may be useful for external event processors to be aware of the amount of buffer space which is currently in-use. We expose the maximum buffer size used by any single queue.