### PR TITLE
new(docker): add builder container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+build*
+.*
+docker/*/Dockerfile

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,0 +1,53 @@
+FROM registry.access.redhat.com/ubi8
+
+LABEL name="sysdig/builder"
+LABEL usage="docker run -v $PWD/..:/source -v $PWD/build:/build sysdig/sysdig-builder cmake"
+
+ARG BUILD_TYPE=release
+ARG BUILD_DRIVER=OFF
+ARG BUILD_BPF=OFF
+ARG BUILD_WARNINGS_AS_ERRORS=ON
+ARG MAKE_JOBS=4
+
+ENV BUILD_TYPE=${BUILD_TYPE}
+ENV BUILD_DRIVER=${BUILD_DRIVER}
+ENV BUILD_BPF=${BUILD_BPF}
+ENV BUILD_WARNINGS_AS_ERRORS=${BUILD_WARNINGS_AS_ERRORS}
+ENV MAKE_JOBS=${MAKE_JOBS}
+
+RUN yum -y install \
+    gcc \
+    gcc-c++ \
+    make \
+    autoconf \
+    automake \
+    pkg-config \
+    patch \
+    libtool \
+    cmake \
+    llvm-toolset \
+    diffutils \
+    zlib-devel \
+    bzip2 \
+    cmake \
+    clang \
+    git
+
+RUN gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
+    12768A96795990107A0D2FDFFC57E3CCACD99A78
+
+WORKDIR /src/elfutils
+RUN curl --remote-name-all -L https://sourceware.org/elfutils/ftp/0.185/elfutils-0.185.tar.bz2{,.sig} \
+    && gpg --verify elfutils-0.185.tar.bz2.sig \
+    && tar --strip-components=1 -xf elfutils-0.185.tar.bz2 \
+    && rm elfutils-0.185.tar.bz2 \
+    && ./configure --enable-libdebuginfod=dummy --disable-debuginfod \
+    && make \
+    && make install-strip
+
+COPY ./root /
+
+WORKDIR /
+
+ENTRYPOINT ["build"]
+CMD ["usage"]

--- a/docker/builder/root/usr/bin/build
+++ b/docker/builder/root/usr/bin/build
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+SOURCE_DIR=/source
+BUILD_DIR=/build
+CMD=${1:-usage}
+shift
+
+# Build type can be "debug" or "release", fallbacks to "release" by default
+BUILD_TYPE=$(echo "$BUILD_TYPE" | tr "[:upper:]" "[:lower:]")
+DRAIOS_DEBUG_FLAGS=
+case "$BUILD_TYPE" in
+"debug")
+    DRAIOS_DEBUG_FLAGS="-D_DEBUG -DNDEBUG"
+    ;;
+*)
+    BUILD_TYPE="release"
+    ;;
+esac
+
+case "$CMD" in
+"cmake")
+    if [ ! -d "$SOURCE_DIR/sysdig" ]; then
+        echo "Missing sysdig source." >&2
+        exit 1
+    fi
+
+    if [ -d "$SOURCE_DIR/libs" ]; then
+        FALCOSECURITY_LIBS_SOURCE_DIR="$SOURCE_DIR/libs"
+    fi
+
+    # Prepare build directory
+    mkdir -p "$BUILD_DIR/$BUILD_TYPE"
+    cd "$BUILD_DIR/$BUILD_TYPE"
+
+    CMAKE_ARGS=(
+        -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+        -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX:-/usr}"
+        -DBUILD_DRIVER="$BUILD_DRIVER"
+        -DBUILD_BPF="$BUILD_BPF"
+        -DBUILD_WARNINGS_AS_ERRORS="$BUILD_WARNINGS_AS_ERRORS"
+        -DSYSDIG_VERSION="$BUILD_VERSION"
+        -DDRAIOS_DEBUG_FLAGS="$DRAIOS_DEBUG_FLAGS"
+        -DUSE_BUNDLED_DEPS=ON
+    )
+
+    if [ ! -z "${FALCOSECURITY_LIBS_SOURCE_DIR:=}" ]; then
+        CMAKE_ARGS+=(-DFALCOSECURITY_LIBS_SOURCE_DIR="$FALCOSECURITY_LIBS_SOURCE_DIR")
+    fi
+
+    CMAKE_ARGS+=("$SOURCE_DIR/sysdig")
+
+    cmake "${CMAKE_ARGS[@]}"
+    exit "$(printf '%d\n' $?)"
+    ;;
+"bash")
+    CMD=/bin/bash
+    ;& # fallthrough
+"usage")
+    exec "$CMD" "$@"
+    ;;
+*)
+    if [ ! -d "$BUILD_DIR/$BUILD_TYPE" ]; then
+        echo "Missing $BUILD_DIR/$BUILD_TYPE directory: run cmake."
+        exit 1
+    fi
+    cd "$BUILD_DIR/$BUILD_TYPE"
+    make -j"$MAKE_JOBS" "$CMD"
+    ;;
+esac

--- a/docker/builder/root/usr/bin/build
+++ b/docker/builder/root/usr/bin/build
@@ -9,7 +9,6 @@ shift
 
 # Build type can be "debug" or "release", fallbacks to "release" by default
 BUILD_TYPE=$(echo "$BUILD_TYPE" | tr "[:upper:]" "[:lower:]")
-DRAIOS_DEBUG_FLAGS=
 case "$BUILD_TYPE" in
 "debug")
     DRAIOS_DEBUG_FLAGS="-D_DEBUG -DNDEBUG"
@@ -41,7 +40,6 @@ case "$CMD" in
         -DBUILD_BPF="$BUILD_BPF"
         -DBUILD_WARNINGS_AS_ERRORS="$BUILD_WARNINGS_AS_ERRORS"
         -DSYSDIG_VERSION="$BUILD_VERSION"
-        -DDRAIOS_DEBUG_FLAGS="$DRAIOS_DEBUG_FLAGS"
         -DUSE_BUNDLED_DEPS=ON
     )
 

--- a/docker/builder/root/usr/bin/usage
+++ b/docker/builder/root/usr/bin/usage
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+gccversion=$(gcc --version | head -n1)
+cppversion=$(g++ -dM -E -x c++ /dev/null | grep -F __cplusplus | cut -d' ' -f3)
+cmakeversion=$(cmake --version | head -n1)
+clangversion=$(clang --version | head -n1)
+
+cat <<EOF
+Hello, this is the Sysdig builder container.
+
+How to use.
+
+    The default commands for the Sysdig builder image reports usage and environment info.
+    * docker run sysdig/sysdig-builder
+    * docker run sysdig/sysdig-builder usage
+
+    It supports bash.
+    * docker run -ti sysdig/sysdig-builder bash
+
+    To build it needs:
+    - The source directory in /source (ie., the directory containing the sysdig tree)
+
+    Optionally, you can also bind-mount the build directory.
+    So, you can execute it from the root directory as follows.
+
+    * docker run -v $PWD/..:/source -v $PWD/build:/build sysdig/sysdig-builder cmake
+    * docker run -v $PWD/..:/source -v $PWD/build:/build sysdig/sysdig-builder [<cmake-target-x>, ..., <cmake-target-y>]
+
+    Eg.,
+    * docker run -v $PWD/..:/source -v $PWD/build:/build sysdig/sysdig-builder tests
+    * docker run -v $PWD/..:/source -v $PWD/build:/build sysdig/sysdig-builder install
+
+How to build.
+
+    * cd docker/builder && DOCKER_BUILDKIT=1 docker build -t sysdig/sysdig-builder .
+
+    In case you want to customise the builder at build time the following build arguments are provided:
+    - BUILD_TYPE                whether you want a "release" or "debug" build (defaults to "release").
+    - BUILD_DRIVER              whether to build the driver or not (defaults to "OFF")
+    - BUILD_BPF                 whether to build the BPF driver or not (defaults to "OFF")
+    - BUILD_WARNINGS_AS_ERRORS  whether to intend warnings as errors or not (defaults to "ON")
+    - MAKE_JOBS                 the number of jobs to use during make (defaults to "4")
+    - BUILD_VERSION             the version to label the build (built from git index in case it is missing)
+
+    It is possible to change these at runtime (in the container) since environment variables with the same names are provided, too.
+
+Environment.
+
+    * ${gccversion}
+    * cplusplus ${cppversion}
+    * ${cmakeversion}
+    * ${clangversion}
+EOF


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca.guerra@sysdig.com>

This PR adds a builder container, in a similar way as Falco. The container has all the dependencies required to build Sysdig and libs and is based on UBI8. 
It can be used both as:
- A standalone image in which you bind-mount the source and build directory on any OS so that you can build Sysdig
- A building step base image to generate a Sysdig container