### PR TITLE
update: udig memfd sock implementation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,16 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+AccessModifierOffset: -8
+BreakBeforeBraces: Allman
+BreakConstructorInitializers: AfterColon
+ColumnLimit: 0
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+DerivePointerAlignment: true
+IndentWidth: 8
+SortIncludes: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeCtorInitializerColon: false
+SpaceBeforeParens: Never
+UseTab: Always

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -604,7 +604,8 @@ scap_t* scap_open_udig_int(char *error, int32_t *rc,
 #ifdef UDIG_USE_SOCKET_MEMFD
 	pthread_t thread;
 	int trc = pthread_create(&thread, NULL, udig_server_thread, (void *)handle);
-	if (trc) {
+	if (trc)
+	{
 		*rc = SCAP_FAILURE;
 		return NULL;	
 	}

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -41,9 +41,9 @@ limitations under the License.
 #endif
 
 #include "scap.h"
-#ifdef UDIG_USE_SOCKET_MEMFD
+#ifndef UDIG_INSTRUMENTER
 #include <pthread.h>
-#endif // UDIG_USE_SOCKET_MEMFD
+#endif
 #ifdef HAS_CAPTURE
 #ifndef CYGWING_AGENT
 #include "driver_config.h"
@@ -133,13 +133,6 @@ static uint32_t get_max_consumers()
 
 	return 0;
 }
-
-#ifdef UDIG_USE_SOCKET_MEMFD
-static void udig_server_thread(scap_t *handle)
-{
-	pthread_exit(udig_fd_server(&(handle->m_devs[0].m_bufinfo_fd), &(handle->m_devs[0].m_fd)));
-}
-#endif
 
 scap_t* scap_open_live_int(char *error, int32_t *rc,
 			   proc_entry_callback proc_callback,
@@ -600,15 +593,6 @@ scap_t* scap_open_udig_int(char *error, int32_t *rc,
 		return NULL;
 	}
 
-#ifdef UDIG_USE_SOCKET_MEMFD
-	pthread_t thread;
-	int trc = pthread_create(&thread, NULL, udig_server_thread, (void *)handle);
-	if (trc)
-	{
-		*rc = SCAP_FAILURE;
-		return NULL;	
-	}
-#endif
 	//
 	// Additional initializations
 	//

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -137,8 +137,7 @@ static uint32_t get_max_consumers()
 #ifdef UDIG_USE_SOCKET_MEMFD
 static void udig_server_thread(scap_t *handle)
 {
-	udig_fd_server(&(handle->m_devs[0].m_bufinfo_fd), &(handle->m_devs[0].m_fd));
-	pthread_exit(NULL);
+	pthread_exit(udig_fd_server(&(handle->m_devs[0].m_bufinfo_fd), &(handle->m_devs[0].m_fd)));
 }
 #endif
 

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -533,6 +533,7 @@ struct ppm_syscall_desc {
 #if defined(LINUX_VERSION_CODE) && LINUX_VERSION_CODE >= KERNEL_VERSION(3, 17, 0)
 #define UDIG_USE_SOCKET_MEMFD
 #define UDIG_RING_CTRL_SOCKET_PATH "/tmp/udig.sock" // XXX: do we want a different path? or make it configurable?
+#define UDIG_RING_CTRL_CONNECT_MAX_ATTEMPTS 500
 #define UDIG_RING_CTRL_SOCKET_CONNECT_BACKLOG  128
 #endif
 #ifndef __APPLE__
@@ -549,8 +550,9 @@ struct udig_ring_buffer_status {
 typedef struct ppm_ring_buffer_info ppm_ring_buffer_info;
 
 
-
-void udig_fd_server(int* ring_descs_fd, int* ring_fd);
+#ifndef UDIG
+int32_t udig_fd_server(int* ring_descs_fd, int* ring_fd);
+#endif // UDIG
 int32_t udig_alloc_ring(int* ring_fd, uint8_t** ring, uint32_t *ringsize, char *error);
 int32_t udig_alloc_ring_descriptors(int* ring_descs_fd, 
 	struct ppm_ring_buffer_info** ring_info, 

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -18,7 +18,9 @@ limitations under the License.
 */
 
 #pragma once
-
+#ifdef __linux__
+#include <linux/version.h>
+#endif
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -528,7 +530,11 @@ struct ppm_syscall_desc {
 #define UDIG_RING_SM_FNAME "udig_buf"
 #define UDIG_RING_DESCS_SM_FNAME "udig_descs"
 #define UDIG_RING_SIZE (8 * 1024 * 1024)
-
+#if defined(LINUX_VERSION_CODE) && LINUX_VERSION_CODE >= KERNEL_VERSION(3, 17, 0)
+#define UDIG_USE_SOCKET_MEMFD
+#define UDIG_RING_CTRL_SOCKET_PATH "/tmp/udig.sock" // XXX: do we want a different path? or make it configurable?
+#define UDIG_RING_CTRL_SOCKET_CONNECT_BACKLOG  128
+#endif
 #ifndef __APPLE__
 struct udig_ring_buffer_status {
 	volatile uint64_t m_buffer_lock;
@@ -542,10 +548,13 @@ struct udig_ring_buffer_status {
 
 typedef struct ppm_ring_buffer_info ppm_ring_buffer_info;
 
+
+
+void udig_fd_server(int* ring_descs_fd, int* ring_fd);
 int32_t udig_alloc_ring(int* ring_fd, uint8_t** ring, uint32_t *ringsize, char *error);
 int32_t udig_alloc_ring_descriptors(int* ring_descs_fd, 
 	struct ppm_ring_buffer_info** ring_info, 
-	struct udig_ring_buffer_status** ring_status, 
+	struct udig_ring_buffer_status** ring_status,
 	char *error);
 void udig_free_ring(uint8_t* addr, uint32_t size);
 void udig_free_ring_descriptors(uint8_t* addr);

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -530,12 +530,10 @@ struct ppm_syscall_desc {
 #define UDIG_RING_SM_FNAME "udig_buf"
 #define UDIG_RING_DESCS_SM_FNAME "udig_descs"
 #define UDIG_RING_SIZE (8 * 1024 * 1024)
-#if defined(LINUX_VERSION_CODE) && LINUX_VERSION_CODE >= KERNEL_VERSION(3, 17, 0)
-#define UDIG_USE_SOCKET_MEMFD
-#define UDIG_RING_CTRL_SOCKET_PATH "/tmp/udig.sock" // XXX: do we want a different path? or make it configurable?
+#define UDIG_RING_CTRL_SOCKET_PATH "/var/run/udig.sock"
 #define UDIG_RING_CTRL_CONNECT_MAX_ATTEMPTS 500
-#define UDIG_RING_CTRL_SOCKET_CONNECT_BACKLOG  128
-#endif
+#define UDIG_RING_CTRL_SOCKET_CONNECT_BACKLOG 128
+
 #ifndef __APPLE__
 struct udig_ring_buffer_status {
 	volatile uint64_t m_buffer_lock;
@@ -549,10 +547,6 @@ struct udig_ring_buffer_status {
 
 typedef struct ppm_ring_buffer_info ppm_ring_buffer_info;
 
-
-#ifndef UDIG
-int32_t udig_fd_server(int* ring_descs_fd, int* ring_fd);
-#endif // UDIG
 int32_t udig_alloc_ring(int* ring_fd, uint8_t** ring, uint32_t *ringsize, char *error);
 int32_t udig_alloc_ring_descriptors(int* ring_descs_fd, 
 	struct ppm_ring_buffer_info** ring_info, 

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -528,7 +528,6 @@ struct ppm_syscall_desc {
 #define UDIG_RING_DESCS_SM_FNAME "udig_descs"
 #define UDIG_RING_SIZE (8 * 1024 * 1024)
 #define UDIG_RING_CTRL_SOCKET_PATH "/var/run/udig.sock"
-#define UDIG_RING_CTRL_CONNECT_MAX_ATTEMPTS 500
 #define UDIG_RING_CTRL_SOCKET_CONNECT_BACKLOG 128
 
 #ifndef __APPLE__

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -18,9 +18,6 @@ limitations under the License.
 */
 
 #pragma once
-#ifdef __linux__
-#include <linux/version.h>
-#endif
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/userspace/libscap/scap_udig.c
+++ b/userspace/libscap/scap_udig.c
@@ -57,7 +57,7 @@ static int udig_receive_fd(int conn, int* ring_fd, int* ring_desc_fd)
 	struct cmsghdr *cmsgh0;
 	struct cmsghdr *cmsgh1;
 
-	/* we need to send some placeholder data for the message to be sent */
+	// we need to send some placeholder data for the message to be sent
 	char placeholder;
 	iov.iov_base = &placeholder;
 	iov.iov_len = sizeof(char);
@@ -308,27 +308,15 @@ int32_t udig_fd_server(int* ring_descs_fd, int* ring_fd)
 		return SCAP_FAILURE;
 	}
 
-	int connect_attempts_left = UDIG_RING_CTRL_CONNECT_MAX_ATTEMPTS;
 	while(true)
 	{
 		conn = accept(sock, (struct sockaddr *) &address, &addrlen);
 		if(conn == -1)
 		{
-			fprintf(stderr, "udig_fd_server: accept error: %s\n", strerror(errno));
-			close(conn);
-			--connect_attempts_left;
-			if(connect_attempts_left <=  0) {
-				fprintf(
-					stderr,
-					"udig_fd_server: no more connect attempts left, shitting down the sockets server to connect new userspace producers, existing producers will still be able to work.\n"
-				);
-				return SCAP_FAILURE;
-			}
 			continue;
 		}
 		udig_send_fds(conn, *ring_fd, *ring_descs_fd);
 		close(conn);
-		connect_attempts_left = UDIG_RING_CTRL_CONNECT_MAX_ATTEMPTS;
 	}
 }
 


### PR DESCRIPTION
The actual implementation of the udig shared memory buffer
between the producer and the consumers relies on two file descriptors
associated to two files can be found in /dev/shm/udig_{buf,descs}

This means that there's a named file associated to the file descriptor.
That approach is very versatile and useful as a discovery
mechanism between the udig and the producers.

However, since it's a file, any user with the right permissions
can easily mess up the associated file descriptor with something like:

```
cat > /dev/shm/udig_buf
```

This is unavoidable in userspace, while in kernel space we can avoid
this because the /dev/sysdig* devices are owned by the module.

To solve the outlined problem, this patch adds a step to distribute
the file descriptors over a unix socket.

This relies on memfd_create, sendmmsg and recvmmsg to create the
anonymous file descriptor and then send/receive it on the two sides.

Kernels that don't have support for memfd_create and non-linux systems will use
the approach that we had before with the shm_open.

When udig starts, the socket is created. Then when a producer wants
the file descriptor, it connects to the socket to get it.
Once the file descriptor is handed, the socket is not needed anymore for
that producer but it's kept up in case new consumers want to connect.

The main advantage of this is that since now the file descriptor
is anonymous, there's no way to mess with it directly.

In the future, we can add an authorization mechanism to the socket
to only allow specific producers to connect. Seals can be added to
regulate reads and writes too.

Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>