### PR TITLE
new(docker): add toolchain builder

### DIFF
--- a/docker/scap-driver-toolchains/Dockerfile
+++ b/docker/scap-driver-toolchains/Dockerfile
@@ -1,23 +1,17 @@
-FROM debian:10.10 AS base
-# Debian 10.10 has been chosen as a toolchain builder base because it's fully supported and is based on lib versions that are
-# compatible with most stable base images in use as of September 2021.
-# If this changes and it becomes required to dynamically link toolchains to newer base libraries (libc/libm, libgmp...)
-# it should be enough to increment the debian version number.
+FROM registry.access.redhat.com/ubi8 AS base
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-	gcc \
-	g++ \
+RUN yum update \
+	&& yum install -y gcc \
+	gcc-c++ \
 	make \
 	cmake \
-	xz-utils \
+	xz \
 	curl \
-	ca-certificates \
-	python \
+	python3 \
 	gnupg \
-	libgmp10-dev \
-	libmpfr-dev \
-	libmpc-dev
+	diffutils \
+	wget \
+	bzip2
 
 RUN curl -O -L https://mirrors.ocf.berkeley.edu/gnu/gnu-keyring.gpg \
 	&& gpg -q --import gnu-keyring.gpg
@@ -43,18 +37,6 @@ RUN curl --remote-name-all -L https://github.com/dell/dkms/archive/refs/tags/v2.
  	&& make tarball \
  	&& make install DESTDIR=/opt/scap-driver-toolchains/dkms
 
-FROM base AS mpfr
-
-WORKDIR /src/mpfr
-
-RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.gz{,.sig} \
-	&& gpg --verify mpfr-4.1.0.tar.gz.sig \
-	&& tar --strip-components=1 -xf mpfr-4.1.0.tar.gz
-
-RUN ./configure --prefix /opt/scap-driver-toolchains/mpfr \
-	&& make \
-	&& make install-strip
-
 FROM base AS llvm-7
 
 WORKDIR /src/llvm/7
@@ -69,7 +51,7 @@ RUN curl --remote-name-all -L https://github.com/llvm/llvm-project/releases/down
 
 WORKDIR /src/llvm/7/build
 
-RUN cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=/opt/scap-driver-toolchains/llvm-7 -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_CXX_FLAGS='-static-libstdc++ -static-libgcc' -G "Unix Makefiles" ../llvm-7.1.0.src \
+RUN cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=/opt/scap-driver-toolchains/llvm-7 -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_CXX_FLAGS='-static-libgcc' -G "Unix Makefiles" ../llvm-7.1.0.src \
 	&& make \
 	&& make install/strip
 
@@ -79,7 +61,9 @@ WORKDIR /src/gcc/5
 
 RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/gcc/gcc-5.5.0/gcc-5.5.0.tar.gz{,.sig} \
 	&& gpg --verify gcc-5.5.0.tar.gz.sig \
-	&& tar --strip-components=1 -xf gcc-5.5.0.tar.gz
+	&& tar --strip-components=1 -xf gcc-5.5.0.tar.gz \
+	&& ./contrib/download_prerequisites
+
 RUN ./configure --prefix=/opt/scap-driver-toolchains/gcc-5 --enable-languages=c --disable-libsanitizer --disable-multilib \
 	&& make \
 	&& make install-strip
@@ -90,7 +74,9 @@ WORKDIR /src/gcc/6
 
 RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/gcc/gcc-6.5.0/gcc-6.5.0.tar.gz{,.sig} \
 	&& gpg --verify gcc-6.5.0.tar.gz.sig \
-	&& tar --strip-components=1 -xf gcc-6.5.0.tar.gz
+	&& tar --strip-components=1 -xf gcc-6.5.0.tar.gz \
+	&& ./contrib/download_prerequisites
+
 RUN ./configure --prefix=/opt/scap-driver-toolchains/gcc-6 --enable-languages=c --disable-libsanitizer --disable-multilib \
 	&& make \
 	&& make install-strip
