### PR TITLE
update: add options to print plugin init conf schema and open param list

### DIFF
--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -29,8 +29,8 @@ else()
   # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
   # -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "3bcacab26c021bcf70ec2239c27e8b43b3467174")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=7a804bd53814c62dd72af7ea0376cb75aadcd9ed2bcf56241597531c27de7c60")
+    set(FALCOSECURITY_LIBS_VERSION "075da069af359954122ed7b8a9fc98bc7bcf3116")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=4cfad3ff77afd3709cac92f244f38c998020156071138fb9edae2fb987954a84")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -380,6 +380,7 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 	bool force_term_compat = false;
 	sinsp_evt::param_fmt event_buffer_format = sinsp_evt::PF_NORMAL;
 	bool page_faults = false;
+	plugin_utils plugins;
 
 	static struct option long_options[] =
 	{
@@ -434,8 +435,8 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 #ifdef HAS_CHISELS
 		add_chisel_dirs(inspector);
 #endif
-		add_plugin_dirs(SYSDIG_PLUGINS_DIR);
-		init_plugins(inspector);
+		plugins.add_directory(SYSDIG_PLUGINS_DIR);
+		plugins.load_plugins_from_dirs(inspector);
 
 		//
 		// Parse the args

--- a/userspace/sysdig/plugin_utils.cpp
+++ b/userspace/sysdig/plugin_utils.cpp
@@ -320,7 +320,7 @@ void plugin_utils::print_plugin_info(sinsp* inspector, const string& name)
             break;
         case SS_PLUGIN_SCHEMA_NONE:
         default:
-            os << "Not available" << std::endl;
+            os << "Not available, plugin does not implement the init config schema functionality" << std::endl;
             break;
     }
     os << schema << std::endl;
@@ -338,7 +338,8 @@ void plugin_utils::print_plugin_info(sinsp* inspector, const string& name)
         auto params = p.plugin->list_open_params();
         if (params.empty())
         {
-            os << "No suggested open params available" << std::endl;
+            os << "No suggested open params available: ";
+            os << "plugin has not been configured, or it does not implement the open params suggestion functionality" << std::endl;
         }
         else
         {

--- a/userspace/sysdig/plugin_utils.cpp
+++ b/userspace/sysdig/plugin_utils.cpp
@@ -30,15 +30,8 @@ limitations under the License.
 #define SHAREDOBJ_EXT ".so"
 #endif
 
-static inline void throw_not_found(std::string name)
-{
-    throw sinsp_exception("plugin not found, use -Il to list all the installed plugins: " + name);
-}
-
-static inline void throw_no_source_cap(std::string name)
-{
-    throw sinsp_exception("plugin does not support the event sourcing capability: " + name);
-}
+static const char* err_plugin_not_found = "plugin not found, use -Il to list all the installed plugins: ";
+static const char* err_plugin_no_source_cap = "plugin does not support the event sourcing capability: ";
 
 static bool iterate_plugins_dirs(
     const std::vector<std::string>& dirs,
@@ -187,7 +180,7 @@ void plugin_utils::load_plugin(sinsp *inspector, const string& name)
 	});
 	if (!found)
 	{
-		throw_not_found(name);
+		throw sinsp_exception(err_plugin_not_found + name);
 	}
 }
 
@@ -216,7 +209,7 @@ plugin_utils::plugin_entry& plugin_utils::find_plugin(const std::string name)
             return p;
         }
     }
-    throw_not_found(name);
+    throw sinsp_exception(err_plugin_not_found + name);
 }
 
 const plugin_utils::plugin_entry& plugin_utils::find_plugin(const std::string name) const
@@ -228,7 +221,7 @@ const plugin_utils::plugin_entry& plugin_utils::find_plugin(const std::string na
             return p;
         }
     }
-    throw_not_found(name);
+    throw sinsp_exception(err_plugin_not_found + name);
 }
 
 void plugin_utils::init_plugin(sinsp *inspector, const string& name, const string& conf)
@@ -251,7 +244,7 @@ void plugin_utils::set_input_plugin(sinsp *inspector, const string& name, const 
         m_has_input_plugin = true;
         return;
     }
-    throw_no_source_cap(name);
+    throw sinsp_exception(err_plugin_no_source_cap + name);
 }
 
 void plugin_utils::print_plugins_list(sinsp* inspector, std::ostringstream& os) const
@@ -334,7 +327,7 @@ void plugin_utils::print_plugin_open_params(sinsp* inspector, const string& name
         }
         return;
     }
-    throw_no_source_cap(name);
+    throw sinsp_exception(err_plugin_no_source_cap + name);
 }
 
 void plugin_utils::load_plugins_from_conf_file(sinsp *inspector, const std::string& config_filename)

--- a/userspace/sysdig/plugin_utils.h
+++ b/userspace/sysdig/plugin_utils.h
@@ -44,9 +44,8 @@ public:
 
 	void set_input_plugin(sinsp *inspector, const string& name, const string& params);
 
