### PR TITLE
fix(cmake): fix driver name in RPM build

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -18,6 +18,10 @@
 configure_file(debian/postinst.in debian/postinst)
 configure_file(debian/prerm.in debian/prerm)
 
+configure_file(rpm/postinstall.in rpm/postinstall)
+configure_file(rpm/postuninstall.in rpm/postuninstall)
+configure_file(rpm/preuninstall.in rpm/preuninstall)
+
 install(FILES completions/bash/sysdig
 	DESTINATION "${DIR_ETC}/bash_completion.d")
 

--- a/scripts/rpm/postinstall.in
+++ b/scripts/rpm/postinstall.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
+# Copyright (C) 2013-2021 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #
@@ -15,10 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-dkms add -m sysdig -v %{version} --rpm_safe_upgrade
+
+mod_version="@PROBE_VERSION@"
+
+dkms add -m sysdig -v $mod_version --rpm_safe_upgrade
 if [ `uname -r | grep -c "BOOT"` -eq 0 ] && [ -e /lib/modules/`uname -r`/build/include ]; then
-	dkms build -m sysdig -v %{version}
-	dkms install --force -m sysdig -v %{version}
+	dkms build -m sysdig -v $mod_version
+	dkms install --force -m sysdig -v $mod_version
 elif [ `uname -r | grep -c "BOOT"` -gt 0 ]; then
 	echo -e ""
 	echo -e "Module build for the currently running kernel was skipped since you"

--- a/scripts/rpm/postuninstall.in
+++ b/scripts/rpm/postuninstall.in
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2013-2021 Draios Inc dba Sysdig.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/scripts/rpm/preuninstall.in
+++ b/scripts/rpm/preuninstall.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
+# Copyright (C) 2013-2021 Draios Inc dba Sysdig.
 #
 # This file is part of sysdig .
 #
@@ -15,4 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-dkms remove -m sysdig -v %{version} --all --rpm_safe_upgrade
+
+mod_version="@PROBE_VERSION@"
+dkms remove -m sysdig -v $mod_version --all --rpm_safe_upgrade


### PR DESCRIPTION
The driver name was still set to the Sysdig version. Since we now switched to libs version, update RPM generation accordingly.