### PR TITLE
fix(builder): make sure dpkg is installed

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -21,7 +21,9 @@ ENV MAKE_JOBS=${MAKE_JOBS}
 RUN yum -y install centos-release-scl && \
     INSTALL_PKGS="devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-toolchain devtoolset-7-libstdc++-devel devtoolset-7-elfutils-libelf-devel llvm-toolset-7 glibc-static autoconf automake libtool createrepo expect git which libcurl-devel zlib-devel rpm-build libyaml-devel" && \
     yum -y install --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS
+    rpm -V $INSTALL_PKGS && \
+    yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum -y install dpkg
 
 ARG CMAKE_VERSION=3.6.3
 RUN source scl_source enable devtoolset-7 llvm-toolset-7 && \


### PR DESCRIPTION
sysdig-CLA-1.0-signed-off-by: Luca Guerra <luca.guerra@sysdig.com>

The CentOS7 based builder does not have dpkg installed by default. This fixes `empty value for 'Architecture' field` when trying to install the produced debs.