@@ -101,7 +87,9 @@ WORKDIR /src/gcc/7
 
 RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/gcc/gcc-7.5.0/gcc-7.5.0.tar.gz{,.sig} \
 	&& gpg --verify gcc-7.5.0.tar.gz.sig \
-	&& tar --strip-components=1 -xf gcc-7.5.0.tar.gz
+	&& tar --strip-components=1 -xf gcc-7.5.0.tar.gz \
+	&& ./contrib/download_prerequisites
+
 RUN ./configure --prefix=/opt/scap-driver-toolchains/gcc-7 --enable-languages=c --disable-libsanitizer --disable-multilib \
 	&& make \
 	&& make install-strip
@@ -112,7 +100,9 @@ WORKDIR /src/gcc/8
 
 RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/gcc/gcc-8.5.0/gcc-8.5.0.tar.gz{,.sig} \
 	&& gpg --verify gcc-8.5.0.tar.gz.sig \
-	&& tar --strip-components=1 -xf gcc-8.5.0.tar.gz
+	&& tar --strip-components=1 -xf gcc-8.5.0.tar.gz \
+	&& ./contrib/download_prerequisites
+
 RUN ./configure --prefix=/opt/scap-driver-toolchains/gcc-8 --enable-languages=c --disable-multilib \
 	&& make \
 	&& make install-strip
@@ -123,7 +113,9 @@ WORKDIR /src/gcc/9
 
 RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/gcc/gcc-9.4.0/gcc-9.4.0.tar.gz{,.sig} \
 	&& gpg --verify gcc-9.4.0.tar.gz.sig \
-	&& tar --strip-components=1 -xf gcc-9.4.0.tar.gz
+	&& tar --strip-components=1 -xf gcc-9.4.0.tar.gz \
+	&& ./contrib/download_prerequisites
+
 RUN ./configure --prefix=/opt/scap-driver-toolchains/gcc-9 --enable-languages=c --disable-multilib \
 	&& make \
 	&& make install-strip
@@ -134,25 +126,21 @@ WORKDIR /src/gcc/10
 
 RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/gcc/gcc-10.3.0/gcc-10.3.0.tar.gz{,.sig} \
 	&& gpg --verify gcc-10.3.0.tar.gz.sig \
-	&& tar --strip-components=1 -xf gcc-10.3.0.tar.gz
+	&& tar --strip-components=1 -xf gcc-10.3.0.tar.gz \
+	&& ./contrib/download_prerequisites
+
 RUN ./configure --prefix=/opt/scap-driver-toolchains/gcc-10 --enable-languages=c --disable-multilib \
 	&& make \
 	&& make install-strip
 
-FROM debian:11
-
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-	make \
-	libmpc3 \
-	libmpfr6
+FROM registry.access.redhat.com/ubi8
 
 COPY --from=tools /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
 COPY --from=llvm-7 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
-COPY --from=mpfr /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
 COPY --from=gcc-5 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
 COPY --from=gcc-6 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
 COPY --from=gcc-7 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
 COPY --from=gcc-8 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
 COPY --from=gcc-9 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
 COPY --from=gcc-10 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
+

