### PR TITLE
Split top-level CMakeLists.txt into modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,36 +153,7 @@ if(NOT MINIMAL_BUILD)
 	include(zlib)
 endif() # MINIMAL_BUILD
 
-#
-# Intel tbb
-#
-if(NOT WIN32)
-	option(USE_BUNDLED_TBB "Enable building of the bundled tbb" ${USE_BUNDLED_DEPS})
-	if(NOT USE_BUNDLED_TBB)
-		find_path(TBB_INCLUDE_DIR tbb.h PATH_SUFFIXES tbb)
-		find_library(TBB_LIB NAMES tbb)
-		if(TBB_INCLUDE_DIR AND TBB_LIB)
-			message(STATUS "Found tbb: include: ${TBB_INCLUDE_DIR}, lib: ${TBB_LIB}")
-		else()
-			message(FATAL_ERROR "Couldn't find system tbb")
-		endif()
-	else()
-		set(TBB_SRC "${PROJECT_BINARY_DIR}/tbb-prefix/src/tbb")
-
-		message(STATUS "Using bundled tbb in '${TBB_SRC}'")
-
-		set(TBB_INCLUDE_DIR "${TBB_SRC}/include/")
-		set(TBB_LIB "${TBB_SRC}/build/lib_release/libtbb.a")
-		ExternalProject_Add(tbb
-			URL "http://s3.amazonaws.com/download.draios.com/dependencies/tbb-2018_U5.tar.gz"
-			URL_MD5 "ff3ae09f8c23892fbc3008c39f78288f"
-			CONFIGURE_COMMAND ""
-			BUILD_COMMAND ${CMD_MAKE} tbb_build_dir=${TBB_SRC}/build tbb_build_prefix=lib extra_inc=big_iron.inc
-			BUILD_IN_SOURCE 1
-			BUILD_BYPRODUCTS ${TBB_LIB}
-			INSTALL_COMMAND "")
-	endif()
-endif()
+include(tbb)
 
 #
 # jq

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,38 +169,7 @@ endif()
 
 if(NOT WIN32 AND NOT MINIMAL_BUILD)
 	include(openssl)
