### PR TITLE
update: catch SCAP_FILTERED_EVENT return code

### DIFF
--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -31,8 +31,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "111135405708f69efa391a5140706e273917e28d")
-    set(DRIVER_CHECKSUM "SHA256=7765bbdf599adf8d3abbbea3d434800232bb48d369dd8b5d6c1c03cfa065758c")
+    set(DRIVER_VERSION "b4c198773bf05486e122f6d3f7f63be125242413")
+    set(DRIVER_CHECKSUM "SHA256=e85fa42a0b58ba21ca7efb38c20ce25207f4816245bdf154e6b9a037a1cce930")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -31,8 +31,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "2.0.0+driver")
-    set(DRIVER_CHECKSUM "SHA256=e616dfe27f95670a63150339ea2484937c5ce9b7e42d176de86c3f61481ae676")
+    set(DRIVER_VERSION "111135405708f69efa391a5140706e273917e28d")
+    set(DRIVER_CHECKSUM "SHA256=7765bbdf599adf8d3abbbea3d434800232bb48d369dd8b5d6c1c03cfa065758c")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -32,8 +32,8 @@ else()
   # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
   # -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "a8747b00a8730344a5400e537598f8401a31b7f5")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=62029dd1b7c1cd7993f26afdd0b1273cd27201cd64545d689f72d176b0eff72c")
+    set(FALCOSECURITY_LIBS_VERSION "111135405708f69efa391a5140706e273917e28d")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=7765bbdf599adf8d3abbbea3d434800232bb48d369dd8b5d6c1c03cfa065758c")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -32,8 +32,8 @@ else()
   # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
   # -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "111135405708f69efa391a5140706e273917e28d")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=7765bbdf599adf8d3abbbea3d434800232bb48d369dd8b5d6c1c03cfa065758c")
+    set(FALCOSECURITY_LIBS_VERSION "b4c198773bf05486e122f6d3f7f63be125242413")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=e85fa42a0b58ba21ca7efb38c20ce25207f4816245bdf154e6b9a037a1cce930")
   endif()
 
   # cd /path/to/build && cmake /path/to/source
@@ -73,6 +73,7 @@ set(WITH_CHISEL ON CACHE INTERNAL "" FORCE)
 set(USE_BUNDLED_TBB ON CACHE BOOL "")
 set(USE_BUNDLED_B64 ON CACHE BOOL "")
 set(USE_BUNDLED_JSONCPP ON CACHE BOOL "")
+set(USE_BUNDLED_VALIJSON ON CACHE BOOL "")
 
 list(APPEND CMAKE_MODULE_PATH "${FALCOSECURITY_LIBS_SOURCE_DIR}/cmake/modules")
 

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -303,7 +303,7 @@ captureinfo do_inspect(sinsp* inspector,
 
 		res = inspector->next(&ev);
 
-		if(res == SCAP_TIMEOUT)
+		if(res == SCAP_TIMEOUT || res == SCAP_FILTERED_EVENT)
 		{
 			continue;
 		}

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -764,9 +764,9 @@ captureinfo do_inspect(sinsp* inspector,
 		}
 		res = inspector->next(&ev);
 
-		if(res == SCAP_TIMEOUT)
+		if(res == SCAP_TIMEOUT || res == SCAP_FILTERED_EVENT)
 		{
-			if(ev != NULL && ev->is_filtered_out())
+			if(res == SCAP_FILTERED_EVENT && ev != NULL && ev->is_filtered_out())
 			{
 				//
 				// The event has been dropped by the filtering system.


### PR DESCRIPTION
Following up https://github.com/falcosecurity/libs/pull/490, this adds support to the SCAP_FILTERED_EVENT return code. A libs/driver bump was required.