### PR TITLE
revert: changes in PR#1660

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1402,40 +1402,6 @@ Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_
 	return ret;
 }
 
-string sinsp_evt::get_cwd(uint32_t id, sinsp_threadinfo *tinfo)
-{
-	auto cwd = tinfo->get_cwd();
-
-	// Defensively ensure that pathname is not at index 0
-	if (id > 0)
-	{
-		auto param = &(m_params[id]);
-		auto payload = param->m_val;
-
-		// If pathname is relative (does not start with a "/")
-		if (strncmp(payload, "/", 1) != 0)
-		{
-			// Get the previous parameter
-			auto prev_id = id - 1;
-			auto prev_param = &(m_params[prev_id]);
-			auto prev_payload = prev_param->m_val;
-			auto prev_param_info = &(m_info->params[prev_id]);
-			// If the previous param is a fd with a value other than AT_FDCWD,
-			// use such value as the current working directory
-			if (prev_param_info->type == PT_FD && *prev_payload != PPM_AT_FDCWD)
-			{
-				auto prev_fdinfo = tinfo->get_fd(*(int64_t *)prev_payload);
-				// Make sure we remove invalid characters from the resolved name
-				auto sanitized_prev_fd_str = prev_fdinfo->m_name;
-				sanitize_string(sanitized_prev_fd_str);
-				cwd = sanitized_prev_fd_str + "/";
-			}
-		}
-	}
-
-	return cwd;
-}
-
 const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_str, sinsp_evt::param_fmt fmt)
 {
 	char* prfmt;
@@ -1644,7 +1610,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 		{
 			if (strncmp(payload, "<NA>", 4) != 0)
 			{
-				string cwd = get_cwd(id, tinfo);
+				string cwd = tinfo->get_cwd();
 
 				if(payload_len + cwd.length() >= m_resolved_paramstr_storage.size())
 				{

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -391,9 +391,6 @@ private:
 
 	void set_iosize(uint32_t size);
 	uint32_t get_iosize();
-
-	std::string get_cwd(uint32_t id, sinsp_threadinfo* tinfo);
-
 	const char* get_param_as_str(uint32_t id, OUT const char** resolved_str, param_fmt fmt = PF_NORMAL);
 	Json::Value get_param_as_json(uint32_t id, OUT const char** resolved_str, param_fmt fmt = PF_NORMAL);
 


### PR DESCRIPTION
Reverted commit 14aa823ce7f08969429e8ca7d81bcfc47c1dd847
Reverted commit 9b8344caf7b718f3d45c350bf1f3a9e1355c550d

The reason for this is that there are some edge cases
that are arising in certain systems such as CentOS 7 based systems
that requires more observation.

Co-Authored-By: Leonardo Grasso <me@leonardograsso.com>
Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>