### PR TITLE
various const-correctness improvements

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -101,12 +101,12 @@ uint32_t sinsp_evt::get_dump_flags()
 	return scap_event_get_dump_flags(m_inspector->m_h);
 }
 
-const char *sinsp_evt::get_name()
+const char *sinsp_evt::get_name() const
 {
 	return m_info->name;
 }
 
-event_direction sinsp_evt::get_direction()
+event_direction sinsp_evt::get_direction() const
 {
 	return (event_direction)(m_pevt->type & PPME_DIRECTION_FLAG);
 }

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -178,7 +178,7 @@ public:
 	/*!
 	  \brief Get the number of the CPU where this event was captured.
 	*/
-	inline int16_t get_cpuid()
+	inline int16_t get_cpuid() const
 	{
 		return m_cpuid;
 	}
@@ -188,7 +188,7 @@ public:
 
 	  \note For a list of event types, refer to \ref etypes.
 	*/
-	inline uint16_t get_type()
+	inline uint16_t get_type() const override
 	{
 		return m_pevt->type;
 	}
@@ -196,7 +196,7 @@ public:
 	/*!
 	  \brief Get the event's flags.
 	*/
-	inline ppm_event_flags get_info_flags()
+	inline ppm_event_flags get_info_flags() const
 	{
 		return m_info->flags;
 	}
@@ -204,7 +204,7 @@ public:
 	/*!
 	\brief Get the event's category.
 	*/
-	inline ppm_event_category get_info_category()
+	inline ppm_event_category get_info_category() const
 	{
 		return m_info->category;
 	}
@@ -212,14 +212,14 @@ public:
 	/*!
 	  \brief Return the event direction: in or out.
 	*/
-	event_direction get_direction();
+	event_direction get_direction() const;
 
 	/*!
 	  \brief Get the event timestamp.
 
 	  \return The event timestamp, in nanoseconds from epoch
 	*/
-	inline uint64_t get_ts()
+	inline uint64_t get_ts() const override
 	{
 		return m_pevt->ts;
 	}
@@ -227,12 +227,12 @@ public:
 	/*!
 	  \brief Return the event name string, e.g. 'open' or 'socket'.
 	*/
-	const char* get_name();
+	const char* get_name() const;
 
 	/*!
 	  \brief Return the event category.
 	*/
-	inline ppm_event_category get_category()
+	inline ppm_event_category get_category() const
 	{
 		return m_info->category;
 	}
@@ -261,7 +261,7 @@ public:
 		return m_fdinfo;
 	}
 
-	inline bool fdinfo_name_changed()
+	inline bool fdinfo_name_changed() const
 	{
 		return m_fdinfo_name_changed;
 	}
@@ -347,7 +347,7 @@ public:
 
 	bool simple_consumer_consider();
 
-	inline uint16_t get_source()
+	inline uint16_t get_source() const override
 	{
 		return ESRC_SINSP;
 	}

--- a/userspace/libsinsp/gen_filter.cpp
+++ b/userspace/libsinsp/gen_filter.cpp
@@ -37,7 +37,7 @@ void gen_event::set_check_id(int32_t id)
 	}
 }
 
-int32_t gen_event::get_check_id()
+int32_t gen_event::get_check_id() const
 {
 	return m_check_id;
 }

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -76,20 +76,20 @@ public:
 	/*!
 	  \brief Get the opaque "check id" (-1 if not set).
 	*/
-	int32_t get_check_id();
+	int32_t get_check_id() const;
 
 	// Every event must expose a timestamp
-	virtual uint64_t get_ts() = 0;
+	virtual uint64_t get_ts() const = 0;
 
 	/*!
 	  \brief Get the source of the event.
 	*/
-	virtual uint16_t get_source() = 0;
+	virtual uint16_t get_source() const = 0;
 
 	/*!
 	  \brief Get the type of the event.
 	*/
-	virtual uint16_t get_type() = 0;
+	virtual uint16_t get_type() const = 0;
 
 private:
 	int32_t m_check_id = 0;

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -484,17 +484,17 @@ void sinsp_threadinfo::init(scap_threadinfo* pi)
 	}
 }
 
-string sinsp_threadinfo::get_comm()
+std::string sinsp_threadinfo::get_comm() const
 {
 	return m_comm;
 }
 
-string sinsp_threadinfo::get_exe()
+std::string sinsp_threadinfo::get_exe() const
 {
 	return m_exe;
 }
 
-string sinsp_threadinfo::get_exepath()
+std::string sinsp_threadinfo::get_exepath() const
 {
 	return m_exepath;
 }

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -493,9 +493,9 @@ public:
 		m_threads.clear();
 	}
 
-	bool const_loop(const_visitor_t callback)
+	bool const_loop(const_visitor_t callback) const
 	{
-		for (auto& it : m_threads)
+		for (const auto& it : m_threads)
 		{
 			if (!callback(*it.second.get()))
 			{

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -76,17 +76,17 @@ public:
 	/*!
 	  \brief Return the name of the process containing this thread, e.g. "top".
 	*/
-	std::string get_comm();
+	std::string get_comm() const;
 
 	/*!
 	  \brief Return the name of the process containing this thread from argv[0], e.g. "/bin/top".
 	*/
-	std::string get_exe();
+	std::string get_exe() const;
 
 	/*!
 	  \brief Return the full executable path of the process containing this thread, e.g. "/bin/top".
 	*/
-	std::string get_exepath();
+	std::string get_exepath() const;
 
 	/*!
 	  \brief Return the working directory of the process containing this thread.
@@ -454,6 +454,7 @@ VISIBILITY_PRIVATE
 class threadinfo_map_t
 {
 public:
+	typedef std::function<bool(const sinsp_threadinfo&)> const_visitor_t;
 	typedef std::function<bool(sinsp_threadinfo&)> visitor_t;
 	typedef std::shared_ptr<sinsp_threadinfo> ptr_t;
 
@@ -490,6 +491,18 @@ public:
 	inline void clear()
 	{
 		m_threads.clear();
+	}
+
+	bool const_loop(const_visitor_t callback)
+	{
+		for (auto& it : m_threads)
+		{
+			if (!callback(*it.second.get()))
+			{
+				return false;
+			}
+		}
+		return true;
 	}
 
 	bool loop(visitor_t callback)


### PR DESCRIPTION
I wanted pass sinsp_evt and sinsp_threadinfo around as const which led to improving the const-correctness to some of this code.