### PR TITLE
fix(userspace/libscap): use proper module name in sysfs paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ if(NOT WIN32)
 			set(PROBE_NAME "sysdig-probe")
 		endif()
 
+		string(REGEX REPLACE "[,-]" "_" SYSFS_NAME ${PROBE_NAME})
+
 		if(NOT DEFINED PROBE_DEVICE_NAME)
 			set(PROBE_DEVICE_NAME "sysdig")
 		endif()

--- a/driver/driver_config.h.in
+++ b/driver/driver_config.h.in
@@ -13,3 +13,5 @@ or GPL2.txt for full copies of the license.
 #define PROBE_NAME "${PROBE_NAME}"
 
 #define PROBE_DEVICE_NAME "${PROBE_DEVICE_NAME}"
+
+#define SYSFS_NAME "${SYSFS_NAME}"

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -100,7 +100,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 static uint32_t get_max_consumers()
 {
 	uint32_t max;
-	FILE *pfile = fopen("/sys/module/" PROBE_DEVICE_NAME "_probe/parameters/max_consumers", "r");
+	FILE *pfile = fopen("/sys/module/" SYSFS_NAME "/parameters/max_consumers", "r");
 	if(pfile != NULL)
 	{
 		int w = fscanf(pfile, "%"PRIu32, &max);
@@ -328,7 +328,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 				else if(errno == EBUSY)
 				{
 					uint32_t curr_max_consumers = get_max_consumers();
-					snprintf(error, SCAP_LASTERR_SIZE, "Too many sysdig instances attached to device %s. Current value for /sys/module/" PROBE_DEVICE_NAME "_probe/parameters/max_consumers is '%"PRIu32"'.", filename, curr_max_consumers);
+					snprintf(error, SCAP_LASTERR_SIZE, "Too many sysdig instances attached to device %s. Current value for /sys/module/" SYSFS_NAME "/parameters/max_consumers is '%"PRIu32"'.", filename, curr_max_consumers);
 				}
 				else
 				{


### PR DESCRIPTION
Current solution appending _probe to `PROBE_DEVICE_NAME` won't work if `PROBE_NAME` doesn't end in '-probe'.

Define SYSFS_NAME matching kbuild's KBUILD_MODNAME:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/Makefile.lib#n111

sysdig-CLA-1.0-signed-off-by: Antoine Deschênes <antoine@antoinedeschenes.com>