### PR TITLE
chore(build): update driverkit to v0.5.0

### DIFF
--- a/.github/workflows/build-drivers.yaml
+++ b/.github/workflows/build-drivers.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: falcosecurity/driverkit
-          ref: ea976707ebead03fe743c42183b50a16eddd6564
+          ref: v0.5.0
           path: driverkit-repo
 
       - name: Build Driverkit


### PR DESCRIPTION
Update driverkit to the latest version to make sure we can build the same drivers that Falco can.