### PR TITLE
fix(chisels): added parentheses around ambiguos boolean filters

### DIFF
--- a/userspace/sysdig/chisels/v_connections.lua
+++ b/userspace/sysdig/chisels/v_connections.lua
@@ -26,7 +26,7 @@ view_info =
 	tags = {"Default", "wsysdig"},
 	view_type = "table",
 	applies_to = {"", "container.id", "proc.pid", "thread.nametid", "proc.name", "thread.tid", "fd.sport", "fd.sproto", "fd.dport", "fd.dproto", "fd.port", "fd.proto", "fd.lport", "fd.rport", "evt.res", "k8s.pod.id", "k8s.rc.id", "k8s.rs.id", "k8s.svc.id", "k8s.ns.id", "marathon.app.id", "marathon.group.name", "mesos.task.id", "mesos.framework.name"},
-	filter = "fd.type=ipv4 or fd.type=ipv6 and fd.name!=''",
+	filter = "(fd.type=ipv4 or fd.type=ipv6) and fd.name!=''",
 	use_defaults = true,
 	drilldown_target = "incoming_connections",
 	columns = 

--- a/userspace/sysdig/chisels/v_directories.lua
+++ b/userspace/sysdig/chisels/v_directories.lua
@@ -26,7 +26,7 @@ view_info =
 	tags = {"Default", "wsysdig"},
 	view_type = "table",
 	applies_to = {"", "container.id", "proc.pid", "thread.nametid", "proc.name", "thread.tid", "fd.sport", "fd.sproto", "evt.res", "k8s.pod.id", "k8s.rc.id", "k8s.rs.id", "k8s.svc.id", "k8s.ns.id", "marathon.app.id", "marathon.group.name", "mesos.task.id", "mesos.framework.name"},
-	filter = "fd.type=file or fd.type=directory and fd.name!=''",
+	filter = "(fd.type=file or fd.type=directory) and fd.name!=''",
 	use_defaults = true,
 	drilldown_target = "files",
 	columns = 

--- a/userspace/sysdig/chisels/v_files.lua
+++ b/userspace/sysdig/chisels/v_files.lua
@@ -26,7 +26,7 @@ view_info =
 	tags = {"Default", "wsysdig"},
 	view_type = "table",
 	applies_to = {"", "container.id", "proc.pid", "thread.nametid", "proc.name", "thread.tid", "fd.sport", "fd.sproto", "fd.directory", "fd.containerdirectory", "fd.containerdirectory", "evt.res", "k8s.pod.id", "k8s.rc.id", "k8s.rs.id", "k8s.svc.id", "k8s.ns.id", "marathon.app.id", "marathon.group.name", "mesos.task.id", "mesos.framework.name"},
-	filter = "fd.type=file or fd.type=directory and fd.name!=''",
+	filter = "(fd.type=file or fd.type=directory) and fd.name!=''",
 	use_defaults = true,
 	drilldown_target = "procs",
 	columns = 


### PR DESCRIPTION
These views crashed with the following message:

```
filter error at position 49: expression mixes 'and' and 'or' in an ambiguous way. Please use brackets.
```