### PR TITLE
new(ci): add Github Action for publishing the Sysdig builder container

### DIFF
--- a/.github/workflows/builder-update.yaml
+++ b/.github/workflows/builder-update.yaml
@@ -1,0 +1,31 @@
+name: Builder update
+on:
+  push:
+    branches: [dev]
+    paths: ['docker/builder/**']
+
+jobs:
+  update-builder:
+    env:
+      REGISTRY: ghcr.io
+      BUILDER_IMAGE_BASE: ghcr.io/draios/sysdig-builder
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sysdig
+        uses: actions/checkout@v2
+
+      - name: Login to Github Packages
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build new builder
+        id: build-builder
+        uses: docker/build-push-action@v2
+        with:
+          context: docker/builder
+          tags: ${{ format('{0}:dev,{0}:{1}', env.BUILDER_IMAGE_BASE, github.sha) }}
+          push: true


### PR DESCRIPTION
This PR adds a Github Action workflow that, upon every push in `dev`, if the builder has been modified will update the relevant container image and tag it with `dev`.

The repo used is the internal Github `ghcr.io` in the `draios` organization.