### PR TITLE
new(github-actions): finalize release process

### DIFF
--- a/.github/workflows/release-final.yaml
+++ b/.github/workflows/release-final.yaml
@@ -1,0 +1,193 @@
+name: Finalize release
+on:
+  release:
+    types: [published]
+
+jobs:
+  push-final-images:
+    runs-on: ubuntu-latest
+    env:
+      SYSDIG_IMAGE_BASE: ghcr.io/sysdig/sysdig
+      SYSDIG_DOCKERHUB_IMAGE_BASE: docker.io/sysdig/sysdig
+      RELEASE: ${{ github.event.release.name }}
+
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Login to Github Packages
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish final docker images
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ${{ env.SYSDIG_IMAGE_BASE }}:${{ env.RELEASE }}-draft
+          dst: |
+            ${{ env.SYSDIG_IMAGE_BASE }}:${{ env.RELEASE }}
+            ${{ env.SYSDIG_IMAGE_BASE }}:latest
+            ${{ env.SYSDIG_DOCKERHUB_IMAGE_BASE }}:${{ env.RELEASE }}
+            ${{ env.SYSDIG_DOCKERHUB_IMAGE_BASE }}:latest
+
+  release-rpm:
+    runs-on: ubuntu-latest
+    env:
+      RPM_BASEARCH: x86_64
+      RELEASE_ARCH: x86_64
+      REPOSITORY_NAME: stable
+      REPOSITORY_DIR: rpm_repo
+      PACKAGES_DIR: packages
+      S3_BUCKET: download.draios.com
+      RELEASE: ${{ github.event.release.name }}
+
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    container:
+      image: centos:8
+
+    steps:
+      - name: Install deps
+        run: |
+          yum -y install unzip createrepo_c git
+          cd /tmp
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          ./aws/install
+
+      - name: Checkout Sysdig
+        uses: actions/checkout@v2
+        with:
+          path: sysdig
+
+      - name: Create directories
+        run: |
+          mkdir -p $REPOSITORY_DIR
+          mkdir -p $PACKAGES_DIR
+
+      - name: Download RPM
+        uses: dsaltares/fetch-gh-release-asset@master
+        with:
+          version: "tags/${{ env.RELEASE }}"
+          file: sysdig-${{ env.RELEASE }}-${{ env.RELEASE_ARCH }}.rpm
+          target: ${{ env.PACKAGES_DIR }}/sysdig-${{ env.RELEASE }}-${{ env.RELEASE_ARCH }}.rpm
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@fcd8bb1e0a3c9d2a0687615ee31d34d8aea18a96
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
+      - name: Release RPMs
+        env:
+          SCRIPTS_DIR: sysdig/scripts/release
+        run: sysdig/scripts/release/release_rpm.sh
+        
+  release-deb:
+    runs-on: ubuntu-latest
+    env:
+      DEB_BASEARCH: amd64
+      RELEASE_ARCH: x86_64
+      REPOSITORY_NAME: stable
+      REPOSITORY_DIR: deb_repo
+      PACKAGES_DIR: packages
+      RELEASE: ${{ github.event.release.name }}
+      S3_BUCKET: download.draios.com
+      KEY_ID: EC51E8C4
+    
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Install deps
+        run: |
+          sudo apt-get update && sudo apt-get -y install dpkg-dev gpg
+
+      - name: Checkout Sysdig
+        uses: actions/checkout@v2
+        with:
+          path: sysdig
+
+      - name: Create directories
+        run: |
+          mkdir -p $REPOSITORY_DIR
+          mkdir -p $PACKAGES_DIR
+
+      - name: Download DEB
+        uses: dsaltares/fetch-gh-release-asset@master
+        with:
+          version: "tags/${{ env.RELEASE }}"
+          file: sysdig-${{ env.RELEASE }}-${{ env.RELEASE_ARCH }}.deb
+          target: ${{ env.PACKAGES_DIR }}/sysdig-${{ env.RELEASE }}-${{ env.RELEASE_ARCH }}.deb
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@fcd8bb1e0a3c9d2a0687615ee31d34d8aea18a96
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
+      - name: Import private key
+        env:
+          PRIVATE_KEY: ${{ secrets.SYSDIG_REPO_SIGNING_KEY }}
+        run: printenv PRIVATE_KEY | gpg --import -
+
+      - name: Release DEBs
+        env:
+          SCRIPTS_DIR: sysdig/scripts/release
+        run: sysdig/scripts/release/release_deb.sh
+  
+  release-tgz:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_ARCH: x86_64
+      TGZ_BASEARCH: x86_64
+      REPOSITORY_NAME: stable
+      REPOSITORY_DIR: tgz_repo
+      PACKAGES_DIR: packages
+      RELEASE: ${{ github.event.release.name }}
+      S3_BUCKET: download.draios.com
+
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout Sysdig
+        uses: actions/checkout@v2
+        with:
+          path: sysdig
+
+      - name: Create directories
+        run: |
+          mkdir -p $REPOSITORY_DIR
+          mkdir -p $PACKAGES_DIR
+
+      - name: Download targz
+        uses: dsaltares/fetch-gh-release-asset@master
+        with:
+          version: "tags/${{ env.RELEASE }}"
+          file: sysdig-${{ env.RELEASE }}-${{ env.RELEASE_ARCH }}.tar.gz
+          target: ${{ env.PACKAGES_DIR }}/sysdig-${{ env.RELEASE }}-${{ env.RELEASE_ARCH }}.tar.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@fcd8bb1e0a3c9d2a0687615ee31d34d8aea18a96
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+      
+      - name: Release tar.gz
+        run: sysdig/scripts/release/release_tgz.sh

