### PR TITLE
Prevent FTBFS on mips from syscall table overflow

### DIFF
--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -27,7 +27,11 @@ or GPL2.txt for full copies of the license.
 #endif
 #else /* __KERNEL__ */
 #include <linux/unistd.h>
+#ifdef __mips__
+#define SYSCALL_TABLE_ID0 __NR_Linux
+#else /* __mips__ */
 #define SYSCALL_TABLE_ID0 0
+#endif /* __mips__ */
 #endif /* __KERNEL__ */
 
 #include "ppm_events_public.h"


### PR DESCRIPTION
On mips, syscalls start at 4k, 5k, or 6, instead of 0.  Though this
special case is handled in ppm.h, in syscall_table.c, that file is
included only when in __kernel__.  All the other special cases handled
in the ifdef block in ppm.h eventually end up setting the value to 0, so
we only special case mips here for the moment.

sysdig-CLA-1.0-signed-off-by: Harlan Lieberman-Berg <hlieberman@setec.io>