### PR TITLE
ppc64le travis buildfix

### DIFF
--- a/.travis-scripts/linux/build.sh
+++ b/.travis-scripts/linux/build.sh
@@ -27,6 +27,13 @@ else
 	export CC="gcc-4.8"
 	export CXX="g++-4.8"
 fi
+
+# this is a workaround to fix the build on ppc64le due to the change in the host kernel on the ppc64le travis backend.
+if [[ "$arch" == "ppc64le" ]]; then
+	sudo apt-get install linux-headers-generic libelf-dev rpm
+	export KERNELDIR=/lib/modules/$(ls /lib/modules/|sort|head -1)/build
+fi
+
 wget https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4.tar.gz
 tar -xzf cmake-3.16.4.tar.gz
 cd cmake-3.16.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,14 @@ matrix:
       os: osx
     - env: BUILD_TYPE=Release
       os: osx
-#    - env: BUILD_TYPE=Debug
-#      os: linux
-#      arch: ppc64le
-#      dist: bionic
-#    - env: BUILD_TYPE=Release
-#      os: linux
-#      arch: ppc64le
-#      dist: bionic
+    - env: BUILD_TYPE=Debug
+      os: linux
+      arch: ppc64le
+      dist: bionic
+    - env: BUILD_TYPE=Release
+      os: linux
+      arch: ppc64le
+      dist: bionic
     - env: BUILD_TYPE=Debug
       os: linux
       arch: s390x


### PR DESCRIPTION
this fixes the travis build for ppc64le by using existing Ubuntu generic kernel headers instead of trying to use the ones for the running kernel . 

sysdig-CLA-1.0-contributing-entity: IBM
sysdig-CLA-1.0-signed-off-by: Amit Shirodkar amit.shirodkar@ibm.com