--- a/docker/scap-driver-toolchains/Dockerfile
+++ b/docker/scap-driver-toolchains/Dockerfile
@@ -1,0 +1,158 @@
+FROM debian:10.10 AS base
+# Debian 10.10 has been chosen as a toolchain builder base because it's fully supported and is based on lib versions that are
+# compatible with most stable base images in use as of September 2021.
+# If this changes and it becomes required to dynamically link toolchains to newer base libraries (libc/libm, libgmp...)
+# it should be enough to increment the debian version number.
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+	gcc \
+	g++ \
+	make \
+	cmake \
+	xz-utils \
+	curl \
+	ca-certificates \
+	python \
+	gnupg \
+	libgmp10-dev \
+	libmpfr-dev \
+	libmpc-dev
+
+RUN curl -O -L https://mirrors.ocf.berkeley.edu/gnu/gnu-keyring.gpg \
+	&& gpg -q --import gnu-keyring.gpg
+
+RUN gpg --batch --keyserver keyserver.ubuntu.com --recv-keys A2C794A986419D8A
+
+FROM base AS tools
+
+WORKDIR /src/binutils
+
+RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/binutils/binutils-2.30.tar.gz{,.sig} \
+	&& gpg --verify binutils-2.30.tar.gz.sig \
+	&& tar --strip-components=1 -xf binutils-2.30.tar.gz
+
+RUN ./configure --prefix=/opt/scap-driver-toolchains/binutils-2.30 \
+	&& make \
+	&& make install-strip
+
+WORKDIR /src/dkms
+
+RUN curl --remote-name-all -L https://github.com/dell/dkms/archive/refs/tags/v2.8.5.tar.gz \
+	&& tar --strip-components=1 -xf v2.8.5.tar.gz \
+ 	&& make tarball \
+ 	&& make install DESTDIR=/opt/scap-driver-toolchains/dkms
+
+FROM base AS mpfr
+
+WORKDIR /src/mpfr
+
+RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.gz{,.sig} \
+	&& gpg --verify mpfr-4.1.0.tar.gz.sig \
+	&& tar --strip-components=1 -xf mpfr-4.1.0.tar.gz
+
+RUN ./configure --prefix /opt/scap-driver-toolchains/mpfr \
+	&& make \
+	&& make install-strip
+
+FROM base AS llvm-7
+
+WORKDIR /src/llvm/7
+
+RUN curl --remote-name-all -L https://github.com/llvm/llvm-project/releases/download/llvmorg-7.1.0/cfe-7.1.0.src.tar.xz{,.sig} \
+	https://github.com/llvm/llvm-project/releases/download/llvmorg-7.1.0/llvm-7.1.0.src.tar.xz{,.sig} \
+	&& gpg --verify cfe-7.1.0.src.tar.xz.sig \
+	&& gpg --verify llvm-7.1.0.src.tar.xz.sig \
+	&& tar -xf llvm-7.1.0.src.tar.xz \
+	&& tar -xf cfe-7.1.0.src.tar.xz \
+	&& mv cfe-7.1.0.src clang
+
+WORKDIR /src/llvm/7/build
+
+RUN cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=/opt/scap-driver-toolchains/llvm-7 -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_CXX_FLAGS='-static-libstdc++ -static-libgcc' -G "Unix Makefiles" ../llvm-7.1.0.src \
+	&& make \
+	&& make install/strip
+
+FROM base AS gcc-5
+
+WORKDIR /src/gcc/5
+
+RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/gcc/gcc-5.5.0/gcc-5.5.0.tar.gz{,.sig} \
+	&& gpg --verify gcc-5.5.0.tar.gz.sig \
+	&& tar --strip-components=1 -xf gcc-5.5.0.tar.gz
+RUN ./configure --prefix=/opt/scap-driver-toolchains/gcc-5 --enable-languages=c --disable-libsanitizer --disable-multilib \
+	&& make \
+	&& make install-strip
+
+FROM base AS gcc-6
+
+WORKDIR /src/gcc/6
+
+RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/gcc/gcc-6.5.0/gcc-6.5.0.tar.gz{,.sig} \
+	&& gpg --verify gcc-6.5.0.tar.gz.sig \
+	&& tar --strip-components=1 -xf gcc-6.5.0.tar.gz
+RUN ./configure --prefix=/opt/scap-driver-toolchains/gcc-6 --enable-languages=c --disable-libsanitizer --disable-multilib \
+	&& make \
+	&& make install-strip
+
+FROM base AS gcc-7
+
+WORKDIR /src/gcc/7
+
+RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/gcc/gcc-7.5.0/gcc-7.5.0.tar.gz{,.sig} \
+	&& gpg --verify gcc-7.5.0.tar.gz.sig \
+	&& tar --strip-components=1 -xf gcc-7.5.0.tar.gz
+RUN ./configure --prefix=/opt/scap-driver-toolchains/gcc-7 --enable-languages=c --disable-libsanitizer --disable-multilib \
+	&& make \
+	&& make install-strip
+
+FROM base AS gcc-8
+
+WORKDIR /src/gcc/8
+
+RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/gcc/gcc-8.5.0/gcc-8.5.0.tar.gz{,.sig} \
+	&& gpg --verify gcc-8.5.0.tar.gz.sig \
+	&& tar --strip-components=1 -xf gcc-8.5.0.tar.gz
+RUN ./configure --prefix=/opt/scap-driver-toolchains/gcc-8 --enable-languages=c --disable-multilib \
+	&& make \
+	&& make install-strip
+
+FROM base AS gcc-9
+
+WORKDIR /src/gcc/9
+
+RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/gcc/gcc-9.4.0/gcc-9.4.0.tar.gz{,.sig} \
+	&& gpg --verify gcc-9.4.0.tar.gz.sig \
+	&& tar --strip-components=1 -xf gcc-9.4.0.tar.gz
+RUN ./configure --prefix=/opt/scap-driver-toolchains/gcc-9 --enable-languages=c --disable-multilib \
+	&& make \
+	&& make install-strip
+
+FROM base AS gcc-10
+
+WORKDIR /src/gcc/10
+
+RUN curl --remote-name-all -L https://ftp.gnu.org/gnu/gcc/gcc-10.3.0/gcc-10.3.0.tar.gz{,.sig} \
+	&& gpg --verify gcc-10.3.0.tar.gz.sig \
+	&& tar --strip-components=1 -xf gcc-10.3.0.tar.gz
+RUN ./configure --prefix=/opt/scap-driver-toolchains/gcc-10 --enable-languages=c --disable-multilib \
+	&& make \
+	&& make install-strip
+
+FROM debian:11
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+	make \
+	libmpc3 \
+	libmpfr6
+
+COPY --from=tools /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
+COPY --from=llvm-7 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
+COPY --from=mpfr /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
+COPY --from=gcc-5 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
+COPY --from=gcc-6 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
+COPY --from=gcc-7 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
+COPY --from=gcc-8 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
+COPY --from=gcc-9 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/
+COPY --from=gcc-10 /opt/scap-driver-toolchains/ /opt/scap-driver-toolchains/


