### PR TITLE
Switch to Debian Stable in docker images

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:unstable
+FROM debian:stable
 
 MAINTAINER Sysdig <support@sysdig.com>
 

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:unstable
+FROM debian:stable
 
 MAINTAINER Sysdig <support@sysdig.com>
 

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:unstable
+FROM debian:stable
 
 MAINTAINER Sysdig <support@sysdig.com>
 


### PR DESCRIPTION
The current unstable fails to build with

    dpkg: dependency problems prevent configuration of libbinutils:amd64:
     libctf-nobfd0:amd64 (2.34-5) breaks libbinutils (<< 2.33.50.20191128-1~) and is installed.
      Version of libbinutils:amd64 to be configured is 2.30-22.
