### PR TITLE
fix build against glibc 2.31 ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,8 +489,8 @@ if(NOT WIN32 AND NOT APPLE)
 		if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
                         ExternalProject_Add(protobuf
                         DEPENDS openssl zlib
-                        URL "http://download.sysdig.com/dependencies/protobuf-cpp-3.5.0.tar.gz"
-                        URL_MD5 "e4ba8284a407712168593e79e6555eb2"
+                        URL "https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/protobuf-cpp-3.8.0.tar.gz"
+                        URL_MD5 "9054bb5571905a28b3ae787d1d6cf8de"
                         PATCH_COMMAND wget http://download.sysdig.com/dependencies/protobuf-3.5.0-s390x.patch && patch -p1 -i protobuf-3.5.0-s390x.patch
                         # TODO what if using system zlib?
                         CONFIGURE_COMMAND /usr/bin/env CPPFLAGS=-I${ZLIB_INCLUDE} LDFLAGS=-L${ZLIB_SRC} ./configure --with-zlib --prefix=${PROTOBUF_SRC}/target
@@ -502,8 +502,8 @@ if(NOT WIN32 AND NOT APPLE)
                 else()
                         ExternalProject_Add(protobuf
                         DEPENDS openssl zlib
-                        URL "http://download.sysdig.com/dependencies/protobuf-cpp-3.5.0.tar.gz"
-                        URL_MD5 "e4ba8284a407712168593e79e6555eb2"
+                        URL "https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/protobuf-cpp-3.8.0.tar.gz"
+                        URL_MD5 "9054bb5571905a28b3ae787d1d6cf8de"
                         # TODO what if using system zlib?
                         CONFIGURE_COMMAND /usr/bin/env CPPFLAGS=-I${ZLIB_INCLUDE} LDFLAGS=-L${ZLIB_SRC} ./configure --with-zlib --prefix=${PROTOBUF_SRC}/target
                         BUILD_COMMAND ${CMD_MAKE}
@@ -551,8 +551,8 @@ if(NOT WIN32 AND NOT APPLE)
 
 		ExternalProject_Add(grpc
 		DEPENDS protobuf zlib c-ares
-		URL "http://download.draios.com/dependencies/grpc-1.8.1.tar.gz"
-		URL_MD5 "2fc42c182a0ed1b48ad77397f76bb3bc"
+		URL "https://github.com/grpc/grpc/archive/v1.25.0.tar.gz"
+		URL_MD5 "3a875f7b3f0e3bdd3a603500bcef3d41"
 		CONFIGURE_COMMAND ""
 		# TODO what if using system openssl, protobuf or cares?
 		BUILD_COMMAND CFLAGS=-Wno-implicit-fallthrough HAS_SYSTEM_ZLIB=false LDFLAGS=-static PATH=${PROTOC_DIR}:$ENV{PATH} PKG_CONFIG_PATH=${OPENSSL_BUNDLE_DIR}:${PROTOBUF_SRC}:${CARES_SRC} PKG_CONFIG=${PKG_CONFIG_EXECUTABLE} make grpc_cpp_plugin static_cxx static_c
@@ -560,7 +560,7 @@ if(NOT WIN32 AND NOT APPLE)
 		BUILD_BYPRODUCTS ${GRPC_LIB} ${GRPCPP_LIB}
 		# TODO s390x support
 		# TODO what if using system zlib
-		PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && wget https://download.sysdig.com/dependencies/grpc-1.8.1-Makefile.patch && patch < grpc-1.8.1-Makefile.patch
+		PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && patch -p1 < ${PROJECT_SOURCE_DIR}/cmake/patch/grpc-1.25.0-Makefile.patch
 		INSTALL_COMMAND "")
 	endif()
 endif() # NOT WIN32 AND NOT APPLE

--- a/cmake/patch/grpc-1.25.0-Makefile.patch
+++ b/cmake/patch/grpc-1.25.0-Makefile.patch
@@ -1,0 +1,24 @@
+diff --git a/Makefile b/Makefile
+index 8fd7044dd9..428da4c6c5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -852,6 +852,7 @@ ifneq ($(LDFLAGS_PROTOBUF_PKG_CONFIG),)
+ LDFLAGS_PROTOBUF_PKG_CONFIG += $(shell $(PKG_CONFIG) --libs-only-L protobuf | sed s/L/Wl,-rpath,/)
+ endif
+ endif
++LDFLAGS := $(LDFLAGS_PROTOBUF_PKG_CONFIG) $(LDFLAGS)
+ else
+ PC_LIBS_GRPCXX = -lprotobuf
+ endif
+diff --git a/templates/Makefile.template b/templates/Makefile.template
+index 8063bd4771..eac629d1c7 100644
+--- a/templates/Makefile.template
++++ b/templates/Makefile.template
+@@ -749,6 +749,7 @@
+   LDFLAGS_PROTOBUF_PKG_CONFIG += $(shell $(PKG_CONFIG) --libs-only-L protobuf | sed s/L/Wl,-rpath,/)
+   endif
+   endif
++  LDFLAGS := $(LDFLAGS_PROTOBUF_PKG_CONFIG) $(LDFLAGS)
+   else
+   PC_LIBS_GRPCXX = -lprotobuf
+   endif


### PR DESCRIPTION
Tried porting update gRPC to 1.25.0 from falcosecurity/falco#939. Now fails with 

```bash
[GRPC]    Generating gRPC's protobuf service CC file from src/proto/grpc/channelz/channelz.proto
third_party/protobuf/src: warning: directory does not exist.
terminate called after throwing an instance of 'std::system_error'
  what():  Unknown error -1
--grpc_out: protoc-gen-grpc: Plugin killed by signal 6.
make[3]: *** [Makefile:2668: /home/ubuntu/sysdig/build/grpc-prefix/src/grpc/gens/src/proto/grpc/channelz/channelz.grpc.pb.cc] Error 1
make[2]: *** [CMakeFiles/grpc.dir/build.make:118: grpc-prefix/src/grpc-stamp/grpc-build] Error 2
make[1]: *** [CMakeFiles/Makefile2:668: CMakeFiles/grpc.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```
