### PR TITLE
fix(docker): allow the builder container to build deb and rpm packages

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -31,19 +31,56 @@ RUN yum -y install \
     bzip2 \
     cmake \
     clang \
-    git
+    git \
+    file \
+    xz \
+    perl \
+    rpm-build \
+    rsync
+
+RUN curl -O -L https://mirrors.ocf.berkeley.edu/gnu/gnu-keyring.gpg \
+	&& gpg -q --import gnu-keyring.gpg
 
 RUN gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
     12768A96795990107A0D2FDFFC57E3CCACD99A78
 
-WORKDIR /src/elfutils
-RUN curl --remote-name-all -L https://sourceware.org/elfutils/ftp/0.185/elfutils-0.185.tar.bz2{,.sig} \
+RUN mkdir -p /usr/share/debian-keyrings \
+    && rsync -az --progress keyring.debian.org::keyrings/keyrings/ /usr/share/debian-keyrings
+
+WORKDIR /src
+RUN mkdir /src/elfutils \
+    && cd /src/elfutils \ 
+    && curl --remote-name-all -L https://sourceware.org/elfutils/ftp/0.185/elfutils-0.185.tar.bz2{,.sig} \
     && gpg --verify elfutils-0.185.tar.bz2.sig \
     && tar --strip-components=1 -xf elfutils-0.185.tar.bz2 \
-    && rm elfutils-0.185.tar.bz2 \
     && ./configure --enable-libdebuginfod=dummy --disable-debuginfod \
     && make \
-    && make install-strip
+    && make install-strip \
+    && rm -fr /src/elfutils
+
+# needed for dpkg autogen
+RUN mkdir /src/gettext \
+    && cd /src/gettext \ 
+    && curl --remote-name-all -L https://ftp.gnu.org/pub/gnu/gettext/gettext-0.21.tar.gz{,.sig} \
+    && gpg --verify gettext-0.21.tar.gz.sig \
+    && tar --strip-components=1 -xf gettext-0.21.tar.gz \
+    && ./configure \
+    && make \
+    && make install-strip \
+    && rm -fr /src/gettext
+
+RUN mkdir /src/dpkg \
+    && cd /src/dpkg \
+    && curl --remote-name-all -L http://deb.debian.org/debian/pool/main/d/dpkg/dpkg_1.20.9{.tar.xz,.dsc} \
+    && gpg --keyring /usr/share/debian-keyrings/debian-keyring.gpg --verify ./dpkg_1.20.9.dsc \
+    && SIGNED_CHECKSUM=$(grep Checksums-Sha256 -A 1 dpkg_1.20.9.dsc | grep dpkg_1.20.9.tar.xz | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | cut -d ' ' -f 1) \
+    && ACTUAL_CHECKSUM=$(sha256sum ./dpkg_1.20.9.tar.xz | cut -d ' ' -f 1) \
+    && [[ $SIGNED_CHECKSUM == $ACTUAL_CHECKSUM ]] \
+    && tar --strip-components=1 -xf dpkg_1.20.9.tar.xz \
+    && ./autogen \
+    && ./configure --disable-dselect --disable-start-stop-daemon --disable-update-alternatives \
+    && make install-strip \
+    && rm -fr /src/dpkg
 
 COPY ./root /
 


### PR DESCRIPTION
The builder container was missing `dpkg` since it's a Red Hat image.
There's no UBI package available for it so we can install it from source. Since the checksum is in dsc format and we're missing the tools for parsing it we'll use the smallest bash command we can to verify the signature and hash.