### PR TITLE
fix(driver/bpf): check cursour offset is not greather than the SCRATCH_SIZE_HALF

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -300,6 +300,9 @@ static __always_inline int bpf_poll_parse_fds(struct filler_data *data,
 #endif
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 
+	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
+		return PPM_FAILURE_BUFFER_FULL;
+
 	off = data->state->tail_ctx.curoff + sizeof(u16);
 	fds_count = 0;
 


### PR DESCRIPTION
This solves another boundary issue with the verifier.

The `bpf_poll_parse_fds` function uses an offset to access FDs (and
their flags too). Among other things, we need to check that the starting
value of such offset (ie., `...->tail_ctx.curoff`) is not greater than
the SCRATCH_SIZE_HALF value.

Refs #1658 

Co-authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>