### PR TITLE
Fixing Travis build failures on s390x and ppc64le

### DIFF
--- a/.travis-scripts/linux/build.sh
+++ b/.travis-scripts/linux/build.sh
@@ -27,9 +27,9 @@ else
 	export CC="gcc-4.8"
 	export CXX="g++-4.8"
 fi
-wget https://s3.amazonaws.com/download.draios.com/dependencies/cmake-3.3.2.tar.gz
-tar -xzf cmake-3.3.2.tar.gz
-cd cmake-3.3.2
+wget https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4.tar.gz
+tar -xzf cmake-3.16.4.tar.gz
+cd cmake-3.16.4
 ./bootstrap --prefix=/usr
 make
 sudo make install


### PR DESCRIPTION
Recent [commit ](https://github.com/google/googletest/commit/23b2a3b1cf803999fb38175f6e9e038a4495c8a5#comments) in Googletest caused Travis builds to break. Upgrading cmake version to fix the issue through this PR.

sysdig-CLA-1.0-contributing-entity: IBM
sysdig-CLA-1.0-signed-off-by: Namrata Bhave Namrata.Bhave@ibm.com