### PR TITLE
Implement registration of pending conns for audit tap

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2530,7 +2530,7 @@ void sinsp_parser::parse_connect_enter(sinsp_evt *evt){
 
     packed_data = (uint8_t*)parinfo->m_val;
 
-    fill_socket_info(evt, packed_data);
+    fill_client_socket_info(evt, packed_data);
 
     //
     // If there's a listener callback, invoke it
@@ -2541,7 +2541,7 @@ void sinsp_parser::parse_connect_enter(sinsp_evt *evt){
     }
 }
 
-inline void sinsp_parser::fill_socket_info(sinsp_evt *evt, uint8_t *packed_data){
+inline void sinsp_parser::fill_client_socket_info(sinsp_evt *evt, uint8_t *packed_data){
     uint8_t family;
     const char *parstr;
     bool changed;
@@ -2695,7 +2695,7 @@ void sinsp_parser::parse_connect_exit(sinsp_evt *evt)
 
 	packed_data = (uint8_t*)parinfo->m_val;
 
-    fill_socket_info(evt, packed_data);
+    fill_client_socket_info(evt, packed_data);
 
 	//
 	// Call the protocol decoder callbacks associated to this event

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2503,7 +2503,7 @@ void sinsp_parser::parse_bind_exit(sinsp_evt *evt)
  * Register a socket in pending state
  */
 void sinsp_parser::parse_connect_enter(sinsp_evt *evt){
-    if (!m_track_connection_pending){
+    if(!m_track_connection_status){
         return;
     }
 
@@ -2515,11 +2515,7 @@ void sinsp_parser::parse_connect_enter(sinsp_evt *evt){
         return;
     }
 
-    if(m_track_connection_status)
-    {
-        evt->m_fdinfo->set_socket_pending();
-    }
-
+    evt->m_fdinfo->set_socket_pending();
     parinfo = evt->get_param(1);
     if(parinfo->m_len == 0)
     {

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -177,7 +177,6 @@ private:
 	string m_tracer_error_string;
 
 	bool m_track_connection_status = false;
-	bool m_track_connection_pending = false;
 
 	// FD listener callback
 	sinsp_fd_listener* m_fd_listener;

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -146,7 +146,7 @@ private:
 	void parse_setsid_exit(sinsp_evt *evt);
 	void parse_getsockopt_exit(sinsp_evt *evt);
 
-	inline void fill_socket_info(sinsp_evt* evt, uint8_t* packed_data);
+	inline void fill_client_socket_info(sinsp_evt* evt, uint8_t* packed_data);
 	inline void add_socket(sinsp_evt* evt, int64_t fd, uint32_t domain, uint32_t type, uint32_t protocol);
 	inline void infer_sendto_fdinfo(sinsp_evt *evt);
 	inline void add_pipe(sinsp_evt *evt, int64_t tid, int64_t fd, uint64_t ino);

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -103,6 +103,7 @@ private:
 	void parse_pipe_exit(sinsp_evt* evt);
 	void parse_socketpair_exit(sinsp_evt* evt);
 	void parse_socket_exit(sinsp_evt* evt);
+	void parse_connect_enter(sinsp_evt* evt);
 	void parse_connect_exit(sinsp_evt* evt);
 	void parse_accept_exit(sinsp_evt* evt);
 	void parse_close_enter(sinsp_evt* evt);
@@ -145,6 +146,7 @@ private:
 	void parse_setsid_exit(sinsp_evt *evt);
 	void parse_getsockopt_exit(sinsp_evt *evt);
 
+	inline void fill_socket_info(sinsp_evt* evt, uint8_t* packed_data);
 	inline void add_socket(sinsp_evt* evt, int64_t fd, uint32_t domain, uint32_t type, uint32_t protocol);
 	inline void infer_sendto_fdinfo(sinsp_evt *evt);
 	inline void add_pipe(sinsp_evt *evt, int64_t tid, int64_t fd, uint64_t ino);
@@ -175,6 +177,7 @@ private:
 	string m_tracer_error_string;
 
 	bool m_track_connection_status = false;
+	bool m_track_connection_pending = false;
 
 	// FD listener callback
 	sinsp_fd_listener* m_fd_listener;


### PR DESCRIPTION
This PR adds the possibility to track the pending connections. It does so by registering registering the connection on the entry to connect syscall.