### PR TITLE
fix(sysdig): remove unused variable and fix chisel compilation warning

### DIFF
--- a/userspace/sinspui/ctext.cpp
+++ b/userspace/sinspui/ctext.cpp
@@ -40,7 +40,7 @@ ctext_config config_default;
 void search_copy(ctext_search *dst, ctext_search *src)
 {
 	// Because c++ makes life impossibly difficult.
-	memcpy(dst, src, sizeof(ctext_search) - sizeof(string));
+	memcpy(reinterpret_cast<void*>(dst), src, sizeof(ctext_search) - sizeof(string));
 	dst->_query = src->_query;
 }
 

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -776,10 +776,9 @@ void reset_tty_input_mode(void)
 
 void disable_tty_echo() {
 	struct termios tattr;
-	char *name;
 
 	/* Make sure stdin is a terminal. */
-	if (!isatty (STDIN_FILENO))
+	if (!isatty(STDIN_FILENO))
 	{
 		return;
 	}


### PR DESCRIPTION
sysdig-CLA-1.0-signed-off-by: Luca Guerra <luca.guerra@sysdig.com>

Simple changes to fix compilation warnings on new compilers. If you're wondering about the ugly cast, I believe the comment that was already there says it all.