### PR TITLE
refactor: bump libs version to 3bcacab26c021bcf70ec2239c27e8b43b3467174

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,10 @@ if(APPLE)
 	set(CMAKE_EXE_LINKER_FLAGS "-pagezero_size 10000 -image_base 100000000")
 endif()
 
+if(NOT DEFINED SYSDIG_COMPONENT_NAME)
+    set(SYSDIG_COMPONENT_NAME "${CMAKE_PROJECT_NAME}")
+endif()
+
 include(falcosecurity-libs)
 include(yaml-cpp)
 include(nlohmann-json)
@@ -168,6 +172,12 @@ set(CPACK_PROJECT_CONFIG_FILE "${PROJECT_SOURCE_DIR}/CMakeCPackOptions.cmake")
 set(CPACK_STRIP_FILES "ON")
 
 set(CPACK_GENERATOR DEB RPM TGZ)
+
+# Built packages will include only the following components
+set(CPACK_INSTALL_CMAKE_PROJECTS
+  "${CMAKE_CURRENT_BINARY_DIR};${SYSDIG_COMPONENT_NAME};${SYSDIG_COMPONENT_NAME};/"
+  "${CMAKE_CURRENT_BINARY_DIR};${DRIVER_COMPONENT_NAME};${DRIVER_COMPONENT_NAME};/"
+)
 
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Sysdig <support@sysdig.com>")
 set(CPACK_DEBIAN_PACKAGE_SECTION "utils")

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -29,8 +29,8 @@ else()
   # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
   # -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "e5c53d648f3c4694385bbe488e7d47eaa36c229a")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=80903bc57b7f9c5f24298ecf1531cf66ef571681b4bd1e05f6e4db704ffb380b")
+    set(FALCOSECURITY_LIBS_VERSION "3bcacab26c021bcf70ec2239c27e8b43b3467174")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=7a804bd53814c62dd72af7ea0376cb75aadcd9ed2bcf56241597531c27de7c60")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -46,6 +46,8 @@ else()
   set(FALCOSECURITY_LIBS_SOURCE_DIR "${FALCOSECURITY_LIBS_CMAKE_WORKING_DIR}/falcosecurity-libs-prefix/src/falcosecurity-libs")
 endif()
 
+set(LIBS_PACKAGE_NAME "sysdig")
+set(DRIVER_COMPONENT_NAME "scap-driver")
 set(DRIVER_VERSION "${FALCOSECURITY_LIBS_VERSION}")
 
 if(NOT LIBSCAP_DIR)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -25,13 +25,13 @@ configure_file(rpm/preuninstall.in rpm/preuninstall)
 configure_file(scap-driver-loader.in scap-driver-loader @ONLY)
 
 install(FILES completions/bash/sysdig
-	DESTINATION "${DIR_ETC}/bash_completion.d")
+	DESTINATION "${DIR_ETC}/bash_completion.d" COMPONENT "${SYSDIG_COMPONENT_NAME}")
 
 install(FILES completions/zsh/_sysdig
-	DESTINATION share/zsh/vendor-completions)
+	DESTINATION share/zsh/vendor-completions COMPONENT "${SYSDIG_COMPONENT_NAME}")
 
 install(FILES completions/zsh/_sysdig
-	DESTINATION share/zsh/site-functions)
+	DESTINATION share/zsh/site-functions COMPONENT "${SYSDIG_COMPONENT_NAME}")
 
 install(PROGRAMS "${CMAKE_BINARY_DIR}/scripts/scap-driver-loader"
-	DESTINATION bin)
+	DESTINATION bin COMPONENT "${SYSDIG_COMPONENT_NAME}")

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -102,13 +102,13 @@ if(NOT WIN32)
 	add_subdirectory(man)
 
 	install(TARGETS sysdig 
-		DESTINATION bin)
+		DESTINATION bin COMPONENT "${SYSDIG_COMPONENT_NAME}")
 
 	install(TARGETS csysdig 
-		DESTINATION bin)
+		DESTINATION bin COMPONENT "${SYSDIG_COMPONENT_NAME}")
 
 	install(DIRECTORY chisels
-		DESTINATION share/sysdig)
+		DESTINATION share/sysdig COMPONENT "${SYSDIG_COMPONENT_NAME}")
 
 	file(COPY chisels
 		DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -668,7 +668,6 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 		//
 		if(optind + n_filterargs < argc)
 		{
-#ifdef HAS_FILTERING
 			for(int32_t j = optind + n_filterargs; j < argc; j++)
 			{
 				filter += argv[j];
@@ -677,11 +676,6 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 					filter += " ";
 				}
 			}
-#else
-			fprintf(stderr, "filtering not compiled.\n");
-			res.m_res = EXIT_FAILURE;
-			goto exit;
-#endif
 		}
 
 		if(!bpf)

