### PR TITLE
update(driver): renameat2 support

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -3337,6 +3337,64 @@ FILLER(sys_renameat_x, true)
 	return res;
 }
 
+FILLER(sys_renameat2_x, true)
+{
+	unsigned long val;
+	long retval;
+	int res;
+
+	retval = bpf_syscall_get_retval(data->ctx);
+	res = bpf_val_to_ring(data, retval);
+	if (res != PPM_SUCCESS)
+		return res;
+
+	/*
+	 * olddirfd
+	 */
+	val = bpf_syscall_get_argument(data, 0);
+
+	if ((int)val == AT_FDCWD)
+		val = PPM_AT_FDCWD;
+
+	res = bpf_val_to_ring(data, val);
+	if (res != PPM_SUCCESS)
+		return res;
+
+	/*
+	 * oldpath
+	 */
+	val = bpf_syscall_get_argument(data, 1);
+	res = bpf_val_to_ring(data, val);
+	if (res != PPM_SUCCESS)
+		return res;
+
+	/*
+	 * newdirfd
+	 */
+	val = bpf_syscall_get_argument(data, 2);
+
+	if ((int)val == AT_FDCWD)
+		val = PPM_AT_FDCWD;
+
+	res = bpf_val_to_ring(data, val);
+	if (res != PPM_SUCCESS)
+		return res;
+
+	/*
+	 * newpath
+	 */
+	val = bpf_syscall_get_argument(data, 3);
+	res = bpf_val_to_ring(data, val);
+
+	/*
+	 * flags
+	 */
+	val = bpf_syscall_get_argument(data, 4);
+	res = bpf_val_to_ring(data, val);
+
+	return res;
+}
+
 FILLER(sys_symlinkat_x, true)
 {
 	unsigned long val;

--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -329,8 +329,9 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_SYSCALL_CHMOD_E */{"chmod", EC_FILE, EF_NONE, 0},
 	/* PPME_SYSCALL_CHMOD_X */{"chmod", EC_FILE, EF_NONE, 3, {{"res", PT_ERRNO, PF_DEC}, {"filename", PT_FSPATH, PF_NA}, {"mode", PT_MODE, PF_OCT, chmod_mode} } },
 	/* PPME_SYSCALL_FCHMOD_E */{"fchmod", EC_FILE, EF_NONE, 0},
-	/* PPME_SYSCALL_FCHMOD_X */{"fchmod", EC_FILE, EF_NONE, 3, {{"res", PT_ERRNO, PF_DEC}, {"fd", PT_FD, PF_DEC}, {"mode", PT_MODE, PF_OCT, chmod_mode} } }
-
+	/* PPME_SYSCALL_FCHMOD_X */{"fchmod", EC_FILE, EF_NONE, 3, {{"res", PT_ERRNO, PF_DEC}, {"fd", PT_FD, PF_DEC}, {"mode", PT_MODE, PF_OCT, chmod_mode} } },
+	/* PPME_SYSCALL_RENAMEAT2_E */{"renameat2", EC_FILE, EF_NONE, 0 },
+	/* PPME_SYSCALL_RENAMEAT2_X */{"renameat2", EC_FILE, EF_NONE, 6, {{"res", PT_ERRNO, PF_DEC}, {"olddirfd", PT_FD, PF_DEC}, {"oldpath", PT_CHARBUF, PF_NA}, {"newdirfd", PT_FD, PF_DEC}, {"newpath", PT_CHARBUF, PF_NA}, {"flags", PT_FLAGS32, PF_HEX, renameat2_flags} } }
 	/* NB: Starting from scap version 1.2, event types will no longer be changed when an event is modified, and the only kind of change permitted for pre-existent events is adding parameters.
 	 *     New event types are allowed only for new syscalls or new internal events.
 	 *     The number of parameters can be used to differentiate between event versions.

--- a/driver/fillers_table.c
+++ b/driver/fillers_table.c
@@ -292,5 +292,7 @@ const struct ppm_event_entry g_ppm_events[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_CHMOD_E] = {FILLER_REF(sys_empty)},
 	[PPME_SYSCALL_CHMOD_X] = {FILLER_REF(sys_chmod_x)},
 	[PPME_SYSCALL_FCHMOD_E] = {FILLER_REF(sys_empty)},
-	[PPME_SYSCALL_FCHMOD_X] = {FILLER_REF(sys_fchmod_x)}
+	[PPME_SYSCALL_FCHMOD_X] = {FILLER_REF(sys_fchmod_x)},
+	[PPME_SYSCALL_RENAMEAT2_E] = {FILLER_REF(sys_empty)},
+	[PPME_SYSCALL_RENAMEAT2_X] = {FILLER_REF(sys_renameat2_x)}
 };

--- a/driver/flags_table.c
+++ b/driver/flags_table.c
@@ -518,3 +518,10 @@ const struct ppm_name_value chmod_mode[] = {
     {"S_ISUID", PPM_S_ISUID},
     {0, 0},
 };
+
+const struct ppm_name_value renameat2_flags[] = {
+	{"RENAME_NOREPLACE", PPM_RENAME_NOREPLACE},
+	{"RENAME_EXCHANGE", PPM_RENAME_EXCHANGE},
+	{"RENAME_WHITEOUT", PPM_RENAME_WHITEOUT},
+	{0, 0},
+};

--- a/driver/ppm_compat_unistd_32.h
+++ b/driver/ppm_compat_unistd_32.h
@@ -354,10 +354,11 @@
 #define __NR_ia32_setns		346
 #define __NR_ia32_process_vm_readv	347
 #define __NR_ia32_process_vm_writev	348
+#define __NR_ia32_renameat2 349
 
 #ifdef __KERNEL__
 
-#define NR_ia32_syscalls 349
+#define NR_ia32_syscalls 350
 
 #define __ARCH_WANT_IPC_PARSE_VERSION
 #define __ARCH_WANT_OLD_READDIR

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -585,6 +585,14 @@ or GPL2.txt for full copies of the license.
 #define PPM_PF_RESERVED_PAGE		(1 << 6)
 #define PPM_PF_INSTRUCTION_FETCH	(1 << 7)
 
+
+/*
+ * Rename flags
+ */
+#define PPM_RENAME_NOREPLACE	(1 << 0)	/* Don't overwrite target */
+#define PPM_RENAME_EXCHANGE		(1 << 1)	/* Exchange source and dest */
+#define PPM_RENAME_WHITEOUT		(1 << 2)	/* Whiteout source */
+
 /*
  * SuS says limits have to be unsigned.
  * Which makes a ton more sense anyway.
@@ -947,7 +955,9 @@ enum ppm_event_type {
 	PPME_SYSCALL_CHMOD_X = 315,
 	PPME_SYSCALL_FCHMOD_E = 316,
 	PPME_SYSCALL_FCHMOD_X = 317,
-	PPM_EVENT_MAX = 318
+	PPME_SYSCALL_RENAMEAT2_E = 318,
+	PPME_SYSCALL_RENAMEAT2_X = 319,
+	PPM_EVENT_MAX = 320
 };
 /*@}*/
 
@@ -1275,7 +1285,8 @@ enum ppm_syscall_code {
 	PPM_SC_SIGALTSTACK = 317,
 	PPM_SC_GETRANDOM = 318,
 	PPM_SC_FADVISE64 = 319,
-	PPM_SC_MAX = 320,
+	PPM_SC_RENAMEAT2 = 320,
+	PPM_SC_MAX = 321,
 };
 
 /*
@@ -1497,6 +1508,7 @@ extern const struct ppm_name_value pf_flags[];
 extern const struct ppm_name_value unlinkat_flags[];
 extern const struct ppm_name_value linkat_flags[];
 extern const struct ppm_name_value chmod_mode[];
+extern const struct ppm_name_value renameat2_flags[];
 
 extern const struct ppm_param_info sockopt_dynamic_param[];
 extern const struct ppm_param_info ptrace_dynamic_param[];

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -4129,6 +4129,69 @@ int f_sys_renameat_x(struct event_filler_arguments *args)
 	return add_sentinel(args);
 }
 
+int f_sys_renameat2_x(struct event_filler_arguments *args)
+{
+	unsigned long val;
+	int res;
+	int64_t retval;
+
+	retval = (int64_t)syscall_get_return_value(current, args->regs);
+	res = val_to_ring(args, retval, 0, false, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	/*
+	 * olddirfd
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
+
+	if ((int)val == AT_FDCWD)
+		val = PPM_AT_FDCWD;
+
+	res = val_to_ring(args, val, 0, false, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	/*
+	 * oldpath
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 1, 1, &val);
+	res = val_to_ring(args, val, 0, true, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	/*
+	 * newdirfd
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 2, 1, &val);
+
+	if ((int)val == AT_FDCWD)
+		val = PPM_AT_FDCWD;
+
+	res = val_to_ring(args, val, 0, false, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	/*
+	 * newpath
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 3, 1, &val);
+	res = val_to_ring(args, val, 0, true, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+
+	/*
+	 * flags
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 4, 1, &val);
+	res = val_to_ring(args, val, 0, false, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	return add_sentinel(args);
+}
+
 int f_sys_symlinkat_x(struct event_filler_arguments *args)
 {
 	unsigned long val;

--- a/driver/ppm_fillers.h
+++ b/driver/ppm_fillers.h
@@ -85,6 +85,7 @@ or GPL2.txt for full copies of the license.
 	FN(sys_mmap_e)				\
 	FN(sys_brk_munmap_mmap_x)		\
 	FN(sys_renameat_x)			\
+	FN(sys_renameat2_x)			\
 	FN(sys_symlinkat_x)			\
 	FN(sys_procexit_e)			\
 	FN(sys_sendfile_e)			\

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -195,9 +195,6 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 
 	[__NR_rename - SYSCALL_TABLE_ID0] =                     {UF_USED, PPME_SYSCALL_RENAME_E, PPME_SYSCALL_RENAME_X},
 	[__NR_renameat - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_RENAMEAT_E, PPME_SYSCALL_RENAMEAT_X},
-#ifdef __NR_renameat2
-	[__NR_renameat2 - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_RENAMEAT2_E, PPME_SYSCALL_RENAMEAT2_X},
-#endif
 	[__NR_symlink - SYSCALL_TABLE_ID0] =                    {UF_USED, PPME_SYSCALL_SYMLINK_E, PPME_SYSCALL_SYMLINK_X},
 	[__NR_symlinkat - SYSCALL_TABLE_ID0] =                  {UF_USED, PPME_SYSCALL_SYMLINKAT_E, PPME_SYSCALL_SYMLINKAT_X},
 	[__NR_sendfile - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_SENDFILE_E, PPME_SYSCALL_SENDFILE_X},
@@ -299,6 +296,9 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 #endif
 #ifdef __NR_seccomp
 	[__NR_seccomp - SYSCALL_TABLE_ID0] =                    {UF_USED, PPME_SYSCALL_SECCOMP_E, PPME_SYSCALL_SECCOMP_X},
+#endif
+#ifdef __NR_renameat2
+	[__NR_renameat2 - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_RENAMEAT2_E, PPME_SYSCALL_RENAMEAT2_X},
 #endif
 };
 
@@ -545,9 +545,6 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_futimesat - SYSCALL_TABLE_ID0] = PPM_SC_FUTIMESAT,
 	[__NR_unlinkat - SYSCALL_TABLE_ID0] = PPM_SC_UNLINKAT,
 	[__NR_renameat - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT,
-#ifdef __NR_renameat2
-	[__NR_renameat2 - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT2,
-#endif
 	[__NR_linkat - SYSCALL_TABLE_ID0] = PPM_SC_LINKAT,
 	[__NR_symlinkat - SYSCALL_TABLE_ID0] = PPM_SC_SYMLINKAT,
 	[__NR_readlinkat - SYSCALL_TABLE_ID0] = PPM_SC_READLINKAT,
@@ -854,6 +851,9 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 #ifdef __NR_fadvise64
 	[__NR_fadvise64 - SYSCALL_TABLE_ID0] = PPM_SC_FADVISE64,
 #endif
+#ifdef __NR_renameat2
+	[__NR_renameat2 - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT2,
+#endif
 };
 
 #ifdef CONFIG_IA32_EMULATION
@@ -994,6 +994,7 @@ const struct syscall_evt_pair g_syscall_ia32_table[SYSCALL_TABLE_SIZE] = {
 #endif
 
 	[__NR_ia32_rename - SYSCALL_TABLE_ID0] =                     {UF_USED, PPME_SYSCALL_RENAME_E, PPME_SYSCALL_RENAME_X},
+	[__NR_ia32_renameat - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_RENAMEAT_E, PPME_SYSCALL_RENAMEAT_X},
 	[__NR_ia32_symlink - SYSCALL_TABLE_ID0] =                    {UF_USED, PPME_SYSCALL_SYMLINK_E, PPME_SYSCALL_SYMLINK_X},
 	[__NR_ia32_symlinkat - SYSCALL_TABLE_ID0] =                  {UF_USED, PPME_SYSCALL_SYMLINKAT_E, PPME_SYSCALL_SYMLINKAT_X},
 	[__NR_ia32_sendfile - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_SENDFILE_E, PPME_SYSCALL_SENDFILE_X},
@@ -1089,7 +1090,6 @@ const struct syscall_evt_pair g_syscall_ia32_table[SYSCALL_TABLE_SIZE] = {
 #ifdef __NR_ia32_renameat2
 	[__NR_ia32_renameat2 - SYSCALL_TABLE_ID0] =                  {UF_USED, PPME_SYSCALL_RENAMEAT2_E, PPME_SYSCALL_RENAMEAT2_X},
 #endif
-	[__NR_ia32_renameat - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_RENAMEAT_E, PPME_SYSCALL_RENAMEAT_X},
 };
 
 /*
@@ -1337,9 +1337,6 @@ const enum ppm_syscall_code g_syscall_ia32_code_routing_table[SYSCALL_TABLE_SIZE
 	[__NR_ia32_futimesat - SYSCALL_TABLE_ID0] = PPM_SC_FUTIMESAT,
 	[__NR_ia32_unlinkat - SYSCALL_TABLE_ID0] = PPM_SC_UNLINKAT,
 	[__NR_ia32_renameat - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT,
-#ifdef __NR_ia32_renameat2
-	[__NR_ia32_renameat2 - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT2,
-#endif
 	[__NR_ia32_linkat - SYSCALL_TABLE_ID0] = PPM_SC_LINKAT,
 	[__NR_ia32_symlinkat - SYSCALL_TABLE_ID0] = PPM_SC_SYMLINKAT,
 	[__NR_ia32_readlinkat - SYSCALL_TABLE_ID0] = PPM_SC_READLINKAT,
@@ -1645,6 +1642,9 @@ const enum ppm_syscall_code g_syscall_ia32_code_routing_table[SYSCALL_TABLE_SIZE
 #endif
 #ifdef __NR_ia32_fadvise64
 	[__NR_ia32_fadvise64 - SYSCALL_TABLE_ID0] = PPM_SC_FADVISE64,
+#endif
+#ifdef __NR_ia32_renameat2
+	[__NR_ia32_renameat2 - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT2,
 #endif
 };
 

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -1337,7 +1337,7 @@ const enum ppm_syscall_code g_syscall_ia32_code_routing_table[SYSCALL_TABLE_SIZE
 	[__NR_ia32_futimesat - SYSCALL_TABLE_ID0] = PPM_SC_FUTIMESAT,
 	[__NR_ia32_unlinkat - SYSCALL_TABLE_ID0] = PPM_SC_UNLINKAT,
 	[__NR_ia32_renameat - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT,
-#ifdef __NR_ia32_getcpu
+#ifdef __NR_ia32_renameat2
 	[__NR_ia32_renameat2 - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT2,
 #endif
 	[__NR_ia32_linkat - SYSCALL_TABLE_ID0] = PPM_SC_LINKAT,

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -1,6 +1,6 @@
 /*
 
-Copyright (c) 2013-2018 Draios Inc. dba Sysdig.
+Copyright (c) 2020 Sysdig Inc
 
 This file is dual licensed under either the MIT or GPL 2. See MIT.txt
 or GPL2.txt for full copies of the license.
@@ -195,6 +195,9 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 
 	[__NR_rename - SYSCALL_TABLE_ID0] =                     {UF_USED, PPME_SYSCALL_RENAME_E, PPME_SYSCALL_RENAME_X},
 	[__NR_renameat - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_RENAMEAT_E, PPME_SYSCALL_RENAMEAT_X},
+#ifdef __NR_renameat2
+	[__NR_renameat2 - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_RENAMEAT2_E, PPME_SYSCALL_RENAMEAT2_X},
+#endif
 	[__NR_symlink - SYSCALL_TABLE_ID0] =                    {UF_USED, PPME_SYSCALL_SYMLINK_E, PPME_SYSCALL_SYMLINK_X},
 	[__NR_symlinkat - SYSCALL_TABLE_ID0] =                  {UF_USED, PPME_SYSCALL_SYMLINKAT_E, PPME_SYSCALL_SYMLINKAT_X},
 	[__NR_sendfile - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_SENDFILE_E, PPME_SYSCALL_SENDFILE_X},
@@ -542,6 +545,9 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_futimesat - SYSCALL_TABLE_ID0] = PPM_SC_FUTIMESAT,
 	[__NR_unlinkat - SYSCALL_TABLE_ID0] = PPM_SC_UNLINKAT,
 	[__NR_renameat - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT,
+#ifdef __NR_renameat2
+	[__NR_renameat2 - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT2,
+#endif
 	[__NR_linkat - SYSCALL_TABLE_ID0] = PPM_SC_LINKAT,
 	[__NR_symlinkat - SYSCALL_TABLE_ID0] = PPM_SC_SYMLINKAT,
 	[__NR_readlinkat - SYSCALL_TABLE_ID0] = PPM_SC_READLINKAT,
@@ -988,7 +994,6 @@ const struct syscall_evt_pair g_syscall_ia32_table[SYSCALL_TABLE_SIZE] = {
 #endif
 
 	[__NR_ia32_rename - SYSCALL_TABLE_ID0] =                     {UF_USED, PPME_SYSCALL_RENAME_E, PPME_SYSCALL_RENAME_X},
-	[__NR_ia32_renameat - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_RENAMEAT_E, PPME_SYSCALL_RENAMEAT_X},
 	[__NR_ia32_symlink - SYSCALL_TABLE_ID0] =                    {UF_USED, PPME_SYSCALL_SYMLINK_E, PPME_SYSCALL_SYMLINK_X},
 	[__NR_ia32_symlinkat - SYSCALL_TABLE_ID0] =                  {UF_USED, PPME_SYSCALL_SYMLINKAT_E, PPME_SYSCALL_SYMLINKAT_X},
 	[__NR_ia32_sendfile - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_SENDFILE_E, PPME_SYSCALL_SENDFILE_X},
@@ -1081,6 +1086,10 @@ const struct syscall_evt_pair g_syscall_ia32_table[SYSCALL_TABLE_SIZE] = {
 #ifdef __NR_ia32_seccomp
 	[__NR_ia32_seccomp - SYSCALL_TABLE_ID0] =                    {UF_USED, PPME_SYSCALL_SECCOMP_E, PPME_SYSCALL_SECCOMP_X},
 #endif
+#ifdef __NR_ia32_renameat2
+	[__NR_ia32_renameat2 - SYSCALL_TABLE_ID0] =                  {UF_USED, PPME_SYSCALL_RENAMEAT2_E, PPME_SYSCALL_RENAMEAT2_X},
+#endif
+	[__NR_ia32_renameat - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_RENAMEAT_E, PPME_SYSCALL_RENAMEAT_X},
 };
 
 /*
@@ -1328,6 +1337,9 @@ const enum ppm_syscall_code g_syscall_ia32_code_routing_table[SYSCALL_TABLE_SIZE
 	[__NR_ia32_futimesat - SYSCALL_TABLE_ID0] = PPM_SC_FUTIMESAT,
 	[__NR_ia32_unlinkat - SYSCALL_TABLE_ID0] = PPM_SC_UNLINKAT,
 	[__NR_ia32_renameat - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT,
+#ifdef __NR_ia32_getcpu
+	[__NR_ia32_renameat2 - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT2,
+#endif
 	[__NR_ia32_linkat - SYSCALL_TABLE_ID0] = PPM_SC_LINKAT,
 	[__NR_ia32_symlinkat - SYSCALL_TABLE_ID0] = PPM_SC_SYMLINKAT,
 	[__NR_ia32_readlinkat - SYSCALL_TABLE_ID0] = PPM_SC_READLINKAT,

--- a/userspace/libscap/syscall_info_table.c
+++ b/userspace/libscap/syscall_info_table.c
@@ -351,6 +351,7 @@ const struct ppm_syscall_desc g_syscall_info_table[PPM_SC_MAX] = {
 	/*PPM_SC_SIGALTSTACK*/ { EC_IO_OTHER, (enum ppm_event_flags)(EF_NONE), "sigaltstack" },
 	/*PPM_SC_GETRANDOM*/ { EC_IO_OTHER, (enum ppm_event_flags)(EF_NONE), "getrandom" },
 	/*PPM_SC_FADVISE64*/ { EC_IO_OTHER, (enum ppm_event_flags)(EF_NONE), "fadvise64" },
+	/*PPM_SC_RENAMEAT2*/ { EC_FILE, (enum ppm_event_flags)(EF_NONE), "renameat2" },
 };
 
 bool validate_info_table_size()

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -3179,7 +3179,7 @@ uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, OUT uint32_t 
 	uint16_t etype = evt->get_type();
 
 	const char *dirfdarg = NULL, *patharg = NULL;
