### PR TITLE
ensure socket handler ares channel destroy works even when try_resolve has not been called

### DIFF
--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -1616,7 +1616,7 @@ private:
 	http_parser_data         m_http_parser_data;
 	unsigned                 m_data_limit = 524288; // bytes
 
-	ares_channel             m_ares_channel;
+	ares_channel             m_ares_channel = nullptr;
 	ares_options             m_ares_opts;
 	ares_cb_result           m_ares_cb_res;
 


### PR DESCRIPTION

Co-authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>