### PR TITLE
Fix compilation on i586

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -1523,13 +1523,14 @@ static inline int drop_event(struct ppm_consumer_t *consumer,
 	}
 
 	if (consumer->dropping_mode) {
+		nanoseconds ns2 = ns;
 		if (drop_flags & UF_ALWAYS_DROP) {
 			ASSERT((drop_flags & UF_NEVER_DROP) == 0);
 			return 1;
 		}
 
 		if (consumer->sampling_interval < SECOND_IN_NS &&
-		    (ns % SECOND_IN_NS) >= consumer->sampling_interval) {
+		    do_div(ns2, SECOND_IN_NS) >= consumer->sampling_interval) {
 			if (consumer->is_dropping == 0) {
 				consumer->is_dropping = 1;
 				record_drop_e(consumer, ns, drop_flags);


### PR DESCRIPTION
Without this patch, compilation on i586 failed with
```
ERROR: modpost: "__umoddi3" [/home/abuild/rpmbuild/BUILD/sysdig-0.27.0/build/driver/src/sysdig-probe.ko] undefined!
```

**Note**: it compiles, but is not tested otherwise.