### PR TITLE
fix(userspace/libsinsp): correct pathname expansion for *at syscalls

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1402,6 +1402,34 @@ Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_
 	return ret;
 }
 
+string sinsp_evt::get_cwd(uint32_t id, sinsp_threadinfo* tinfo)
+{
+	auto cwd = tinfo->get_cwd();
+
+	auto param = &(m_params[id]);
+	auto payload = param->m_val;
+
+	// If pathname is relative (does not start with a "/")
+	if (strncmp(payload, "/", 1) != 0) {
+		// Get the previous parameter
+		auto prev_id = id - 1;
+		auto prev_param = &(m_params[prev_id]);
+		auto prev_payload = prev_param->m_val;
+		auto prev_param_info = &(m_info->params[prev_id]);
+		// If the previous param is a fd with a value other than AT_FDCWD,
+		// use such value as the current working directory
+		if (prev_param_info->type == PT_FD && *prev_payload != PPM_AT_FDCWD) {
+			auto prev_fdinfo = tinfo->get_fd(*(int64_t*)prev_payload);
+			// Make sure we remove invalid characters from the resolved name
+			auto sanitized_prev_fd_str = prev_fdinfo->m_name;
+			sanitize_string(sanitized_prev_fd_str);
+			cwd = sanitized_prev_fd_str + "/";
+		}
+	}
+
+	return cwd;
+}
+
 const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_str, sinsp_evt::param_fmt fmt)
 {
 	char* prfmt;
@@ -1610,7 +1638,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 		{
 			if (strncmp(payload, "<NA>", 4) != 0)
 			{
-				string cwd = tinfo->get_cwd();
+				string cwd = get_cwd(id, tinfo);
 
 				if(payload_len + cwd.length() >= m_resolved_paramstr_storage.size())
 				{

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -391,6 +391,9 @@ private:
 
 	void set_iosize(uint32_t size);
 	uint32_t get_iosize();
+
+	std::string get_cwd(uint32_t id, sinsp_threadinfo* tinfo);
+
 	const char* get_param_as_str(uint32_t id, OUT const char** resolved_str, param_fmt fmt = PF_NORMAL);
 	Json::Value get_param_as_json(uint32_t id, OUT const char** resolved_str, param_fmt fmt = PF_NORMAL);
 


### PR DESCRIPTION
If the pathname is relative, for *at syscalls, it should be considered relative to the directory specified by the dirfd file descriptor.

Fixes #1659

Co-authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>