### PR TITLE
create a static container type which matches ALL threads

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SINSP_SOURCES
 	chisel_api.cpp
 	container.cpp
 	container_engine/container_engine_base.cpp
+	container_engine/static_container.cpp
 	container_info.cpp
 	ctext.cpp
 	cyclewriter.cpp

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -42,7 +42,7 @@ using namespace libsinsp;
 sinsp_container_manager::sinsp_container_manager(sinsp* inspector, bool static_continaer, const std::string static_id, const std::string static_name, const std::string static_image) :
 	m_inspector(inspector),
 	m_last_flush_time_ns(0),
-	m_static_Container(static_container),
+	m_static_container(static_container),
 	m_static_id(static_id),
 	m_static_name(static_name),
 	m_static_image(static_image)

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -39,7 +39,7 @@ limitations under the License.
 
 using namespace libsinsp;
 
-sinsp_container_manager::sinsp_container_manager(sinsp* inspector, bool static_continaer, const std::string static_id, const std::string static_name, const std::string static_image) :
+sinsp_container_manager::sinsp_container_manager(sinsp* inspector, bool static_container, const std::string static_id, const std::string static_name, const std::string static_image) :
 	m_inspector(inspector),
 	m_last_flush_time_ns(0),
 	m_static_container(static_container),

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 #include "container_engine/lxc.h"
 #include "container_engine/mesos.h"
 #include "container_engine/bpm.h"
+#include "container_engine/static_container.h"
 #endif // MINIMAL_BUILD
 
 #include "sinsp.h"
@@ -38,9 +39,13 @@ limitations under the License.
 
 using namespace libsinsp;
 
-sinsp_container_manager::sinsp_container_manager(sinsp* inspector) :
+sinsp_container_manager::sinsp_container_manager(sinsp* inspector, bool static_continaer, const std::string static_id, const std::string static_name, const std::string static_image) :
 	m_inspector(inspector),
-	m_last_flush_time_ns(0)
+	m_last_flush_time_ns(0),
+	m_static_Container(static_container),
+	m_static_id(static_id),
+	m_static_name(static_name),
+	m_static_image(static_image)
 {
 }
 