### PR DESCRIPTION
The current image we use as a base for Sysdig is based on Debian 10. In order to build the driver or BPF probe it requires the following toolchains installed:
* GCC from version 5.x to the latest that may be required to compile kernel modules
* clang 7 to compile the BPF probe (newer versions of clang are not supported)
* ld from Binutils 2.30 since kernel modules compiled with a newer version are not compatible with all kernel versions
* make, dkms and the likes

In order to do this, currently we import older deb files from snapshots and we try to make it work. This is not sustainable in the long run because:
* upgrading debian version on the container will make some of those older debs not installable because the older required dependencies are not there anymore
* more packages are deemed unsupported as time passes and require more .deb hacks
* likewise, installing other packages may become a problem since now everything we try to install may have newer dependencies that you can't install

In addition, this poses a security risk since when we downgrade some packages (e.g. binutils) we bring in old and unsupported libraries as dependencies which may contain vulnerabilities asnd happen to dynamically link with something that may process untrusted data. This kind of risk is picked up by automated vulnerability scanners which will alert about all old potentially vunlerable packages we install.

To solve this, I propose to compile all the specific versions of the toolchains we need and distribute them in binary form. The only requirement for them to work is that the dynamic libraries that they link to are present and compatible on the target base image. For example, the libraries used in this file would work fine on recent Debian (incl. Debian 11) and RedHat base images.

The advantages, in my opinion, are as follows:
* No more old/broken dependencies to bring in: this leaves the package manager in a sane state, allows us to install more software in the image if required and does not introduce potential vulnerabilities
* Precise control over which versions we install for all the toolchains to ensure maximum compatibility with kernel versions we support
* No tight dependency from a single type and version of base image
* Potentially, multi architecture support. None of the code in the Dockerfile is arch specific so we could technically build this for any supported arch and have the toolchains ready for its base image

Note that this Dockerfile takes a very long time to build (at least three hours even if done in parallel). However, once it's built it can be uploaded to Quay or Docker hub and would _not_ become the Sysdig base image. Simply, the Sysdig base image only needs to `COPY` the required files from the final layer. This image would need to be rebuilt only if the versions of the toolchains we use change, which I expect to happen very rarely.