### PR TITLE
build: CMake error only if the build was requested in the main source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 # Prior to doing anything, we make sure that we aren't trying to
 # run cmake in-tree. (see Issue 71: https://github.com/draios/sysdig/issues/71)
-if(EXISTS CMakeLists.txt)
+if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CMakeLists.txt)
 	message(FATAL_ERROR
 		"Looks like you are trying to run cmake from the base sysdig source directory.\n"
 		"** RUNNING CMAKE FROM THE BASE SYSDIG DIRECTORY WILL NOT WORK **\n"


### PR DESCRIPTION
The old behavior was only looking if the build was started from
the current working directory with the assumption that $CWD == sysdig
source dir.

However, this is not always true, let's see an example:

```bash
cmake -B /home/fntlnz/Projects/draios/sysdig/build
```

The command above, will fail under the current configuration, even
if the build directory is not inside the source directory. Why?
Because the cmake program checks if the CMakeLists.txt is in the current
working directory instead of build directory.

Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>