### PR TITLE
Restore Minikube probe builder support

### DIFF
--- a/probe-builder/Dockerfile.minikube-gcc7.4
+++ b/probe-builder/Dockerfile.minikube-gcc7.4
@@ -1,0 +1,21 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get -y --no-install-recommends install \
+	cmake \
+	g++ \
+	git \
+	kmod \
+	libc6-dev \
+	libelf-dev \
+	make \
+	pkg-config \
+	bison \
+	flex \
+	kernel-package \
+	libssl-dev \
+	&& apt-get clean
+
+ADD builder-entrypoint-minikube.sh /
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint-minikube.sh" ]
+

--- a/probe-builder/build-probe-binaries
+++ b/probe-builder/build-probe-binaries
@@ -634,6 +634,59 @@ function debian_build {
 	done
 }
 
+function minikube_build {
+	BUILDER_DISTRO=${BUILDER_DISTRO:-minikube}
+	for MINIKUBE_ARCHIVE in "$@"
+	do
+		MINIKUBE_VERSION=$(basename "$MINIKUBE_ARCHIVE" .tar.gz)
+		MINIKUBE_VERSION=${MINIKUBE_VERSION##v}
+
+		TARGET=build/$DISTRO/minikube-$MINIKUBE_VERSION
+		MARKER=$TARGET/.$(basename $MINIKUBE_ARCHIVE)
+		if [ -e $MARKER ]
+		then
+			echo "$MINIKUBE_ARCHIVE already unpacked in $TARGET"
+		else
+			echo "Unpacking $MINIKUBE_ARCHIVE to $TARGET"
+			mkdir -p $TARGET
+			tar -C build/$DISTRO -xzxf $MINIKUBE_ARCHIVE
+			touch $MARKER
+		fi
+	done
+
+	for MINIKUBE_ARCHIVE in "$@"
+	do
+		MINIKUBE_VERSION=$(basename "$MINIKUBE_ARCHIVE" .tar.gz)
+		MINIKUBE_VERSION=${MINIKUBE_VERSION##v}
+
+		TARGET=build/$DISTRO/minikube-$MINIKUBE_VERSION
+		MINIKUBE_KERNEL_VERSION=$(awk '/^KERNEL_VERSION/ { print $NF }' ${TARGET}/Makefile)
+
+
+		TGZ_NAME=linux-${MINIKUBE_KERNEL_VERSION}.tar.xz
+		MAJOR=$(echo $MINIKUBE_KERNEL_VERSION | cut -d. -f1)
+		MINOR=$(echo $MINIKUBE_KERNEL_VERSION | cut -d. -f2)
+
+		KERNEL_CONFIG=${TARGET}/deploy/iso/minikube-iso/board/coreos/minikube/linux_defconfig
+
+		export KERNELDIR=${TARGET}/linux-${MINIKUBE_KERNEL_VERSION}
+
+		if [ ! -d ${KERNELDIR} ]; then
+				wget -c -P build/$DISTRO --timeout=${DOWNLOAD_TIMEOUT} --tries=${RETRIES} https://www.kernel.org/pub/linux/kernel/v${MAJOR}.x/${TGZ_NAME}
+				tar -C $TARGET -xf build/$DISTRO/${TGZ_NAME}
+		fi
+
+		make -C ${KERNELDIR} distclean
+		cp ${KERNEL_CONFIG} ${KERNELDIR}/.config
+
+		KERNEL_RELEASE=${MINIKUBE_KERNEL_VERSION}
+		HASH=minikube-$MINIKUBE_VERSION
+		HASH_ORIG=minikube-$MINIKUBE_VERSION
+		echo "Building probe for Minikube $MINIKUBE_VERSION kernel $KERNEL_RELEASE"
+		build_probe
+	done
+}
+
 function build_group_ubuntu {
 	#
 	# Ubuntu build
@@ -869,6 +922,27 @@ function build_group_rhel {
 	rhel_build $DISTRO/*.rpm
 }
 
+function build_group_minikube {
+	#
+	# Minikube build
+	#
+	DISTRO=minikube
+	BUILDER_DISTRO=minikube
+	if [ "$DOWNLOAD_CONCURRENCY" != "0" ]
+	then
+		echo Downloading Minikube sources
+		DIR=$(dirname $(readlink -f $0))
+		mkdir -p $DISTRO
+
+		curl -s https://api.github.com/repos/kubernetes/minikube/releases | \
+			jq -r '"https://github.com/kubernetes/minikube/archive/" + .[].name + ".tar.gz"' | \
+			grep -v beta | head -10 | \
+			xargs -n 1 -P $DOWNLOAD_CONCURRENCY wget -c --timeout=${DOWNLOAD_TIMEOUT} --tries=${RETRIES} -P $DISTRO
+	fi
+	echo "Building Minikube"
+	minikube_build $DISTRO/*.tar.gz
+}
+
 function build_everything {
 	build_group_rhel
 	build_group_ubuntu
@@ -882,6 +956,7 @@ function build_everything {
 	build_group_oracle_ol7_uek
 	build_group_amazonlinux
 	build_group_amazonlinux2
+	build_group_minikube
 }
 
 case "$KERNEL_TYPE" in
@@ -936,6 +1011,10 @@ case "$KERNEL_TYPE" in
 	RHEL)
 		checkout_sysdig
 		build_group_rhel
+		;;
+	Minikube)
+		checkout_sysdig
+		build_group_minikube
 		;;
 	CustomCentOS)
 		checkout_sysdig

--- a/probe-builder/builder-entrypoint-minikube.sh
+++ b/probe-builder/builder-entrypoint-minikube.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# required env vars:
+# HASH
+# HASH_ORIG
+# KERNELDIR
+# KERNEL_RELEASE
+# OUTPUT
+# PROBE_DEVICE_NAME
+# PROBE_NAME
+# PROBE_VERSION
+
+set -euo pipefail
+
+ARCH=$(uname -m)
+
+if [[ -f "${KERNELDIR}/scripts/gcc-plugins/stackleak_plugin.so" ]]; then
+	echo "Rebuilding gcc plugins for ${KERNELDIR}"
+	(cd "${KERNELDIR}" && make gcc-plugins)
+fi
+
+(cd $KERNELDIR && make olddefconfig modules_prepare)
+
+echo Building $PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
+
+mkdir -p /build/sysdig
+cd /build/sysdig
+
+cmake -DCMAKE_BUILD_TYPE=Release -DPROBE_NAME=$PROBE_NAME -DPROBE_VERSION=$PROBE_VERSION -DPROBE_DEVICE_NAME=$PROBE_DEVICE_NAME -DCREATE_TEST_TARGETS=OFF /build/probe/sysdig
+make driver
+strip -g driver/$PROBE_NAME.ko
+
+KO_VERSION=$(/sbin/modinfo driver/$PROBE_NAME.ko | grep vermagic | tr -s " " | cut -d " " -f 2)
+if [ "$KO_VERSION" != "$KERNEL_RELEASE" ]; then
+	echo "Corrupted probe, KO_VERSION " $KO_VERSION ", KERNEL_RELEASE " $KERNEL_RELEASE
+	exit 1
+fi
+
+cp driver/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
+cp driver/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko
+
+

--- a/scripts/sysdig-probe-loader
+++ b/scripts/sysdig-probe-loader
@@ -70,6 +70,13 @@ cos_version_greater()
 
 
 get_kernel_config() {
+	if [ ! -z "${SYSDIG_HOST_ROOT}" -a -f "${SYSDIG_HOST_ROOT}/etc/VERSION" -a -s ${SYSDIG_HOST_ROOT}/etc/version ]; then
+		MINIKUBE=1
+		MINIKUBE_VERSION="$(cat ${SYSDIG_HOST_ROOT}/etc/VERSION)"
+		HASH=minikube-${MINIKUBE_VERSION##v}
+		return
+	fi
+
 	if [ -f /proc/config.gz ]; then
 		echo "Found kernel config at /proc/config.gz"
 		KERNEL_CONFIG_PATH=/proc/config.gz


### PR DESCRIPTION
Given that we regenerate the kernel .config (the shipped one is just a minimal set of non-default settings), we can't easily match the config hash. Instead, detect the minikube version via /etc/VERSION and use that as the config hash.