### PR TITLE
chore(cmake): update libs to 2160111cd088aea9ae2235d3385ecb0b1ab6623c

### DIFF
--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -29,8 +29,8 @@ else()
   # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
   # -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "de277bbc1e7a92edc84db9a925fb3e12c7b1cb07")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=5b9f415b8abf9abadc79e7907708b4be116e8a5ee760e322e4d9b0d2fac064b8")
+    set(FALCOSECURITY_LIBS_VERSION "2160111cd088aea9ae2235d3385ecb0b1ab6623c")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=f84edc4f7490064a0e2264594013c01c205bc5fc968376bfb0ecc17582e5e112")
   endif()
 
   # cd /path/to/build && cmake /path/to/source


### PR DESCRIPTION
sysdig-CLA-1.0-signed-off-by: Luca Guerra <luca.guerra@sysdig.com>

This includes recent fixes to libs to make Sysdig compile on MacOS. (https://github.com/falcosecurity/libs/commit/2160111cd088aea9ae2235d3385ecb0b1ab6623c)