### PR TITLE
docs: remove driver folder notice

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -14,11 +14,6 @@ limitations under the License.
 
 SYSDIG SUBCOMPONENTS:
 
--The files in <driver/> and its subdirectories are used to compile the
- kernel module and may be injected into eBPF; these are dual licensed
- under the MIT license or the GNU General Public License 2. Copies of
- both licenses are available in the subdirectory.
-
 -The following files are under Apache 2.0:
 
           userspace/sysdig/chisels/fileslower.lua, Copyright (C) 2014 Brendan Gregg

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ License Terms
 ---
 The sysdig userspace programs and supporting code are licensed to you under the [Apache 2.0](./COPYING) open source license.
 
-The sysdig kernel module, which is in the `driver` subdirectory, is licensed to you under both the [MIT](https://github.com/draios/sysdig/blob/dev/driver/MIT.txt) and [GPLv2](https://github.com/draios/sysdig/blob/dev/driver/GPL2.txt) open source licenses.
-
 Contributor License Agreements
 ---
 ### Background


### PR DESCRIPTION
This PR follows up https://github.com/draios/sysdig/pull/1737 removing (now unnecessary) notices regarding the `driver` subdirectory.