### PR TITLE
add thread allocation to external processor to allow users to do work on

### DIFF
--- a/userspace/libsinsp/container_info.cpp
+++ b/userspace/libsinsp/container_info.cpp
@@ -148,7 +148,7 @@ const sinsp_container_info::container_mount_info *sinsp_container_info::mount_by
 
 std::shared_ptr<sinsp_threadinfo> sinsp_container_info::get_tinfo(sinsp* inspector) const
 {
-	auto tinfo = make_shared<sinsp_threadinfo>(inspector);
+	std::shared_ptr<sinsp_threadinfo> tinfo(inspector->build_threadinfo());
 	tinfo->m_tid = -1;
 	tinfo->m_pid = -1;
 	tinfo->m_vtid = -2;

--- a/userspace/libsinsp/include/sinsp_external_processor.h
+++ b/userspace/libsinsp/include/sinsp_external_processor.h
@@ -1,6 +1,4 @@
 #pragma once
-#include "sinsp.h"
-#include "threadinfo.h"
 
 /**
  * This api defines a relationship between libsinsp and an external event processor.
@@ -10,6 +8,8 @@
 
 // Required until the chisel_api dependency on the analyzer can be removed
 class statsd_metric;
+class sinsp;
+class threadinfo;
 
 namespace libsinsp
 {

--- a/userspace/libsinsp/include/sinsp_external_processor.h
+++ b/userspace/libsinsp/include/sinsp_external_processor.h
@@ -1,4 +1,6 @@
 #pragma once
+#include "sinsp.h"
+#include "threadinfo.h"
 
 /**
  * This api defines a relationship between libsinsp and an external event processor.
@@ -40,6 +42,16 @@ public:
 	 * Required until the chisel_api dependency on the analyzer can be removed
 	 */
 	virtual void add_chisel_metric(statsd_metric* metric) = 0;
+
+	/**
+     * Some event processors allocate different thread types with extra data.
+     *
+     * This allows the processor to override the thread builder. Note that
+     * If this is overriden by the event processor, the processor MUST be registered
+     * before the sinsp object is init-ed
+     */
+    virtual sinsp_threadinfo* build_threadinfo(sinsp* inspector);
+
 };
 
 }

--- a/userspace/libsinsp/include/sinsp_external_processor.h
+++ b/userspace/libsinsp/include/sinsp_external_processor.h
@@ -11,8 +11,8 @@
 // Required until the chisel_api dependency on the analyzer can be removed
 class statsd_metric;
 
-namespace libsinsp {
-
+namespace libsinsp
+{
 enum event_return
 {
 	EVENT_RETURN_TIMEOUT,
@@ -44,14 +44,13 @@ public:
 	virtual void add_chisel_metric(statsd_metric* metric) = 0;
 
 	/**
-     * Some event processors allocate different thread types with extra data.
-     *
-     * This allows the processor to override the thread builder. Note that
-     * If this is overriden by the event processor, the processor MUST be registered
-     * before the sinsp object is init-ed
-     */
-    virtual sinsp_threadinfo* build_threadinfo(sinsp* inspector);
-
+	 * Some event processors allocate different thread types with extra data.
+	 *
+	 * This allows the processor to override the thread builder. Note that
+	 * If this is overriden by the event processor, the processor MUST be registered
+	 * before the sinsp object is init-ed
+	 */
+	virtual sinsp_threadinfo* build_threadinfo(sinsp* inspector);
 };
 
-}
+}  // namespace libsinsp

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1159,7 +1159,7 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 	// XXX this should absolutely not do a malloc, but get the item from a
 	// preallocated list
 	//
