### PR TITLE
new(github-actions): add github action to build module and probe

### DIFF
--- a/.github/workflows/build-drivers.yaml
+++ b/.github/workflows/build-drivers.yaml
@@ -5,7 +5,7 @@ on:
     paths: ['scripts/driverkit/**']
 
 jobs:
-  aws-test-job:
+  build-drivers:
     runs-on: ubuntu-latest
     env:
       S3_BUCKET: download.draios.com
@@ -51,6 +51,8 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1
+          # This timeout is longer because the complete job may take at least 4 hours to complete
+          role-duration-seconds: 21600
 
       - name: Build drivers if not present
         working-directory: scripts/driverkit/build

--- a/.github/workflows/build-drivers.yaml
+++ b/.github/workflows/build-drivers.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       S3_BUCKET: download.draios.com
-      S3_PREFIX: stable/sysdig-drivers
+      S3_PREFIX: scap-drivers
 
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:

--- a/.github/workflows/build-drivers.yaml
+++ b/.github/workflows/build-drivers.yaml
@@ -1,0 +1,57 @@
+name: Build Drivers with Driverkit
+on:
+  push:
+    branches: [dev]
+    paths: ['scripts/driverkit/**']
+
+jobs:
+  aws-test-job:
+    runs-on: ubuntu-latest
+    env:
+      S3_BUCKET: download.draios.com
+      S3_PREFIX: stable/sysdig-drivers
+
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout Sysdig
+        uses: actions/checkout@v2
+
+      - name: Checkout Driverkit
+        uses: actions/checkout@v2
+        with:
+          repository: falcosecurity/driverkit
+          ref: ea976707ebead03fe743c42183b50a16eddd6564
+          path: driverkit-repo
+
+      - name: Build Driverkit
+        working-directory: driverkit-repo
+        run: |
+          GIT_COMMIT=$(git rev-parse HEAD)
+          LDFLAGS="-X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/driverbuilder.builderBaseImage=falcosecurity/driverkit-builder:af65823"
+
+          CGO_ENABLED=1 go build -v -ldflags "$LDFLAGS" -tags 'sqlite_omit_load_extension linux' -o driverkit
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Setup poetry
+        uses: abatilo/actions-poetry@v2.0.0
+
+      - name: Install deps
+        working-directory: scripts/driverkit/build
+        run: poetry install
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@fcd8bb1e0a3c9d2a0687615ee31d34d8aea18a96
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
+      - name: Build drivers if not present
+        working-directory: scripts/driverkit/build
+        run: poetry run python build.py ../config --driverkit ../../../driverkit-repo/driverkit --s3-bucket ${{ env.S3_BUCKET }} --s3-prefix ${{ env.S3_PREFIX }}

