### PR TITLE
fix(userspace/libsinsp): ts_to_iso_8601 formatting length

### DIFF
--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -958,7 +958,7 @@ void sinsp_utils::ts_to_string(uint64_t ts, OUT string* res, bool date, bool ns)
 void sinsp_utils::ts_to_iso_8601(uint64_t ts, OUT string* res)
 {
 	static const char *fmt = TS_STR_FMT;
-	char buf[sizeof(fmt) + 1];
+	char buf[sizeof(TS_STR_FMT)];
 	uint64_t ns = ts % ONE_SECOND_IN_NS;
 	time_t sec = ts / ONE_SECOND_IN_NS;
 


### PR DESCRIPTION
A formatting error was introduced by mistake on this patch #1604

Co-Authored-By: Leonardo Di Donato <leodidonato@gmail.com>
Signed-off-by: Lorenzo Fontana <lo@linux.com>