### PR TITLE
Fixes for the dockerized probe builder

### DIFF
--- a/probe-builder/Dockerfile
+++ b/probe-builder/Dockerfile
@@ -1,18 +1,18 @@
-FROM centos:7
+FROM alpine
 
-RUN yum -y install \
+RUN apk add \
+    bash \
+    gawk \
+    grep \
 	curl \
-	dpkg-deb \
-	epel-release \
+    dpkg \
+	rpm2cpio \
 	git \
 	jq \
-	kpartx \
-	python-lxml \
+	multipath-tools \
+	py3-lxml \
 	wget \
-	&& yum -y install jq \
-	&& yum clean all
-
-RUN curl -fsSL https://get.docker.io | bash
+    docker
 
 ADD . /builder
 WORKDIR /builder

--- a/probe-builder/build-probe-binaries
+++ b/probe-builder/build-probe-binaries
@@ -33,6 +33,7 @@ PROBE_NAME=sysdig-probe
 RETRIES=10
 DOWNLOAD_TIMEOUT=300
 PROBE_VERSION=
+RUNNING_IN_DOCKER=
 
 usage() {
 	cat >&2 <<EOF
@@ -147,7 +148,8 @@ do
 		a) ARTIFACTORY_SERVER=$OPTARG;;
 		A) ARTIFACTORY_KEY=$OPTARG;;
 		b) BUILDER_IMAGE_PREFIX=$OPTARG;;
-		B) DOCKER_BASEDIR=$OPTARG;;
+		B) DOCKER_BASEDIR=$OPTARG
+		   RUNNING_IN_DOCKER=1;;
 		d) DOWNLOAD_CONCURRENCY=$OPTARG;;
 		k) KERNEL_TYPE=$OPTARG;;
 		p) PROBE_NAME=$OPTARG;;
@@ -236,6 +238,40 @@ function build_toolkit {
 	fi
 }
 
