### PR TITLE
chore(cmake): remove unused K8S_DISABLE_THREAD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,6 @@ endif()
 set(PACKAGE_NAME "sysdig")
 
 add_definitions(-DPLATFORM_NAME="${CMAKE_SYSTEM_NAME}")
-add_definitions(-DK8S_DISABLE_THREAD)
 
 option(BUILD_WARNINGS_AS_ERRORS "Enable building with -Wextra -Werror flags")
 


### PR DESCRIPTION
K8S_DISABLE_THREAD was removed in e48054d5

Signed-off-by: Angelo Puglisi <angelopuglisi86@gmail.com>