### PR TITLE
userspace/sinspui: always use "%s"-style format for printf()-style fu…

### DIFF
--- a/userspace/sinspui/cursescomponents.cpp
+++ b/userspace/sinspui/cursescomponents.cpp
@@ -875,7 +875,7 @@ void curses_textbox::print_no_data()
 	string wstr = "No Data For This Selection";
 	mvprintw(m_parent->m_screenh / 2,
 		m_parent->m_screenw / 2 - wstr.size() / 2,
-		wstr.c_str());
+		"%s", wstr.c_str());
 
 	refresh();
 }
@@ -1098,7 +1098,7 @@ void curses_textbox::render()
 		attrset(m_parent->m_colors[sinsp_cursesui::LARGE_NUMBER]);
 		mvprintw(0,
 			m_parent->m_screenw / 2 - wstr.size() / 2,
-			wstr.c_str());
+			"%s", wstr.c_str());
 	}
 
 	//

--- a/userspace/sinspui/cursesspectro.cpp
+++ b/userspace/sinspui/cursesspectro.cpp
@@ -223,8 +223,8 @@ void curses_spectro::print_error(string wstr)
 
 	mvwprintw(m_tblwin, 
 		m_parent->m_screenh / 2,
-		m_parent->m_screenw / 2 - wstr.size() / 2, 
-		wstr.c_str());	
+		m_parent->m_screenw / 2 - wstr.size() / 2,
+		"%s", wstr.c_str());
 }
 
 void curses_spectro::update_data(vector<sinsp_sample_row>* data, bool force_selection_change)

--- a/userspace/sinspui/cursestable.cpp
+++ b/userspace/sinspui/cursestable.cpp
@@ -252,7 +252,7 @@ void curses_table::print_line_centered(string line, int32_t off)
 		mvwprintw(m_tblwin, 
 			m_parent->m_screenh / 2 + off,
 			m_parent->m_screenw / 2 - line.size() / 2, 
-			line.c_str());
+			"%s", line.c_str());
 	}
 	else
 	{
@@ -266,7 +266,7 @@ glogf("2, %d %s\n", spos, ss.c_str());
 			mvwprintw(m_tblwin, 
 				m_parent->m_screenh / 2 + off + j,
 				0,
-				ss.c_str());
+				"%s", ss.c_str());
 
 			spos += m_parent->m_screenw;
 			if(spos >= line.size())
@@ -325,8 +325,8 @@ void curses_table::print_error(string wstr)
 
 	mvwprintw(m_tblwin, 
 		m_parent->m_screenh / 2,
-		m_parent->m_screenw / 2 - wstr.size() / 2, 
-		wstr.c_str());	
+		m_parent->m_screenw / 2 - wstr.size() / 2,
+		"%s", wstr.c_str());
 }
 
 void curses_table::render(bool data_changed)

--- a/userspace/sinspui/cursesui.cpp
+++ b/userspace/sinspui/cursesui.cpp
@@ -821,8 +821,8 @@ void sinsp_cursesui::render_header()
 		string wstr = "PAUSED";
 		attrset(m_colors[sinsp_cursesui::LARGE_NUMBER]);
 		mvprintw(0,
-			m_screenw / 2 - wstr.size() / 2, 
-			wstr.c_str());	
+			m_screenw / 2 - wstr.size() / 2,
+			"%s", wstr.c_str());
 	}
 
 	//
@@ -1120,7 +1120,7 @@ void sinsp_cursesui::render_filtersearch_main_menu()
 
 		m_cursor_pos = cursor_pos;
 
-		mvprintw(m_screenh - 1, m_cursor_pos, str->c_str());
+		mvprintw(m_screenh - 1, m_cursor_pos, "%s", str->c_str());
 
 		m_cursor_pos += str->size();
 	}
@@ -2185,8 +2185,8 @@ void sinsp_cursesui::print_progress(double progress)
 
 	string wstr = "Processing File";
 	mvprintw(m_screenh / 2,
-		m_screenw / 2 - wstr.size() / 2, 
-		wstr.c_str());	
+		m_screenw / 2 - wstr.size() / 2,
+		"%s", wstr.c_str());
 
 	//
 	// Using sprintf because to_string doesn't support setting the precision 
@@ -2195,8 +2195,8 @@ void sinsp_cursesui::print_progress(double progress)
 	sprintf(numbuf, "%.2lf", progress);
 	wstr = "Progress: " + string(numbuf);
 	mvprintw(m_screenh / 2 + 1,
-		m_screenw / 2 - wstr.size() / 2, 
-		wstr.c_str());
+		m_screenw / 2 - wstr.size() / 2,
+		"%s", wstr.c_str());
 
 	refresh();
 }
@@ -2304,8 +2304,8 @@ sysdig_table_action sinsp_cursesui::handle_textbox_input(int ch)
 
 						attrset(m_colors[sinsp_cursesui::FAILED_SEARCH]);
 						mvprintw(m_screenh / 2,
-							m_screenw / 2 - wstr.size() / 2, 
-							wstr.c_str());	
+							m_screenw / 2 - wstr.size() / 2,
+							"%s", wstr.c_str());
 
 						//
 						// Restore the cursor
@@ -2360,7 +2360,7 @@ sysdig_table_action sinsp_cursesui::handle_textbox_input(int ch)
 
 					mvprintw(m_screenh / 2,
 						m_screenw / 2 - wstr.size() / 2, 
-						wstr.c_str());
+						"%s", wstr.c_str());
 
 					render();
 				}
@@ -2433,7 +2433,7 @@ sysdig_table_action sinsp_cursesui::handle_textbox_input(int ch)
 
 				mvprintw(m_screenh / 2,
 					m_screenw / 2 - wstr.size() / 2, 
-					wstr.c_str());
+					"%s", wstr.c_str());
 
 				render();
 			}


### PR DESCRIPTION
…nctions

`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    sysdig/userspace/sinspui/cursescomponents.cpp: In member function 'void curses_textbox::print_no_data()':
    sysdig/userspace/sinspui/cursescomponents.cpp:878:15: error: format not a string literal and no format arguments [-Werror=format-security]
      878 |   wstr.c_str());
          |               ^

Let's wrap all the missing places with "%s" format.