### PR TITLE
fix(driver/bpf): fixup_evt_arg_len check that argument number does not exceed max args number.

### DIFF
--- a/driver/bpf/ring_helpers.h
+++ b/driver/bpf/ring_helpers.h
@@ -34,6 +34,10 @@ static __always_inline void fixup_evt_arg_len(char *p,
 					      unsigned int argnum,
 					      unsigned int arglen)
 {
+	if (argnum > PPM_MAX_EVENT_PARAMS)
+	{
+		return;
+	}
 	volatile unsigned int argnumv = argnum;
 	*((u16 *)&p[sizeof(struct ppm_evt_hdr)] + (argnumv & (PPM_MAX_EVENT_PARAMS - 1))) = arglen;
 }


### PR DESCRIPTION
The check is needed so that the verifier knows about the boundary.

Ref #1658 

Co-Authored-By: Leonardo Di Donato <leodidonato@gmail.com>
Signed-off-by: Lorenzo Fontana <lo@linux.com>