-	sinsp_threadinfo* tinfo = new sinsp_threadinfo(m_inspector);
+	sinsp_threadinfo* tinfo = m_inspector->build_threadinfo();
 
 	//
 	// Set the tid and parent tid

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -828,7 +828,7 @@ void sinsp::on_new_entry_from_proc(void* context,
 	if(fdinfo == NULL)
 	{
 		bool thread_added = false;
-		sinsp_threadinfo* newti = new sinsp_threadinfo(this);
+		sinsp_threadinfo* newti = build_threadinfo();
 		newti->init(tinfo);
 		if(is_nodriver())
 		{
@@ -852,7 +852,7 @@ void sinsp::on_new_entry_from_proc(void* context,
 
 		if(!sinsp_tinfo)
 		{
-			sinsp_threadinfo* newti = new sinsp_threadinfo(this);
+			sinsp_threadinfo* newti = build_threadinfo();
 			newti->init(tinfo);
 
 			if (!m_thread_manager->add_thread(newti, true)) {
@@ -895,7 +895,7 @@ void sinsp::import_thread_table()
 	//
 	HASH_ITER(hh, table, pi, tpi)
 	{
-		sinsp_threadinfo* newti = new sinsp_threadinfo(this);
+		sinsp_threadinfo* newti = build_threadinfo();
 		newti->init(pi);
 		m_thread_manager->add_thread(newti, true);
 	}
@@ -1425,7 +1425,7 @@ threadinfo_map_t::ptr_t sinsp::get_thread_ref(int64_t tid, bool query_os_if_not_
 		}
 
 		scap_threadinfo* scap_proc = NULL;
-		sinsp_threadinfo* newti = new sinsp_threadinfo(this);
+		sinsp_threadinfo* newti = build_threadinfo();
 
 		m_n_proc_lookups++;
 
@@ -2578,3 +2578,9 @@ std::shared_ptr<std::string> sinsp::lookup_cgroup_dir(const string& subsys)
 	}
 }
 #endif
+
+sinsp_threadinfo*
+libsinsp::event_processor::build_threadinfo(sinsp* inspector)
+{
+	return inspector->build_threadinfo();
+}

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -2582,5 +2582,5 @@ std::shared_ptr<std::string> sinsp::lookup_cgroup_dir(const string& subsys)
 sinsp_threadinfo*
 libsinsp::event_processor::build_threadinfo(sinsp* inspector)
 {
-	return inspector->build_threadinfo();
+	return new sinsp_threadinfo(inspector);
 }

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -519,6 +519,12 @@ public:
 
 	libsinsp::event_processor* m_external_event_processor;
 
+	sinsp_threadinfo* build_threadinfo()
+    {
+        return m_external_event_processor ? m_external_event_processor->build_threadinfo(this)
+                                          : new sinsp_threadinfo(this);
+    } 
+
 	/*!
 	  \brief registers external event processor.
 	  After this, callbacks on libsinsp::event_processor will happen at

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -40,19 +40,11 @@ static void copy_ipv6_address(uint32_t* dest, uint32_t* src)
 ///////////////////////////////////////////////////////////////////////////////
 // sinsp_threadinfo implementation
 ///////////////////////////////////////////////////////////////////////////////
-sinsp_threadinfo::sinsp_threadinfo() :
-	m_fdtable(NULL)
-{
-	m_inspector = NULL;
-	m_tracer_parser = NULL;
-	init();
-}
-
-sinsp_threadinfo::sinsp_threadinfo(sinsp *inspector) :
+sinsp_threadinfo::sinsp_threadinfo(sinsp* inspector) :
+	m_tracer_parser(NULL),
+	m_inspector(inspector),
 	m_fdtable(inspector)
 {
-	m_inspector = inspector;
-	m_tracer_parser = NULL;
 	init();
 }
 

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -71,9 +71,8 @@ typedef struct erase_fd_params
 class SINSP_PUBLIC sinsp_threadinfo
 {
 public:
-	sinsp_threadinfo();
-	sinsp_threadinfo(sinsp *inspector);
-	~sinsp_threadinfo();
+	sinsp_threadinfo(sinsp *inspector = nullptr);
+	virtual ~sinsp_threadinfo();
 
 	/*!
 	  \brief Return the name of the process containing this thread, e.g. "top".
@@ -352,14 +351,7 @@ public: // types required for use in sets
 		}
 	};
 
-VISIBILITY_PRIVATE
-	void init();
-	// return true if, based on the current inspector filter, this thread should be kept
-	void init(scap_threadinfo* pi);
-	void fix_sockets_coming_from_proc();
-	sinsp_fdinfo_t* add_fd(int64_t fd, sinsp_fdinfo_t *fdinfo);
-	void add_fd_from_scap(scap_fdinfo *fdinfo, OUT sinsp_fdinfo_t *res);
-	void remove_fd(int64_t fd);
+protected:
 	inline sinsp_fdtable* get_fd_table()
 	{
 		sinsp_threadinfo* root;
@@ -379,6 +371,16 @@ VISIBILITY_PRIVATE
 
 		return &(root->m_fdtable);
 	}
+
+public:
+VISIBILITY_PRIVATE
+	void init();
+	// return true if, based on the current inspector filter, this thread should be kept
+	void init(scap_threadinfo* pi);
+	void fix_sockets_coming_from_proc();
+	sinsp_fdinfo_t* add_fd(int64_t fd, sinsp_fdinfo_t *fdinfo);
+	void add_fd_from_scap(scap_fdinfo *fdinfo, OUT sinsp_fdinfo_t *res);
+	void remove_fd(int64_t fd);
 	void set_cwd(const char *cwd, uint32_t cwdlen);
 	sinsp_threadinfo* get_cwd_root();
 	void set_args(const char* args, size_t len);

--- a/userspace/libsinsp/tracers.cpp
+++ b/userspace/libsinsp/tracers.cpp
@@ -1304,17 +1304,12 @@ inline void sinsp_tracerparser::init_partial_tracer(sinsp_partial_tracer* pae)
 
 void sinsp_tracerparser::test()
 {
-//	char doc[] = "[\">\\\"\", 12435, [\"mysql\", \"query\", \"init\"], [{\"argname1\":\"argval1\"}, {\"argname2\":\"argval2\"}, {\"argname3\":\"argval3\"}]]";
-//	char doc1[] = "[\"<t\", 12435, [\"mysql\", \"query\", \"init\"], []]";
 	char doc1[] = "[\">\",     12345, [\"mysql\", \"query\", \"init\"], [{\"argname1\":\"argval1\"}, {\"argname2\":\"argval2\"}, {\"argname3\":\"argval3\"}]]";
-//	char doc1[] = ">:1111:u\\:\\=a.u\\:\\>.aaa.33.aa\\::a=b\\:\\=,c=d\\:\\=a:";
 
-	sinsp_threadinfo tinfo;
-	
-	m_tinfo = &tinfo;
-	tinfo.m_ptid = 11;
-	tinfo.m_pid = 22;
-	tinfo.m_tid = 33;
+	m_tinfo = new sinsp_threadinfo(nullptr);
+	m_tinfo->m_ptid = 11;
+	m_tinfo->m_pid = 22;
+	m_tinfo->m_tid = 33;
 
 	printf("1\n");
 
@@ -1339,4 +1334,7 @@ void sinsp_tracerparser::test()
 
 	cpu_time = ((float)clock()/ CLOCKS_PER_SEC) - cpu_time;
 	printf ("time: %5.2f\n", cpu_time);
+
+	delete m_tinfo;
+	m_tinfo = nullptr;
 }


### PR DESCRIPTION
this is the first step in removing the sinsp dependency on the analyzer's thread structure.