--- a/scripts/driverkit/build/build.py
+++ b/scripts/driverkit/build/build.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import yaml
+import boto3
+import shutil
+import argparse
+import subprocess
+from pathlib import Path
+from botocore.errorfactory import ClientError
+
+def driverkit_build(driverkit: str, config_file: Path, driverversion: str, devicename: str, drivername: str) -> bool:
+    args = [driverkit, 'docker',
+            '-c', str(config_file.resolve()),
+            '--driverversion', driverversion,
+            '--moduledevicename', devicename,
+            '--moduledrivername', drivername,
+            '--timeout', '1000']
+    print('[*] {}'.format(' '.join(args)))
+    status = subprocess.run(args)
+
+    return status.returncode == 0
+
+def s3_exists(s3, bucket: str, key: str) -> bool:
+    try:
+        s3.head_object(Bucket=bucket, Key=key)
+    except ClientError:
+        # Not found
+        return False
+
+    return True
+
+def delete_file(filename: str):
+    try:
+        os.remove(filename)
+    except OSError:
+        pass
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('config_dir', help='The directory containing driverkit config files, organized as <driver_version>/<configN>.yaml')
+    ap.add_argument('--driverkit', help='Path to the driverkit binary to use')
+    ap.add_argument('--s3-bucket', help='The S3 bucket name')
+    ap.add_argument('--s3-prefix', help='S3 key prefix')
+    ap.add_argument('--moduledrivername', default='scap', help='The module driver name')
+    ap.add_argument('--moduledevicename', default='scap', help='The module device name')
+    args = ap.parse_args()
+
+    config_dir = Path(args.config_dir)
+    if not config_dir.exists():
+        print(f"[-] config directory does not exist: {config_dir}")
+        return 1
+
+    driverkit = shutil.which('driverkit')
+    if args.driverkit is not None:
+        driverkit = args.driverkit
+
+    if driverkit is None:
+        print(f"[-] driverkit not found. Select the driverkit binary with --driverkit")
+        return 1
+
+    if not os.path.exists(driverkit):
+        print(f"[-] driverkit binary {driverkit} does not exist")
+        return 1
+
+    s3 = None
+    s3_bucket = None
+    s3_prefix = None
+    if args.s3_bucket is not None and args.s3_prefix is not None:
+        s3 = boto3.client('s3')
+        s3_bucket = args.s3_bucket
+        s3_prefix = args.s3_prefix.lstrip('/')
+
+    dri_dirs = [x for x in config_dir.iterdir() if x.is_dir()]
+    for dri_dir in dri_dirs:
+        driverversion = dri_dir.name
+        print(f"[*] loading drivers from driver version directory {driverversion}")
+        files = list(dri_dir.glob("*.yaml"))
+        print(f"[*] found {len(files)} files")
+
+        count = 0
+        success_count = 0
+        fail_count = 0
+        skip_count = 0
+        for config_file in files:
+            count += 1
+            print('[*] [{:03d}/{:03d}] {}'.format(count, len(files), config_file.name))
+
+            with open(config_file) as fp:
+                conf = yaml.safe_load(fp)
+
+            module_output = conf.get('output', {}).get('module')
+            probe_output = conf.get('output', {}).get('probe')
+            
+            module_s3key = None
+            if module_output is not None:
+                module_basename = os.path.basename(module_output)
+                module_s3key = f"{s3_prefix}/{driverversion}/{module_basename}"
+
+            probe_s3key = None
+            if probe_output is not None:
+                probe_basename = os.path.basename(probe_output)
+                probe_s3key = f"{s3_prefix}/{driverversion}/{probe_basename}"
+
+            if s3:
+                need_module = (module_output is not None) and not s3_exists(s3, s3_bucket, module_s3key)
+                need_probe = (probe_output is not None) and not s3_exists(s3, s3_bucket, probe_s3key)
+            else:
+                need_module = (module_output is not None) and not os.path.exists(module_output)
+                need_probe = (probe_output is not None) and not os.path.exists(probe_output)
+
+            need_build = need_module or need_probe
+            if not need_build:
+                skip_count += 1
+                print('[*] {} already built'.format(config_file))
+                continue
+
+            # Make sure the output directory exists or driverkit will output "open: no such file or directory"
+            if module_output is not None:
+                Path(module_output).parent.mkdir(parents=True, exist_ok=True)
+            if probe_output is not None:
+                Path(probe_output).parent.mkdir(parents=True, exist_ok=True)
+
+            success = driverkit_build(driverkit, config_file, driverversion, args.moduledevicename, args.moduledrivername)
+            if success:
+                print(f"[+] Build completed {config_file}")
+                success_count += 1
+            else:
+                print(f"[-] Build failed {config_file}")
+                fail_count += 1
+                continue
+
+            # upload to s3 and remove
+            if s3:
+                if module_output is not None:
+                    with open(module_output, 'rb') as fp:
+                        s3.upload_fileobj(fp, s3_bucket, module_s3key) # XXX TODO ACL for public read
+                    delete_file(module_output)
+
+                if probe_output is not None:
+                    with open(probe_output, 'rb') as fp:
+                        s3.upload_fileobj(fp, s3_bucket, probe_s3key) # XXX TODO ACL for public read
+                    delete_file(probe_output)
+
+        print(f"[*] Build {driverversion} complete. {success_count}/{count} built, {fail_count}/{count} failed, {skip_count}/{count} already built.")
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/driverkit/build/build.py
+++ b/scripts/driverkit/build/build.py
@@ -135,12 +135,12 @@ def main():
             if s3:
                 if module_output is not None:
                     with open(module_output, 'rb') as fp:
