### PR TITLE
update(driver): copy_file_range support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ driver/driver_config.h
 *.ll
 .vscode
 .cache.mk
+.cache
 build-*
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2361,6 +2361,100 @@ FILLER(sys_sendfile_x, true)
 	return res;
 }
 
+FILLER(sys_copy_file_range_e, true)
+{
+	unsigned long val;
+	loff_t *off_inp;
+	loff_t off_in;
+	loff_t *off_outp;
+	loff_t off_out;
+	int res;
+
+	/*
+	 * fd_in
+	 */
+	val = bpf_syscall_get_argument(data, 0);
+	res = bpf_val_to_ring(data, val);
+	if (res != PPM_SUCCESS)
+		return res;
+
+	/*
+	 * off_in
+	 */
+	off_inp = (loff_t *)bpf_syscall_get_argument(data, 1);
+	off_in = _READ(*off_inp);
+	res = bpf_val_to_ring(data, off_in);
+	if (res != PPM_SUCCESS)
+		return res;
+
+	/*
+	 * fd_out
+	 */
+	val = bpf_syscall_get_argument(data, 2);
+	res = bpf_val_to_ring(data, val);
+	if (res != PPM_SUCCESS)
+		return res;
+
+	/*
+	 * off_out
+	 */
+	off_outp = (loff_t *)bpf_syscall_get_argument(data, 3);
+	off_out = _READ(*off_outp);
+	res = bpf_val_to_ring(data, off_out);
+	if (res != PPM_SUCCESS)
+		return res;
+
+	/*
+	 * len
+	 */
+	val = bpf_syscall_get_argument(data, 4);
+	res = bpf_val_to_ring(data, val);
+	if (res != PPM_SUCCESS)
+		return res;
+
+	/*
+	 * flags
+	 */
+	val = bpf_syscall_get_argument(data, 5);
+	res = bpf_val_to_ring(data, val);
+
+	return res;
+}
+
+FILLER(sys_copy_file_range_x, true)
+{
+	long retval;
+	loff_t *off_inp;
+	loff_t off_in;
+	loff_t *off_outp;
+	loff_t off_out;
+	int res;
+
+	/*
+	 * res
+	 */
+	retval = bpf_syscall_get_retval(data->ctx);
+	res = bpf_val_to_ring(data, retval);
+	if (res != PPM_SUCCESS)
+		return res;
+
+	/*
+	 * off_in
+	 */
+	off_inp = (loff_t *)bpf_syscall_get_argument(data, 1);
+	off_in = _READ(*off_inp);
+	res = bpf_val_to_ring(data, off_in);
+
+	/*
+	 * off_out
+	 */
+	off_outp = (loff_t *)bpf_syscall_get_argument(data, 3);
+	off_out = _READ(*off_outp);
+	res = bpf_val_to_ring(data, off_out);
+
+	return res;
+}
+
 FILLER(sys_prlimit_e, true)
 {
 	unsigned long val;

--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -333,7 +333,7 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_SYSCALL_RENAMEAT2_E */{"renameat2", EC_FILE, EF_NONE, 0 },
 	/* PPME_SYSCALL_RENAMEAT2_X */{"renameat2", EC_FILE, EF_NONE, 6, {{"res", PT_ERRNO, PF_DEC}, {"olddirfd", PT_FD, PF_DEC}, {"oldpath", PT_FSRELPATH, PF_NA, DIRFD_PARAM(1)}, {"newdirfd", PT_FD, PF_DEC}, {"newpath", PT_FSRELPATH, PF_NA, DIRFD_PARAM(3)}, {"flags", PT_FLAGS32, PF_HEX, renameat2_flags} } },
 	/* PPME_SYSCALL_COPY_FILE_RANGE_E */{"copy_file_range", EC_IO_WRITE, EF_USES_FD | EF_DROP_SIMPLE_CONS, 6, {{"fd_in", PT_FD, PF_DEC}, {"off_in", PT_UINT64, PF_DEC}, {"fd_out", PT_FD, PF_DEC}, {"off_out", PT_UINT64, PF_DEC}, {"len", PT_UINT64, PF_DEC} , {"flags", PT_FLAGS32, PF_HEX, file_flags} } },
-	/* PPME_SYSCALL_COPY_FILE_RANGE_X */{"copy_file_range", EC_IO_WRITE, EF_USES_FD | EF_DROP_SIMPLE_CONS, 2, {{"res", PT_ERRNO, PF_DEC}, {"offset", PT_UINT64, PF_DEC} } },
+	/* PPME_SYSCALL_COPY_FILE_RANGE_X */{"copy_file_range", EC_IO_WRITE, EF_USES_FD | EF_DROP_SIMPLE_CONS, 3, {{"res", PT_ERRNO, PF_DEC}, {"off_in", PT_UINT64, PF_DEC}, {"off_out", PT_UINT64, PF_DEC} } },
 	/* NB: Starting from scap version 1.2, event types will no longer be changed when an event is modified, and the only kind of change permitted for pre-existent events is adding parameters.
 	 *     New event types are allowed only for new syscalls or new internal events.
 	 *     The number of parameters can be used to differentiate between event versions.

--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -331,7 +331,9 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_SYSCALL_FCHMOD_E */{"fchmod", EC_FILE, EF_NONE, 0},
 	/* PPME_SYSCALL_FCHMOD_X */{"fchmod", EC_FILE, EF_NONE, 3, {{"res", PT_ERRNO, PF_DEC}, {"fd", PT_FD, PF_DEC}, {"mode", PT_MODE, PF_OCT, chmod_mode} } },
 	/* PPME_SYSCALL_RENAMEAT2_E */{"renameat2", EC_FILE, EF_NONE, 0 },
-	/* PPME_SYSCALL_RENAMEAT2_X */{"renameat2", EC_FILE, EF_NONE, 6, {{"res", PT_ERRNO, PF_DEC}, {"olddirfd", PT_FD, PF_DEC}, {"oldpath", PT_FSRELPATH, PF_NA, DIRFD_PARAM(1)}, {"newdirfd", PT_FD, PF_DEC}, {"newpath", PT_FSRELPATH, PF_NA, DIRFD_PARAM(3)}, {"flags", PT_FLAGS32, PF_HEX, renameat2_flags} } }
+	/* PPME_SYSCALL_RENAMEAT2_X */{"renameat2", EC_FILE, EF_NONE, 6, {{"res", PT_ERRNO, PF_DEC}, {"olddirfd", PT_FD, PF_DEC}, {"oldpath", PT_FSRELPATH, PF_NA, DIRFD_PARAM(1)}, {"newdirfd", PT_FD, PF_DEC}, {"newpath", PT_FSRELPATH, PF_NA, DIRFD_PARAM(3)}, {"flags", PT_FLAGS32, PF_HEX, renameat2_flags} } },
+	/* PPME_SYSCALL_COPY_FILE_RANGE_E */{"copy_file_range", EC_IO_WRITE, EF_USES_FD | EF_DROP_SIMPLE_CONS, 6, {{"fd_in", PT_FD, PF_DEC}, {"off_in", PT_UINT64, PF_DEC}, {"fd_out", PT_FD, PF_DEC}, {"off_out", PT_UINT64, PF_DEC}, {"len", PT_UINT64, PF_DEC} , {"flags", PT_FLAGS32, PF_HEX, file_flags} } },
+	/* PPME_SYSCALL_COPY_FILE_RANGE_X */{"copy_file_range", EC_IO_WRITE, EF_USES_FD | EF_DROP_SIMPLE_CONS, 2, {{"res", PT_ERRNO, PF_DEC}, {"offset", PT_UINT64, PF_DEC} } },
 	/* NB: Starting from scap version 1.2, event types will no longer be changed when an event is modified, and the only kind of change permitted for pre-existent events is adding parameters.
 	 *     New event types are allowed only for new syscalls or new internal events.
 	 *     The number of parameters can be used to differentiate between event versions.

--- a/driver/fillers_table.c
+++ b/driver/fillers_table.c
@@ -294,5 +294,7 @@ const struct ppm_event_entry g_ppm_events[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_FCHMOD_E] = {FILLER_REF(sys_empty)},
 	[PPME_SYSCALL_FCHMOD_X] = {FILLER_REF(sys_fchmod_x)},
 	[PPME_SYSCALL_RENAMEAT2_E] = {FILLER_REF(sys_empty)},
-	[PPME_SYSCALL_RENAMEAT2_X] = {FILLER_REF(sys_renameat2_x)}
+	[PPME_SYSCALL_RENAMEAT2_X] = {FILLER_REF(sys_renameat2_x)},
+	[PPME_SYSCALL_COPY_FILE_RANGE_E] = {FILLER_REF(sys_copy_file_range_e)},
+	[PPME_SYSCALL_COPY_FILE_RANGE_X] = {FILLER_REF(sys_copy_file_range_x)}
 };

--- a/driver/flags_table.c
+++ b/driver/flags_table.c
@@ -525,3 +525,7 @@ const struct ppm_name_value renameat2_flags[] = {
 	{"RENAME_WHITEOUT", PPM_RENAME_WHITEOUT},
 	{0, 0},
 };
+
+const struct ppm_name_value copy_file_range_flags[] = {
+	{0, 0},
+};

--- a/driver/ppm_compat_unistd_32.h
+++ b/driver/ppm_compat_unistd_32.h
@@ -355,10 +355,11 @@
 #define __NR_ia32_process_vm_readv	347
 #define __NR_ia32_process_vm_writev	348
 #define __NR_ia32_renameat2 349
+#define __NR_ia32_copy_file_range 350
 
 #ifdef __KERNEL__
 
-#define NR_ia32_syscalls 350
+#define NR_ia32_syscalls 351
 
 #define __ARCH_WANT_IPC_PARSE_VERSION
 #define __ARCH_WANT_OLD_READDIR

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -957,7 +957,9 @@ enum ppm_event_type {
 	PPME_SYSCALL_FCHMOD_X = 317,
 	PPME_SYSCALL_RENAMEAT2_E = 318,
 	PPME_SYSCALL_RENAMEAT2_X = 319,
-	PPM_EVENT_MAX = 320
+	PPME_SYSCALL_COPY_FILE_RANGE_E = 320,
+	PPME_SYSCALL_COPY_FILE_RANGE_X = 321,
+	PPM_EVENT_MAX = 322
 };
 /*@}*/
 
@@ -1286,7 +1288,8 @@ enum ppm_syscall_code {
 	PPM_SC_GETRANDOM = 318,
 	PPM_SC_FADVISE64 = 319,
 	PPM_SC_RENAMEAT2 = 320,
-	PPM_SC_MAX = 321,
+	PPM_SC_COPY_FILE_RANGE = 321,
+	PPM_SC_MAX = 322,
 };
 
 /*
@@ -1513,6 +1516,7 @@ extern const struct ppm_name_value unlinkat_flags[];
 extern const struct ppm_name_value linkat_flags[];
 extern const struct ppm_name_value chmod_mode[];
 extern const struct ppm_name_value renameat2_flags[];
+extern const struct ppm_name_value copy_file_range_flags[];
 
 extern const struct ppm_param_info sockopt_dynamic_param[];
 extern const struct ppm_param_info ptrace_dynamic_param[];

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -4295,6 +4295,170 @@ int f_sys_sendfile_x(struct event_filler_arguments *args)
 	return add_sentinel(args);
 }
 
+int f_sys_copy_file_range_e(struct event_filler_arguments *args)
+{
+	unsigned long val;
+	int res;
+	loff_t off_in;
+	loff_t off_out;
+
+	/*
+	 * fd_in
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
+	res = val_to_ring(args, val, 0, false, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	/*
+	 * off_in
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 1, 1, &val);
+
+	if (val != 0) {
+#ifdef CONFIG_COMPAT
+		if (!args->compat) {
+#endif
+			res = ppm_copy_from_user(&off_in, (void *)val, sizeof(loff_t));
+#ifdef CONFIG_COMPAT
+		} else {
+			res = ppm_copy_from_user(&off_in, (void *)compat_ptr(val), sizeof(compat_loff_t));
+		}
+#endif
+		if (unlikely(res))
+			val = 0;
+		else
+			val = off_in;
+	}
+
+	res = val_to_ring(args, val, 0, true, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+
+	/*
+	 * fd_out
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 2, 1, &val);
+	res = val_to_ring(args, val, 0, false, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	/*
+	 * off_out
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 3, 1, &val);
+
+	if (val != 0) {
+#ifdef CONFIG_COMPAT
+		if (!args->compat) {
+#endif
+			res = ppm_copy_from_user(&off_out, (void *)val, sizeof(loff_t));
+#ifdef CONFIG_COMPAT
+		} else {
+			res = ppm_copy_from_user(&off_out, (void *)compat_ptr(val), sizeof(compat_loff_t));
+		}
+#endif
+		if (unlikely(res))
+			val = 0;
+		else
+			val = off_out;
+	}
+
+	res = val_to_ring(args, val, 0, true, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	/*
+	 * len
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 4, 1, &val);
+	res = val_to_ring(args, val, 0, false, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	/*
+	 * flags
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 5, 1, &val);
+	res = val_to_ring(args, val, 0, false, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+
+	return add_sentinel(args);
+}
+
+int f_sys_copy_file_range_x(struct event_filler_arguments *args)
+{
+	unsigned long val;
+	int res;
+	int64_t retval;
+	loff_t off_in;
+	loff_t off_out;
+
+	/*
+	 * res
+	 */
+	retval = (int64_t)syscall_get_return_value(current, args->regs);
+	res = val_to_ring(args, retval, 0, false, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	/*
+	 * off_in
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 1, 1, &val);
+
+	if (val != 0) {
+#ifdef CONFIG_COMPAT
+		if (!args->compat) {
+#endif
+			res = ppm_copy_from_user(&off_in, (void *)val, sizeof(loff_t));
+#ifdef CONFIG_COMPAT
+		} else {
+			res = ppm_copy_from_user(&off_in, (void *)compat_ptr(val), sizeof(compat_loff_t));
+		}
+#endif
+		if (unlikely(res))
+			val = 0;
+		else
+			val = off_in;
+	}
+
+	res = val_to_ring(args, val, 0, true, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	/*
+	 * off_out
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 3, 1, &val);
+
+	if (val != 0) {
+#ifdef CONFIG_COMPAT
+		if (!args->compat) {
+#endif
+			res = ppm_copy_from_user(&off_out, (void *)val, sizeof(loff_t));
+#ifdef CONFIG_COMPAT
+		} else {
+			res = ppm_copy_from_user(&off_out, (void *)compat_ptr(val), sizeof(compat_loff_t));
+		}
+#endif
+		if (unlikely(res))
+			val = 0;
+		else
+			val = off_out;
+	}
+
+	res = val_to_ring(args, val, 0, true, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+
+	return add_sentinel(args);
+}
+
 int f_sys_quotactl_e(struct event_filler_arguments *args)
 {
 	unsigned long val;

--- a/driver/ppm_fillers.h
+++ b/driver/ppm_fillers.h
@@ -115,6 +115,8 @@ or GPL2.txt for full copies of the license.
 	FN(sys_mkdirat_x)			\
 	FN(sys_openat_x)			\
 	FN(sys_linkat_x)			\
+	FN(sys_copy_file_range_x)		\
+	FN(sys_copy_file_range_e)		\
 	FN(terminate_filler)
 
 #define FILLER_ENUM_FN(x) PPM_FILLER_##x,

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -7,6 +7,7 @@ or GPL2.txt for full copies of the license.
 
 */
 
+#include <asm/unistd_64.h>
 #ifdef __KERNEL__
 #include <linux/kobject.h>
 #include <linux/cdev.h>
@@ -348,8 +349,12 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_seccomp - SYSCALL_TABLE_ID0] =                    {UF_USED, PPME_SYSCALL_SECCOMP_E, PPME_SYSCALL_SECCOMP_X},
 #endif
 #ifdef __NR_renameat2
-	[__NR_renameat2 - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SYSCALL_RENAMEAT2_E, PPME_SYSCALL_RENAMEAT2_X},
+	[__NR_renameat2 - SYSCALL_TABLE_ID0] =                  {UF_USED, PPME_SYSCALL_RENAMEAT2_E, PPME_SYSCALL_RENAMEAT2_X},
 #endif
+#ifdef __NR_copy_file_range
+	[__NR_copy_file_range - SYSCALL_TABLE_ID0] =            {UF_USED, PPME_SYSCALL_COPY_FILE_RANGE_E, PPME_SYSCALL_COPY_FILE_RANGE_X},
+#endif
+
 };
 
 /*
@@ -1202,6 +1207,10 @@ const struct syscall_evt_pair g_syscall_ia32_table[SYSCALL_TABLE_SIZE] = {
 #ifdef __NR_ia32_renameat2
 	[__NR_ia32_renameat2 - SYSCALL_TABLE_ID0] =                  {UF_USED, PPME_SYSCALL_RENAMEAT2_E, PPME_SYSCALL_RENAMEAT2_X},
 #endif
+#ifdef __NR_ia32_copy_file_range
+	[__NR_ia32_copy_file_range - SYSCALL_TABLE_ID0] =            {UF_USED, PPME_SYSCALL_COPY_FILE_RANGE_E, PPME_SYSCALL_COPY_FILE_RANGE_X},
+#endif
+
 };
 
 /*
@@ -1757,6 +1766,9 @@ const enum ppm_syscall_code g_syscall_ia32_code_routing_table[SYSCALL_TABLE_SIZE
 #endif
 #ifdef __NR_ia32_renameat2
 	[__NR_ia32_renameat2 - SYSCALL_TABLE_ID0] = PPM_SC_RENAMEAT2,
+#endif
+#ifdef __NR_ia32_copy_file_range
+	[__NR_ia32_copy_file_range - SYSCALL_TABLE_ID0] = PPM_SC_COPY_FILE_RANGE,
 #endif
 };
 

--- a/userspace/libscap/syscall_info_table.c
+++ b/userspace/libscap/syscall_info_table.c
@@ -352,6 +352,7 @@ const struct ppm_syscall_desc g_syscall_info_table[PPM_SC_MAX] = {
 	/*PPM_SC_GETRANDOM*/ { EC_IO_OTHER, (enum ppm_event_flags)(EF_NONE), "getrandom" },
 	/*PPM_SC_FADVISE64*/ { EC_IO_OTHER, (enum ppm_event_flags)(EF_NONE), "fadvise64" },
 	/*PPM_SC_RENAMEAT2*/ { EC_FILE, (enum ppm_event_flags)(EF_NONE), "renameat2" },