+function run_toolkit {
+	if [ -z "$RUNNING_IN_DOCKER" ]
+	then
+		build_toolkit
+	fi
+	declare -a DOCKER_OPTS
+	declare -a TOOLKIT_OPTS
+
+	IN_TOOLKIT_OPTS=
+	for i in "$@"
+	do
+		if [ -z "$IN_TOOLKIT_OPTS" ]
+		then
+			if [ "$i" == "--" ]
+			then
+				IN_TOOLKIT_OPTS=1
+			else
+				DOCKER_OPTS+=("$i")
+			fi
+		else
+			TOOLKIT_OPTS+=("$i")
+		fi
+	done
+
+	if [ -z "$RUNNING_IN_DOCKER" ]
+	then
+		# running on the host, use toolkit container
+		docker run --rm --privileged ${DOCKER_OPTS[@]} "${BUILDER_IMAGE_PREFIX:-}sysdig-probe-builder:toolkit" ${TOOLKIT_OPTS[@]}
+	else
+		# already in a container, call the toolkit directly
+		/builder/toolkit-entrypoint.sh ${TOOLKIT_OPTS[@]}
+	fi
+}
+
 declare -A builders
 function build_probe {
 	# Skip Kernel 4.15.0-29 because probe does not build against it
@@ -292,8 +328,7 @@ function build_probe {
 
 		# While ls output is already sorted alphabetically by default, we need to sort it
 		# by version instead so it doesn't break when we add support for gcc 10.0
-		# so use ls -U not to bother with sorting
-		DOCKERFILE=$(ls -U $BUILDER_SOURCE/Dockerfile.${BUILDER_DISTRO}-gcc* | sort -V | awk \
+		DOCKERFILE=$(ls $BUILDER_SOURCE/Dockerfile.${BUILDER_DISTRO}-gcc* | sort -V | awk \
 			-v target=$BUILDER_SOURCE/Dockerfile.${BUILDER_DISTRO}-gcc${BUILDER_GCC_MINOR_VERSION} \
 		'
 		$1 < target { older = $1 }
@@ -358,8 +393,7 @@ function coreos_build {
 			echo "Unpacking $(basename $IMG)"
 			FULL_IMG=$(readlink -f "$IMG")
 			FULL_VERSION_DIR=$(readlink -f "$VERSION_DIR")
-			build_toolkit
-			docker run --rm --privileged -v "$FULL_IMG:$FULL_IMG:ro" -v "$FULL_VERSION_DIR:$FULL_VERSION_DIR" "${BUILDER_IMAGE_PREFIX:-}sysdig-probe-builder:toolkit" coreos "$FULL_IMG" "$FULL_VERSION_DIR"
+			run_toolkit -v "$FULL_IMG:$FULL_IMG:ro" -v "$FULL_VERSION_DIR:$FULL_VERSION_DIR" -- coreos "$FULL_IMG" "$FULL_VERSION_DIR"
 
 			KERNEL_RELEASE=$(cd $VERSION_DIR && ls config-* | sed s/config-//)
 			export COREOS_BUILD=${VERSION%%.*}
@@ -464,7 +498,7 @@ function rhel_build {
 	for RPM in "$@"
 	do
 		RPM_FILE=$(basename $RPM)
-		KERNEL_RELEASE=$(echo $RPM_FILE | awk 'match($0, /[^kernel\-(uek\-)?(core\-|devel\-)?].*[^(\.rpm)]/){ print substr($0, RSTART, RLENGTH) }')
+		KERNEL_RELEASE=$(echo $RPM_FILE | gawk 'match($0, /[^kernel\-(uek\-)?(core\-|devel\-)?].*[^(\.rpm)]/){ print substr($0, RSTART, RLENGTH) }')
 
 		TARGET=build/$DISTRO/$KERNEL_RELEASE
 		MARKER=$TARGET/.$RPM_FILE
@@ -476,8 +510,7 @@ function rhel_build {
 			mkdir -p $TARGET
 			FULL_RPM=$(readlink -f "$RPM")
 			FULL_TARGET=$(readlink -f "$TARGET")
-			build_toolkit
-			docker run --rm --privileged -v "$FULL_RPM:$FULL_RPM:ro" -v "$FULL_TARGET:$FULL_TARGET" "${BUILDER_IMAGE_PREFIX:-}sysdig-probe-builder:toolkit" rpm "$FULL_RPM" "$FULL_TARGET"
+			run_toolkit -v "$FULL_RPM:$FULL_RPM:ro" -v "$FULL_TARGET:$FULL_TARGET" -- rpm "$FULL_RPM" "$FULL_TARGET"
 			touch $MARKER
 		fi
 	done
@@ -485,7 +518,7 @@ function rhel_build {
 	for RPM in "$@"
 	do
 		RPM_FILE=$(basename $RPM)
-		KERNEL_RELEASE=$(echo $RPM_FILE | awk 'match($0, /[^kernel\-(uek\-)?(core\-|devel\-)?].*[^(\.rpm)]/){ print substr($0, RSTART, RLENGTH) }')
+		KERNEL_RELEASE=$(echo $RPM_FILE | gawk 'match($0, /[^kernel\-(uek\-)?(core\-|devel\-)?].*[^(\.rpm)]/){ print substr($0, RSTART, RLENGTH) }')
 		TARGET=build/$DISTRO/$KERNEL_RELEASE
 
 		if [ -f $TARGET/boot/config-$KERNEL_RELEASE ]; then

--- a/probe-builder/kernel-crawler.py
+++ b/probe-builder/kernel-crawler.py
@@ -85,16 +85,6 @@ repos = {
                 "updates/x86_64/Packages/"
             ],
             "page_pattern" : "//body//table/tr/td/a[regex:test(@href, '^kernel-(devel-)?[0-9].*\.rpm$')]/@href"
-        },
-
-        {
-            "root" : "http://vault.centos.org/centos/",
-            "discovery_pattern" : "//body//table/tr/td/a[regex:test(@href, '^6|^7.*$')]/@href",
-            "subdirs" : [
-                "os/x86_64/Packages/",
-                "updates/x86_64/Packages/"
-            ],
-            "page_pattern" : "//body//table/tr/td/a[regex:test(@href, '^kernel-(devel-)?[0-9].*\.rpm$')]/@href"
         }
     ],
 

--- a/probe-builder/kernel-crawler.py
+++ b/probe-builder/kernel-crawler.py
@@ -133,29 +133,15 @@ repos = {
             "root" : "https://mirrors.kernel.org/ubuntu/pool/main/l/",
             "discovery_pattern" : "/html/body//a[regex:test(@href, 'linux-aws.*/')]/@href",
             "subdirs" : [""],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|(aws-.*)?headers)-[3-9].*-aws.*amd64.deb$')]/@href"
-        },
-
-        {
-            "root" : "https://mirrors.kernel.org/ubuntu/pool/main/l/",
-            "discovery_pattern" : "/html/body//a[regex:test(@href, 'linux-aws.*/')]/@href",
-            "subdirs" : [""],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(aws-.*)?headers-[3-9].*_all.deb$')]/@href"
+            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|(aws-.*)?headers|modules)-[3-9].*(all|amd64).deb$')]/@href"
         },
 
         {
             "root" : "http://security.ubuntu.com/ubuntu/pool/main/l/",
             "discovery_pattern" : "/html/body//a[regex:test(@href, 'linux-aws.*/')]/@href",
             "subdirs" : [""],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|(aws-.*)?headers)-[3-9].*-aws.*amd64.deb$')]/@href"
+            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-(image|(aws-.*)?headers|modules)-[3-9].*(all|amd64).deb$')]/@href"
         },
-
-        {
-            "root" : "http://security.ubuntu.com/ubuntu/pool/main/l/",
-            "discovery_pattern" : "/html/body//a[regex:test(@href, 'linux-aws.*/')]/@href",
-            "subdirs" : [""],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-modules-[3-9].*-aws.*amd64.deb$')]/@href"
-        }
     ],
 
     "Fedora" : [

--- a/probe-builder/main-builder-entrypoint.sh
+++ b/probe-builder/main-builder-entrypoint.sh
@@ -63,7 +63,7 @@ build_probes()
 	KERNELS_SRC=$(get_host_mount /kernels)  
 
 	cd /workspace
-	/builder/build-probe-binaries -B $WORKSPACE_SRC -s $SYSDIG_SRC -b $BUILDER_IMAGE_PREFIX "$@" /kernels/*
+	/builder/build-probe-binaries -B $WORKSPACE_SRC -s $SYSDIG_SRC -b "$BUILDER_IMAGE_PREFIX" "$@" /kernels/*
 }
 
 prepare_builders()

--- a/probe-builder/oracle-kernel-crawler.py
+++ b/probe-builder/oracle-kernel-crawler.py
@@ -62,6 +62,9 @@ repos = {
     ]
 }
 
+def progress(distro, current, total, package):
+    sys.stderr.write('\r{} {}/{} {}               '.format(distro, current, total, package))
+
 #
 # In our design you are not supposed to modify the code. The whole script is
 # created so that you just have to add entry to the `repos` array and new
@@ -85,8 +88,11 @@ for repo in repos[sys.argv[1]]:
     except:
         continue
     versions = html.fromstring(root).xpath(repo["discovery_pattern"], namespaces = {"regex": "http://exslt.org/regular-expressions"})
+    vid = 0
     for version in versions:
+        vid += 1
         ver_url = repo["root"] + version
+        progress(repo["root"], vid, len(versions), version)
         try:
             subroot = urlopen(ver_url,timeout=URL_TIMEOUT).read()
         except:

--- a/probe-builder/oracle-kernel-crawler.py
+++ b/probe-builder/oracle-kernel-crawler.py
@@ -18,7 +18,13 @@
 #
 
 import sys
-import urllib2
+
+try:
+    from urllib2 import urlopen, unquote
+except ImportError:
+	from urllib.request import urlopen
+	from urllib.parse import unquote
+
 from lxml import html
 
 #
@@ -75,14 +81,14 @@ if len(sys.argv) < 2 or not sys.argv[1] in repos:
 #
 for repo in repos[sys.argv[1]]:
     try:
-        root = urllib2.urlopen(repo["root"],timeout=URL_TIMEOUT).read()
+        root = urlopen(repo["root"],timeout=URL_TIMEOUT).read()
     except:
         continue
     versions = html.fromstring(root).xpath(repo["discovery_pattern"], namespaces = {"regex": "http://exslt.org/regular-expressions"})
     for version in versions:
         ver_url = repo["root"] + version
         try:
-            subroot = urllib2.urlopen(ver_url,timeout=URL_TIMEOUT).read()
+            subroot = urlopen(ver_url,timeout=URL_TIMEOUT).read()
         except:
             continue
         sub_vers = html.fromstring(subroot).xpath(repo["sub_discovery_pattern"], namespaces = {"regex": "http://exslt.org/regular-expressions"})
@@ -93,12 +99,12 @@ for repo in repos[sys.argv[1]]:
             # packages we need)
             try:
                 source = repo["root"] + sub_ver
-                page = urllib2.urlopen(source,timeout=URL_TIMEOUT).read()
+                page = urlopen(source,timeout=URL_TIMEOUT).read()
                 rpms = html.fromstring(page).xpath(repo["page_pattern"], namespaces = {"regex": "http://exslt.org/regular-expressions"})
 
                 source = source.replace("index.html", "")
                 for rpm in rpms:
-                    urls.add(source + str(urllib2.unquote(rpm)))
+                    urls.add(source + str(unquote(rpm)))
             except:
                 continue
 


### PR DESCRIPTION
The recent introduction of the toolkit container broke the already-containerized builder when using custom kernel packages (the paths didn't line up).

Rather than do some magic to fix things up, I bit the bullet and made the builder and the toolkit a single image, based on Alpine. This involved making the kernel crawler compatible with Python 3. I added some progress info while I was at it and removed a seemingly redundant CentOS mirror.