### PR TITLE
fix(driver/bpf): bpf_parse_readv_writev_bufs avoid overflow while reading readv/writev iovec struct

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -456,11 +456,11 @@ static __always_inline int bpf_parse_readv_writev_bufs(struct filler_data *data,
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 				if (to_read)
-					if (bpf_probe_read(&data->buf[off & SCRATCH_SIZE_HALF],
+					if (bpf_probe_read(&data->buf[off & SCRATCH_SIZE_HALF - 1],
 							   ((to_read - 1) & SCRATCH_SIZE_HALF) + 1,
 							   iov[j].iov_base))
 #else
-				if (bpf_probe_read(&data->buf[off & SCRATCH_SIZE_HALF],
+				if (bpf_probe_read(&data->buf[off & SCRATCH_SIZE_HALF - 1],
 						   to_read & SCRATCH_SIZE_HALF,
 						   iov[j].iov_base))
 #endif


### PR DESCRIPTION
Reading the buffer data from the iovec struct requires to go take a specific area in our buffer to perform the read into the cpu data->buf
map.

New kernels implement the `__check_mem_access` which takes care
of checking if the accessed memory is valid or not in the current
context.

In our case since our scratch buffer is split in a half with two null
terminators, we only need to read the area until the null terminator
happens or the verifier will alert.

Here's the verifier check [0] for this case:

```
    bool size_ok = size > 0 || (size == 0 && zero_size_allowed);
    struct bpf_reg_state *reg;

    if (off >= 0 && size_ok && (u64)off + size <= mem_size)
	    return 0;
```

[0]: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/tree/kernel/bpf/verifier.c?id=541c3bad8dc51b253ba8686d0cd7628e6b9b5f4c#n2552

Refs #1658

Co-Authored-By: Leonardo Di Donato <leodidonato@gmail.com>
Signed-off-by: Lorenzo Fontana <lo@linux.com>