-	#
-	# libcurl
-	#
-	option(USE_BUNDLED_CURL "Enable building of the bundled curl" ${USE_BUNDLED_DEPS})
-
-	if(NOT USE_BUNDLED_CURL)
-		find_package(CURL REQUIRED)
-		message(STATUS "Found CURL: include: ${CURL_INCLUDE_DIR}, lib: ${CURL_LIBRARIES}")
-	else()
-		set(CURL_BUNDLE_DIR "${PROJECT_BINARY_DIR}/curl-prefix/src/curl")
-		set(CURL_INCLUDE_DIR "${CURL_BUNDLE_DIR}/include/")
-		set(CURL_LIBRARIES "${CURL_BUNDLE_DIR}/lib/.libs/libcurl.a")
-
-		if(NOT USE_BUNDLED_OPENSSL)
-			set(CURL_SSL_OPTION "--with-ssl")
-		else()
-			set(CURL_SSL_OPTION "--with-ssl=${OPENSSL_INSTALL_DIR}")
-			message(STATUS "Using bundled curl in '${CURL_BUNDLE_DIR}'")
-			message(STATUS "Using SSL for curl in '${CURL_SSL_OPTION}'")
-		endif()
-
-
-		ExternalProject_Add(curl
-			DEPENDS openssl
-			URL "http://download.draios.com/dependencies/curl-7.61.0.tar.bz2"
-			URL_MD5 "31d0a9f48dc796a7db351898a1e5058a"
-			CONFIGURE_COMMAND ./configure ${CURL_SSL_OPTION} --disable-threaded-resolver --disable-shared --enable-optimize --disable-curldebug --disable-rt --enable-http --disable-ftp --disable-file --disable-ldap --disable-ldaps --disable-rtsp --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-sspi --disable-ntlm-wb --disable-tls-srp --without-winssl --without-darwinssl --without-polarssl --without-cyassl --without-nss --without-axtls --without-ca-path --without-ca-bundle --without-libmetalink --without-librtmp --without-winidn --without-libidn --without-libidn2 --without-nghttp2 --without-libssh2  --without-libpsl
-			BUILD_COMMAND ${CMD_MAKE}
-			BUILD_IN_SOURCE 1
-			BUILD_BYPRODUCTS ${CURL_LIBRARIES}
-			INSTALL_COMMAND "")
-	endif()
+	include(curl)
 endif() # NOT WIN32 AND NOT MINIMAL_BUILD
 
 if(NOT MINIMAL_BUILD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,49 +178,7 @@ endif() # NOT MINIMAL_BUILD
 
 if(NOT WIN32 AND NOT APPLE)
 	if(NOT MINIMAL_BUILD)
-		option(USE_BUNDLED_PROTOBUF "Enable building of the bundled protobuf" ${USE_BUNDLED_DEPS})
-		if(NOT USE_BUNDLED_PROTOBUF)
-			find_program(PROTOC NAMES protoc)
-			find_path(PROTOBUF_INCLUDE NAMES google/protobuf/message.h)
-			find_library(PROTOBUF_LIB NAMES protobuf)
-			if(PROTOC AND PROTOBUF_INCLUDE AND PROTOBUF_LIB)
-				message(STATUS "Found protobuf: compiler: ${PROTOC}, include: ${PROTOBUF_INCLUDE}, lib: ${PROTOBUF_LIB}")
-			else()
-				message(FATAL_ERROR "Couldn't find system protobuf")
-			endif()
-		else()
-			set(PROTOBUF_SRC "${PROJECT_BINARY_DIR}/protobuf-prefix/src/protobuf")
-			message(STATUS "Using bundled protobuf in '${PROTOBUF_SRC}'")
-			set(PROTOC "${PROTOBUF_SRC}/target/bin/protoc")
-			set(PROTOBUF_INCLUDE "${PROTOBUF_SRC}/target/include")
-			set(PROTOBUF_LIB "${PROTOBUF_SRC}/target/lib/libprotobuf.a")
-			if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
-							ExternalProject_Add(protobuf
-							DEPENDS openssl zlib
-							URL "http://download.sysdig.com/dependencies/protobuf-cpp-3.5.0.tar.gz"
-							URL_MD5 "e4ba8284a407712168593e79e6555eb2"
-							PATCH_COMMAND wget http://download.sysdig.com/dependencies/protobuf-3.5.0-s390x.patch && patch -p1 -i protobuf-3.5.0-s390x.patch
-							# TODO what if using system zlib?
-							CONFIGURE_COMMAND /usr/bin/env CPPFLAGS=-I${ZLIB_INCLUDE} LDFLAGS=-L${ZLIB_SRC} ./configure --with-zlib --prefix=${PROTOBUF_SRC}/target
-							COMMAND aclocal && automake
-							BUILD_COMMAND ${CMD_MAKE}
-							BUILD_IN_SOURCE 1
-							BUILD_BYPRODUCTS ${PROTOC} ${PROTOBUF_INCLUDE} ${PROTOBUF_LIB}
-							INSTALL_COMMAND make install)
-					else()
-							ExternalProject_Add(protobuf
-							DEPENDS openssl zlib
-							URL "http://download.sysdig.com/dependencies/protobuf-cpp-3.5.0.tar.gz"
-							URL_MD5 "e4ba8284a407712168593e79e6555eb2"
-							# TODO what if using system zlib?
-							CONFIGURE_COMMAND /usr/bin/env CPPFLAGS=-I${ZLIB_INCLUDE} LDFLAGS=-L${ZLIB_SRC} ./configure --with-zlib --prefix=${PROTOBUF_SRC}/target
-							BUILD_COMMAND ${CMD_MAKE}
-							BUILD_IN_SOURCE 1
-							BUILD_BYPRODUCTS ${PROTOC} ${PROTOBUF_INCLUDE} ${PROTOBUF_LIB}
-							INSTALL_COMMAND make install)
-					endif()
-		endif()
-
+		include(protobuf)
 
 		option(USE_BUNDLED_GRPC "Enable building of the bundled grpc" ${USE_BUNDLED_DEPS})
 		if(NOT USE_BUNDLED_GRPC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,24 +102,12 @@ endif() # MINIMAL_BUILD
 
 option(CREATE_TEST_TARGETS "Enable make-targets for unit testing" ON)
 if(CREATE_TEST_TARGETS AND NOT WIN32)
-	include(gtest)
+	include(libsinsp-tests)
 endif() # NOT WIN32
 
 add_subdirectory(userspace/sysdig)
 include(libscap)
 add_subdirectory(userspace/libsinsp)
-
-if(CREATE_TEST_TARGETS AND NOT WIN32)
-		# Add unit test directories
-		add_subdirectory(userspace/libsinsp/test)
-
-		# Add command to run all unit tests at once via the make system.
-		# This is preferred vs using ctest's add_test because it will build
-		# the code and output to stdout.
-		add_custom_target(run-unit-tests
-			COMMAND ${CMAKE_MAKE_PROGRAM} run-unit-test-libsinsp
-		)
-endif()
 
 set(CPACK_PACKAGE_NAME "${PACKAGE_NAME}")
 set(CPACK_PACKAGE_VENDOR "Sysdig Inc.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,28 +57,6 @@ set(PACKAGE_NAME "sysdig")
 
 include(CompilerFlags)
 
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-		set(KBUILD_FLAGS "${SYSDIG_DEBUG_FLAGS} ${SYSDIG_FEATURE_FLAGS}")
-	else()
-		set(KBUILD_FLAGS "${SYSDIG_FEATURE_FLAGS}")
-	endif()
-
-	if(NOT DEFINED PROBE_VERSION)
-		set(PROBE_VERSION "${SYSDIG_VERSION}")
-	endif()
-	if(NOT DEFINED PROBE_NAME)
-		set(PROBE_NAME "sysdig-probe")
-	endif()
-
-	if(NOT DEFINED PROBE_DEVICE_NAME)
-		set(PROBE_DEVICE_NAME "sysdig")
-	endif()
-
-	add_subdirectory(driver)
-	add_definitions(-DHAS_CAPTURE)
-endif()
-
 add_subdirectory(scripts)
 
 include(ExternalProject)
@@ -128,7 +106,7 @@ if(CREATE_TEST_TARGETS AND NOT WIN32)
 endif() # NOT WIN32
 
 add_subdirectory(userspace/sysdig)
-add_subdirectory(userspace/libscap)
+include(libscap)
 add_subdirectory(userspace/libsinsp)
 
 if(CREATE_TEST_TARGETS AND NOT WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,46 +149,8 @@ option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system
 include(luajit)
 include(jsoncpp)
 
-#
-# zlib
-#
-option(USE_BUNDLED_ZLIB "Enable building of the bundled zlib" ${USE_BUNDLED_DEPS})
-
 if(NOT MINIMAL_BUILD)
-	if(NOT USE_BUNDLED_ZLIB)
-		find_path(ZLIB_INCLUDE zlib.h PATH_SUFFIXES zlib)
-		find_library(ZLIB_LIB NAMES z)
-		if(ZLIB_INCLUDE AND ZLIB_LIB)
-			message(STATUS "Found zlib: include: ${ZLIB_INCLUDE}, lib: ${ZLIB_LIB}")
-		else()
-			message(FATAL_ERROR "Couldn't find system zlib")
-		endif()
-	else()
-		set(ZLIB_SRC "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib")
-		message(STATUS "Using bundled zlib in '${ZLIB_SRC}'")
-		set(ZLIB_INCLUDE "${ZLIB_SRC}")
-		if(NOT WIN32)
-			set(ZLIB_LIB "${ZLIB_SRC}/libz.a")
-			ExternalProject_Add(zlib
-				URL "http://download.draios.com/dependencies/zlib-1.2.11.tar.gz"
-				URL_MD5 "1c9f62f0778697a09d36121ead88e08e"
-				CONFIGURE_COMMAND "./configure"
-				BUILD_COMMAND ${CMD_MAKE}
-				BUILD_IN_SOURCE 1
-				BUILD_BYPRODUCTS ${ZLIB_LIB}
-				INSTALL_COMMAND "")
-		else()
-			set(ZLIB_LIB "${ZLIB_SRC}/zdll.lib")
-			ExternalProject_Add(zlib
-				URL "http://download.draios.com/dependencies/zlib-1.2.11.tar.gz"
-				URL_MD5 "1c9f62f0778697a09d36121ead88e08e"
-				CONFIGURE_COMMAND ""
-				BUILD_COMMAND nmake -f win32/Makefile.msc
-				BUILD_IN_SOURCE 1
-				BUILD_BYPRODUCTS ${ZLIB_LIB}
-				INSTALL_COMMAND "")
-		endif()
-	endif()
+	include(zlib)
 endif() # MINIMAL_BUILD
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,75 +146,7 @@ include(ExternalProject)
 
 option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system ones" ON)
 
-#
-# LuaJIT
-#
-option(USE_BUNDLED_LUAJIT "Enable building of the bundled LuaJIT" ${USE_BUNDLED_DEPS})
-
-if(NOT USE_BUNDLED_LUAJIT)
-	find_path(LUAJIT_INCLUDE luajit.h PATH_SUFFIXES luajit-2.0 luajit)
-	find_library(LUAJIT_LIB NAMES luajit luajit-5.1)
-	if(LUAJIT_INCLUDE AND LUAJIT_LIB)
-		message(STATUS "Found LuaJIT: include: ${LUAJIT_INCLUDE}, lib: ${LUAJIT_LIB}")
-	else()
-		# alternatively try stock Lua
-		find_package(Lua51)
-		set(LUAJIT_LIB ${LUA_LIBRARY})
-		set(LUAJIT_INCLUDE ${LUA_INCLUDE_DIR})
-
-		if(NOT ${LUA51_FOUND})
-			message(FATAL_ERROR "Couldn't find system LuaJIT or Lua")
-		endif()
-	endif()
-else()
-	set(LUAJIT_SRC "${PROJECT_BINARY_DIR}/luajit-prefix/src/luajit/src")
-	message(STATUS "Using bundled LuaJIT in '${LUAJIT_SRC}'")
-	set(LUAJIT_INCLUDE "${LUAJIT_SRC}")
-	if(NOT WIN32)
-		set(LUAJIT_LIB "${LUAJIT_SRC}/libluajit.a")
- 		if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
-		ExternalProject_Add(luajit
-			GIT_REPOSITORY "https://github.com/moonjit/moonjit"
-			GIT_TAG "2.1.2"
-			PATCH_COMMAND sed -i "s/luaL_reg/luaL_Reg/g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/chisel.cpp && sed -i "s/luaL_reg/luaL_Reg/g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/lua_parser.cpp && sed -i "s/luaL_getn/lua_objlen /g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/lua_parser_api.cpp
-			CONFIGURE_COMMAND ""
-			BUILD_COMMAND ${CMD_MAKE}
-			BUILD_IN_SOURCE 1
-			BUILD_BYPRODUCTS ${LUAJIT_LIB}
-			INSTALL_COMMAND "")
-		elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
-                ExternalProject_Add(luajit
-                        GIT_REPOSITORY "https://github.com/linux-on-ibm-z/LuaJIT.git"
-                        GIT_TAG "v2.1"
-                        PATCH_COMMAND sed -i "s/luaL_reg/luaL_Reg/g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/chisel.cpp && sed -i "s/luaL_reg/luaL_Reg/g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/lua_parser.cpp && sed -i "s/luaL_getn/lua_objlen /g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/lua_parser_api.cpp
-                        CONFIGURE_COMMAND ""
-                        BUILD_COMMAND ${CMD_MAKE}
-                        BUILD_IN_SOURCE 1
-                        BUILD_BYPRODUCTS ${LUAJIT_LIB}
-                        INSTALL_COMMAND "")
-		else()
-		ExternalProject_Add(luajit
-			URL "http://download.draios.com/dependencies/LuaJIT-2.0.3.tar.gz"
-			URL_MD5 "f14e9104be513913810cd59c8c658dc0"
-			CONFIGURE_COMMAND ""
-			BUILD_COMMAND ${CMD_MAKE}
-			BUILD_IN_SOURCE 1
-			BUILD_BYPRODUCTS ${LUAJIT_LIB}
-			INSTALL_COMMAND "")
-		endif()
-	else()
-		set(LUAJIT_LIB "${LUAJIT_SRC}/lua51.lib")
-		ExternalProject_Add(luajit
-			URL "http://download.draios.com/dependencies/LuaJIT-2.0.3.tar.gz"
-			URL_MD5 "f14e9104be513913810cd59c8c658dc0"
-			CONFIGURE_COMMAND ""
-			BUILD_COMMAND msvcbuild.bat
-			BUILD_BYPRODUCTS ${LUAJIT_LIB}
-			BINARY_DIR "${LUAJIT_SRC}"
-			INSTALL_COMMAND "")
-	endif()
-endif()
-
+include(luajit)
 include(jsoncpp)
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,38 +155,8 @@ endif() # MINIMAL_BUILD
 
 include(tbb)
 
-#
-# jq
-#
 if(NOT WIN32 AND NOT APPLE)
-	option(USE_BUNDLED_JQ "Enable building of the bundled jq" ${USE_BUNDLED_DEPS})
-
-	if(NOT USE_BUNDLED_JQ)
-		find_path(JQ_INCLUDE jq.h PATH_SUFFIXES jq)
-		find_library(JQ_LIB NAMES jq)
-		if(JQ_INCLUDE AND JQ_LIB)
-			message(STATUS "Found jq: include: ${JQ_INCLUDE}, lib: ${JQ_LIB}")
-		else()
-			message(FATAL_ERROR "Couldn't find system jq")
-		endif()
-	else()
-		set(JQ_SRC "${PROJECT_BINARY_DIR}/jq-prefix/src/jq")
-		message(STATUS "Using bundled jq in '${JQ_SRC}'")
-		set(JQ_INCLUDE "${JQ_SRC}/target/include")
-		set(JQ_INSTALL_DIR "${JQ_SRC}/target")
-		set(JQ_LIB "${JQ_INSTALL_DIR}/lib/libjq.a")
-		set(ONIGURUMA_LIB "${JQ_INSTALL_DIR}/lib/libonig.a")
-		message(STATUS "Bundled jq: include: ${JQ_INCLUDE}, lib: ${JQ_LIB}")
-
-		ExternalProject_Add(
-			jq
-			URL "http://download.draios.com/dependencies/jq-1.6.tar.gz"
-			URL_HASH "SHA256=787518068c35e244334cc79b8e56b60dbab352dff175b7f04a94f662b540bfd9"
-			CONFIGURE_COMMAND ./configure --disable-maintainer-mode --enable-all-static --disable-dependency-tracking --with-oniguruma=builtin --prefix=${JQ_INSTALL_DIR}
-			BUILD_COMMAND ${CMD_MAKE} LDFLAGS=-all-static
-			BUILD_IN_SOURCE 1
-			INSTALL_COMMAND ${CMD_MAKE} install)
-	endif()
+	include(jq)
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,29 +173,7 @@ if(NOT WIN32 AND NOT MINIMAL_BUILD)
 endif() # NOT WIN32 AND NOT MINIMAL_BUILD
 
 if(NOT MINIMAL_BUILD)
-	option(USE_BUNDLED_CARES "Enable building of the bundled c-ares" ${USE_BUNDLED_DEPS})
-	if(NOT USE_BUNDLED_CARES)
-		find_path(CARES_INCLUDE NAMES cares/ares.h ares.h)
-		find_library(CARES_LIB NAMES cares)
-		if(CARES_INCLUDE AND CARES_LIB)
-			message(STATUS "Found c-ares: include: ${CARES_INCLUDE}, lib: ${CARES_LIB}")
-		else()
-			message(FATAL_ERROR "Couldn't find system c-ares")
-		endif()
-	else()
-		set(CARES_SRC "${PROJECT_BINARY_DIR}/c-ares-prefix/src/c-ares")
-		message(STATUS "Using bundled c-ares in '${CARES_SRC}'")
-		set(CARES_INCLUDE "${CARES_SRC}/target/include")
-		set(CARES_LIB "${CARES_SRC}/target/lib/libcares.a")
-		ExternalProject_Add(c-ares
-		URL "http://download.sysdig.com/dependencies/c-ares-1.13.0.tar.gz"
-		URL_MD5 "d2e010b43537794d8bedfb562ae6bba2"
-		CONFIGURE_COMMAND ./configure --prefix=${CARES_SRC}/target
-		BUILD_COMMAND ${CMD_MAKE}
-		BUILD_IN_SOURCE 1
-		BUILD_BYPRODUCTS ${CARES_INCLUDE} ${CARES_LIB}
-		INSTALL_COMMAND ${CMD_MAKE} install)
-	endif()
+	include(cares)
 endif() # NOT MINIMAL_BUILD
 
 if(NOT WIN32 AND NOT APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,26 +215,7 @@ else()
 	endif()
 endif()
 
-#
-# JsonCpp
-#
-option(USE_BUNDLED_JSONCPP "Enable building of the bundled jsoncpp" ${USE_BUNDLED_DEPS})
-
-set(JSONCPP_SRC "${PROJECT_SOURCE_DIR}/userspace/libsinsp/third-party/jsoncpp")
-
-if(NOT USE_BUNDLED_JSONCPP)
-	find_path(JSONCPP_INCLUDE json/json.h PATH_SUFFIXES jsoncpp)
-	find_library(JSONCPP_LIB NAMES jsoncpp)
-	if(JSONCPP_INCLUDE AND JSONCPP_LIB)
-		message(STATUS "Found jsoncpp: include: ${JSONCPP_INCLUDE}, lib: ${JSONCPP_LIB}")
-	else()
-		message(FATAL_ERROR "Couldn't find system jsoncpp")
-	endif()
-else()
-	set(JSONCPP_INCLUDE "${JSONCPP_SRC}")
-	set(JSONCPP_LIB_SRC "${JSONCPP_SRC}/jsoncpp.cpp")
-	message(STATUS "Using bundled jsoncpp in '${JSONCPP_SRC}'")
-endif()
+include(jsoncpp)
 
 #
 # zlib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,57 +179,7 @@ endif() # NOT MINIMAL_BUILD
 if(NOT WIN32 AND NOT APPLE)
 	if(NOT MINIMAL_BUILD)
 		include(protobuf)
-
-		option(USE_BUNDLED_GRPC "Enable building of the bundled grpc" ${USE_BUNDLED_DEPS})
-		if(NOT USE_BUNDLED_GRPC)
-			find_path(GRPCXX_INCLUDE NAMES grpc++/grpc++.h)
-			if(GRPCXX_INCLUDE)
-				set(GRPC_INCLUDE ${GRPCXX_INCLUDE})
-			else()
-				find_path(GRPCPP_INCLUDE NAMES grpcpp/grpcpp.h)
-				set(GRPC_INCLUDE ${GRPCPP_INCLUDE})
-				add_definitions(-DGRPC_INCLUDE_IS_GRPCPP=1)
-			endif()
-			find_library(GRPC_LIB NAMES grpc_unsecure)
-			find_library(GRPCPP_LIB NAMES grpc++_unsecure)
-			if(GRPC_INCLUDE AND GRPC_LIB AND GRPCPP_LIB)
-				message(STATUS "Found grpc: include: ${GRPC_INCLUDE}, C lib: ${GRPC_LIB}, C++ lib: ${GRPCPP_LIB}")
-			else()
-				message(FATAL_ERROR "Couldn't find system grpc")
-			endif()
-			find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin)
-			if(NOT GRPC_CPP_PLUGIN)
-				message(FATAL_ERROR "System grpc_cpp_plugin not found")
-			endif()
-		else()
-			find_package(PkgConfig)
-			if(NOT PKG_CONFIG_FOUND)
-				message(FATAL_ERROR "pkg-config binary not found")
-			endif()
-			message(STATUS "Found pkg-config executable: ${PKG_CONFIG_EXECUTABLE}")
-			set(GRPC_SRC "${PROJECT_BINARY_DIR}/grpc-prefix/src/grpc")
-			message(STATUS "Using bundled grpc in '${GRPC_SRC}'")
-			set(GRPC_INCLUDE "${GRPC_SRC}/include")
-			set(GRPC_LIB "${GRPC_SRC}/libs/opt/libgrpc_unsecure.a")
-			set(GRPCPP_LIB "${GRPC_SRC}/libs/opt/libgrpc++_unsecure.a")
-			set(GRPC_CPP_PLUGIN "${GRPC_SRC}/bins/opt/grpc_cpp_plugin")
-
-			get_filename_component(PROTOC_DIR ${PROTOC} PATH)
-
-			ExternalProject_Add(grpc
-			DEPENDS protobuf zlib c-ares
-			URL "http://download.draios.com/dependencies/grpc-1.8.1.tar.gz"
-			URL_MD5 "2fc42c182a0ed1b48ad77397f76bb3bc"
-			CONFIGURE_COMMAND ""
-			# TODO what if using system openssl, protobuf or cares?
-			BUILD_COMMAND CFLAGS=-Wno-implicit-fallthrough HAS_SYSTEM_ZLIB=false LDFLAGS=-static PATH=${PROTOC_DIR}:$ENV{PATH} PKG_CONFIG_PATH=${OPENSSL_BUNDLE_DIR}:${PROTOBUF_SRC}:${CARES_SRC} PKG_CONFIG=${PKG_CONFIG_EXECUTABLE} make grpc_cpp_plugin static_cxx static_c
-			BUILD_IN_SOURCE 1
-			BUILD_BYPRODUCTS ${GRPC_LIB} ${GRPCPP_LIB}
-			# TODO s390x support
-			# TODO what if using system zlib
-			PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && wget https://download.sysdig.com/dependencies/grpc-1.8.1-Makefile.patch && patch < grpc-1.8.1-Makefile.patch
-			INSTALL_COMMAND "")
-		endif()
+		include(grpc)
 	endif() # NOT WIN32 AND NOT APPLE
 endif() # MINIMAL_BUILD
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,51 +63,15 @@ include(ExternalProject)
 
 option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system ones" ON)
 
-include(luajit)
-include(jsoncpp)
-
-if(NOT MINIMAL_BUILD)
-	include(zlib)
-endif() # MINIMAL_BUILD
-
-include(tbb)
-
-if(NOT WIN32 AND NOT APPLE)
-	include(jq)
-endif()
-
-if(NOT WIN32)
-	include(ncurses)
-endif()
-
-if(NOT WIN32 AND NOT APPLE)
-	include(b64)
-endif()
-
-if(NOT WIN32 AND NOT MINIMAL_BUILD)
-	include(openssl)
-	include(curl)
-endif() # NOT WIN32 AND NOT MINIMAL_BUILD
-
-if(NOT MINIMAL_BUILD)
-	include(cares)
-endif() # NOT MINIMAL_BUILD
-
-if(NOT WIN32 AND NOT APPLE)
-	if(NOT MINIMAL_BUILD)
-		include(protobuf)
-		include(grpc)
-	endif() # NOT WIN32 AND NOT APPLE
-endif() # MINIMAL_BUILD
+include(libsinsp)
 
 option(CREATE_TEST_TARGETS "Enable make-targets for unit testing" ON)
 if(CREATE_TEST_TARGETS AND NOT WIN32)
 	include(libsinsp-tests)
 endif() # NOT WIN32
 
+include(CompilerFlags)
 add_subdirectory(userspace/sysdig)
-include(libscap)
-add_subdirectory(userspace/libsinsp)
 
 set(CPACK_PACKAGE_NAME "${PACKAGE_NAME}")
 set(CPACK_PACKAGE_VENDOR "Sysdig Inc.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,33 +372,7 @@ if(NOT WIN32)
 endif()
 
 if(NOT WIN32 AND NOT APPLE)
-	#
-	# libb64
-	#
-	option(USE_BUNDLED_B64 "Enable building of the bundled b64" ${USE_BUNDLED_DEPS})
-
-	if(NOT USE_BUNDLED_B64)
-		find_path(B64_INCLUDE NAMES b64/encode.h)
-		find_library(B64_LIB NAMES b64)
-		if(B64_INCLUDE AND B64_LIB)
-			message(STATUS "Found b64: include: ${B64_INCLUDE}, lib: ${B64_LIB}")
-		else()
-			message(FATAL_ERROR "Couldn't find system b64")
-		endif()
-	else()
-		set(B64_SRC "${PROJECT_BINARY_DIR}/b64-prefix/src/b64")
-		message(STATUS "Using bundled b64 in '${B64_SRC}'")
-		set(B64_INCLUDE "${B64_SRC}/include")
-		set(B64_LIB "${B64_SRC}/src/libb64.a")
-		ExternalProject_Add(b64
-			URL "http://download.draios.com/dependencies/libb64-1.2.src.zip"
-			URL_MD5 "a609809408327117e2c643bed91b76c5"
-			CONFIGURE_COMMAND ""
-			BUILD_COMMAND ${CMD_MAKE}
-			BUILD_IN_SOURCE 1
-			BUILD_BYPRODUCTS ${B64_LIB}
-			INSTALL_COMMAND "")
-	endif()
+	include(b64)
 endif()
 
 if(NOT WIN32 AND NOT MINIMAL_BUILD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,6 @@ cmake_minimum_required(VERSION 2.8.2)
 
 project(sysdig)
 
-option(MINIMAL_BUILD "Produce a minimal sysdig binary with only the essential features (no eBPF probe driver, no kubernetes, no mesos, no marathon and no container metadata)" OFF)
-option(MUSL_OPTIMIZED_BUILD "Enable if you want a musl optimized build" OFF)
-
 # Add path for custom CMake modules.
 list(APPEND CMAKE_MODULE_PATH
 	"${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
@@ -58,89 +55,31 @@ endif()
 
 set(PACKAGE_NAME "sysdig")
 
-add_definitions(-DPLATFORM_NAME="${CMAKE_SYSTEM_NAME}")
-add_definitions(-DK8S_DISABLE_THREAD)
+include(CompilerFlags)
 
-option(BUILD_WARNINGS_AS_ERRORS "Enable building with -Wextra -Werror flags")
-
-if(MINIMAL_BUILD)
-  set(MINIMAL_BUILD_FLAGS "-DMINIMAL_BUILD")
-endif()
-
-if(MUSL_OPTIMIZED_BUILD)
-	set(SYSDIG_MUSL_FLAGS "-static -Os")
-endif()
-
-
-if(NOT WIN32)
-
-	set(SYSDIG_DEBUG_FLAGS "-D_DEBUG")
-	set(CMAKE_COMMON_FLAGS "-Wall -ggdb ${MINIMAL_BUILD_FLAGS} ${SYSDIG_MUSL_FLAGS}")
-
-	if(BUILD_WARNINGS_AS_ERRORS)
-		set(CMAKE_SUPPRESSED_WARNINGS "-Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare -Wno-type-limits -Wno-implicit-fallthrough -Wno-format-truncation")
-		set(CMAKE_COMMON_FLAGS "${CMAKE_COMMON_FLAGS} -Wextra -Werror ${CMAKE_SUPPRESSED_WARNINGS}")
-	endif()
-
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_COMMON_FLAGS}")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_COMMON_FLAGS} -std=c++0x")
-
-	set(CMAKE_C_FLAGS_DEBUG "${SYSDIG_DEBUG_FLAGS}")
-	set(CMAKE_CXX_FLAGS_DEBUG "${SYSDIG_DEBUG_FLAGS}")
-
-	set(CMAKE_C_FLAGS_RELEASE "-O3 -fno-strict-aliasing -DNDEBUG")
-	set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fno-strict-aliasing -DNDEBUG")
-
-	if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-		if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-			set(KBUILD_FLAGS "${SYSDIG_DEBUG_FLAGS} ${SYSDIG_FEATURE_FLAGS}")
-		else()
-			set(KBUILD_FLAGS "${SYSDIG_FEATURE_FLAGS}")
-		endif()
-
-		if(NOT DEFINED PROBE_VERSION)
-			set(PROBE_VERSION "${SYSDIG_VERSION}")
-		endif()
-		if(NOT DEFINED PROBE_NAME)
-			set(PROBE_NAME "sysdig-probe")
-		endif()
-
-		if(NOT DEFINED PROBE_DEVICE_NAME)
-			set(PROBE_DEVICE_NAME "sysdig")
-		endif()
-
-		add_subdirectory(driver)
-		add_definitions(-DHAS_CAPTURE)
-	endif()
-
-	add_subdirectory(scripts)
-
-	if(CMAKE_SYSTEM_NAME MATCHES "SunOS")
-		set(CMD_MAKE gmake)
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+		set(KBUILD_FLAGS "${SYSDIG_DEBUG_FLAGS} ${SYSDIG_FEATURE_FLAGS}")
 	else()
-		set(CMD_MAKE make)
+		set(KBUILD_FLAGS "${SYSDIG_FEATURE_FLAGS}")
 	endif()
 
-else()
+	if(NOT DEFINED PROBE_VERSION)
+		set(PROBE_VERSION "${SYSDIG_VERSION}")
+	endif()
+	if(NOT DEFINED PROBE_NAME)
+		set(PROBE_NAME "sysdig-probe")
+	endif()
 
-	set(SYSDIG_FLAGS_WIN "-D_CRT_SECURE_NO_WARNINGS -DWIN32 /EHsc /W3 /Zi")
-	set(SYSDIG_FLAGS_WIN_DEBUG "/MTd /Od")
-	set(SYSDIG_FLAGS_WIN_RELEASE "/MT")
+	if(NOT DEFINED PROBE_DEVICE_NAME)
+		set(PROBE_DEVICE_NAME "sysdig")
+	endif()
 
-	set(CMAKE_C_FLAGS "${SYSDIG_FLAGS_WIN}")
-	set(CMAKE_CXX_FLAGS "${SYSDIG_FLAGS_WIN}")
-
-	set(CMAKE_C_FLAGS_DEBUG "${SYSDIG_FLAGS_WIN_DEBUG}")
-	set(CMAKE_CXX_FLAGS_DEBUG "${SYSDIG_FLAGS_WIN_DEBUG}")
-
-	set(CMAKE_C_FLAGS_RELEASE "${SYSDIG_FLAGS_WIN_RELEASE}")
-	set(CMAKE_CXX_FLAGS_RELEASE "${SYSDIG_FLAGS_WIN_RELEASE}")
-
+	add_subdirectory(driver)
+	add_definitions(-DHAS_CAPTURE)
 endif()
 
-if(APPLE)
-	set(CMAKE_EXE_LINKER_FLAGS "-pagezero_size 10000 -image_base 100000000")
-endif()
+add_subdirectory(scripts)
 
 include(ExternalProject)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,33 +168,7 @@ if(NOT WIN32 AND NOT APPLE)
 endif()
 
 if(NOT WIN32 AND NOT MINIMAL_BUILD)
-	#
-	# OpenSSL
-	#
-	option(USE_BUNDLED_OPENSSL "Enable building of the bundled OpenSSL" ${USE_BUNDLED_DEPS})
-
-	if(NOT USE_BUNDLED_OPENSSL)
-		find_package(OpenSSL REQUIRED)
-		message(STATUS "Found OpenSSL: include: ${OPENSSL_INCLUDE_DIR}, lib: ${OPENSSL_LIBRARIES}")
-	else()
-		set(OPENSSL_BUNDLE_DIR "${PROJECT_BINARY_DIR}/openssl-prefix/src/openssl")
-		set(OPENSSL_INSTALL_DIR "${OPENSSL_BUNDLE_DIR}/target")
-		set(OPENSSL_INCLUDE_DIR "${PROJECT_BINARY_DIR}/openssl-prefix/src/openssl/include")
-		set(OPENSSL_LIBRARY_SSL "${OPENSSL_INSTALL_DIR}/lib/libssl.a")
-		set(OPENSSL_LIBRARY_CRYPTO "${OPENSSL_INSTALL_DIR}/lib/libcrypto.a")
-
-		message(STATUS "Using bundled openssl in '${OPENSSL_BUNDLE_DIR}'")
-
-		ExternalProject_Add(openssl
-			URL "http://download.draios.com/dependencies/openssl-1.0.2n.tar.gz"
-			URL_MD5 "13bdc1b1d1ff39b6fd42a255e74676a4"
-			CONFIGURE_COMMAND ./config shared --prefix=${OPENSSL_INSTALL_DIR}
-			BUILD_COMMAND ${CMD_MAKE}
-			BUILD_IN_SOURCE 1
-			BUILD_BYPRODUCTS ${OPENSSL_LIBRARY_SSL} ${OPENSSL_LIBRARY_CRYPTO}
-			INSTALL_COMMAND ${CMD_MAKE} install)
-	endif()
-
+	include(openssl)
 	#
 	# libcurl
 	#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,42 +185,7 @@ endif() # MINIMAL_BUILD
 
 option(CREATE_TEST_TARGETS "Enable make-targets for unit testing" ON)
 if(CREATE_TEST_TARGETS AND NOT WIN32)
-	option(USE_BUNDLED_GTEST "Enable building of the bundled gtest" ${USE_BUNDLED_DEPS})
-	if(NOT USE_BUNDLED_GTEST)
-		find_path(GTEST_INCLUDE_DIR PATH_SUFFIXES gtest NAMES gtest.h)
-		find_library(GTEST_LIB NAMES gtest)
-		find_library(GTEST_MAIN_LIB NAMES gtest_main)
-		if(GTEST_INCLUDE_DIR AND GTEST_LIB AND GTEST_MAIN_LIB)
-			message(STATUS "Found gtest: include: ${GTEST_INCLUDE_DIR}, lib: ${GTEST_LIB}, main lib: ${GTEST_MAIN_LIB}")
-		else()
-			message(FATAL_ERROR "Couldn't find system gtest")
-		endif()
-	else()
-		# https://github.com/google/googletest/tree/master/googletest#incorporating-into-an-existing-cmake-project
-		# Download and unpack googletest at configure time
-		configure_file(CMakeListsGtestInclude.cmake googletest-download/CMakeLists.txt)
-		execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-			RESULT_VARIABLE result
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-		if(result)
-			message(FATAL_ERROR "CMake step for googletest failed: ${result}")
-		endif()
-		execute_process(COMMAND ${CMAKE_COMMAND} --build .
-			RESULT_VARIABLE result
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-		if(result)
-			message(FATAL_ERROR "Build step for googletest failed: ${result}")
-		endif()
-
-		# Add googletest directly to our build. This defines
-		# the gtest and gtest_main targets.
-		add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
-		                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
-		                 EXCLUDE_FROM_ALL)
-
-		set(GTEST_INCLUDE_DIR "${gtest_SOURCE_DIR}/include/gtest")
-		set(GTEST_MAIN_LIB "gtest_main")
-	endif()
+	include(gtest)
 endif() # NOT WIN32
 
 add_subdirectory(userspace/sysdig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,32 +159,8 @@ if(NOT WIN32 AND NOT APPLE)
 	include(jq)
 endif()
 
-#
-# ncurses, keep it simple for the moment
-#
 if(NOT WIN32)
-	option(USE_BUNDLED_NCURSES "Enable building of the bundled ncurses" ${USE_BUNDLED_DEPS})
-
-	if(NOT USE_BUNDLED_NCURSES)
-		set(CURSES_NEED_NCURSES TRUE)
-		find_package(Curses REQUIRED)
-		message(STATUS "Found ncurses: include: ${CURSES_INCLUDE_DIR}, lib: ${CURSES_LIBRARIES}")
-	else()
-		set(CURSES_BUNDLE_DIR "${PROJECT_BINARY_DIR}/ncurses-prefix/src/ncurses")
-		set(CURSES_INCLUDE_DIR "${CURSES_BUNDLE_DIR}/include/")
-		set(CURSES_LIBRARIES "${CURSES_BUNDLE_DIR}/lib/libncurses.a")
-
-		message(STATUS "Using bundled ncurses in '${CURSES_BUNDLE_DIR}'")
-
-		ExternalProject_Add(ncurses
-			URL "http://download.draios.com/dependencies/ncurses-6.0-20150725.tgz"
-			URL_MD5 "32b8913312e738d707ae68da439ca1f4"
-			CONFIGURE_COMMAND ./configure --without-cxx --without-cxx-binding --without-ada --without-manpages --without-progs --without-tests --with-terminfo-dirs=/etc/terminfo:/lib/terminfo:/usr/share/terminfo
-			BUILD_COMMAND ${CMD_MAKE}
-			BUILD_IN_SOURCE 1
-			BUILD_BYPRODUCTS ${CURSES_LIBRARIES}
-			INSTALL_COMMAND "")
-	endif()
+	include(ncurses)
 endif()
 
 if(NOT WIN32 AND NOT APPLE)

--- a/cmake/modules/CompilerFlags.cmake
+++ b/cmake/modules/CompilerFlags.cmake
@@ -1,0 +1,68 @@
+option(BUILD_WARNINGS_AS_ERRORS "Enable building with -Wextra -Werror flags")
+
+option(MINIMAL_BUILD "Produce a minimal sysdig binary with only the essential features (no eBPF probe driver, no kubernetes, no mesos, no marathon and no container metadata)" OFF)
+if(MINIMAL_BUILD)
+	set(MINIMAL_BUILD_FLAGS "-DMINIMAL_BUILD")
+endif()
+
+option(MUSL_OPTIMIZED_BUILD "Enable if you want a musl optimized build" OFF)
+if(MUSL_OPTIMIZED_BUILD)
+	set(SYSDIG_MUSL_FLAGS "-static -Os")
+endif()
+
+add_definitions(-DPLATFORM_NAME="${CMAKE_SYSTEM_NAME}")
+
+if(NOT WIN32)
+
+	set(DEBUG_FLAGS "-D_DEBUG")
+	set(CMAKE_COMMON_FLAGS "-Wall -ggdb ${MINIMAL_BUILD_FLAGS} ${SYSDIG_MUSL_FLAGS}")
+
+	if(BUILD_WARNINGS_AS_ERRORS)
+		set(CMAKE_SUPPRESSED_WARNINGS "-Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare -Wno-type-limits -Wno-implicit-fallthrough -Wno-format-truncation -Wno-unused-function")
+		set(CMAKE_COMMON_FLAGS "${CMAKE_COMMON_FLAGS} -Wextra -Werror ${CMAKE_SUPPRESSED_WARNINGS}")
+	endif()
+
+	if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+	endif()
+
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_COMMON_FLAGS}")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_COMMON_FLAGS} -std=c++0x")
+
+	set(CMAKE_C_FLAGS_DEBUG "${DEBUG_FLAGS}")
+	set(CMAKE_CXX_FLAGS_DEBUG "${DEBUG_FLAGS}")
+
+	set(CMAKE_C_FLAGS_RELEASE "-O3 -fno-strict-aliasing -DNDEBUG")
+	set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fno-strict-aliasing -DNDEBUG")
+
+	if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+		add_definitions(-DHAS_CAPTURE)
+	endif()
+
+	if(CMAKE_SYSTEM_NAME MATCHES "SunOS")
+		set(CMD_MAKE gmake)
+	else()
+		set(CMD_MAKE make)
+	endif()
+
+else()
+
+	set(SYSDIG_FLAGS_WIN "-D_CRT_SECURE_NO_WARNINGS -DWIN32 /EHsc /W3 /Zi")
+	set(SYSDIG_FLAGS_WIN_DEBUG "/MTd /Od")
+	set(SYSDIG_FLAGS_WIN_RELEASE "/MT")
+
+	set(CMAKE_C_FLAGS "${SYSDIG_FLAGS_WIN}")
+	set(CMAKE_CXX_FLAGS "${SYSDIG_FLAGS_WIN}")
+
+	set(CMAKE_C_FLAGS_DEBUG "${SYSDIG_FLAGS_WIN_DEBUG}")
+	set(CMAKE_CXX_FLAGS_DEBUG "${SYSDIG_FLAGS_WIN_DEBUG}")
+
+	set(CMAKE_C_FLAGS_RELEASE "${SYSDIG_FLAGS_WIN_RELEASE}")
+	set(CMAKE_CXX_FLAGS_RELEASE "${SYSDIG_FLAGS_WIN_RELEASE}")
+
+endif()
+
+if(APPLE)
+	set(CMAKE_EXE_LINKER_FLAGS "-pagezero_size 10000 -image_base 100000000")
+endif()
+

--- a/cmake/modules/b64.cmake
+++ b/cmake/modules/b64.cmake
@@ -1,0 +1,30 @@
+#
+# libb64
+#
+option(USE_BUNDLED_B64 "Enable building of the bundled b64" ${USE_BUNDLED_DEPS})
+
+if(TARGET b64)
+elseif(NOT USE_BUNDLED_B64)
+	find_path(B64_INCLUDE NAMES b64/encode.h)
+	find_library(B64_LIB NAMES b64)
+	if(B64_INCLUDE AND B64_LIB)
+		message(STATUS "Found b64: include: ${B64_INCLUDE}, lib: ${B64_LIB}")
+	else()
+		message(FATAL_ERROR "Couldn't find system b64")
+	endif()
+else()
+	set(B64_SRC "${PROJECT_BINARY_DIR}/b64-prefix/src/b64")
+	message(STATUS "Using bundled b64 in '${B64_SRC}'")
+	set(B64_INCLUDE "${B64_SRC}/include")
+	set(B64_LIB "${B64_SRC}/src/libb64.a")
+	ExternalProject_Add(b64
+		URL "http://download.draios.com/dependencies/libb64-1.2.src.zip"
+		URL_MD5 "a609809408327117e2c643bed91b76c5"
+		CONFIGURE_COMMAND ""
+		BUILD_COMMAND ${CMD_MAKE}
+		BUILD_IN_SOURCE 1
+		BUILD_BYPRODUCTS ${B64_LIB}
+		INSTALL_COMMAND "")
+endif()
+
+include_directories("${B64_INCLUDE}")

--- a/cmake/modules/cares.cmake
+++ b/cmake/modules/cares.cmake
@@ -1,0 +1,29 @@
+#
+# c-ares
+#
+option(USE_BUNDLED_CARES "Enable building of the bundled c-ares" ${USE_BUNDLED_DEPS})
+if(TARGET cares)
+elseif(NOT USE_BUNDLED_CARES)
+	find_path(CARES_INCLUDE NAMES cares/ares.h ares.h)
+	find_library(CARES_LIB NAMES cares)
+	if(CARES_INCLUDE AND CARES_LIB)
+		message(STATUS "Found c-ares: include: ${CARES_INCLUDE}, lib: ${CARES_LIB}")
+	else()
+		message(FATAL_ERROR "Couldn't find system c-ares")
+	endif()
+else()
+	set(CARES_SRC "${PROJECT_BINARY_DIR}/c-ares-prefix/src/c-ares")
+	message(STATUS "Using bundled c-ares in '${CARES_SRC}'")
+	set(CARES_INCLUDE "${CARES_SRC}/target/include")
+	set(CARES_LIB "${CARES_SRC}/target/lib/libcares.a")
+	ExternalProject_Add(c-ares
+		URL "http://download.sysdig.com/dependencies/c-ares-1.13.0.tar.gz"
+		URL_MD5 "d2e010b43537794d8bedfb562ae6bba2"
+		CONFIGURE_COMMAND ./configure --prefix=${CARES_SRC}/target
+		BUILD_COMMAND ${CMD_MAKE}
+		BUILD_IN_SOURCE 1
+		BUILD_BYPRODUCTS ${CARES_INCLUDE} ${CARES_LIB}
+		INSTALL_COMMAND ${CMD_MAKE} install)
+endif()
+
+include_directories("${CARES_INCLUDE}")

--- a/cmake/modules/curl.cmake
+++ b/cmake/modules/curl.cmake
@@ -1,0 +1,34 @@
+#
+# libcurl
+#
+option(USE_BUNDLED_CURL "Enable building of the bundled curl" ${USE_BUNDLED_DEPS})
+
+if(TARGET curl)
+elseif(NOT USE_BUNDLED_CURL)
+	find_package(CURL REQUIRED)
+	message(STATUS "Found CURL: include: ${CURL_INCLUDE_DIR}, lib: ${CURL_LIBRARIES}")
+else()
+	set(CURL_BUNDLE_DIR "${PROJECT_BINARY_DIR}/curl-prefix/src/curl")
+	set(CURL_INCLUDE_DIR "${CURL_BUNDLE_DIR}/include/")
+	set(CURL_LIBRARIES "${CURL_BUNDLE_DIR}/lib/.libs/libcurl.a")
+
+	if(NOT USE_BUNDLED_OPENSSL)
+		set(CURL_SSL_OPTION "--with-ssl")
+	else()
+		set(CURL_SSL_OPTION "--with-ssl=${OPENSSL_INSTALL_DIR}")
+		message(STATUS "Using bundled curl in '${CURL_BUNDLE_DIR}'")
+		message(STATUS "Using SSL for curl in '${CURL_SSL_OPTION}'")
+	endif()
+
+
+	ExternalProject_Add(curl
+		DEPENDS openssl
+		URL "http://download.draios.com/dependencies/curl-7.61.0.tar.bz2"
+		URL_MD5 "31d0a9f48dc796a7db351898a1e5058a"
+		CONFIGURE_COMMAND ./configure ${CURL_SSL_OPTION} --disable-threaded-resolver --disable-shared --enable-optimize --disable-curldebug --disable-rt --enable-http --disable-ftp --disable-file --disable-ldap --disable-ldaps --disable-rtsp --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-sspi --disable-ntlm-wb --disable-tls-srp --without-winssl --without-darwinssl --without-polarssl --without-cyassl --without-nss --without-axtls --without-ca-path --without-ca-bundle --without-libmetalink --without-librtmp --without-winidn --without-libidn --without-libidn2 --without-nghttp2 --without-libssh2  --without-libpsl
+		BUILD_COMMAND ${CMD_MAKE}
+		BUILD_IN_SOURCE 1
+		BUILD_BYPRODUCTS ${CURL_LIBRARIES}
+		INSTALL_COMMAND "")
+endif()
+include_directories("${CURL_INCLUDE_DIR}")

--- a/cmake/modules/grpc.cmake
+++ b/cmake/modules/grpc.cmake
@@ -1,0 +1,52 @@
+option(USE_BUNDLED_GRPC "Enable building of the bundled grpc" ${USE_BUNDLED_DEPS})
+if(TARGET grpc)
+elseif(NOT USE_BUNDLED_GRPC)
+	find_path(GRPCXX_INCLUDE NAMES grpc++/grpc++.h)
+	if(GRPCXX_INCLUDE)
+		set(GRPC_INCLUDE ${GRPCXX_INCLUDE})
+	else()
+		find_path(GRPCPP_INCLUDE NAMES grpcpp/grpcpp.h)
+		set(GRPC_INCLUDE ${GRPCPP_INCLUDE})
+		add_definitions(-DGRPC_INCLUDE_IS_GRPCPP=1)
+	endif()
+	find_library(GRPC_LIB NAMES grpc_unsecure)
+	find_library(GRPCPP_LIB NAMES grpc++_unsecure)
+	if(GRPC_INCLUDE AND GRPC_LIB AND GRPCPP_LIB)
+		message(STATUS "Found grpc: include: ${GRPC_INCLUDE}, C lib: ${GRPC_LIB}, C++ lib: ${GRPCPP_LIB}")
+	else()
+		message(FATAL_ERROR "Couldn't find system grpc")
+	endif()
+	find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin)
+	if(NOT GRPC_CPP_PLUGIN)
+		message(FATAL_ERROR "System grpc_cpp_plugin not found")
+	endif()
+else()
+	find_package(PkgConfig)
+	if(NOT PKG_CONFIG_FOUND)
+		message(FATAL_ERROR "pkg-config binary not found")
+	endif()
+	message(STATUS "Found pkg-config executable: ${PKG_CONFIG_EXECUTABLE}")
+	set(GRPC_SRC "${PROJECT_BINARY_DIR}/grpc-prefix/src/grpc")
+	message(STATUS "Using bundled grpc in '${GRPC_SRC}'")
+	set(GRPC_INCLUDE "${GRPC_SRC}/include")
+	set(GRPC_LIB "${GRPC_SRC}/libs/opt/libgrpc_unsecure.a")
+	set(GRPCPP_LIB "${GRPC_SRC}/libs/opt/libgrpc++_unsecure.a")
+	set(GRPC_CPP_PLUGIN "${GRPC_SRC}/bins/opt/grpc_cpp_plugin")
+
+	get_filename_component(PROTOC_DIR ${PROTOC} PATH)
+
+	ExternalProject_Add(grpc
+		DEPENDS protobuf zlib c-ares
+		URL "http://download.draios.com/dependencies/grpc-1.8.1.tar.gz"
+		URL_MD5 "2fc42c182a0ed1b48ad77397f76bb3bc"
+		CONFIGURE_COMMAND ""
+		# TODO what if using system openssl, protobuf or cares?
+		BUILD_COMMAND CFLAGS=-Wno-implicit-fallthrough HAS_SYSTEM_ZLIB=false LDFLAGS=-static PATH=${PROTOC_DIR}:$ENV{PATH} PKG_CONFIG_PATH=${OPENSSL_BUNDLE_DIR}:${PROTOBUF_SRC}:${CARES_SRC} PKG_CONFIG=${PKG_CONFIG_EXECUTABLE} make grpc_cpp_plugin static_cxx static_c
+		BUILD_IN_SOURCE 1
+		BUILD_BYPRODUCTS ${GRPC_LIB} ${GRPCPP_LIB}
+		# TODO s390x support
+		# TODO what if using system zlib
+		PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && wget https://download.sysdig.com/dependencies/grpc-1.8.1-Makefile.patch && patch < grpc-1.8.1-Makefile.patch
+		INSTALL_COMMAND "")
+endif()
+include_directories("${GRPC_INCLUDE}")

--- a/cmake/modules/gtest.cmake
+++ b/cmake/modules/gtest.cmake
@@ -1,0 +1,38 @@
+option(USE_BUNDLED_GTEST "Enable building of the bundled gtest" ${USE_BUNDLED_DEPS})
+if(TARGET gtest)
+elseif(NOT USE_BUNDLED_GTEST)
+	find_path(GTEST_INCLUDE_DIR PATH_SUFFIXES gtest NAMES gtest.h)
+	find_library(GTEST_LIB NAMES gtest)
+	find_library(GTEST_MAIN_LIB NAMES gtest_main)
+	if(GTEST_INCLUDE_DIR AND GTEST_LIB AND GTEST_MAIN_LIB)
+		message(STATUS "Found gtest: include: ${GTEST_INCLUDE_DIR}, lib: ${GTEST_LIB}, main lib: ${GTEST_MAIN_LIB}")
+	else()
+		message(FATAL_ERROR "Couldn't find system gtest")
+	endif()
+else()
+	# https://github.com/google/googletest/tree/master/googletest#incorporating-into-an-existing-cmake-project
+	# Download and unpack googletest at configure time
+	configure_file(CMakeListsGtestInclude.cmake googletest-download/CMakeLists.txt)
+	execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+		RESULT_VARIABLE result
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+	if(result)
+		message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+	endif()
+	execute_process(COMMAND ${CMAKE_COMMAND} --build .
+		RESULT_VARIABLE result
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+	if(result)
+		message(FATAL_ERROR "Build step for googletest failed: ${result}")
+	endif()
+
+	# Add googletest directly to our build. This defines
+	# the gtest and gtest_main targets.
+	add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+		${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+		EXCLUDE_FROM_ALL)
+
+	set(GTEST_INCLUDE_DIR "${gtest_SOURCE_DIR}/include/gtest")
+	set(GTEST_MAIN_LIB "gtest_main")
+endif()
+include_directories("${GTEST_INCLUDE_DIR}")

--- a/cmake/modules/jq.cmake
+++ b/cmake/modules/jq.cmake
@@ -1,0 +1,33 @@
+#
+# jq
+#
+option(USE_BUNDLED_JQ "Enable building of the bundled jq" ${USE_BUNDLED_DEPS})
+
+if (TARGET jq)
+elseif(NOT USE_BUNDLED_JQ)
+	find_path(JQ_INCLUDE jq.h PATH_SUFFIXES jq)
+	find_library(JQ_LIB NAMES jq)
+	if(JQ_INCLUDE AND JQ_LIB)
+		message(STATUS "Found jq: include: ${JQ_INCLUDE}, lib: ${JQ_LIB}")
+	else()
+		message(FATAL_ERROR "Couldn't find system jq")
+	endif()
+else()
+	set(JQ_SRC "${PROJECT_BINARY_DIR}/jq-prefix/src/jq")
+	message(STATUS "Using bundled jq in '${JQ_SRC}'")
+	set(JQ_INCLUDE "${JQ_SRC}/target/include")
+	set(JQ_INSTALL_DIR "${JQ_SRC}/target")
+	set(JQ_LIB "${JQ_INSTALL_DIR}/lib/libjq.a")
+	set(ONIGURUMA_LIB "${JQ_INSTALL_DIR}/lib/libonig.a")
+	message(STATUS "Bundled jq: include: ${JQ_INCLUDE}, lib: ${JQ_LIB}")
+
+	ExternalProject_Add(
+		jq
+		URL "http://download.draios.com/dependencies/jq-1.6.tar.gz"
+		URL_HASH "SHA256=787518068c35e244334cc79b8e56b60dbab352dff175b7f04a94f662b540bfd9"
+		CONFIGURE_COMMAND ./configure --disable-maintainer-mode --enable-all-static --disable-dependency-tracking --with-oniguruma=builtin --prefix=${JQ_INSTALL_DIR}
+		BUILD_COMMAND ${CMD_MAKE} LDFLAGS=-all-static
+		BUILD_IN_SOURCE 1
+		INSTALL_COMMAND ${CMD_MAKE} install)
+endif()
+include_directories("${JQ_INCLUDE}")

--- a/cmake/modules/jsoncpp.cmake
+++ b/cmake/modules/jsoncpp.cmake
@@ -1,0 +1,22 @@
+#
+# JsonCpp
+#
+option(USE_BUNDLED_JSONCPP "Enable building of the bundled jsoncpp" ${USE_BUNDLED_DEPS})
+
+if(JSONCPP_INCLUDE AND JSONCPP_LIB)
+	message(STATUS "Using jsoncpp: include: ${JSONCPP_INCLUDE}, lib: ${JSONCPP_LIB}")
+elseif(NOT USE_BUNDLED_JSONCPP)
+	find_path(JSONCPP_INCLUDE json/json.h PATH_SUFFIXES jsoncpp)
+	find_library(JSONCPP_LIB NAMES jsoncpp)
+	if(JSONCPP_INCLUDE AND JSONCPP_LIB)
+		message(STATUS "Found jsoncpp: include: ${JSONCPP_INCLUDE}, lib: ${JSONCPP_LIB}")
+	else()
+		message(FATAL_ERROR "Couldn't find system jsoncpp")
+	endif()
+else()
+	set(JSONCPP_SRC "${CMAKE_CURRENT_LIST_DIR}/../../userspace/libsinsp/third-party/jsoncpp")
+	set(JSONCPP_INCLUDE "${JSONCPP_SRC}")
+	set(JSONCPP_LIB_SRC "${JSONCPP_SRC}/jsoncpp.cpp")
+	message(STATUS "Using bundled jsoncpp in '${JSONCPP_SRC}'")
+endif()
+include_directories("${JSONCPP_INCLUDE}")

--- a/cmake/modules/libscap.cmake
+++ b/cmake/modules/libscap.cmake
@@ -1,0 +1,49 @@
+include(CompilerFlags)
+
+if(NOT LIBSCAP_DIR)
+	get_filename_component(LIBSCAP_DIR ${CMAKE_CURRENT_LIST_DIR}/../.. ABSOLUTE)
+endif()
+
+include(ExternalProject)
+
+option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system ones" ON)
+
+if(NOT MINIMAL_BUILD)
+	include(zlib)
+endif() # MINIMAL_BUILD
+
+add_definitions(-DPLATFORM_NAME="${CMAKE_SYSTEM_NAME}")
+
+get_filename_component(DRIVER_CONFIG_DIR ${CMAKE_BINARY_DIR}/driver/src ABSOLUTE)
+get_filename_component(LIBSCAP_INCLUDE_DIR ${LIBSCAP_DIR}/userspace/libscap ABSOLUTE)
+set(LIBSCAP_INCLUDE_DIRS ${LIBSCAP_INCLUDE_DIR} ${DRIVER_CONFIG_DIR})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+		set(KBUILD_FLAGS "${SYSDIG_DEBUG_FLAGS}")
+	else()
+		set(KBUILD_FLAGS "")
+	endif()
+
+	if(NOT DEFINED PROBE_VERSION)
+		set(PROBE_VERSION "${SYSDIG_VERSION}")
+	endif()
+	if(NOT DEFINED PROBE_NAME)
+		set(PROBE_NAME "sysdig-probe")
+	endif()
+
+	if(NOT DEFINED PROBE_DEVICE_NAME)
+		set(PROBE_DEVICE_NAME "sysdig")
+	endif()
+
+	add_definitions(-DHAS_CAPTURE)
+	add_subdirectory(${LIBSCAP_DIR}/driver ${CMAKE_BINARY_DIR}/driver)
+endif()
+
+add_subdirectory(${LIBSCAP_DIR}/userspace/libscap ${CMAKE_BINARY_DIR}/libscap)
+
+get_directory_property(hasParent PARENT_DIRECTORY)
+if(hasParent)
+	set(LIBSCAP_INCLUDE_DIRS ${LIBSCAP_INCLUDE_DIRS} PARENT_SCOPE)
+	set(DRIVER_CONFIG_DIR ${DRIVER_CONFIG_DIR} PARENT_SCOPE)
+endif()

--- a/cmake/modules/libsinsp-tests.cmake
+++ b/cmake/modules/libsinsp-tests.cmake
@@ -1,0 +1,11 @@
+include(gtest)
+
+# Add unit test directories
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../userspace/libsinsp/test ${CMAKE_BINARY_DIR}/libsinsp/test)
+
+# Add command to run all unit tests at once via the make system.
+# This is preferred vs using ctest's add_test because it will build
+# the code and output to stdout.
+add_custom_target(run-unit-tests
+	COMMAND ${CMAKE_MAKE_PROGRAM} run-unit-test-libsinsp
+	)

--- a/cmake/modules/libsinsp.cmake
+++ b/cmake/modules/libsinsp.cmake
@@ -1,0 +1,53 @@
+include(CompilerFlags)
+
+if(NOT LIBSINSP_DIR)
+	get_filename_component(LIBSINSP_DIR ${CMAKE_CURRENT_LIST_DIR}/../.. ABSOLUTE)
+endif()
+
+if(LIBSCAP_DIR)
+	list(APPEND CMAKE_MODULE_PATH ${LIBSCAP_DIR}/cmake/modules)
+endif()
+
+include(ExternalProject)
+
+include(luajit)
+include(jsoncpp)
+include(tbb)
+
+if(NOT MINIMAL_BUILD)
+	include(zlib)
+	include(cares)
+endif() # NOT MINIMAL_BUILD
+
+if(NOT WIN32 AND NOT MINIMAL_BUILD)
+	include(openssl)
+	include(curl)
+endif() # NOT WIN32 AND NOT MINIMAL_BUILD
+
+if(NOT WIN32 AND NOT APPLE)
+	include(jq)
+	include(b64)
+	if(NOT MINIMAL_BUILD)
+		include(protobuf)
+		include(grpc)
+	endif() # MINIMAL_BUILD
+endif()
+
+if(NOT WIN32)
+	include(ncurses)
+endif()
+
+include(libscap)
+
+set(LIBSINSP_INCLUDE_DIRS ${LIBSINSP_DIR}/userspace/libsinsp ${LIBSCAP_INCLUDE_DIRS} ${DRIVER_CONFIG_DIR})
+get_filename_component(TBB_ABSOLUTE_INCLUDE_DIR ${TBB_INCLUDE_DIR} ABSOLUTE)
+list(APPEND LIBSINSP_INCLUDE_DIRS ${TBB_ABSOLUTE_INCLUDE_DIR})
+get_filename_component(JSONCPP_ABSOLUTE_INCLUDE_DIR ${JSONCPP_INCLUDE} ABSOLUTE)
+list(APPEND LIBSINSP_INCLUDE_DIRS ${JSONCPP_ABSOLUTE_INCLUDE_DIR})
+
+get_directory_property(hasParent PARENT_DIRECTORY)
+if(hasParent)
+	set(LIBSINSP_INCLUDE_DIRS ${LIBSINSP_INCLUDE_DIRS} PARENT_SCOPE)
+	set(CURSES_LIBRARIES ${CURSES_LIBRARIES} PARENT_SCOPE)
+endif()
+add_subdirectory(${LIBSINSP_DIR}/userspace/libsinsp ${CMAKE_BINARY_DIR}/libsinsp)

--- a/cmake/modules/luajit.cmake
+++ b/cmake/modules/luajit.cmake
@@ -1,0 +1,71 @@
+#
+# LuaJIT
+#
+option(USE_BUNDLED_LUAJIT "Enable building of the bundled LuaJIT" ${USE_BUNDLED_DEPS})
+
+if(TARGET luajit)
+	message("Already have luajit")
+elseif(NOT USE_BUNDLED_LUAJIT)
+	find_path(LUAJIT_INCLUDE luajit.h PATH_SUFFIXES luajit-2.0 luajit)
+	find_library(LUAJIT_LIB NAMES luajit luajit-5.1)
+	if(LUAJIT_INCLUDE AND LUAJIT_LIB)
+		message(STATUS "Found LuaJIT: include: ${LUAJIT_INCLUDE}, lib: ${LUAJIT_LIB}")
+	else()
+		# alternatively try stock Lua
+		find_package(Lua51)
+		set(LUAJIT_LIB ${LUA_LIBRARY})
+		set(LUAJIT_INCLUDE ${LUA_INCLUDE_DIR})
+
+		if(NOT ${LUA51_FOUND})
+			message(FATAL_ERROR "Couldn't find system LuaJIT or Lua")
+		endif()
+	endif()
+else()
+	set(LUAJIT_SRC "${PROJECT_BINARY_DIR}/luajit-prefix/src/luajit/src")
+	message(STATUS "Using bundled LuaJIT in '${LUAJIT_SRC}'")
+	set(LUAJIT_INCLUDE "${LUAJIT_SRC}")
+	if(NOT WIN32)
+		set(LUAJIT_LIB "${LUAJIT_SRC}/libluajit.a")
+		if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+			ExternalProject_Add(luajit
+				GIT_REPOSITORY "https://github.com/moonjit/moonjit"
+				GIT_TAG "2.1.2"
+				PATCH_COMMAND sed -i "s/luaL_reg/luaL_Reg/g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/chisel.cpp && sed -i "s/luaL_reg/luaL_Reg/g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/lua_parser.cpp && sed -i "s/luaL_getn/lua_objlen /g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/lua_parser_api.cpp
+				CONFIGURE_COMMAND ""
+				BUILD_COMMAND ${CMD_MAKE}
+				BUILD_IN_SOURCE 1
+				BUILD_BYPRODUCTS ${LUAJIT_LIB}
+				INSTALL_COMMAND "")
+		elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
+			ExternalProject_Add(luajit
+				GIT_REPOSITORY "https://github.com/linux-on-ibm-z/LuaJIT.git"
+				GIT_TAG "v2.1"
+				PATCH_COMMAND sed -i "s/luaL_reg/luaL_Reg/g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/chisel.cpp && sed -i "s/luaL_reg/luaL_Reg/g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/lua_parser.cpp && sed -i "s/luaL_getn/lua_objlen /g" ${PROJECT_SOURCE_DIR}/userspace/libsinsp/lua_parser_api.cpp
+				CONFIGURE_COMMAND ""
+				BUILD_COMMAND ${CMD_MAKE}
+				BUILD_IN_SOURCE 1
+				BUILD_BYPRODUCTS ${LUAJIT_LIB}
+				INSTALL_COMMAND "")
+		else()
+			ExternalProject_Add(luajit
+				URL "http://download.draios.com/dependencies/LuaJIT-2.0.3.tar.gz"
+				URL_MD5 "f14e9104be513913810cd59c8c658dc0"
+				CONFIGURE_COMMAND ""
+				BUILD_COMMAND ${CMD_MAKE}
+				BUILD_IN_SOURCE 1
+				BUILD_BYPRODUCTS ${LUAJIT_LIB}
+				INSTALL_COMMAND "")
+		endif()
+	else()
+		set(LUAJIT_LIB "${LUAJIT_SRC}/lua51.lib")
+		ExternalProject_Add(luajit
+			URL "http://download.draios.com/dependencies/LuaJIT-2.0.3.tar.gz"
+			URL_MD5 "f14e9104be513913810cd59c8c658dc0"
+			CONFIGURE_COMMAND ""
+			BUILD_COMMAND msvcbuild.bat
+			BUILD_BYPRODUCTS ${LUAJIT_LIB}
+			BINARY_DIR "${LUAJIT_SRC}"
+			INSTALL_COMMAND "")
+	endif()
+endif()
+include_directories("${LUAJIT_INCLUDE}")

--- a/cmake/modules/ncurses.cmake
+++ b/cmake/modules/ncurses.cmake
@@ -1,0 +1,27 @@
+#
+# ncurses, keep it simple for the moment
+#
+option(USE_BUNDLED_NCURSES "Enable building of the bundled ncurses" ${USE_BUNDLED_DEPS})
+
+if(TARGET ncurses)
+elseif(NOT USE_BUNDLED_NCURSES)
+	set(CURSES_NEED_NCURSES TRUE)
+	find_package(Curses REQUIRED)
+	message(STATUS "Found ncurses: include: ${CURSES_INCLUDE_DIR}, lib: ${CURSES_LIBRARIES}")
+else()
+	set(CURSES_BUNDLE_DIR "${PROJECT_BINARY_DIR}/ncurses-prefix/src/ncurses")
+	set(CURSES_INCLUDE_DIR "${CURSES_BUNDLE_DIR}/include/")
+	set(CURSES_LIBRARIES "${CURSES_BUNDLE_DIR}/lib/libncurses.a")
+
+	message(STATUS "Using bundled ncurses in '${CURSES_BUNDLE_DIR}'")
+
+	ExternalProject_Add(ncurses
+		URL "http://download.draios.com/dependencies/ncurses-6.0-20150725.tgz"
+		URL_MD5 "32b8913312e738d707ae68da439ca1f4"
+		CONFIGURE_COMMAND ./configure --without-cxx --without-cxx-binding --without-ada --without-manpages --without-progs --without-tests --with-terminfo-dirs=/etc/terminfo:/lib/terminfo:/usr/share/terminfo
+		BUILD_COMMAND ${CMD_MAKE}
+		BUILD_IN_SOURCE 1
+		BUILD_BYPRODUCTS ${CURSES_LIBRARIES}
+		INSTALL_COMMAND "")
+endif()
+include_directories("${CURSES_INCLUDE_DIR}")

--- a/cmake/modules/openssl.cmake
+++ b/cmake/modules/openssl.cmake
@@ -1,0 +1,28 @@
+#
+# OpenSSL
+#
+option(USE_BUNDLED_OPENSSL "Enable building of the bundled OpenSSL" ${USE_BUNDLED_DEPS})
+
+if(TARGET openssl)
+elseif(NOT USE_BUNDLED_OPENSSL)
+	find_package(OpenSSL REQUIRED)
+	message(STATUS "Found OpenSSL: include: ${OPENSSL_INCLUDE_DIR}, lib: ${OPENSSL_LIBRARIES}")
+else()
+	set(OPENSSL_BUNDLE_DIR "${PROJECT_BINARY_DIR}/openssl-prefix/src/openssl")
+	set(OPENSSL_INSTALL_DIR "${OPENSSL_BUNDLE_DIR}/target")
+	set(OPENSSL_INCLUDE_DIR "${PROJECT_BINARY_DIR}/openssl-prefix/src/openssl/include")
+	set(OPENSSL_LIBRARY_SSL "${OPENSSL_INSTALL_DIR}/lib/libssl.a")
+	set(OPENSSL_LIBRARY_CRYPTO "${OPENSSL_INSTALL_DIR}/lib/libcrypto.a")
+
+	message(STATUS "Using bundled openssl in '${OPENSSL_BUNDLE_DIR}'")
+
+	ExternalProject_Add(openssl
+		URL "http://download.draios.com/dependencies/openssl-1.0.2n.tar.gz"
+		URL_MD5 "13bdc1b1d1ff39b6fd42a255e74676a4"
+		CONFIGURE_COMMAND ./config shared --prefix=${OPENSSL_INSTALL_DIR}
+		BUILD_COMMAND ${CMD_MAKE}
+		BUILD_IN_SOURCE 1
+		BUILD_BYPRODUCTS ${OPENSSL_LIBRARY_SSL} ${OPENSSL_LIBRARY_CRYPTO}
+		INSTALL_COMMAND ${CMD_MAKE} install)
+endif()
+include_directories("${OPENSSL_INCLUDE_DIR}")

--- a/cmake/modules/protobuf.cmake
+++ b/cmake/modules/protobuf.cmake
@@ -1,0 +1,44 @@
+option(USE_BUNDLED_PROTOBUF "Enable building of the bundled protobuf" ${USE_BUNDLED_DEPS})
+if(TARGET protobuf)
+elseif(NOT USE_BUNDLED_PROTOBUF)
+	find_program(PROTOC NAMES protoc)
+	find_path(PROTOBUF_INCLUDE NAMES google/protobuf/message.h)
+	find_library(PROTOBUF_LIB NAMES protobuf)
+	if(PROTOC AND PROTOBUF_INCLUDE AND PROTOBUF_LIB)
+		message(STATUS "Found protobuf: compiler: ${PROTOC}, include: ${PROTOBUF_INCLUDE}, lib: ${PROTOBUF_LIB}")
+	else()
+		message(FATAL_ERROR "Couldn't find system protobuf")
+	endif()
+else()
+	set(PROTOBUF_SRC "${PROJECT_BINARY_DIR}/protobuf-prefix/src/protobuf")
+	message(STATUS "Using bundled protobuf in '${PROTOBUF_SRC}'")
+	set(PROTOC "${PROTOBUF_SRC}/target/bin/protoc")
+	set(PROTOBUF_INCLUDE "${PROTOBUF_SRC}/target/include")
+	set(PROTOBUF_LIB "${PROTOBUF_SRC}/target/lib/libprotobuf.a")
+	if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
+		ExternalProject_Add(protobuf
+			DEPENDS openssl zlib
+			URL "http://download.sysdig.com/dependencies/protobuf-cpp-3.5.0.tar.gz"
+			URL_MD5 "e4ba8284a407712168593e79e6555eb2"
+			PATCH_COMMAND wget http://download.sysdig.com/dependencies/protobuf-3.5.0-s390x.patch && patch -p1 -i protobuf-3.5.0-s390x.patch
+			# TODO what if using system zlib?
+			CONFIGURE_COMMAND /usr/bin/env CPPFLAGS=-I${ZLIB_INCLUDE} LDFLAGS=-L${ZLIB_SRC} ./configure --with-zlib --prefix=${PROTOBUF_SRC}/target
+			COMMAND aclocal && automake
+			BUILD_COMMAND ${CMD_MAKE}
+			BUILD_IN_SOURCE 1
+			BUILD_BYPRODUCTS ${PROTOC} ${PROTOBUF_INCLUDE} ${PROTOBUF_LIB}
+			INSTALL_COMMAND make install)
+	else()
+		ExternalProject_Add(protobuf
+			DEPENDS openssl zlib
+			URL "http://download.sysdig.com/dependencies/protobuf-cpp-3.5.0.tar.gz"
+			URL_MD5 "e4ba8284a407712168593e79e6555eb2"
+			# TODO what if using system zlib?
+			CONFIGURE_COMMAND /usr/bin/env CPPFLAGS=-I${ZLIB_INCLUDE} LDFLAGS=-L${ZLIB_SRC} ./configure --with-zlib --prefix=${PROTOBUF_SRC}/target
+			BUILD_COMMAND ${CMD_MAKE}
+			BUILD_IN_SOURCE 1
+			BUILD_BYPRODUCTS ${PROTOC} ${PROTOBUF_INCLUDE} ${PROTOBUF_LIB}
+			INSTALL_COMMAND make install)
+	endif()
+endif()
+include_directories("${PROTOBUF_INCLUDE}")

--- a/cmake/modules/tbb.cmake
+++ b/cmake/modules/tbb.cmake
@@ -1,0 +1,32 @@
+#
+# Intel tbb
+#
+if(TARGET tbb)
+elseif(NOT WIN32)
+	option(USE_BUNDLED_TBB "Enable building of the bundled tbb" ${USE_BUNDLED_DEPS})
+	if(NOT USE_BUNDLED_TBB)
+		find_path(TBB_INCLUDE_DIR tbb.h PATH_SUFFIXES tbb)
+		find_library(TBB_LIB NAMES tbb)
+		if(TBB_INCLUDE_DIR AND TBB_LIB)
+			message(STATUS "Found tbb: include: ${TBB_INCLUDE_DIR}, lib: ${TBB_LIB}")
+		else()
+			message(FATAL_ERROR "Couldn't find system tbb")
+		endif()
+	else()
+		set(TBB_SRC "${PROJECT_BINARY_DIR}/tbb-prefix/src/tbb")
+
+		message(STATUS "Using bundled tbb in '${TBB_SRC}'")
+
+		set(TBB_INCLUDE_DIR "${TBB_SRC}/include/")
+		set(TBB_LIB "${TBB_SRC}/build/lib_release/libtbb.a")
+		ExternalProject_Add(tbb
+			URL "http://s3.amazonaws.com/download.draios.com/dependencies/tbb-2018_U5.tar.gz"
+			URL_MD5 "ff3ae09f8c23892fbc3008c39f78288f"
+			CONFIGURE_COMMAND ""
+			BUILD_COMMAND ${CMD_MAKE} tbb_build_dir=${TBB_SRC}/build tbb_build_prefix=lib extra_inc=big_iron.inc
+			BUILD_IN_SOURCE 1
+			BUILD_BYPRODUCTS ${TBB_LIB}
+			INSTALL_COMMAND "")
+	endif()
+endif()
+include_directories("${TBB_INCLUDE_DIR}")

--- a/cmake/modules/zlib.cmake
+++ b/cmake/modules/zlib.cmake
@@ -1,0 +1,41 @@
+#
+# zlib
+#
+option(USE_BUNDLED_ZLIB "Enable building of the bundled zlib" ${USE_BUNDLED_DEPS})
+
+if(TARGET zlib)
+elseif(NOT USE_BUNDLED_ZLIB)
+	find_path(ZLIB_INCLUDE zlib.h PATH_SUFFIXES zlib)
+	find_library(ZLIB_LIB NAMES z)
+	if(ZLIB_INCLUDE AND ZLIB_LIB)
+		message(STATUS "Found zlib: include: ${ZLIB_INCLUDE}, lib: ${ZLIB_LIB}")
+	else()
+		message(FATAL_ERROR "Couldn't find system zlib")
+	endif()
+else()
+	set(ZLIB_SRC "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib")
+	message(STATUS "Using bundled zlib in '${ZLIB_SRC}'")
+	set(ZLIB_INCLUDE "${ZLIB_SRC}")
+	if(NOT WIN32)
+		set(ZLIB_LIB "${ZLIB_SRC}/libz.a")
+		ExternalProject_Add(zlib
+			URL "http://download.draios.com/dependencies/zlib-1.2.11.tar.gz"
+			URL_MD5 "1c9f62f0778697a09d36121ead88e08e"
+			CONFIGURE_COMMAND "./configure"
+			BUILD_COMMAND ${CMD_MAKE}
+			BUILD_IN_SOURCE 1
+			BUILD_BYPRODUCTS ${ZLIB_LIB}
+			INSTALL_COMMAND "")
+	else()
+		set(ZLIB_LIB "${ZLIB_SRC}/zdll.lib")
+		ExternalProject_Add(zlib
+			URL "http://download.draios.com/dependencies/zlib-1.2.11.tar.gz"
+			URL_MD5 "1c9f62f0778697a09d36121ead88e08e"
+			CONFIGURE_COMMAND ""
+			BUILD_COMMAND nmake -f win32/Makefile.msc
+			BUILD_IN_SOURCE 1
+			BUILD_BYPRODUCTS ${ZLIB_LIB}
+			INSTALL_COMMAND "")
+	endif()
+endif()
+include_directories("${ZLIB_INCLUDE}")

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -16,9 +16,6 @@
 # limitations under the License.
 #
 include_directories("${PROJECT_SOURCE_DIR}/common")
-if(NOT MINIMAL_BUILD)
-include_directories("${ZLIB_INCLUDE}")
-endif()
 if(CYGWIN)
 include_directories("${WIN_HAL_INCLUDE}")
 endif()

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -20,7 +20,6 @@ include_directories(../../common)
 include_directories(../libscap)
 include_directories(../async)
 include_directories(./include)
-include_directories("${JSONCPP_INCLUDE}")
 include_directories("${LUAJIT_INCLUDE}")
 
 if(NOT MINIMAL_BUILD)

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -33,7 +33,6 @@ if(NOT WIN32 AND NOT APPLE)
 		include_directories("${OPENSSL_INCLUDE_DIR}")
 		include_directories("${CURL_INCLUDE_DIR}")
 	endif() # NOT MINIMAL_BUILD
-	include_directories("${JQ_INCLUDE}")
 	include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -37,10 +37,6 @@ if(NOT WIN32 AND NOT APPLE)
 	include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 
-if(NOT WIN32)
-	include_directories("${TBB_INCLUDE_DIR}")
-endif() # NOT WIN32
-
 set(SINSP_SOURCES
 	chisel.cpp
 	chisel_api.cpp

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -22,9 +22,6 @@ include_directories(../async)
 include_directories(./include)
 
 if(NOT WIN32 AND NOT APPLE)
-	if(NOT MINIMAL_BUILD)
-		include_directories("${GRPC_INCLUDE}")
-	endif() # NOT MINIMAL_BUILD
 	include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -24,7 +24,6 @@ include_directories(./include)
 if(NOT WIN32 AND NOT APPLE)
 	if(NOT MINIMAL_BUILD)
 		include_directories("${GRPC_INCLUDE}")
-		include_directories("${PROTOBUF_INCLUDE}")
 	endif() # NOT MINIMAL_BUILD
 	include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 endif()

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -29,7 +29,6 @@ if(NOT WIN32 AND NOT APPLE)
 	if(NOT MINIMAL_BUILD)
 		include_directories("${GRPC_INCLUDE}")
 		include_directories("${PROTOBUF_INCLUDE}")
-		include_directories("${CURL_INCLUDE_DIR}")
 	endif() # NOT MINIMAL_BUILD
 	include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 endif()

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -26,7 +26,6 @@ if(NOT MINIMAL_BUILD)
 endif()
 
 if(NOT WIN32 AND NOT APPLE)
-	include_directories("${CURSES_INCLUDE_DIR}")
 	if(NOT MINIMAL_BUILD)
 		include_directories("${GRPC_INCLUDE}")
 		include_directories("${PROTOBUF_INCLUDE}")

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -20,7 +20,6 @@ include_directories(../../common)
 include_directories(../libscap)
 include_directories(../async)
 include_directories(./include)
-include_directories("${LUAJIT_INCLUDE}")
 
 if(NOT MINIMAL_BUILD)
 	include_directories("${CARES_INCLUDE}")

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -15,11 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_directories(./)
-include_directories(../../common)
-include_directories(../libscap)
+include_directories(${LIBSINSP_INCLUDE_DIRS})
 include_directories(../async)
-include_directories(./include)
 
 if(NOT WIN32 AND NOT APPLE)
 	include_directories("${CMAKE_CURRENT_BINARY_DIR}")

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -229,7 +229,7 @@ if(NOT WIN32)
 		endif() # NOT MINIMAL_BUILD
 		# when JQ is compiled statically, it will
 		# also compile a static object for oniguruma we need to link
-		if(USE_BUNDLED_JQ)
+		if(ONIGURUMA_LIB)
 			target_link_libraries(sinsp
 			"${ONIGURUMA_LIB}")
 		endif()

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -29,7 +29,6 @@ if(NOT WIN32 AND NOT APPLE)
 	if(NOT MINIMAL_BUILD)
 		include_directories("${GRPC_INCLUDE}")
 		include_directories("${PROTOBUF_INCLUDE}")
-		include_directories("${OPENSSL_INCLUDE_DIR}")
 		include_directories("${CURL_INCLUDE_DIR}")
 	endif() # NOT MINIMAL_BUILD
 	include_directories("${CMAKE_CURRENT_BINARY_DIR}")

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -28,7 +28,6 @@ if(NOT MINIMAL_BUILD)
 endif()
 
 if(NOT WIN32 AND NOT APPLE)
-	include_directories("${B64_INCLUDE}")
 	include_directories("${CURSES_INCLUDE_DIR}")
 	if(NOT MINIMAL_BUILD)
 		include_directories("${GRPC_INCLUDE}")

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -21,10 +21,6 @@ include_directories(../libscap)
 include_directories(../async)
 include_directories(./include)
 
-if(NOT MINIMAL_BUILD)
-	include_directories("${CARES_INCLUDE}")
-endif()
-
 if(NOT WIN32 AND NOT APPLE)
 	if(NOT MINIMAL_BUILD)
 		include_directories("${GRPC_INCLUDE}")

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -17,7 +17,6 @@
 #
 
 include_directories("${GTEST_INCLUDE_DIR}")
-include_directories("${JSONCPP_INCLUDE}")
 include_directories("${TBB_INCLUDE_DIR}")
 if(NOT MINIMAL_BUILD)
 	include_directories("${CURL_INCLUDE_DIR}")

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -17,7 +17,7 @@
 #
 
 include_directories("..")
-include_directories("../../libscap")
+include_directories("${LIBSCAP_INCLUDE_DIRS}")
 
 add_executable(unit-test-libsinsp
 	cgroup_list_counter.ut.cpp

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -16,8 +16,6 @@
 # limitations under the License.
 #
 
-include_directories("${GTEST_INCLUDE_DIR}")
-
 include_directories("..")
 include_directories("../../libscap")
 

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -17,7 +17,6 @@
 #
 
 include_directories("${GTEST_INCLUDE_DIR}")
-include_directories("${TBB_INCLUDE_DIR}")
 if(NOT MINIMAL_BUILD)
 	include_directories("${CURL_INCLUDE_DIR}")
 endif() # MINIMAL_BUILD

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -17,9 +17,6 @@
 #
 
 include_directories("${GTEST_INCLUDE_DIR}")
-if(NOT MINIMAL_BUILD)
-	include_directories("${CURL_INCLUDE_DIR}")
-endif() # MINIMAL_BUILD
 
 include_directories("..")
 include_directories("../../libscap")

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -16,12 +16,6 @@
 # limitations under the License.
 #
 
-if(NOT WIN32)
-	if(NOT MINIMAL_BUILD)
-		include_directories("${CURL_INCLUDE_DIR}")
-	endif() # MINIMAL_BUILD
-endif() # NOT WIN32
-
 include_directories("${PROJECT_SOURCE_DIR}/common")
 include_directories("${PROJECT_SOURCE_DIR}/userspace/libscap")
 include_directories("${PROJECT_SOURCE_DIR}/userspace/libsinsp")

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_directories("${JSONCPP_INCLUDE}")
 
 if(NOT WIN32)
 	include_directories("${TBB_INCLUDE_DIR}")

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -20,7 +20,6 @@ if(NOT WIN32)
 	if(NOT MINIMAL_BUILD)
 		include_directories("${CURL_INCLUDE_DIR}")
 	endif() # MINIMAL_BUILD
-	include_directories("${CURSES_INCLUDE_DIR}")
 endif() # NOT WIN32
 
 include_directories("${PROJECT_SOURCE_DIR}/common")

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -17,7 +17,6 @@
 #
 
 if(NOT WIN32)
-	include_directories("${TBB_INCLUDE_DIR}")
 	if(NOT MINIMAL_BUILD)
 		include_directories("${CURL_INCLUDE_DIR}")
 	endif() # MINIMAL_BUILD


### PR DESCRIPTION
This makes the code more modular and hopefully easier for consumers of the code to substitute their own way of supplying dependencies.

The libsinsp and libscap modules also define variables containing the required `include_directories` so that consumers don't need to maintain them (LIBSINSP_INCLUDE_DIRS and LIBSCAP_INCLUDE_DIRS, respectively).