### PR TITLE
add CLI options for gVisor and fix driver cmake

### DIFF
--- a/cmake/modules/driver-repo/CMakeLists.txt
+++ b/cmake/modules/driver-repo/CMakeLists.txt
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2013-2022 Draios Inc dba Sysdig.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cmake_minimum_required(VERSION 3.5.1)
+
+project(driver-repo NONE)
+
+include(ExternalProject)
+message(STATUS "Driver version: ${DRIVER_VERSION}")
+
+ExternalProject_Add(
+  driver
+  URL "https://github.com/falcosecurity/libs/archive/${DRIVER_VERSION}.tar.gz"
+  URL_HASH "${DRIVER_CHECKSUM}"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  TEST_COMMAND ""
+  PATCH_COMMAND sh -c "mv ./driver ../driver.tmp && rm -rf ./* && mv ../driver.tmp/* ."
+)

--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -31,8 +31,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "1.0.0-alpha2+driver")
-    set(DRIVER_CHECKSUM "SHA256=25bf8a7d45adc101137285e796e4dbbf71d012fb47d8e93827a432b98ea618ef")
+    set(DRIVER_VERSION "2.0.0+driver")
+    set(DRIVER_CHECKSUM "SHA256=e616dfe27f95670a63150339ea2484937c5ce9b7e42d176de86c3f61481ae676")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2013-2022 Draios Inc dba Sysdig.
+#
+# This file is part of sysdig .
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set(DRIVER_CMAKE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/driver-repo")
+set(DRIVER_CMAKE_WORKING_DIR "${CMAKE_BINARY_DIR}/driver-repo")
+
+file(MAKE_DIRECTORY ${DRIVER_CMAKE_WORKING_DIR})
+
+if(DRIVER_SOURCE_DIR)
+  set(DRIVER_VERSION "0.0.0-local")
+  message(STATUS "Using local version for driver: '${DRIVER_SOURCE_DIR}'")
+else()
+  # DRIVER_VERSION accepts a git reference (branch name, commit hash, or tag) to the falcosecurity/libs repository
+  # which contains the driver source code under the `/driver` directory.
+  # The chosen driver version must be compatible with the given FALCOSECURITY_LIBS_VERSION.
+  # In case you want to test against another driver version (or branch, or commit) just pass the variable -
+  # ie., `cmake -DDRIVER_VERSION=dev ..`
+  if(NOT DRIVER_VERSION)
+    set(DRIVER_VERSION "1.0.0-alpha2+driver")
+    set(DRIVER_CHECKSUM "SHA256=25bf8a7d45adc101137285e796e4dbbf71d012fb47d8e93827a432b98ea618ef")
+  endif()
+
+  # cd /path/to/build && cmake /path/to/source
+  execute_process(COMMAND "${CMAKE_COMMAND}" -DDRIVER_VERSION=${DRIVER_VERSION} -DDRIVER_CHECKSUM=${DRIVER_CHECKSUM}
+    ${DRIVER_CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${DRIVER_CMAKE_WORKING_DIR})
+
+  # cmake --build .
+  execute_process(COMMAND "${CMAKE_COMMAND}" --build . WORKING_DIRECTORY "${DRIVER_CMAKE_WORKING_DIR}")
+  set(DRIVER_SOURCE_DIR "${DRIVER_CMAKE_WORKING_DIR}/driver-prefix/src/driver")
+endif()
+
+add_definitions(-D_GNU_SOURCE)
+
+set(DRIVER_NAME "scap")
+set(DRIVER_PACKAGE_NAME "scap")
+set(DRIVER_COMPONENT_NAME "scap-driver")
+
+add_subdirectory(${DRIVER_SOURCE_DIR} ${PROJECT_BINARY_DIR}/driver)

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -32,8 +32,8 @@ else()
   # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
   # -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "0.7.0-rc4")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=e89950fbf44610398d572ee9abdff4e3eb565b9695e99cb2631894ff1d7c86a6")
+    set(FALCOSECURITY_LIBS_VERSION "0.7.0")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=3adc1620c0e830554a54cdd486158dc2c0c40552e113785b70fbbc99edb7d96f")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -32,8 +32,8 @@ else()
   # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
   # -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "a3b4b5bd586b491d329529d827d50443f98b240a")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=b5dc5ea985cc21aaf9047e0a6d8bb9e372d88ab33f3eeb229f1a820389c1acfe")
+    set(FALCOSECURITY_LIBS_VERSION "0.7.0-rc4")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=e89950fbf44610398d572ee9abdff4e3eb565b9695e99cb2631894ff1d7c86a6")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -21,47 +21,60 @@ set(FALCOSECURITY_LIBS_CMAKE_WORKING_DIR "${CMAKE_BINARY_DIR}/falcosecurity-libs
 
 file(MAKE_DIRECTORY ${FALCOSECURITY_LIBS_CMAKE_WORKING_DIR})
 
+# explicitly disable the bundled driver, since we pull it separately
+set(USE_BUNDLED_DRIVER OFF CACHE BOOL "")
+
 if(FALCOSECURITY_LIBS_SOURCE_DIR)
-  set(FALCOSECURITY_LIBS_VERSION "local")
-  message(STATUS "Using local falcosecurity/libs in '${FALCOSECURITY_LIBS_SOURCE_DIR}'")
+  set(FALCOSECURITY_LIBS_VERSION "0.0.0-local")
+  message(STATUS "Using local version of falcosecurity/libs: '${FALCOSECURITY_LIBS_SOURCE_DIR}'")
 else()
   # The falcosecurity/libs git reference (branch name, commit hash, or tag) To update falcosecurity/libs version for the next release, change the
   # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
   # -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "075da069af359954122ed7b8a9fc98bc7bcf3116")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=4cfad3ff77afd3709cac92f244f38c998020156071138fb9edae2fb987954a84")
+    set(FALCOSECURITY_LIBS_VERSION "a3b4b5bd586b491d329529d827d50443f98b240a")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=b5dc5ea985cc21aaf9047e0a6d8bb9e372d88ab33f3eeb229f1a820389c1acfe")
   endif()
 
   # cd /path/to/build && cmake /path/to/source
   execute_process(COMMAND "${CMAKE_COMMAND}" -DFALCOSECURITY_LIBS_VERSION=${FALCOSECURITY_LIBS_VERSION} -DFALCOSECURITY_LIBS_CHECKSUM=${FALCOSECURITY_LIBS_CHECKSUM}
-                          ${FALCOSECURITY_LIBS_CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${FALCOSECURITY_LIBS_CMAKE_WORKING_DIR})
-
-  # todo(leodido, fntlnz) > use the following one when CMake version will be >= 3.13
-
-  # execute_process(COMMAND "${CMAKE_COMMAND}" -B ${FALCOSECURITY_LIBS_CMAKE_WORKING_DIR} WORKING_DIRECTORY
-  # "${FALCOSECURITY_LIBS_CMAKE_SOURCE_DIR}")
+    ${FALCOSECURITY_LIBS_CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${FALCOSECURITY_LIBS_CMAKE_WORKING_DIR})
 
   execute_process(COMMAND "${CMAKE_COMMAND}" --build . WORKING_DIRECTORY "${FALCOSECURITY_LIBS_CMAKE_WORKING_DIR}")
   set(FALCOSECURITY_LIBS_SOURCE_DIR "${FALCOSECURITY_LIBS_CMAKE_WORKING_DIR}/falcosecurity-libs-prefix/src/falcosecurity-libs")
 endif()
 
 set(LIBS_PACKAGE_NAME "sysdig")
-set(DRIVER_COMPONENT_NAME "scap-driver")
-set(DRIVER_VERSION "${FALCOSECURITY_LIBS_VERSION}")
+
+add_definitions(-D_GNU_SOURCE)
+add_definitions(-DHAS_CAPTURE)
+
+if(MUSL_OPTIMIZED_BUILD)
+  add_definitions(-DMUSL_OPTIMIZED)
+endif()
+
+set(SCAP_BPF_PROBE_ENV_VAR_NAME "SCAP_BPF_PROBE")
+set(SCAP_HOST_ROOT_ENV_VAR_NAME "HOST_ROOT")
 
 if(NOT LIBSCAP_DIR)
   set(LIBSCAP_DIR "${FALCOSECURITY_LIBS_SOURCE_DIR}")
 endif()
 set(LIBSINSP_DIR "${FALCOSECURITY_LIBS_SOURCE_DIR}")
 
-# explicitly disable the tests of this dependency
+# configure gVisor support
+set(BUILD_LIBSCAP_GVISOR ${BUILD_SYSDIG_GVISOR} CACHE BOOL "")
+
+# explicitly disable the tests/examples of this dependency
 set(CREATE_TEST_TARGETS OFF CACHE BOOL "")
+set(BUILD_LIBSCAP_EXAMPLES OFF CACHE BOOL "")
 
 set(WITH_CHISEL ON CACHE INTERNAL "" FORCE)
 
-list(APPEND CMAKE_MODULE_PATH "${LIBSCAP_DIR}/cmake/modules")
-list(APPEND CMAKE_MODULE_PATH "${LIBSINSP_DIR}/cmake/modules")
+set(USE_BUNDLED_TBB ON CACHE BOOL "")
+set(USE_BUNDLED_B64 ON CACHE BOOL "")
+set(USE_BUNDLED_JSONCPP ON CACHE BOOL "")
+
+list(APPEND CMAKE_MODULE_PATH "${FALCOSECURITY_LIBS_SOURCE_DIR}/cmake/modules")
 
 include(CheckSymbolExists)
 check_symbol_exists(strlcpy "string.h" HAVE_STRLCPY)
@@ -72,5 +85,6 @@ else()
 	message(STATUS "No strlcpy found, will use local definition")
 endif()
 
+include(driver)
 include(libscap)
 include(libsinsp)


### PR DESCRIPTION
This PR:
- adds CLI options for gVisor, totally equivalent to what we have in Falco already
- use the new driver cmake