### PR TITLE
rpm: fix postinstinstall command

### DIFF
--- a/scripts/rpm/postinstall.in
+++ b/scripts/rpm/postinstall.in
@@ -20,7 +20,7 @@ mod_version="@PROBE_VERSION@"
 mod_name="@DRIVER_PACKAGE_NAME@"
 
 dkms add -m $mod_name -v $mod_version --rpm_safe_upgrade
-if [ `uname -r | $mod_name -c "BOOT"` -eq 0 ] && [ -e /lib/modules/`uname -r`/build/include ]; then
+if [ `uname -r | grep -c "BOOT"` -eq 0 ] && [ -e /lib/modules/`uname -r`/build/include ]; then
 	dkms build -m $mod_name -v $mod_version
 	dkms install --force -m $mod_name -v $mod_version
 elif [ `uname -r | grep -c "BOOT"` -gt 0 ]; then


### PR DESCRIPTION
sysdig-CLA-1.0-signed-off-by: Luca Guerra <luca.guerra@sysdig.com>

Fix overzealous copy-paste that made `grep` become `$mod_name` 😅 