### PR TITLE
Remove driver_config.h include from sysdig.h

### DIFF
--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -30,6 +30,9 @@ limitations under the License.
 
 #include <sinsp.h>
 #include "chisel.h"
+#ifdef HAS_CAPTURE
+#include "driver_config.h"
+#endif // HAS_CAPTURE
 #include "sysdig.h"
 #include "table.h"
 #include "utils.h"

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -32,6 +32,9 @@ limitations under the License.
 #include "chisel.h"
 #include "scap_open_exception.h"
 #include "sinsp_capture_interrupt_exception.h"
+#ifdef HAS_CAPTURE
+#include "driver_config.h"
+#endif // HAS_CAPTURE
 #include "sysdig.h"
 #include "utils.h"
 

--- a/userspace/sysdig/sysdig.h
+++ b/userspace/sysdig/sysdig.h
@@ -20,10 +20,6 @@ limitations under the License.
 #pragma once
 
 #include <config_sysdig.h>
-#ifdef HAS_CAPTURE
-#include "driver_config.h"
-#endif // HAS_CAPTURE
-
 //
 // ASSERT implementation
 //


### PR DESCRIPTION
Driver config is an internal detail of libscap. If a user
of this code needs to include it, it can do so directly,
no need to inflict this on everybody, especially as this
header is generated and needs its own -I flag