--- a/userspace/sysdig/man/CMakeLists.txt
+++ b/userspace/sysdig/man/CMakeLists.txt
@@ -23,18 +23,18 @@ if (PANDOC)
 		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 		VERBATIM)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sysdig.8
-		DESTINATION share/man/man8)
+		DESTINATION share/man/man8 COMPONENT "${SYSDIG_COMPONENT_NAME}")
 
 	add_custom_target(man_csysdig ALL
 		COMMAND ${PANDOC} -s -f markdown_github -t man csysdig.md -o ${CMAKE_CURRENT_BINARY_DIR}/csysdig.8
 		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 		VERBATIM)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/csysdig.8
-		DESTINATION share/man/man8)
+		DESTINATION share/man/man8 COMPONENT "${SYSDIG_COMPONENT_NAME}")
 else()
 	install(FILES sysdig.8
-		DESTINATION share/man/man8)
+		DESTINATION share/man/man8 COMPONENT "${SYSDIG_COMPONENT_NAME}")
 
 	install(FILES csysdig.8
-		DESTINATION share/man/man8)
+		DESTINATION share/man/man8 COMPONENT "${SYSDIG_COMPONENT_NAME}")
 endif()

--- a/userspace/sysdig/plugin_utils.cpp
+++ b/userspace/sysdig/plugin_utils.cpp
@@ -23,6 +23,12 @@ limitations under the License.
 
 #include <utility>
 
