### PR TITLE
Move installation of sysdig-probe-loader to driver/CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ project(sysdig)
 
 option(MINIMAL_BUILD "Produce a minimal sysdig binary with only the essential features (no eBPF probe driver, no kubernetes, no mesos, no marathon and no container metadata)" OFF)
 option(MUSL_OPTIMIZED_BUILD "Enable if you want a musl optimized build" OFF)
+option(INSTALL_PROBE_LOADER "Install the prebuilt probe loader" ON)
 
 # Add path for custom CMake modules.
 list(APPEND CMAKE_MODULE_PATH

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 option(BUILD_DRIVER "Build the driver on Linux" ON)
 option(ENABLE_DKMS "Enable DKMS on Linux" ON)
+option(INSTALL_PROBE_LOADER "Install the prebuilt probe loader" OFF)
 
 # The driver build process is somewhat involved because we use the same
 # sources for building the driver locally and for shipping as a DKMS module.
@@ -105,6 +106,13 @@ if(ENABLE_DKMS)
 		DESTINATION "src/${PACKAGE_NAME}-${PROBE_VERSION}"
 		COMPONENT agent-kmodule)
 
+endif()
+
+if(INSTALL_PROBE_LOADER)
+	install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/sysdig-probe-loader
+		DESTINATION bin
+		RENAME ${PROBE_NAME}-loader
+		COMPONENT agent-slim)
 endif()
 
 add_subdirectory(bpf)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -26,6 +26,3 @@ install(FILES completions/zsh/_sysdig
 
 install(FILES completions/zsh/_sysdig
 	DESTINATION share/zsh/site-functions)
-
-install(PROGRAMS sysdig-probe-loader
-	DESTINATION bin)


### PR DESCRIPTION
The probe loader is logically a part of the driver (it's useful if
and only if we're expecting to use the driver) so make it the driver
target's responsibility to install it.