### PR TITLE
Linux 5.8: replace probe_kernel_read() with copy_from_kernel_nofault()

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -716,6 +716,8 @@ long probe_kernel_read(void *dst, const void *src, size_t size)
 
 	return ret ? -EFAULT : 0;
 }
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+#define probe_kernel_read copy_from_kernel_nofault
 #endif
 
 static int ppm_get_tty(void)


### PR DESCRIPTION
See also commit fe557319aa06c23cffc9346000f119547e0f289a "maccess: rename
probe_kernel_{read,write} to copy_{from,to}_kernel_nofault" upstream.

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>