### PR TITLE
cmake: Check USE_BUNDLED_DEPS before getting nlohmann-json.

### DIFF
--- a/cmake/modules/nlohmann-json.cmake
+++ b/cmake/modules/nlohmann-json.cmake
@@ -16,13 +16,22 @@
 # limitations under the License.
 #
 
-set(NJSON_SRC "${PROJECT_BINARY_DIR}/njson-prefix/src/njson")
-message(STATUS "Using bundled nlohmann-json in '${NJSON_SRC}'")
-set(NJSON_INCLUDE_DIR "${NJSON_SRC}/single_include")
-ExternalProject_Add(
-  njson
-  URL "https://github.com/nlohmann/json/archive/v3.3.0.tar.gz"
-  URL_HASH "SHA256=2fd1d207b4669a7843296c41d3b6ac5b23d00dec48dba507ba051d14564aa801"
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND ""
-  INSTALL_COMMAND "")
+if(NOT USE_BUNDLED_DEPS)
+  find_path(NJSON_INCLUDE_DIR NAMES nlohmann/json.hpp)
+  if(NJSON_INCLUDE_DIR)
+    message(STATUS "Found njson: include: ${NJSON_INCLUDE_DIR}")
+  else()
+    message(FATAL_ERROR "Couldn't find system njson")
+  endif()
+else()
+  set(NJSON_SRC "${PROJECT_BINARY_DIR}/njson-prefix/src/njson")
+  message(STATUS "Using bundled nlohmann-json in '${NJSON_SRC}'")
+  set(NJSON_INCLUDE_DIR "${NJSON_SRC}/single_include")
+  ExternalProject_Add(
+    njson
+    URL "https://github.com/nlohmann/json/archive/v3.3.0.tar.gz"
+    URL_HASH "SHA256=2fd1d207b4669a7843296c41d3b6ac5b23d00dec48dba507ba051d14564aa801"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND "")
+endif()


### PR DESCRIPTION
Hi.


In this PR, I added a check to `USE_BUNDLED_DEPS` before getting `nlohmann-json`.
Indeed, this is only package which is always downloaded no matter what is the value of `USE_BUNDLED_DEPS` and the behavior all of always getting the package can not be the desired one.

This patch was written to add sysdig/falcosecurity-libs to [buildroot](https://marc.info/?l=buildroot&m=165063788908641&w=1).

If you find any way to improve this contribution, feel free to share.

Best regards.
