### PR TITLE
Add a created_time container metadata field

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -160,6 +160,7 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 	container["privileged"] = container_info.m_privileged;
 	container["is_pod_sandbox"] = container_info.m_is_pod_sandbox;
 	container["lookup_state"] = static_cast<int>(container_info.m_lookup_state);
+	container["created_time"] = (Json::Value::Int64) container_info.m_created_time;
 
 	Json::Value mounts = Json::arrayValue;
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -160,7 +160,7 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 	container["privileged"] = container_info.m_privileged;
 	container["is_pod_sandbox"] = container_info.m_is_pod_sandbox;
 	container["lookup_state"] = static_cast<int>(container_info.m_lookup_state);
-	container["created_time"] = (Json::Value::Int64) container_info.m_created_time;
+	container["created_time"] = static_cast<Json::Value::Int64>(container_info.m_created_time);
 
 	Json::Value mounts = Json::arrayValue;
 

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -115,6 +115,9 @@ bool cri_async_source::parse_cri(sinsp_container_info& container, const libsinsp
 	container.m_full_id = resp_container.id();
 	container.m_name = resp_container.metadata().name();
 
+	// This is in Nanoseconds(in CRI API). Need to convert it to seconds.
+	container.m_created_time = static_cast<int64_t>(resp_container.created_at() / ONE_SECOND_IN_NS );
+
 	for(const auto &pair : resp_container.labels())
 	{
 		container.m_labels[pair.first] = pair.second;

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -698,8 +698,8 @@ bool docker_async_source::parse_docker(const docker_async_instruction& instructi
 		container.m_is_pod_sandbox = true;
 	}
 
-	// Get the created time - this will be string format i.e. "YYYY-MM-DDTHH:MM:SS"
-	// Convert it to seconds.
+	// Get the created time - this will be string format i.e. "%Y-%m-%dT%H:%M:%SZ"
+	// Convert it to seconds. This can be done with get_epoc_utc_seconds()
 	container.m_created_time = static_cast<int64_t>(get_epoch_utc_seconds(root["Created"].asString()));
 
 	const Json::Value& net_obj = root["NetworkSettings"];

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -698,6 +698,10 @@ bool docker_async_source::parse_docker(const docker_async_instruction& instructi
 		container.m_is_pod_sandbox = true;
 	}
 
+	// Get the created time - this will be string format i.e. "YYYY-MM-DDTHH:MM:SS"
+	// Convert it to seconds.
+	container.m_created_time = static_cast<int64_t>(get_epoch_utc_seconds(root["Created"].asString()));
+
 	const Json::Value& net_obj = root["NetworkSettings"];
 
 	string ip = net_obj["IPAddress"].asString();

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -259,4 +259,11 @@ public:
 	 * This is not filled by default.
 	 */
 	int64_t m_size_rw_bytes;
+
+	/**
+	 * The time at which the container was created (IN SECONDS), cast from a value of `time_t`
+	 * We choose int64_t as we are not certain what type `time_t` is in a given
+	 * implementation; int64_t is the safest bet. Many default to int64_t anyway (e.g. CRI).
+	 */
+	int64_t m_created_time;
 };

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4654,6 +4654,12 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 			}
 		}
 
+		const Json::Value& created_time = container["created_time"];
+		if(check_int64_json_is_convertible(created_time, "created_time"))
+		{
+			container_info->m_created_time = created_time.asInt64();
+		}
+
 #ifndef _WIN32
 		libsinsp::container_engine::docker::parse_json_mounts(container["Mounts"], container_info->m_mounts);
 #endif


### PR DESCRIPTION
This PR adds a `m_created_time` metadata field to `container_info`
It simply records the time a container was created. This data is available in both `docker` and `cri-based` runtimes; albeit with different formats. 
We use the info from both and store this value as `int64_t` in terms of seconds eplased from UTC Epoch time. 
