### PR TITLE
cleanup(sysdig): remove references to HAS_FILTERING

### DIFF
--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -668,7 +668,6 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 		//
 		if(optind + n_filterargs < argc)
 		{
-#ifdef HAS_FILTERING
 			for(int32_t j = optind + n_filterargs; j < argc; j++)
 			{
 				filter += argv[j];
@@ -677,11 +676,6 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 					filter += " ";
 				}
 			}
-#else
-			fprintf(stderr, "filtering not compiled.\n");
-			res.m_res = EXIT_FAILURE;
-			goto exit;
-#endif
 		}
 
 		if(!bpf)

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -1668,7 +1668,6 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 		//
 		if(optind + n_filterargs < argc)
 		{
-#ifdef HAS_FILTERING
 			for(int32_t j = optind + n_filterargs; j < argc; j++)
 			{
 				filter += argv[j];
@@ -1683,11 +1682,6 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				sinsp_filter_compiler compiler(inspector, filter);
 				display_filter = compiler.compile();
 			}
-#else
-			fprintf(stderr, "filtering not compiled.\n");
-			res.m_res = EXIT_FAILURE;
-			goto exit;
-#endif
 		}
 
 		if(signal(SIGINT, signal_callback) == SIG_ERR)
@@ -1766,12 +1760,10 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 
 		for(uint32_t j = 0; j < infiles.size() || infiles.size() == 0; j++)
 		{
-#ifdef HAS_FILTERING
 			if(filter.size() && !is_filter_display)
 			{
 				inspector->set_filter(filter);
 			}
-#endif
 
 			// Suppress any comms specified via -U. We
 			// need to do this *before* opening the


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca.guerra@sysdig.com>

Latest versions of falcosecurity/libs got rid of `HAS_FILTERING`, meaning it's as if it's always enabled. This means we can remove some `#ifdef`s.