### PR TITLE
Container json parse error

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -638,3 +638,8 @@ void sinsp_container_manager::set_cri_delay(uint64_t delay_ms)
 #endif
 }
 
+void sinsp_container_manager::set_container_labels_max_len(uint32_t max_label_len)
+{
+	sinsp_container_info::m_container_label_max_length = max_label_len;
+}
+

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -144,6 +144,7 @@ public:
 	void set_cri_timeout(int64_t timeout_ms);
 	void set_cri_async(bool async);
 	void set_cri_delay(uint64_t delay_ms);
+	void set_container_labels_max_len(uint32_t max_label_len);
 	sinsp* get_inspector() { return m_inspector; }
 
 	/**

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -120,8 +120,7 @@ bool cri_async_source::parse_cri(sinsp_container_info& container, const libsinsp
 
 	for(const auto &pair : resp_container.labels())
 	{
-		std::string label_val = pair.second;
-		if(label_val.length() <= sinsp_container_info::m_container_label_max_length) {
+		if(pair.second.length() <= sinsp_container_info::m_container_label_max_length) {
 			container.m_labels[pair.first] = pair.second;
 		}
 	}

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -120,7 +120,10 @@ bool cri_async_source::parse_cri(sinsp_container_info& container, const libsinsp
 
 	for(const auto &pair : resp_container.labels())
 	{
-		container.m_labels[pair.first] = pair.second;
+		std::string label_val = pair.second;
+		if(label_val.length() <= sinsp_container_info::m_container_label_max_length) {
+			container.m_labels[pair.first] = pair.second;
+		}
 	}
 
 	m_cri->parse_cri_image(resp_container, container);

--- a/userspace/libsinsp/container_engine/docker_common.cpp
+++ b/userspace/libsinsp/container_engine/docker_common.cpp
@@ -793,7 +793,9 @@ bool docker_async_source::parse_docker(const docker_async_instruction& instructi
 	for(vector<string>::const_iterator it = labels.begin(); it != labels.end(); ++it)
 	{
 		string val = config_obj["Labels"][*it].asString();
-		container.m_labels[*it] = val;
+		if(val.length() <= sinsp_container_info::m_container_label_max_length ) {
+			container.m_labels[*it] = val;
+		}
 	}
 
 	const Json::Value& env_vars = config_obj["Env"];

--- a/userspace/libsinsp/container_engine/rkt.cpp
+++ b/userspace/libsinsp/container_engine/rkt.cpp
@@ -215,7 +215,10 @@ bool rkt::rkt::parse_rkt(sinsp_container_info &container, const string &podid, c
 		container.m_image = jroot["name"].asString();
 		for(const auto& label_entry : jroot["labels"])
 		{
-			container.m_labels.emplace(label_entry["name"].asString(), label_entry["value"].asString());
+			string val = label_entry["value"].asString();
+			if(val.length() <= sinsp_container_info::m_container_label_max_length ) {
+				container.m_labels.emplace(label_entry["name"].asString(), val);
+			}
 		}
 		auto version_label_it = container.m_labels.find("version");
 		if(version_label_it != container.m_labels.end())

--- a/userspace/libsinsp/container_info.cpp
+++ b/userspace/libsinsp/container_info.cpp
@@ -31,6 +31,9 @@ std::vector<std::string> sinsp_container_info::container_health_probe::probe_typ
 	"End"
 };
 
+// Initialize container max label length to default 100 value
+uint32_t sinsp_container_info::m_container_label_max_length = 100; 
+
 sinsp_container_info::container_health_probe::container_health_probe()
 {
 }

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -266,4 +266,10 @@ public:
 	 * implementation; int64_t is the safest bet. Many default to int64_t anyway (e.g. CRI).
 	 */
 	int64_t m_created_time;
+
+	/**
+	 * The max container label length value. This is static because it is 
+	 * universal across all instances and needs to be set once only.
+	 */
+	static uint32_t m_container_label_max_length;
 };

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4846,7 +4846,9 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 	{
 		std::string errstr;
 		errstr = Json::Reader().getFormattedErrorMessages();
-		throw sinsp_exception("Invalid JSON encountered while parsing container info: " + json + "error=" + errstr);
+		// We should not be throwing an exception that doesn't get handled.
+		// If a container JSON could not be parsed, throw a warning and move on.
+		SINSP_WARNING("Invalid JSON encountered while parsing container info json: %s. Error = %s", json, errstr);
 	}
 }
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4845,10 +4845,8 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 	else
 	{
 		std::string errstr;
-		errstr = Json::Reader().getFormattedErrorMessages();
-		// We should not be throwing an exception that doesn't get handled.
-		// If a container JSON could not be parsed, throw a warning and move on.
-		SINSP_WARNING("Invalid JSON encountered while parsing container info json: %s. Error = %s", json.c_str(), errstr.c_str());
+                errstr = Json::Reader().getFormattedErrorMessages();
+                throw sinsp_exception("Invalid JSON encountered while parsing container info: " + json + "error=" + errstr);
 	}
 }
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4848,7 +4848,7 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		errstr = Json::Reader().getFormattedErrorMessages();
 		// We should not be throwing an exception that doesn't get handled.
 		// If a container JSON could not be parsed, throw a warning and move on.
-		SINSP_WARNING("Invalid JSON encountered while parsing container info json: %s. Error = %s", json, errstr);
+		SINSP_WARNING("Invalid JSON encountered while parsing container info json: %s. Error = %s", json.c_str(), errstr.c_str());
 	}
 }
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4845,8 +4845,8 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 	else
 	{
 		std::string errstr;
-                errstr = Json::Reader().getFormattedErrorMessages();
-                throw sinsp_exception("Invalid JSON encountered while parsing container info: " + json + "error=" + errstr);
+		errstr = Json::Reader().getFormattedErrorMessages();
+		throw sinsp_exception("Invalid JSON encountered while parsing container info: " + json + "error=" + errstr);
 	}
 }
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1623,6 +1623,11 @@ void sinsp::set_cri_delay(uint64_t delay_ms)
 	m_container_manager.set_cri_delay(delay_ms);
 }
 
+void sinsp::set_container_labels_max_len(uint32_t max_label_len)
+{
+	m_container_manager.set_container_labels_max_len(max_label_len);
+}
+
 void sinsp::set_snaplen(uint32_t snaplen)
 {
 	//

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -893,6 +893,7 @@ public:
 	void set_cri_timeout(int64_t timeout_ms);
 	void set_cri_async(bool async);
 	void set_cri_delay(uint64_t delay_ms);
+	void set_container_labels_max_len(uint32_t max_label_len);
 
 VISIBILITY_PROTECTED
 	bool add_thread(const sinsp_threadinfo *ptinfo);


### PR DESCRIPTION
We introduce a max container label length that is used to filter labels above a certain length. 

Clients of sinsp can set this value to their wish at startup. Defaults to `100` 
