### PR TITLE
Delay /proc/pid/mountinfo reads

### DIFF
--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -257,6 +257,8 @@ int32_t scap_fd_scan_fd_dir(scap_t* handle, char * procdir, scap_threadinfo* pi,
 int32_t scap_fd_read_ipv4_sockets_from_proc_fs(scap_t* handle, const char * dir, int l4proto, scap_fdinfo ** sockets);
 // read all sockets and add them to the socket table hashed by their ino
 int32_t scap_fd_read_sockets(scap_t* handle, char* procdir, struct scap_ns_socket_list* sockets, char *error);
+// get the device major/minor number for the requested_mount_id, looking in procdir/mountinfo if needed
+uint32_t scap_get_device_by_mount_id(scap_t *handle, const char *procdir, unsigned long requested_mount_id);
 // prints procs details for a give tid
 void scap_proc_print_proc_by_tid(scap_t* handle, uint64_t tid);
 // Allocate and return the list of interfaces on this system

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -199,6 +199,7 @@ typedef struct scap_fdinfo
 		{
 			uint32_t open_flags; ///< Flags associated with the file
 			char fname[SCAP_MAX_PATH_SIZE]; ///< Name associated to this file
+			uint32_t mount_id; ///< The id of the vfs mount the file is in until we find dev major:minor
 			uint32_t dev; ///< Major/minor number of the device containing this file
 		} regularinfo; ///< Information specific to regular files
 		char fname[SCAP_MAX_PATH_SIZE];  ///< The name for file system FDs

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -823,7 +823,7 @@ static inline uint32_t open_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static uint32_t scap_get_device_by_mount_id(scap_t *handle, const char *procdir, unsigned long requested_mount_id)
+uint32_t scap_get_device_by_mount_id(scap_t *handle, const char *procdir, unsigned long requested_mount_id)
 {
 	char fd_dir_name[SCAP_MAX_PATH_SIZE];
 	char line[SCAP_MAX_PATH_SIZE];
@@ -886,6 +886,8 @@ void scap_fd_flags_file(scap_t *handle, scap_fdinfo *fdi, const char *procdir)
 	{
 		return;
 	}
+	fdi->info.regularinfo.mount_id = 0;
+	fdi->info.regularinfo.dev = 0;
 
 	while(fgets(line, sizeof(line), finfo) != NULL)
 	{
@@ -915,20 +917,13 @@ void scap_fd_flags_file(scap_t *handle, scap_fdinfo *fdi, const char *procdir)
 		}
 		else if(!strncmp(line, "mnt_id:\t", sizeof("mnt_id:\t") - 1))
 		{
-			uint32_t dev;
 			errno = 0;
 			unsigned long mount_id = strtoul(line + sizeof("mnt_id:\t") - 1, NULL, 10);
 
-			if(errno == ERANGE)
+			if(errno != ERANGE)
 			{
-				dev = 0;
+				fdi->info.regularinfo.mount_id = mount_id;
 			}
-			else
-			{
-				dev = scap_get_device_by_mount_id(handle, procdir, mount_id);
-			}
-
-			fdi->info.regularinfo.dev = dev;
 		}
 	}
 

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -118,6 +118,7 @@ public:
 		m_oldname = other.m_oldname;
 		m_flags = other.m_flags;
 		m_dev = other.m_dev;
+		m_mount_id = other.m_mount_id;
 		m_ino = other.m_ino;
 		
 		if(free_state)
@@ -492,6 +493,7 @@ private:
 	T* m_usrstate;
 	uint32_t m_flags;
 	uint32_t m_dev;
+	uint32_t m_mount_id;
 	uint64_t m_ino;
 
 	fd_callbacks_info* m_callbacks;
@@ -553,6 +555,7 @@ public:
 	#endif
 			m_last_accessed_fd = fd;
 			m_last_accessed_fdinfo = &(fdit->second);
+			lookup_device(&(fdit->second), fd);
 			return &(fdit->second);
 		}
 	}
@@ -573,4 +576,8 @@ public:
 	//
 	int64_t m_last_accessed_fd;
 	sinsp_fdinfo_t *m_last_accessed_fdinfo;
+	uint64_t m_tid;
+
+private:
+	void lookup_device(sinsp_fdinfo_t* fdi, uint64_t fd);
 };

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2136,6 +2136,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 		}
 
 		fdi.m_openflags = flags;
+		fdi.m_mount_id = 0;
 		fdi.m_dev = dev;
 		fdi.add_filename(fullpath);
 

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -317,6 +317,7 @@ void sinsp_threadinfo::add_fd_from_scap(scap_fdinfo *fdi, OUT sinsp_fdinfo_t *re
 		newfdi->m_openflags = fdi->info.regularinfo.open_flags;
 		newfdi->m_name = fdi->info.regularinfo.fname;
 		newfdi->m_dev = fdi->info.regularinfo.dev;
+		newfdi->m_mount_id = fdi->info.regularinfo.mount_id;
 
 		if(newfdi->m_name == USER_EVT_DEVICE_NAME)
 		{
@@ -402,6 +403,7 @@ void sinsp_threadinfo::init(scap_threadinfo* pi)
 	m_flags |= pi->flags;
 	m_flags |= PPM_CL_ACTIVE; // Assume that all the threads coming from /proc are real, active threads
 	m_fdtable.clear();
+	m_fdtable.m_tid = m_tid;
 	m_fdlimit = pi->fdlimit;
 	m_uid = pi->uid;
 	m_gid = pi->gid;
@@ -1144,6 +1146,7 @@ void sinsp_threadinfo::fd_to_scap(scap_fdinfo *dst, sinsp_fdinfo_t* src)
 		dst->info.regularinfo.open_flags = src->m_openflags;
 		strncpy(dst->info.regularinfo.fname, src->m_name.c_str(), SCAP_MAX_PATH_SIZE);
 		dst->info.regularinfo.dev = src->m_dev;
+		dst->info.regularinfo.mount_id = src->m_mount_id;
 		break;
 	case SCAP_FD_FIFO:
 	case SCAP_FD_FILE:


### PR DESCRIPTION
On a system with many open files and many containers, we may read
various /proc/pid/mountinfo files during the initial /proc scan.
While usually this is very fast, we noticed it may take up to about
200 ms. Multiplied by hundreds of containers (each containing
its own, mostly unique, set of mounts), the initial /proc scan
took multiple minutes.

This patch delays the mountinfo read until the inspector fetches
the fd. The upside is the mountinfo reads are spread over time
and some may not happen at all (if there is no I/O to a particular
file). On the flip side, this read happens in the main event loop,
so in the observed case, it will stall the event processing for
that amount of time until we find all the device information we need.