### PR TITLE
update(ci): use centos7 and not eol centos8 in github workflows.

### DIFF
--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -62,7 +62,7 @@ jobs:
       BUILD_VERSION: ${{ github.ref_name }}
       KEY_ID: EC51E8C4
     container:
-      image: centos:8 # ubi8 does not have rpmsign so we'll use CentOS
+      image: centos:7 # ubi8 does not have rpmsign so we'll use CentOS
     steps:
       - name: Install deps
         run: yum install -y rpm-sign

--- a/.github/workflows/release-final.yaml
+++ b/.github/workflows/release-final.yaml
@@ -53,7 +53,7 @@ jobs:
       contents: read
 
     container:
-      image: centos:8
+      image: centos:7
 
     steps:
       - name: Install deps


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>