### PR TITLE
new(github-actions): add draft release process and new Sysdig Docker container

### DIFF
--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -1,0 +1,131 @@
+name: Create Sysdig draft/RC release
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build-release-linux:
+    runs-on: ubuntu-latest
+    env:
+      BUILD_VERSION: ${{ github.ref_name }}
+    container:
+      image: ghcr.io/draios/sysdig-builder:dev
+    steps:
+      - name: Checkout Sysdig
+        uses: actions/checkout@v2
+        with:
+          path: sysdig
+      - name: Link paths
+        run: |
+          mkdir -p /source
+          ln -s "$GITHUB_WORKSPACE/sysdig" /source/sysdig
+      - name: Build
+        run: build cmake
+      - name: Build packages
+        run: build package
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: sysdig-release-${{ env.BUILD_VERSION }}
+          path: /build/release/sysdig-${{ env.BUILD_VERSION }}*
+
+  push-container-image:
+    runs-on: ubuntu-latest
+    env:
+      BUILD_VERSION: ${{ github.ref_name }}
+      REGISTRY: ghcr.io
+      SYSDIG_IMAGE_BASE: ghcr.io/draios/sysdig
+    steps:
+      - name: Checkout Sysdig
+        uses: actions/checkout@v2
+      - name: Login to Github Packages
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push container images
+        uses: docker/build-push-action@v2
+        with:
+          file: docker/sysdig/Dockerfile
+          context: .
+          tags: ${{ env.SYSDIG_IMAGE_BASE }}:${{ env.BUILD_VERSION }}-draft
+          push: true
+          build-args:
+            BUILD_VERSION=${{ env.BUILD_VERSION }}
+
+  sign-rpms:
+    runs-on: ubuntu-latest
+    needs: [build-release-linux]
+    env:
+      BUILD_VERSION: ${{ github.ref_name }}
+      KEY_ID: EC51E8C4
+    container:
+      image: centos:8 # ubi8 does not have rpmsign so we'll use CentOS
+    steps:
+      - name: Install deps
+        run: yum install -y rpm-sign
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: sysdig-release-${{ env.BUILD_VERSION }}
+      - name: Import private key
+        env:
+          PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
+        run: printenv PRIVATE_KEY | gpg --import -
+      - name: Sign RPMs 
+        run: rpm --define "_gpg_name ${{ env.KEY_ID }}" --addsign *.rpm
+      - name: Check signature
+        run: test "$(rpm -qpi *.rpm | awk '/Signature/' | grep -i none | wc -l)" -eq 0
+      - name: Upload Signed RPMs
+        uses: actions/upload-artifact@v2
+        with:
+          name: sysdig-release-${{ env.BUILD_VERSION }}
+          path: "*.rpm"
+
+  sign-debs:
+    runs-on: ubuntu-latest
+    needs: [build-release-linux]
+    env:
+      BUILD_VERSION: ${{ github.ref_name }}
+      KEY_ID: EC51E8C4
+    container:
+      image: debian:bullseye-slim
+    steps:
+      - name: Install deps
+        run: apt-get update && apt-get -y install dpkg-sig
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: sysdig-release-${{ env.BUILD_VERSION }}
+      - name: Import private key
+        env:
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        run: printenv PRIVATE_KEY | gpg --import -
+      - name: Sign DEBs
+        run: dpkg-sig -k ${{ env.KEY_ID }} -s builder *.deb
+      - name: Check signature
+        run: dpkg-sig --verify *.deb
+      - name: Upload Signed DEBs
+        uses: actions/upload-artifact@v2
+        with:
+          name: sysdig-release-${{ env.BUILD_VERSION }}
+          path: "*.deb"
+
+  create-draft-release:
+    runs-on: ubuntu-latest
+    needs: [push-container-image, build-release-linux, sign-rpms, sign-debs]
+    env:
+      BUILD_VERSION: ${{ github.ref_name }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: sysdig-release-${{ env.BUILD_VERSION }}
+      - name: Create draft release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            sysdig-${{ env.BUILD_VERSION }}*
+          draft: true

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -72,7 +72,7 @@ jobs:
           name: sysdig-release-${{ env.BUILD_VERSION }}
       - name: Import private key
         env:
-          PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
+          PRIVATE_KEY: ${{ secrets.SYSDIG_REPO_SIGNING_KEY }}
         run: printenv PRIVATE_KEY | gpg --import -
       - name: Sign RPMs 
         run: rpm --define "_gpg_name ${{ env.KEY_ID }}" --addsign *.rpm
@@ -101,7 +101,7 @@ jobs:
           name: sysdig-release-${{ env.BUILD_VERSION }}
       - name: Import private key
         env:
-          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY: ${{ secrets.SYSDIG_REPO_SIGNING_KEY }}
         run: printenv PRIVATE_KEY | gpg --import -
       - name: Sign DEBs
         run: dpkg-sig -k ${{ env.KEY_ID }} -s builder *.deb

--- a/docker/sysdig/Dockerfile
+++ b/docker/sysdig/Dockerfile
@@ -1,0 +1,47 @@
+FROM ghcr.io/draios/sysdig-builder:dev AS builder
+
+ARG BUILD_VERSION=0.1.1dev
+ENV BUILD_VERSION=${BUILD_VERSION}
+
+WORKDIR /source
+
+COPY . /source/sysdig
+
+RUN if [ -d /source/sysdig/falcosecurity-libs ]; then ln -s /source/sysdig/falcosecurity-libs /source/libs; fi
+
+RUN INSTALL_PREFIX=/opt/sysdig build cmake
+RUN build install
+
+FROM registry.access.redhat.com/ubi8/ubi
+
+RUN yum -y install \
+    make \
+    kmod \
+    gcc \
+    clang \
+    llvm-toolset
+
+RUN mkdir -p /tmp/dkms \
+    && cd /tmp/dkms \
+    && curl --remote-name-all -L https://github.com/dell/dkms/archive/refs/tags/v2.8.5.tar.gz \
+    && tar --strip-components=1 -xf v2.8.5.tar.gz \
+    && make tarball \
+    && make install \
+    && cd /tmp \
+    && rm -fr /tmp/dkms
+
+COPY --from=builder /opt/sysdig /opt/sysdig
+RUN for b in /opt/sysdig/bin/*; do ln -s "$b" /usr/bin/$(basename "$b"); done \
+    && for b in /opt/sysdig/src/*; do ln -s "$b" /usr/src/$(basename "$b"); done
+
+COPY docker/sysdig/docker-entrypoint.sh /
+
+ENV HOST_ROOT /host
+ENV SYSDIG_HOST_ROOT /host
+
+RUN rm -df /lib/modules \
+	&& ln -s $HOST_ROOT/lib/modules /lib/modules
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["bash"]

--- a/docker/sysdig/Dockerfile
+++ b/docker/sysdig/Dockerfile
@@ -19,7 +19,8 @@ RUN yum -y install \
     kmod \
     gcc \
     clang \
-    llvm-toolset
+    llvm-toolset \
+    less
 
 RUN mkdir -p /tmp/dkms \
     && cd /tmp/dkms \

--- a/docker/sysdig/README.md
+++ b/docker/sysdig/README.md
@@ -1,0 +1,5 @@
+# Sysdig Docker image
+
+To build the Sysdig image, run `docker build -f docker/sysdig/Dockerfile .` from the Sysdig root directory
+
+By default, a compatible version of the `falcosecurity/libs` dependency is downloaded from GitHub and built. If you want to link against a local falcosecurity/libs version you can do so by putting it under `falcosecurity-libs` in the Sysdig root directory.

--- a/docker/sysdig/docker-entrypoint.sh
+++ b/docker/sysdig/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright (C) 2013-2018 Draios Inc dba Sysdig.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#set -e
+
+echo "* Setting up /usr/src links from host"
+
+for i in $(ls $HOST_ROOT/usr/src)
+do
+    ln -s $HOST_ROOT/usr/src/$i /usr/src/$i
+done
+
+/usr/bin/sysdig-driver-loader
+
+exec "$@"

--- a/docker/sysdig/docker-entrypoint.sh
+++ b/docker/sysdig/docker-entrypoint.sh
@@ -25,6 +25,6 @@ do
     ln -s $HOST_ROOT/usr/src/$i /usr/src/$i
 done
 
-/usr/bin/sysdig-driver-loader
+/usr/bin/scap-driver-loader
 
 exec "$@"


### PR DESCRIPTION
sysdig-CLA-1.0-signed-off-by: Luca Guerra <luca.guerra@sysdig.com>

This PR adds a Github Action workflow that builds Sysdig, its container image specified by the Dockerfile, signs the debs and RPMs and creates a Draft release out of it. A maintainer can then fill the release notes (since there's no automated process for that yet) and push the button to complete the operation, which will trigger another workflow that publishes all the artifacts and updates the `latest` on the relevant repositories.

⚠️ NOTE: before merging this we need to make sure the driver loader script is correct and current with `scap-driver-loader` https://github.com/draios/sysdig/pull/1807, which can only be finalized after the driver builder (https://github.com/draios/sysdig/pull/1792) is added! ⚠️ 