+	/*PPM_SC_COPY_FILE_RANGE*/ { EC_FILE, (enum ppm_event_flags)(EF_NONE), "copy_file_range" },
 };
 
 bool validate_info_table_size()


### PR DESCRIPTION
## Support copy_file_range syscall

Example output:

![copy_file_range](https://user-images.githubusercontent.com/38809344/102517693-a4d7b380-4090-11eb-846f-32ef8bf28cc2.PNG)

### For testing purposes
```c
#include <sys/types.h>
#define _GNU_SOURCE
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <sys/stat.h>
#include <sys/syscall.h>
#include <unistd.h>

/* On versions of glibc before 2.27, we must invoke copy_file_range()
   using syscall(2) */

int main(int argc, char **argv) {
  int fd_in, fd_out;
  struct stat stat;
  loff_t len, ret;

  if (argc != 3) {
    fprintf(stderr, "Usage: %s <source> <destination>\n", argv[0]);
    exit(EXIT_FAILURE);
  }

  fd_in = open(argv[1], O_RDONLY);
  if (fd_in == -1) {
    perror("open (argv[1])");
    exit(EXIT_FAILURE);
  }

  if (fstat(fd_in, &stat) == -1) {
    perror("fstat");
    exit(EXIT_FAILURE);
  }

  len = stat.st_size;

  fd_out = open(argv[2], O_CREAT | O_WRONLY | O_TRUNC, 0644);
  if (fd_out == -1) {
    perror("open (argv[2])");
    exit(EXIT_FAILURE);
  }

  loff_t buffin = 0;
  loff_t buffout = 2;

  ret = syscall(__NR_copy_file_range, fd_in, &buffin, fd_out, &buffout, len, 0);

  if (ret == -1) {
    perror("copy_file_range");
    exit(EXIT_FAILURE);
  }

  close(fd_in);
  close(fd_out);
  exit(EXIT_SUCCESS);
}
```
Compile it
```bash
gcc -o copy_file_range.o copy_file_range.c
```

Run it
```bash
./copy_file_range.o srcfile dstfile
```

## Notes

- Implementation detail follows the line of preexisiting syscall [**sendfile()**](https://github.com/draios/sysdig/blob/ded615cd7e1f25e20b86e49878986afbdd29ea22/driver/ppm_fillers.c#L4215)
- Empty flag structure and loff_t type has been declared to comply with [https://man7.org/linux/man-pages/man2/copy_file_range.2.html](https://man7.org/linux/man-pages/man2/copy_file_range.2.html) function parameters declaration

sysdig-CLA-1.0-signed-off-by: Luca Montechiesi <lucamontechiesi@gmail.com>



