### PR TITLE
refactor threadinfo to move thread manager specific functions and state

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -140,7 +140,7 @@ sinsp_threadinfo* sinsp_evt::get_thread_info(bool query_os_if_not_found)
 		return m_tinfo;
 	}
 
-	return m_inspector->get_thread(m_pevt->tid, query_os_if_not_found, false);
+	return &*m_inspector->get_thread_ref(m_pevt->tid, query_os_if_not_found, false);
 }
 
 int64_t sinsp_evt::get_fd_num()
@@ -836,7 +836,7 @@ Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_
 			ASSERT(payload_len == sizeof(int64_t));
 			ret = (Json::Value::UInt64)*(int64_t *)payload;
 
-			sinsp_threadinfo* atinfo = m_inspector->get_thread(*(int64_t *)payload, false, true);
+			sinsp_threadinfo* atinfo = &*m_inspector->get_thread_ref(*(int64_t *)payload, false, true);
 			if(atinfo != NULL)
 			{
 				string& tcomm = atinfo->m_comm;
@@ -1555,7 +1555,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 					 "%" PRId64, *(int64_t *)payload);
 
 
-			sinsp_threadinfo* atinfo = m_inspector->get_thread(*(int64_t *)payload, false, true);
+			sinsp_threadinfo* atinfo = &*m_inspector->get_thread_ref(*(int64_t *)payload, false, true);
 			if(atinfo != NULL)
 			{
 				string& tcomm = atinfo->m_comm;

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -2122,7 +2122,7 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 			// Relying on the convention that a session id is the process id of the session leader
 			//
 			sinsp_threadinfo* sinfo =
-				m_inspector->get_thread(tinfo->m_sid, false, true);
+				&*m_inspector->get_thread_ref(tinfo->m_sid, false, true);
 
 			if(sinfo != NULL)
 			{
@@ -2309,7 +2309,7 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 	case TYPE_PNAME:
 		{
 			sinsp_threadinfo* ptinfo =
-				m_inspector->get_thread(tinfo->m_ptid, false, true);
+				&*m_inspector->get_thread_ref(tinfo->m_ptid, false, true);
 
 			if(ptinfo != NULL)
 			{
@@ -2324,7 +2324,7 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 	case TYPE_PCMDLINE:
 		{
 			sinsp_threadinfo* ptinfo =
-				m_inspector->get_thread(tinfo->m_ptid, false, true);
+				&*m_inspector->get_thread_ref(tinfo->m_ptid, false, true);
 
 			if(ptinfo != NULL)
 			{
@@ -5530,7 +5530,7 @@ inline uint8_t* sinsp_filter_check_evtin::extract_tracer(sinsp_evt *evt, sinsp_p
 		//
 		// If this is a *.p.* field, reject anything that doesn't come from the same process
 		//
-		sinsp_threadinfo* tinfo = m_inspector->get_thread(pae->m_tid);
+		sinsp_threadinfo* tinfo = &*m_inspector->get_thread_ref(pae->m_tid);
 
 		if(tinfo)
 		{
@@ -5551,7 +5551,7 @@ inline uint8_t* sinsp_filter_check_evtin::extract_tracer(sinsp_evt *evt, sinsp_p
 		//
 		// If this is a *.p.* field, reject anything that doesn't share the same parent
 		//
-		sinsp_threadinfo* tinfo = m_inspector->get_thread(pae->m_tid);
+		sinsp_threadinfo* tinfo = &*m_inspector->get_thread_ref(pae->m_tid);
 
 		if(tinfo)
 		{

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -567,7 +567,7 @@ bool sinsp_parser::reset(sinsp_evt *evt)
 	{
 		if(etype == PPME_PROCINFO_E)
 		{
-			evt->m_tinfo = m_inspector->get_thread(evt->m_pevt->tid, false, false);
+			evt->m_tinfo = &*m_inspector->get_thread_ref(evt->m_pevt->tid, false, false);
 		}
 		else
 		{
@@ -612,7 +612,7 @@ bool sinsp_parser::reset(sinsp_evt *evt)
 	}
 	else
 	{
-		evt->m_tinfo = m_inspector->get_thread(evt->m_pevt->tid, query_os, false);
+		evt->m_tinfo = &*m_inspector->get_thread_ref(evt->m_pevt->tid, query_os, false);
 	}
 
 	if(etype == PPME_SCHEDSWITCH_6_E)
@@ -1099,7 +1099,7 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 	//
 	// Lookup the thread that called clone() so we can copy its information
 	//
-	sinsp_threadinfo* ptinfo = m_inspector->get_thread(tid, true, true);
+	sinsp_threadinfo* ptinfo = &*m_inspector->get_thread_ref(tid, true, true);
 	if(NULL == ptinfo)
 	{
 		//
@@ -1118,7 +1118,7 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 	//
 	// See if the child is already there
 	//
-	sinsp_threadinfo* child = m_inspector->get_thread(childtid, false, true);
+	sinsp_threadinfo* child = &*m_inspector->get_thread_ref(childtid, false, true);
 	if(NULL != child)
 	{
 		//
@@ -1192,7 +1192,7 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 		m_inspector->remove_thread(tid, true);
 		tid_collision = true;
 
-		ptinfo = m_inspector->get_thread(tid,
+		ptinfo = &*m_inspector->get_thread_ref(tid,
 			true, true);
 
 		if(ptinfo == NULL)
@@ -4332,7 +4332,7 @@ void sinsp_parser::parse_prlimit_exit(sinsp_evt *evt)
 					tid = evt->get_tid();
 				}
 
-				sinsp_threadinfo* ptinfo = m_inspector->get_thread(tid, true, true);
+				sinsp_threadinfo* ptinfo = &*m_inspector->get_thread_ref(tid, true, true);
 				if(ptinfo == NULL)
 				{
 					ASSERT(false);

--- a/userspace/libsinsp/sinsp_int.h
+++ b/userspace/libsinsp/sinsp_int.h
@@ -87,20 +87,6 @@ extern sinsp_logger g_logger;
 // Prototype of the callback invoked by the thread table when a thread is 
 // created or destroyed
 //
-class sinsp_threadtable_listener
-{
-public:
-	virtual ~sinsp_threadtable_listener()
-	{
-	}
-	virtual void on_thread_created(sinsp_threadinfo* tinfo) = 0;
-	virtual void on_thread_destroyed(sinsp_threadinfo* tinfo) = 0;
-};
-
-//
-// Prototype of the callback invoked by the thread table when a thread is 
-// created or destroyed
-//
 class sinsp_fd_listener
 {
 public:


### PR DESCRIPTION
the three get thread methods are identical. nuked them. moved the remaining functionality INTO thread manager, so now thread manager actually owns the thread code instead of it being split.