+#ifdef _WIN32
+#define SHAREDOBJ_EXT ".dll"
+#else
+#define SHAREDOBJ_EXT ".so"
+#endif
+
 vector<plugin_dir_info> g_plugin_dirs;
 
 /*
@@ -100,7 +106,13 @@ static bool iterate_plugins_dirs(const std::function<bool(const tinydir_file &)>
 			tinydir_file file;
 			tinydir_readfile(&dir, &file);
 
-			if (strcmp(file.name, ".") == 0 || strcmp(file.name, "..") == 0)
+			auto namelen = strlen(file.name);
+			auto extlen = strlen(SHAREDOBJ_EXT);
+			if (file.is_dir
+                || strcmp(file.name, ".") == 0
+				|| strcmp(file.name, "..") == 0
+				|| (namelen > extlen
+				    && strcmp(file.name + namelen -extlen, SHAREDOBJ_EXT) != 0))
 			{
 				continue;
 			}

--- a/userspace/sysdig/plugin_utils.cpp
+++ b/userspace/sysdig/plugin_utils.cpp
@@ -141,6 +141,10 @@ void init_plugins(sinsp *inspector)
 	iterate_plugins_dirs([&inspector] (const tinydir_file file) -> bool {
 		auto plugin = inspector->register_plugin(file.path, "");
 		g_selected_plugins_registered.emplace(plugin->name(), plugin);
+		if (plugin->caps() & CAP_EXTRACTION)
+		{
+			g_filterlist.add_filter_check(sinsp_plugin::new_filtercheck(plugin));
+		}
 		return false;
 	});
 }
@@ -152,6 +156,10 @@ void select_plugin_init(sinsp *inspector, string& name, const string& init_confi
 	{
 		auto p = inspector->register_plugin(name, init_config);
 		g_selected_plugins_registered.emplace(name, p);
+		if (p->caps() & CAP_EXTRACTION)
+		{
+			g_filterlist.add_filter_check(sinsp_plugin::new_filtercheck(p));
+		}
 		return;
 	}
 
@@ -165,6 +173,10 @@ void select_plugin_init(sinsp *inspector, string& name, const string& init_confi
 		{
 			auto p = inspector->register_plugin(file.path, init_config);
 			g_selected_plugins_registered.emplace(name, p);
+			if (p->caps() & CAP_EXTRACTION)
+			{
+				g_filterlist.add_filter_check(sinsp_plugin::new_filtercheck(p));
+			}
 			return true; // break-out
 		}
 		return false;
@@ -204,6 +216,7 @@ bool enable_source_plugin(sinsp *inspector)
                 throw sinsp_exception("only one source plugin can be enabled at a time.");
             }
             inspector->set_input_plugin(plugin->name(), open_params);
+			g_filterlist.add_filter_check(inspector->new_generic_filtercheck());
             source_plugin_enabled = true;
         }
     }

--- a/userspace/sysdig/plugin_utils.cpp
+++ b/userspace/sysdig/plugin_utils.cpp
@@ -197,7 +197,7 @@ bool enable_source_plugin(sinsp *inspector)
         }
 
         auto plugin = itr->second;
-        if (plugin->caps() == CAP_SOURCING)
+        if (plugin->caps() & CAP_SOURCING)
         {
             if(source_plugin_enabled)
             {
@@ -292,7 +292,7 @@ bool parse_plugin_configuration_file(sinsp *inspector, const std::string& config
 			// This is always existent, otherwise select_plugin_init() throws an exception
 	        auto itr = g_selected_plugins_registered.find(library_path);
 	        auto p = itr->second;
-	        if (p->caps() == CAP_SOURCING)
+	        if (p->caps() & CAP_SOURCING)
 	        {
 		        select_plugin_enable(library_path, open_params);
 		        input_plugin = true;

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -960,7 +960,7 @@ static void list_plugins(sinsp *inspector)
 		os_info << "Capabilities: " << std::endl;
 		if(p->caps() & CAP_SOURCING)
 		{
-			os_info << "  - Event Sourcing: (ID=" << p->id();
+			os_info << "  - Event Sourcing (ID=" << p->id();
 			os_info << ", source='" << p->event_source() << "')" << std::endl;
 		}
 		if(p->caps() & CAP_EXTRACTION)
@@ -1808,10 +1808,13 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 					}
 					catch(const sinsp_exception& e)
 					{
-						if (!g_plugin_input)
+						if (g_plugin_input)
 						{
-							open_success = false;
+							throw e;
 						}
+						// if we are opening the syscall source, we retry later
+						// by loading the driver with modprobe
+						open_success = false;
 					}
 #ifndef _WIN32
 					//

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -1666,7 +1666,6 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 		//
 		if(optind + n_filterargs < argc)
 		{
-#ifdef HAS_FILTERING
 			for(int32_t j = optind + n_filterargs; j < argc; j++)
 			{
 				filter += argv[j];
@@ -1681,11 +1680,6 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				sinsp_filter_compiler compiler(inspector, filter);
 				display_filter = compiler.compile();
 			}
-#else
-			fprintf(stderr, "filtering not compiled.\n");
-			res.m_res = EXIT_FAILURE;
-			goto exit;
-#endif
 		}
 
 		if(signal(SIGINT, signal_callback) == SIG_ERR)
@@ -1764,12 +1758,10 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 
 		for(uint32_t j = 0; j < infiles.size() || infiles.empty(); j++)
 		{
-#ifdef HAS_FILTERING
 			if(!filter.empty() && !is_filter_display)
 			{
 				inspector->set_filter(filter);
 			}
-#endif
 
 			// Suppress any comms specified via -U. We
 			// need to do this *before* opening the


### PR DESCRIPTION
This makes Sysdig compile successfully with the latest changes in falcosecurity/libs.

**What is added**

This PR adds checks when plugins are loaded from a directory. There used to be no filter about the files opened, so if any non-shared-library file was present in the plugins directory sysdig exited with an error. This now just looks for shared object files (`.so` suffix, or `.dll` in Windows). This aims to make the UX better for users and plugin developers.

**What is missing**

1. **We do not print the init schema and the open parameters of plugins**. Doing that requires separating the logic of registration and initialization of plugins in libsinsp, which are still tied together in a single operation in `sinsp::register_plugin`. This needs to change in the future, but we'll work on it after the upcoming new version of Falco gets released.
2. Plugin filterchecks are all added to the same filtercheck list (the global `g_filterchecks`). This breaks part of the plugin system UX contract: it should be possible for two different event sources to have extractable fields with the same name. In Falco, this is guaranteed because rulesets are partitioned by event source, so there is no ambiguity in a filtering condition. On the other hand, sysdig filters are source-agnostic so it's not possible to know which fields can be used in the filtering condition before-hand. Ideally, this can be mitigated by the fact that the library currently do not support having multiple event sources opened at the same time, but this assumption breaks when reading `.scap` capture files (they can contain events from both syscalls and plugins). As such, the current approach is to add all the extractable fields to the same filtercheck list with no event source partitioning, leaving a degree of ambiguity in case plugins define fields with same name for different event sources (which is expected to be an unlikely collision).