### PR TITLE
Add a knob to prevent the use of the toolkit container for CoreOS/RPMs

### DIFF
--- a/probe-builder/Dockerfile.toolkit
+++ b/probe-builder/Dockerfile.toolkit
@@ -1,5 +1,5 @@
 FROM alpine
 
-RUN apk add rpm2cpio multipath-tools
+RUN apk add bash rpm2cpio multipath-tools
 ADD toolkit-entrypoint.sh /toolkit-entrypoint.sh
 ENTRYPOINT ["/toolkit-entrypoint.sh"]

--- a/probe-builder/build-probe-binaries
+++ b/probe-builder/build-probe-binaries
@@ -35,6 +35,10 @@ DOWNLOAD_TIMEOUT=300
 PROBE_VERSION=
 RUNNING_IN_DOCKER=
 
+TOOLKIT_NATIVE_COREOS=${TOOLKIT_NATIVE_COREOS:-}
+TOOLKIT_NATIVE_RPM=${TOOLKIT_NATIVE_RPM:-}
+SCRIPT_DIR=$(dirname $(readlink -f $0))
+
 usage() {
 	cat >&2 <<EOF
 Usage: $0 -v PROBE_VERSION [options...] [archives]
@@ -238,11 +242,9 @@ function build_toolkit {
 	fi
 }
 
-function run_toolkit {
-	if [ -z "$RUNNING_IN_DOCKER" ]
-	then
-		build_toolkit
-	fi
+function run_toolkit_docker {
+	# running on the host, use toolkit container
+	build_toolkit
 	declare -a DOCKER_OPTS
 	declare -a TOOLKIT_OPTS
 
@@ -262,13 +264,45 @@ function run_toolkit {
 		fi
 	done
 
-	if [ -z "$RUNNING_IN_DOCKER" ]
+	docker run --rm --privileged ${DOCKER_OPTS[@]} "${BUILDER_IMAGE_PREFIX:-}sysdig-probe-builder:toolkit" ${TOOLKIT_OPTS[@]}
+}
+
+function run_toolkit_native {
+	# already in a container, call the toolkit directly
+	declare -a TOOLKIT_OPTS
+
+	IN_TOOLKIT_OPTS=
+	for i in "$@"
+	do
+		if [ -z "$IN_TOOLKIT_OPTS" ]
+		then
+			if [ "$i" == "--" ]
+			then
+				IN_TOOLKIT_OPTS=1
+			fi
+		else
+			TOOLKIT_OPTS+=("$i")
+		fi
+	done
+
+	$SCRIPT_DIR/toolkit-entrypoint.sh ${TOOLKIT_OPTS[@]}
+}
+
+function run_toolkit_coreos {
+	if [ -z "$RUNNING_IN_DOCKER" -a -z "$TOOLKIT_NATIVE_COREOS" ]
 	then
-		# running on the host, use toolkit container
-		docker run --rm --privileged ${DOCKER_OPTS[@]} "${BUILDER_IMAGE_PREFIX:-}sysdig-probe-builder:toolkit" ${TOOLKIT_OPTS[@]}
+		run_toolkit_docker "$@"
 	else
-		# already in a container, call the toolkit directly
-		/builder/toolkit-entrypoint.sh ${TOOLKIT_OPTS[@]}
+		run_toolkit_native "$@"
+	fi
+}
+
+function run_toolkit_rpm {
+	if [ -z "$RUNNING_IN_DOCKER" -a -z "$TOOLKIT_NATIVE_RPM" ]
+	then
+		run_toolkit_docker "$@"
+	else
+		run_toolkit_native "$@"
 	fi
 }
 
@@ -393,7 +427,7 @@ function coreos_build {
 			echo "Unpacking $(basename $IMG)"
 			FULL_IMG=$(readlink -f "$IMG")
 			FULL_VERSION_DIR=$(readlink -f "$VERSION_DIR")
-			run_toolkit -v "$FULL_IMG:$FULL_IMG:ro" -v "$FULL_VERSION_DIR:$FULL_VERSION_DIR" -- coreos "$FULL_IMG" "$FULL_VERSION_DIR"
+			run_toolkit_coreos -v "$FULL_IMG:$FULL_IMG:ro" -v "$FULL_VERSION_DIR:$FULL_VERSION_DIR" -- coreos "$FULL_IMG" "$FULL_VERSION_DIR"
 
 			KERNEL_RELEASE=$(cd $VERSION_DIR && ls config-* | sed s/config-//)
 			export COREOS_BUILD=${VERSION%%.*}
@@ -510,7 +544,7 @@ function rhel_build {
 			mkdir -p $TARGET
 			FULL_RPM=$(readlink -f "$RPM")
 			FULL_TARGET=$(readlink -f "$TARGET")
-			run_toolkit -v "$FULL_RPM:$FULL_RPM:ro" -v "$FULL_TARGET:$FULL_TARGET" -- rpm "$FULL_RPM" "$FULL_TARGET"
+			run_toolkit_rpm -v "$FULL_RPM:$FULL_RPM:ro" -v "$FULL_TARGET:$FULL_TARGET" -- rpm "$FULL_RPM" "$FULL_TARGET"
 			touch $MARKER
 		fi
 	done

--- a/probe-builder/oracle-kernel-crawler.py
+++ b/probe-builder/oracle-kernel-crawler.py
@@ -37,7 +37,7 @@ repos = {
         {
             # yum.oracle.com has a bad cert, so use http instead of https
             "root": "http://yum.oracle.com/",
-            "discovery_pattern": "/html/body//h3/a[regex:test(@href, 'oracle-linux-6\.html')]/@href",
+            "discovery_pattern": "/html/body//a[regex:test(@href, 'oracle-linux-6\.html')]/@href",
             "sub_discovery_pattern": "/html/body//h3[regex:test(., '^UEK Release [3-9]:')]/a[regex:test(@href, 'x86_64/index.html')]/@href",
             "page_pattern": "/html/body//a[regex:test(@href, '^getPackage/kernel-uek-(devel-)?[0-9].*\.rpm$')]/@href",
         }
@@ -46,7 +46,7 @@ repos = {
     "OL7-UEK": [
         {
             "root": "http://yum.oracle.com/",
-            "discovery_pattern": "/html/body//h3/a[regex:test(@href, 'oracle-linux-7\.html')]/@href",
+            "discovery_pattern": "/html/body//a[regex:test(@href, 'oracle-linux-7\.html')]/@href",
             "sub_discovery_pattern": "/html/body//h3[regex:test(., '^UEK Release [3-9]:')]/a[regex:test(@href, 'x86_64/index.html')]/@href",
             "page_pattern": "/html/body//a[regex:test(@href, '^getPackage/kernel-uek-(devel-)?[0-9].*\.rpm$')]/@href",
         }
@@ -55,7 +55,7 @@ repos = {
     "Oracle-RHCK": [
         {
             "root": "http://yum.oracle.com/",
-            "discovery_pattern": "/html/body//h3/a[regex:test(@href, 'oracle-linux-[6-7]+\.html')]/@href",
+            "discovery_pattern": "/html/body//a[regex:test(@href, 'oracle-linux-[6-7]+\.html')]/@href",
             "sub_discovery_pattern": "/html/body//h3[regex:test(., '^Latest:')]/a[regex:test(@href, 'x86_64/index.html')]/@href",
             "page_pattern": "/html/body//a[regex:test(@href, '^getPackage/kernel-(devel-)?[0-9].*\.rpm$')]/@href",
         }

--- a/probe-builder/toolkit-entrypoint.sh
+++ b/probe-builder/toolkit-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/probe-builder/toolkit-entrypoint.sh
+++ b/probe-builder/toolkit-entrypoint.sh
@@ -32,6 +32,7 @@ unpack_coreos_kernel()
 	# umount and remove the developer container
 	umount /mnt
 	kpartx -dv /tmp/container.img
+	rm -f /tmp/container.img
 }
 
 unpack_rpm()


### PR DESCRIPTION
Trying to track down:

    Error response from daemon: Driver devicemapper failed to remove root filesystem (...): Device is Busy

The EBUSY in the toolkit container looks like a strange interaction between Docker w/the devicemapper storage driver and kpartx that uses device-mapper underneath.