-	void print_plugins_list(sinsp* inspector, std::ostringstream& os) const;
-	void print_plugin_init_schema(sinsp* inspector, const string& name, std::ostringstream& os) const;
-	void print_plugin_open_params(sinsp* inspector, const string& name, std::ostringstream& os) const;
+	void print_plugin_info(sinsp* inspector, const string& name);
+	void print_plugin_info_list(sinsp* inspector) const;
 
 	bool has_plugins() const;
 	bool has_input_plugin() const;
@@ -58,6 +57,7 @@ private:
 		std::shared_ptr<sinsp_plugin> plugin;
 		
 		void init(const std::string& conf);
+		void print_info(std::ostringstream& os) const;
 	};
 
 	void add_dir(std::string dirname, bool front_add);

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -188,12 +188,12 @@ static void usage()
 "                    create a ring buffer of events.\n"
 " -h, --help         Print this page\n"
 " -H <pluginname>[:<initconfig>], --plugin <pluginname>[:<initconfig>]\n"
-"                    registers a plugin, using the passed init config if present.\n"
+"                    Registers a plugin, using the passed init config if present.\n"
 "                    The format of initconf is controlled by the plugin, refer to each\n"
 "                    plugin's documentation to learn about it.\n"
 "                    A path can also be used as pluginname.\n"
 " -I <pluginname>[:<openparams>], --input <pluginname>[:<openparams>]\n"
-"                    set a previously registered plugin as input plugin,\n"
+"                    Set a previously registered plugin as input,\n"
 "                    capturing events using it and passing the \n"
 "                    openparams string as open parameters.\n"
 "                    Only a single source plugin can be registered.\n"
@@ -206,8 +206,7 @@ static void usage()
 "                    and https://falco.org/docs/plugins/plugin-api-reference/#ss-instance-t-plugin-open-ss-plugin-t-s-const-char-params-int32-t-rc-required-yes for more infos.\n"
 "                    The event sources available for capture vary depending on which \n"
 "                    plugins have been installed.\n"
-" -Il\n"
-"                    lists the loaded plugins. If no plugin has been registered through '-H',\n"
+" -Il                Lists the loaded plugins. If no plugin has been registered through '-H',\n"
 "                    Sysdig looks for plugins in the directories \n"
 "                    specified by ;-separated environment variable SYSDIG_PLUGIN_DIR and\n"
 "                    in " SYSDIG_PLUGINS_DIR ".\n"
@@ -215,6 +214,11 @@ static void usage()
 " -i <chiselname>, --chisel-info <chiselname>\n"
 "                    Get a longer description and the arguments associated with\n"
 "                    a chisel found in the -cl option list.\n"
+" --input-open-params <pluginname>\n"
+"                    Print the list of suggest open parameters for a previously\n"
+"                    registered plugin, if present.\n"
+"                    Any of the values in the returned list are valid parameters for opening\n"
+"                    the plugin as an input with the -I option.\n"
 #endif
 " -j, --json         Emit output as json, data buffer encoding will depend from the\n"
 "                    print format selected.\n"
@@ -276,6 +280,11 @@ static void usage()
 "                    With -pk or -pkubernetes will use a kubernetes-friendly format.\n"
 "                    With -pm or -pmesos will use a mesos-friendly format.\n"
 "                    See the examples section below for more info.\n"
+" --plugin-init-schema <pluginname>\n"
+"                    Print the schema for the init configuration of a plugin, if present.\n"
+"                    The format of the schema is controlled by the plugin, refer to each\n"
+"                    plugin's documentation to learn about it.\n"
+"                    A path can also be used as pluginname.\n"
 " -q, --quiet        Don't print events on the screen\n"
 "                    Useful when dumping to disk.\n"
 " -R                 Resolve port numbers to names.\n"
@@ -940,42 +949,6 @@ std::string escape_output_format(const std::string& s)
     return ss.str();
 }
 
-static void list_plugins(sinsp *inspector)
-{
-	// This will either register any found plugin or
-	// only plugins marked with '-H'
-	init_plugins(inspector);
-	const auto& plugins = inspector->get_plugin_manager()->plugins();
-	std::ostringstream os_dirs, os_info;
-
-	for(const plugin_dir_info& path : get_plugin_dirs())
-	{
-		os_dirs << path.m_dir << " ";
-	}
-
-	for (auto &p : plugins)
-	{
-		os_info << "Name: " << p->name() << std::endl;
-		os_info << "Description: " << p->description() << std::endl;
-		os_info << "Contact: " << p->contact() << std::endl;
-		os_info << "Version: " << p->plugin_version().as_string() << std::endl;
-		os_info << "Capabilities: " << std::endl;
-		if(p->caps() & CAP_SOURCING)
-		{
-			os_info << "  - Event Sourcing (ID=" << p->id();
-			os_info << ", source='" << p->event_source() << "')" << std::endl;
-		}
-		if(p->caps() & CAP_EXTRACTION)
-		{
-			os_info << "  - Field Extraction" << std::endl;
-		}
-		os_info << std::endl;
-	}
-
-	printf("Plugin search paths are: %s\n", os_dirs.str().c_str());
-	printf("%lu Plugins Loaded:\n\n%s\n", plugins.size(), os_info.str().c_str());
-}
-
 //
 // ARGUMENT PARSING AND PROGRAM SETUP
 //
