### PR TITLE
fix(driver/bpf): exact check on bpf_probe_read_str() return value

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -741,7 +741,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 			res = bpf_probe_read_str(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
 						 PPM_MAX_ARG_SIZE,
 						 (const void *)val);
-			if (res < 0)
+			if (res == -EFAULT)
 				return PPM_FAILURE_INVALID_USER_MEMORY;
 			len = res;
 		} else {

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1478,7 +1478,7 @@ static __always_inline int __bpf_append_cgroup(struct css_set *cgroups,
 	int res = bpf_probe_read_str(&buf[off & SCRATCH_SIZE_HALF],
 				     SCRATCH_SIZE_HALF,
 				     subsys_name);
-	if (res < 0)
+	if (res == -EFAULT)
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 
 	off += res - 1;
@@ -1602,7 +1602,7 @@ static __always_inline int bpf_accumulate_argv_or_env(struct filler_data *data,
 			return PPM_FAILURE_BUFFER_FULL;
 
 		len = bpf_probe_read_str(&data->buf[off & SCRATCH_SIZE_HALF], SCRATCH_SIZE_HALF, arg);
-		if (len < 0)
+		if (len == -EFAULT)
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 
 		*args_len += len;
@@ -1704,7 +1704,7 @@ FILLER(proc_startupdate, true)
 						SCRATCH_SIZE_HALF,
 						&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]);
 
-		if (exe_len < 0)
+		if (exe_len == -EFAULT)
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 
 		/*


### PR DESCRIPTION
The `bpf_probe_read_str` returns a value >= 0 or `-EFAULT` (-14) when there's a page fault.
To avoid issues with the BPF VM branch analysis we need to check for the negative case exactly.

Fixes #1610
Ref https://github.com/falcosecurity/falco/issues/896 

Co-authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>