### PR TITLE
docker: use Falco builder image (Centos7 Based)

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8
+FROM centos:7
 
 LABEL name="sysdig/builder"
 LABEL usage="docker run -v $PWD/..:/source -v $PWD/build:/build sysdig/sysdig-builder cmake"
@@ -17,74 +17,28 @@ ENV BUILD_VERSION=${BUILD_VERSION}
 ENV BUILD_WARNINGS_AS_ERRORS=${BUILD_WARNINGS_AS_ERRORS}
 ENV MAKE_JOBS=${MAKE_JOBS}
 
-RUN yum -y install \
-    gcc \
-    gcc-c++ \
-    make \
-    autoconf \
-    automake \
-    pkg-config \
-    patch \
-    libtool \
-    cmake \
-    llvm-toolset \
-    diffutils \
-    zlib-devel \
-    bzip2 \
-    cmake \
-    clang \
-    git \
-    file \
-    xz \
-    perl \
-    rpm-build \
-    rsync
+# build toolchain
+RUN yum -y install centos-release-scl && \
+    INSTALL_PKGS="devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-toolchain devtoolset-7-libstdc++-devel devtoolset-7-elfutils-libelf-devel llvm-toolset-7 glibc-static autoconf automake libtool createrepo expect git which libcurl-devel zlib-devel rpm-build libyaml-devel" && \
+    yum -y install --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS
 
-RUN curl -O -L https://mirrors.ocf.berkeley.edu/gnu/gnu-keyring.gpg \
-	&& gpg -q --import gnu-keyring.gpg
-
-RUN gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
-    12768A96795990107A0D2FDFFC57E3CCACD99A78
-
-RUN mkdir -p /usr/share/debian-keyrings \
-    && rsync -az --progress keyring.debian.org::keyrings/keyrings/ /usr/share/debian-keyrings
-
-WORKDIR /src
-RUN mkdir /src/elfutils \
-    && cd /src/elfutils \ 
-    && curl --remote-name-all -L https://sourceware.org/elfutils/ftp/0.185/elfutils-0.185.tar.bz2{,.sig} \
-    && gpg --verify elfutils-0.185.tar.bz2.sig \
-    && tar --strip-components=1 -xf elfutils-0.185.tar.bz2 \
-    && ./configure --enable-libdebuginfod=dummy --disable-debuginfod \
-    && make \
-    && make install-strip \
-    && rm -fr /src/elfutils
-
-# needed for dpkg autogen
-RUN mkdir /src/gettext \
-    && cd /src/gettext \ 
-    && curl --remote-name-all -L https://ftp.gnu.org/pub/gnu/gettext/gettext-0.21.tar.gz{,.sig} \
-    && gpg --verify gettext-0.21.tar.gz.sig \
-    && tar --strip-components=1 -xf gettext-0.21.tar.gz \
-    && ./configure \
-    && make \
-    && make install-strip \
-    && rm -fr /src/gettext
-
-RUN mkdir /src/dpkg \
-    && cd /src/dpkg \
-    && curl --remote-name-all -L http://deb.debian.org/debian/pool/main/d/dpkg/dpkg_1.20.9{.tar.xz,.dsc} \
-    && gpg --keyring /usr/share/debian-keyrings/debian-keyring.gpg --verify ./dpkg_1.20.9.dsc \
-    && SIGNED_CHECKSUM=$(grep Checksums-Sha256 -A 1 dpkg_1.20.9.dsc | grep dpkg_1.20.9.tar.xz | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | cut -d ' ' -f 1) \
-    && ACTUAL_CHECKSUM=$(sha256sum ./dpkg_1.20.9.tar.xz | cut -d ' ' -f 1) \
-    && [[ $SIGNED_CHECKSUM == $ACTUAL_CHECKSUM ]] \
-    && tar --strip-components=1 -xf dpkg_1.20.9.tar.xz \
-    && ./autogen \
-    && ./configure --disable-dselect --disable-start-stop-daemon --disable-update-alternatives \
-    && make install-strip \
-    && rm -fr /src/dpkg
+ARG CMAKE_VERSION=3.6.3
+RUN source scl_source enable devtoolset-7 llvm-toolset-7 && \
+    cd /tmp && \
+    curl -L https://github.com/kitware/cmake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz | tar xz; \
+    cd cmake-${CMAKE_VERSION} && \
+    ./bootstrap --system-curl && \
+    make -j${MAKE_JOBS} && \
+    make install && \
+    rm -rf /tmp/cmake-${CMAKE_VERSION}
 
 COPY ./root /
+
+# DTS
+ENV BASH_ENV=/usr/bin/scl_enable \
+    ENV=/usr/bin/scl_enable \
+    PROMPT_COMMAND=". /usr/bin/scl_enable"
 
 WORKDIR /
 

--- a/docker/builder/root/usr/bin/scl_enable
+++ b/docker/builder/root/usr/bin/scl_enable
@@ -1,0 +1,7 @@
+
+# IMPORTANT: Do not add more content to this file unless you know what you are doing.
+#            This file is sourced everytime the shell session is opened.
+#
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable devtoolset-7 llvm-toolset-7


### PR DESCRIPTION
sysdig-CLA-1.0-signed-off-by: Luca Guerra <luca.guerra@sysdig.com>

This PR changes the builder image to use the same that Falco has.
The following images have been tested in order to come to the conclusion that the Falco one is still the best:
- The previous image, based on UBI8, works well but the binaries it compiles won't work on CentOS 7 which is still supported
- UBI7 cannot be used as it doesn't natively support SCL without a RedHat subscription, leaving us with aincent compilers
- The binaries this image produces do work with UBI8/RHEL8 so we are still compatible