### PR TITLE
curl_multi_wait timeout must be positive (to do not error on libcurl >= 7.69.0)

### DIFF
--- a/userspace/libsinsp/container_engine/docker_linux.cpp
+++ b/userspace/libsinsp/container_engine/docker_linux.cpp
@@ -147,7 +147,7 @@ docker_async_source::docker_response docker_async_source::get_docker(const std::
 		}
 
 		int numfds;
-		res = curl_multi_wait(m_curlm, NULL, 0, -1, &numfds);
+		res = curl_multi_wait(m_curlm, NULL, 0, 1000, &numfds);
 		if(res != CURLM_OK)
 		{
 			g_logger.format(sinsp_logger::SEV_DEBUG,


### PR DESCRIPTION

When compiling sysdig with libcurl >= 7.69.0 `timeout_ms` equal to `-1` causes `curl_multi_wait` to return an error ([ref](https://github.com/jay/curl/blob/master/lib/multi.c#L1056-L1057)). This new behaviour has been introduced with [this patch](https://github.com/jay/curl/commit/b700662b1c77c8af7e290538f748b71d75a79ae7.patch).

More details on the reasoning behind this choice can be found in this [issue](https://github.com/curl/curl/issues/4763).

So, to obtain the same behavior disregarding the libcurl version sysdig has been built with, this patch increases the `timeout_ms` value to `1000`.

Please notice that this does not mean it will use `1000` as timeout value since internally `curl_multi_wait` sets the actual timeout value to `timeout_internal` in case this is less than the passed `timeout_ms` argument.

Co-authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>