### PR TITLE
GIT_TAG changed from master to main

### DIFF
--- a/CMakeListsGtestInclude.cmake
+++ b/CMakeListsGtestInclude.cmake
@@ -23,7 +23,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
sysdig-CLA-1.0-contributing-entity: IBM
sysdig-CLA-1.0-signed-off-by: Pooja Soni Pooja.Soni@ibm.com

Changed GIT_TAG from master to main in CMakeListsGtestInclude.cmake as googletest has removed master branch.