-                        s3.upload_fileobj(fp, s3_bucket, module_s3key) # XXX TODO ACL for public read
+                        s3.upload_fileobj(fp, s3_bucket, module_s3key, ExtraArgs={'ACL':'public-read'})
                     delete_file(module_output)
 
                 if probe_output is not None:
                     with open(probe_output, 'rb') as fp:
-                        s3.upload_fileobj(fp, s3_bucket, probe_s3key) # XXX TODO ACL for public read
+                        s3.upload_fileobj(fp, s3_bucket, module_s3key, ExtraArgs={'ACL':'public-read'})
                     delete_file(probe_output)
 
         print(f"[*] Build {driverversion} complete. {success_count}/{count} built, {fail_count}/{count} failed, {skip_count}/{count} already built.")

--- a/scripts/driverkit/build/poetry.lock
+++ b/scripts/driverkit/build/poetry.lock
@@ -1,0 +1,163 @@
+[[package]]
+name = "boto3"
+version = "1.20.6"
+description = "The AWS SDK for Python"
+category = "main"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+botocore = ">=1.23.6,<1.24.0"
+jmespath = ">=0.7.1,<1.0.0"
+s3transfer = ">=0.5.0,<0.6.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.23.6"
+description = "Low-level, data-driven core of boto 3."
+category = "main"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+jmespath = ">=0.7.1,<1.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = ">=1.25.4,<1.27"
+
+[package.extras]
+crt = ["awscrt (==0.12.5)"]
+
+[[package]]
+name = "jmespath"
+version = "0.10.0"
+description = "JSON Matching Expressions"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "s3transfer"
+version = "0.5.0"
+description = "An Amazon S3 Transfer Manager"
+category = "main"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+botocore = ">=1.12.36,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "urllib3"
+version = "1.26.7"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.8"
+content-hash = "13f7c4eb3ab2050c8eca13f1c083ee6887c5d546d47d49c8b7520031c1490c5a"
+
+[metadata.files]
+boto3 = [
+    {file = "boto3-1.20.6-py3-none-any.whl", hash = "sha256:265d949fb6f86b5e698ca17393864d073fe0ed9225ebad6b58281297e3e1196c"},
+    {file = "boto3-1.20.6.tar.gz", hash = "sha256:9c0bb2315ef2d718d31322f27eff68c8175234105a5d3859a2683acf7681ffd0"},
+]
+botocore = [
+    {file = "botocore-1.23.6-py3-none-any.whl", hash = "sha256:66e8ae9249b1a66f049baae05b2d0556193db9efae58fc5791186341e123001c"},
+    {file = "botocore-1.23.6.tar.gz", hash = "sha256:9e8d870a0a4335ce4816c707137da54b1ab7bf98f0ed959a7ba59c98c7f6c057"},
+]
+jmespath = [
+    {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
+    {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
+s3transfer = [
+    {file = "s3transfer-0.5.0-py3-none-any.whl", hash = "sha256:9c1dc369814391a6bda20ebbf4b70a0f34630592c9aa520856bf384916af2803"},
+    {file = "s3transfer-0.5.0.tar.gz", hash = "sha256:50ed823e1dc5868ad40c8dc92072f757aa0e653a192845c94a3b676f4a62da4c"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
+    {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
+]

--- a/scripts/driverkit/build/pyproject.toml
+++ b/scripts/driverkit/build/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "sysdig-driverkit"
+version = "0.1.0"
+description = ""
+authors = ["Sysdig Inc. <support@sysdig.com>"]
+license = "Apache 2.0"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+boto3 = "^1.20.5"
+PyYAML = "^6.0"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
sysdig-CLA-1.0-signed-off-by: Luca Guerra <luca.guerra@sysdig.com>

This PR adds a GitHub Actions job and a corresponding script to build the drivers (i.e. kernel module and ebpf probe) for Sysdig via the Falco Driverkit tool. In order to be able to upload them to S3 it will need the necessary permissions added to the repo. Note that it doesn't rely on AWS tokens but it requires an AWS_ROLE_TO_ASSUME instead. It would only work when properly registered via OIDC on AWS side, which allows permissions to be managed directly from that console.