@@ -508,6 +513,16 @@ void sinsp_container_manager::subscribe_on_remove_container(remove_container_cb 
 
 void sinsp_container_manager::create_engines()
 {
+	if (m_static_container)
+	{
+		auto engine = std::make_shared<container_engine::static_container>(*this,
+																		   m_static_id,
+																		   m_static_name,
+																		   m_static_image);
+		m_container_engines.push_back(engine);
+		m_container_engine_by_type[CT_STATIC] = engine;
+		return;
+	}
 #ifndef MINIMAL_BUILD
 #ifdef CYGWING_AGENT
 	{

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -45,7 +45,19 @@ class sinsp_container_manager :
 public:
 	using map_ptr_t = libsinsp::ConstMutexGuard<std::unordered_map<std::string, sinsp_container_info::ptr_t>>;
 
-	sinsp_container_manager(sinsp* inspector);
+	/**
+	 * Due to how the container manager is architected, it makes it difficult
+	 * to dynamically select which engines we want to be valid. As such, we unfortunately
+	 * need to indicate at construction time which we want, with the only possible options
+	 * right now being "static" or not. I'm sure we will find time in the future to do this
+	 * in a more general way. 2020/11/24
+	 */
+	sinsp_container_manager(sinsp* inspector,
+	                        bool static_container = false,
+	                        const std::string static_id = "",
+	                        const std::string static_name = "",
+	                        const std::string static_image = "");
+
 	virtual ~sinsp_container_manager();
 
 	/**
@@ -197,6 +209,14 @@ private:
 	uint64_t m_last_flush_time_ns;
 	std::list<new_container_cb> m_new_callbacks;
 	std::list<remove_container_cb> m_remove_callbacks;
+
+	// indicates whether we should use only the static container engine, or the other engines.
+	// if true, we expect to have the subsequent bits of metadata as well. If this bool is false,
+	// then the values of those metadata are undefined
+	bool m_static_container;
+	std::string m_static_id;
+	std::string m_static_name;
+	std::string m_static_image;
 
 	friend class test_helper;
 };

--- a/userspace/libsinsp/container_engine/sinsp_container_type.h
+++ b/userspace/libsinsp/container_engine/sinsp_container_type.h
@@ -31,4 +31,5 @@ enum sinsp_container_type
 	CT_CONTAINERD = 7,
 	CT_CRIO = 8,
 	CT_BPM = 9,
+	CT_STATIC = 10,
 };

--- a/userspace/libsinsp/container_engine/static_container.cpp
+++ b/userspace/libsinsp/container_engine/static_container.cpp
@@ -1,0 +1,45 @@
+/*
+Copyright (C) 2013-2019 Draios Inc dba Sysdig.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "sinsp.h"
+
+#include "container_engine/static_container.h"
+
+using namespace libsinsp::container_engine;
+
+static_container::static_container(container_cache_interface& cache,
+                                   const std::string& id,
+                                   const std::string& name,
+                                   const std::string& image)
+    : container_engine_base(cache)
+{
+	m_static_container_info = std::make_shared<sinsp_container_info>();
+	m_static_container_info->m_id = id;
+	m_static_container_info->m_type = CT_STATIC;
+	m_static_container_info->m_name = name;
+	m_static_container_info->m_image = image;
+
+	cache.add_container(m_static_container_info, nullptr);
+}
+
+bool static_container::resolve(sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
+{
+	tinfo->m_container_id = m_static_container_info->m_id;
+	return true;
+}

--- a/userspace/libsinsp/container_engine/static_container.h
+++ b/userspace/libsinsp/container_engine/static_container.h
@@ -1,0 +1,52 @@
+/*
+Copyright (C) 2013-2019 Draios Inc dba Sysdig.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+class sinsp_container_info;
+class sinsp_threadinfo;
+
+#include "container_engine/container_engine_base.h"
+#include "container_engine/sinsp_container_type.h"
+
+namespace libsinsp
+{
+namespace container_engine
+{
+/**
+ * static container can be used in cases where we a-priori know that every thread comes from a
+ * single container, for which there is not necessarily an accessible runtime interface, and for
+ * which we already know all appropriate metadata statically. It can be used, say, for userspace
+ * monitoring inside a single container
+ */
+class static_container : public container_engine_base
+{
+public:
+	static_container(container_cache_interface& cache,
+	                 const std::string& id,
+	                 const std::string& name,
+	                 const std::string& image);
+
+	bool resolve(sinsp_threadinfo* tinfo, bool query_os_for_missing_info) override;
+
+private:
+	std::shared_ptr<sinsp_container_info> m_static_container_info;
+};
+}  // namespace container_engine
+}  // namespace libsinsp

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -69,11 +69,11 @@ void on_new_entry_from_proc(void* context, scap_t* handle, int64_t tid, scap_thr
 ///////////////////////////////////////////////////////////////////////////////
 // sinsp implementation
 ///////////////////////////////////////////////////////////////////////////////
-sinsp::sinsp() :
+sinsp::sinsp(bool static_container, const std::string static_id, const std::string static_name, const std::string static_image) :
 	m_external_event_processor(),
 	m_evt(this),
 	m_lastevent_ts(0),
-	m_container_manager(this),
+	m_container_manager(this, static_container, static_id, static_name, static_image),
 	m_suppressed_comms()
 {
 #if !defined(MINIMAL_BUILD) && !defined(CYGWING_AGENT) && defined(HAS_CAPTURE)

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -195,7 +195,10 @@ public:
 	typedef std::set<std::string> k8s_ext_list_t;
 	typedef std::shared_ptr<k8s_ext_list_t> k8s_ext_list_ptr_t;
 
-	sinsp();
+	sinsp(bool static_container = false,
+		  const std::string static_id = "",
+		  const std::string static_name = "",
+		  const std::string static_image = "");
 	virtual ~sinsp();
 
 	/*!


### PR DESCRIPTION
In situations such as operating with userspace tracing inside a container, we know a-priori that every thread comes from a single container. Further, in such cases, we may not have (and don't necessarily need) access to a container runtime interface. As such, we need every thread to automatically show up under that container.

So the solution is to create a container type that always returns some static data that is configured with the container manager.