### PR TITLE
fix(driver/bpf): bpf_addr_to_kernel takes an unsigned length (less than BPF_MAX_VAR_SIZE)

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -20,6 +20,7 @@ or GPL2.txt for full copies of the license.
 #include "../ppm_flag_helpers.h"
 
 // Maximum var size allowed by the verifier
+// From BPF_MAX_VAR_SIZ in linux/bpf_verifier.h
 #define BPF_MAX_VAR_SIZE 1ULL << 29
 
 static __always_inline bool in_port_range(uint16_t port, uint16_t min, uint16_t max)

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2640,7 +2640,7 @@ FILLER(sys_recvfrom_x, true)
 	unsigned long val;
 	u16 size = 0;
 	long retval;
-	int addrlen;
+	unsigned long addrlen;
 	int err = 0;
 	int res;
 	int fd;
@@ -2770,7 +2770,7 @@ FILLER(sys_recvmsg_x_2, true)
 	unsigned long val;
 	u16 size = 0;
 	long retval;
-	int addrlen;
+	unsigned long addrlen;
 	int res;
 	int fd;
 
@@ -2832,7 +2832,7 @@ FILLER(sys_sendmsg_e, true)
 	unsigned long iovcnt;
 	unsigned long val;
 	u16 size = 0;
-	int addrlen;
+	unsigned long addrlen;
 	int err = 0;
 	int res;
 	int fd;


### PR DESCRIPTION

The `bpf_syscall_get_argument` function returns an `unsigned long` that
was assigned to an `int` and passed to the `bpf_addr_to_kernel` function (`ulen`
variable).

We need to ensure the value is always unsigned (thus removing the inner
check `> 0`).

We also need to ensure it is not bigger than `1ULL << 29` (ie.,
`BPF_MAX_VAR_SIZE`).

Otherwise, the verifier gives un an "unbounded memory access" error.
This happens for Linux kernels (eg., >= 5.8) containing [this
patch](https://lore.kernel.org/bpf/20190614072557.196239-10-ast@kernel.org/).

Refs #1658 

Co-authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>