@@ -1025,6 +998,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 	string cri_socket_path;
 #endif
 	bool udig = false;
+	plugin_utils plugins;
 
 	// These variables are for the cycle_writer engine
 	int duration_seconds = 0;
@@ -1055,6 +1029,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 		{"help", no_argument, 0, 'h' },
 		{"plugin", required_argument, 0, 'H' },
 		{"input", required_argument, 0, 'I' },
+		{"input-open-params", required_argument, 0, 0 },
 #ifdef HAS_CHISELS
 		{"chisel-info", required_argument, 0, 'i' },
 #endif
@@ -1077,6 +1052,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 		{"numevents", required_argument, 0, 'n' },
 		{"page-faults", no_argument, 0, 0 },
 		{"plugin-config-file", required_argument, 0, 0},
+		{"plugin-init-schema", required_argument, 0, 0 },
 		{"progress", required_argument, 0, 'P' },
 		{"print", required_argument, 0, 'p' },
 		{"quiet", no_argument, 0, 'q' },
@@ -1117,7 +1093,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 #ifdef HAS_CHISELS
 		add_chisel_dirs(inspector);
 #endif
-		add_plugin_dirs(SYSDIG_PLUGINS_DIR);
+		plugins.add_directory(SYSDIG_PLUGINS_DIR);
 
 		//
 		// Parse the args
@@ -1234,7 +1210,8 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 						pgname = pluginname.substr(0, cpos);
 						pginitconf = pluginname.substr(cpos + 1);
 					}
-					select_plugin_init(inspector, pgname, pginitconf);
+					plugins.load_plugin(inspector, pgname);
+					plugins.init_plugin(inspector, pgname, pginitconf);
 					break;
 				}
 			case 'I':
@@ -1242,7 +1219,9 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 					string inputname = optarg;
 					if(inputname == "l")
 					{
-						list_plugins(inspector);
+						std::ostringstream os;
+						plugins.print_plugins_list(inspector, os);
+						printf("%s", os.str().c_str());
 						delete inspector;
 						return sysdig_init_res(EXIT_SUCCESS);
 					}
@@ -1256,9 +1235,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 						pgname = inputname.substr(0, cpos);
 						pgpars = inputname.substr(cpos + 1);
 					}
-
-					select_plugin_enable(pgname, pgpars);
-					g_plugin_input = true;
+					plugins.set_input_plugin(inspector, pgname, pgpars);
 				}
 				break;
 #ifdef HAS_CHISELS
@@ -1568,11 +1545,32 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 					}
 
 					else if(optname == "plugin-config-file") {
-						g_plugin_input = parse_plugin_configuration_file(inspector, optarg);
+						plugins.load_plugins_from_conf_file(inspector, optarg);
 					}
 
 					else if (optname == "page-faults") {
 						page_faults = true;
+					}
+
+					else if (optname == "plugin-init-schema")
+					{
+						auto name = std::string(optarg);
+						std::ostringstream os;
+						plugins.load_plugin(inspector, name);
+						plugins.print_plugin_init_schema(inspector, name, os);
+						printf("%s", os.str().c_str());
+						delete inspector;
+						return sysdig_init_res(EXIT_SUCCESS);
+					}
+
+					else if (optname == "input-open-params")
+					{
+						auto name = std::string(optarg);
+						std::ostringstream os;
+						plugins.print_plugin_open_params(inspector, name, os);
+						printf("%s", os.str().c_str());
+						delete inspector;
+						return sysdig_init_res(EXIT_SUCCESS);
 					}
 				}
 				break;
@@ -1586,11 +1584,14 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 			}
 		}
 
-		init_plugins(inspector);
-		if(g_plugin_input)
+		// if we haven't loaded plugins through CLI options, load them from
+		// the directories
+		if (!plugins.has_plugins())
 		{
-			enable_source_plugin(inspector);
+			plugins.load_plugins_from_dirs(inspector);
 		}
+
+		g_plugin_input = plugins.has_input_plugin();
 
 #ifdef HAS_CAPTURE
 		if(!cri_socket_path.empty())


### PR DESCRIPTION
- Bump libs version to 075da069af359954122ed7b8a9fc98bc7bcf3116
- Refactor `plugin_utils` code
- Add a `--plugin-info` CLI option to print plugin detailed info, including init config schema and suggested open parameters
- Solve bugs of plugins CLI support and make it more stable