-	if(etype == PPME_SYSCALL_RENAMEAT_X)
+	if(etype == PPME_SYSCALL_RENAMEAT_X || etype == PPME_SYSCALL_RENAMEAT2_X)
 	{
 		if(m_argid == 0 || m_argid == 1)
 		{


### PR DESCRIPTION
* Support the renameat2 syscall
* Flags transformer for renameat2 flags

Example output:

```
287009 18:42:37.921613466 6 mv (37734) > renameat2
287010 18:42:37.921655483 6 mv (37734) < renameat2 res=0 olddirfd=-100(AT_FDCWD) oldpath=oldname newdirfd=-100(AT_FDCWD) newpath=newname flags=1(RENAME_NOREPLACE)
```

In case anyone needs to test this on a system that has the `renameat2` syscall but hasn't glibc support.

```c
#define _GNU_SOURCE
#include <unistd.h>

#include <sys/syscall.h>
#include <linux/fs.h>
#include <sys/types.h>
#include <sys/stat.h>
#include <fcntl.h>


int main() {
  //Open the old directories to obtain fds
  int src_fd = open("/tmp", O_PATH);
  int dest_fd = open("/tmp", O_PATH);
  const char* src_path = "old";
  const char* dest_path = "new";

  unsigned int flags = RENAME_NOREPLACE;
  syscall(SYS_renameat2, src_fd, src_path, dest_fd, dest_path, flags);
}
```

Then use it

```bash
gcc renameat2.c
touch /tmp/old
./a.out
```


Here is a simple chisel for the renameat2 syscall.

```lua
-- Chisel description
description = "log all renameat2 syscalls";
short_description = "renameat2 log";
category = "Application";
args = {}


-- Initialization callback
function on_init()
    -- The -pc or -pcontainer options was supplied on the cmd line
    print_container = sysdig.is_print_container_data()
    olddirfd = chisel.request_field("evt.arg.olddirfd")
    oldpath = chisel.request_field("evt.arg.oldpath")
    newdirfd = chisel.request_field("evt.arg.newdirfd")
    newpath = chisel.request_field("evt.arg.newpath")
    flags = chisel.request_field("evt.arg.flags")

    chisel.set_filter("evt.type=renameat2 and evt.dir=<")
    return true
end

function on_event()
  local olddirfd = evt.field(olddirfd)
  local oldpath = evt.field(oldpath)
  local newdirfd = evt.field(newdirfd)
  local newpath = evt.field(newpath)
  local flags = evt.field(flags)
  print(string.format("renameat2: %s %s %s %s %s", olddirfd, oldpath, newdirfd, newpath, flags))
end
```

## Notes for the reviewer

We are still keeping `syscall_get_arguments_deprecated` in our code base so that we are compatible with older kernels. Internally, it gets conveniently converted to `syscall_get_arguments` - look [here](https://github.com/draios/sysdig/blob/1ef0569aed071f53a12735536867a2afbc5c0ad5/driver/ppm_fillers.c#L127-L138)

Fixes #1603 

Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>