--- a/scripts/release/draios.list
+++ b/scripts/release/draios.list
@@ -1,0 +1,1 @@
+deb https://download.sysdig.com/_REPOSITORY_/deb stable-$(ARCH)/

--- a/scripts/release/draios.repo
+++ b/scripts/release/draios.repo
@@ -1,0 +1,7 @@
+[draios]
+name=Draios
+baseurl=https://download.sysdig.com/_REPOSITORY_/rpm/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://download.sysdig.com/DRAIOS-GPG-KEY.public
+#repo_gpgcheck=1

--- a/scripts/release/release_deb.sh
+++ b/scripts/release/release_deb.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+echo "REPOSITORY_DIR: $REPOSITORY_DIR"
+echo "DEB_BASEARCH: $DEB_BASEARCH" # e.g. amd64
+echo "REPOSITORY_NAME: $REPOSITORY_NAME"
+echo "PACKAGES_DIR: $PACKAGES_DIR"
+echo "SCRIPTS_DIR: $SCRIPTS_DIR"
+echo "S3_BUCKET: $S3_BUCKET"
+KEY_ID="$KEY_ID" # only check that it is set
+
+DEB_REPOSITORY_DIR=$REPOSITORY_DIR/deb/
+
+mkdir -p $REPOSITORY_DIR/deb/stable-$DEB_BASEARCH
+
+aws s3 sync s3://$S3_BUCKET/$REPOSITORY_NAME/deb/stable-$DEB_BASEARCH/ $REPOSITORY_DIR/deb/stable-$DEB_BASEARCH/ --exact-timestamps --acl public-read # --delete
+# ls -1tdr $REPOSITORY_DIR/deb/stable-$DEB_BASEARCH/*sysdig* | head -n -5 | xargs -d '\n' rm -f || true
+
+cp $PACKAGES_DIR/*deb $REPOSITORY_DIR/deb/stable-$DEB_BASEARCH
+dpkg-scanpackages --multiversion $REPOSITORY_DIR/deb/stable-$DEB_BASEARCH | sed s@$DEB_REPOSITORY_DIR@@ > $REPOSITORY_DIR/deb/stable-$DEB_BASEARCH/Packages
+
+gzip -c $REPOSITORY_DIR/deb/stable-$DEB_BASEARCH/Packages > $REPOSITORY_DIR/deb/stable-$DEB_BASEARCH/Packages.gz
+cd $REPOSITORY_DIR/deb/stable-$DEB_BASEARCH
+echo "Date:" $(date -R) > Release
+echo "Suite: stable-$DEB_BASEARCH" >> Release
+echo "MD5Sum:" >> Release
+echo -n " "$(md5sum Packages | cut -d" " -f1) >> Release
+echo " "$(du -b Packages) >> Release
+echo -n " "$(md5sum Packages.gz | cut -d" " -f1) >> Release
+echo " "$(du -b Packages.gz) >> Release
+echo "SHA1:" >> Release
+echo -n " "$(sha1sum Packages | cut -d" " -f1) >> Release
+echo " "$(du -b Packages) >> Release
+echo -n " "$(sha1sum Packages.gz | cut -d" " -f1) >> Release
+echo " "$(du -b Packages.gz) >> Release
+echo "SHA256:" >> Release
+echo -n " "$(sha256sum Packages | cut -d" " -f1) >> Release
+echo " "$(du -b Packages) >> Release
+echo -n " "$(sha256sum Packages.gz | cut -d" " -f1) >> Release
+echo " "$(du -b Packages.gz) >> Release
+echo "SHA512:" >> Release
+echo -n " "$(sha512sum Packages | cut -d" " -f1) >> Release
+echo " "$(du -b Packages) >> Release
+echo -n " "$(sha512sum Packages.gz | cut -d" " -f1) >> Release
+echo " "$(du -b Packages.gz) >> Release
+
+gpg --local-user "$KEY_ID" --batch --no-tty --yes --digest-algo SHA256 -abs -o Release.gpg Release
+gpg --local-user "$KEY_ID" --batch --no-tty --yes -a -s --clearsign --digest-algo SHA256 --output  InRelease Release
+
+cd -
+
+sed -e s/_REPOSITORY_/$REPOSITORY_NAME/g < $SCRIPTS_DIR/draios.list > $REPOSITORY_DIR/deb/draios.list
+
+aws s3 cp $REPOSITORY_DIR/deb/draios.list s3://$S3_BUCKET/$REPOSITORY_NAME/deb/ --acl public-read
+aws s3 sync $REPOSITORY_DIR/deb/stable-$DEB_BASEARCH/ s3://$S3_BUCKET/$REPOSITORY_NAME/deb/stable-$DEB_BASEARCH/ --exact-timestamps --acl public-read --delete

--- a/scripts/release/release_rpm.sh
+++ b/scripts/release/release_rpm.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# required env variables
+echo "REPOSITORY_DIR: $REPOSITORY_DIR" # root repo directory on the local filesystem
+echo "RPM_BASEARCH: $RPM_BASEARCH"
+echo "REPOSITORY_NAME: $REPOSITORY_NAME"
+echo "PACKAGES_DIR: $PACKAGES_DIR"
+echo "SCRIPTS_DIR: $SCRIPTS_DIR"
+echo "S3_BUCKET: $S3_BUCKET"
+
+mkdir -p $REPOSITORY_DIR/rpm/$RPM_BASEARCH
+
+aws s3 sync s3://$S3_BUCKET/$REPOSITORY_NAME/rpm/$RPM_BASEARCH/ $REPOSITORY_DIR/rpm/$RPM_BASEARCH/ --exact-timestamps --acl public-read # --delete
+# ls -1tdr $REPOSITORY_DIR/rpm/$RPM_BASEARCH/*sysdig*.rpm | head -n -5 | xargs -d '\n' rm -f || true
+
+cp $PACKAGES_DIR/*rpm $REPOSITORY_DIR/rpm/$RPM_BASEARCH
+createrepo $REPOSITORY_DIR/rpm/$RPM_BASEARCH
+
+cp $SCRIPTS_DIR/draios.repo $REPOSITORY_DIR/rpm
+sed -i s/_REPOSITORY_/$REPOSITORY_NAME/g $REPOSITORY_DIR/rpm/draios.repo
+
+aws s3 cp $REPOSITORY_DIR/rpm/draios.repo s3://$S3_BUCKET/$REPOSITORY_NAME/rpm/ --acl public-read # --delete
+aws s3 sync $REPOSITORY_DIR/rpm/$RPM_BASEARCH/ s3://$S3_BUCKET/$REPOSITORY_NAME/rpm/$RPM_BASEARCH/ --exact-timestamps --acl public-read --delete

--- a/scripts/release/release_tgz.sh
+++ b/scripts/release/release_tgz.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+echo "REPOSITORY_DIR: $REPOSITORY_DIR"
+echo "TGZ_BASEARCH: $TGZ_BASEARCH"
+echo "REPOSITORY_NAME: $REPOSITORY_NAME"
+echo "S3_BUCKET: $S3_BUCKET"
+echo "PACKAGES_DIR: $PACKAGES_DIR"
+
+mkdir -p $REPOSITORY_DIR/tgz/$TGZ_BASEARCH
+
+for tgz_file in $PACKAGES_DIR/*tar.gz; do
+    aws s3 cp "$tgz_file" s3://$S3_BUCKET/$REPOSITORY_NAME/tgz/$TGZ_BASEARCH/ --acl public-read
+done


### PR DESCRIPTION
This adds the release process finalize job, which takes the artifacts produced by the draft release job and, upon pressing the green release button, will perform complete upload of all binaries, rpm, tgz and docker images.

Requires the draft job to exist first.