### PR TITLE
fix(build): upload the driverkit probe file with the correct filename

### DIFF
--- a/scripts/driverkit/build/build.py
+++ b/scripts/driverkit/build/build.py
@@ -133,7 +133,7 @@ def main():
 
             # upload to s3 and remove
             if s3:
-                print(f"[*] Attempting upload to s3 bucket {s3_bucket} with key {module_s3key}")
+                print(f"[*] Attempting upload to s3 bucket {s3_bucket} with module key {module_s3key}")
                 if module_output is not None:
                     with open(module_output, 'rb') as fp:
                         s3.upload_fileobj(fp, s3_bucket, module_s3key, ExtraArgs={'ACL':'public-read'})
@@ -141,7 +141,7 @@ def main():
 
                 if probe_output is not None:
                     with open(probe_output, 'rb') as fp:
-                        s3.upload_fileobj(fp, s3_bucket, module_s3key, ExtraArgs={'ACL':'public-read'})
+                        s3.upload_fileobj(fp, s3_bucket, probe_s3key, ExtraArgs={'ACL':'public-read'})
                     delete_file(probe_output)
 
         print(f"[*] Build {driverversion} complete. {success_count}/{count} built, {fail_count}/{count} failed, {skip_count}/{count} already built.")


### PR DESCRIPTION
Fix the bpf probe filename in the upload script.

Since the previous iteration was overwriting kmods with bpf probes we will also need to rebuild everything to be sure.