### PR TITLE
SECCOMP-26723 change download references to download.sysdig.com

### DIFF
--- a/cmake/modules/ncurses.cmake
+++ b/cmake/modules/ncurses.cmake
@@ -19,7 +19,7 @@ else()
 
 		ExternalProject_Add(ncurses
 			PREFIX "${PROJECT_BINARY_DIR}/ncurses-prefix"
-			URL "http://download.draios.com/dependencies/ncurses-6.0-20150725.tgz"
+			URL "https://download.sysdig.com/dependencies/ncurses-6.0-20150725.tgz"
 			URL_MD5 "32b8913312e738d707ae68da439ca1f4"
 			CONFIGURE_COMMAND ./configure --without-cxx --without-cxx-binding --without-ada --without-manpages --without-progs --without-tests --with-terminfo-dirs=/etc/terminfo:/lib/terminfo:/usr/share/terminfo
 			BUILD_COMMAND ${CMD_MAKE}

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -12,7 +12,7 @@ ENV HOME /root
 
 RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
-ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
+ADD https://download.sysdig.com/apt-draios-priority /etc/apt/preferences.d/
 
 RUN apt-get update \
  && apt-get upgrade -y \
@@ -41,15 +41,15 @@ RUN apt-get update \
 # prefix https://snapshot.debian.org/archive/debian/20170517T033514Z
 # or so.
 
-RUN curl -o cpp-6_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/cpp-6_6.3.0-18_amd64.deb \
-    && curl -o gcc-6-base_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/gcc-6-base_6.3.0-18_amd64.deb \
-    && curl -o gcc-6_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/gcc-6_6.3.0-18_amd64.deb \
-    && curl -o libasan3_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libasan3_6.3.0-18_amd64.deb \
-    && curl -o libcilkrts5_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libcilkrts5_6.3.0-18_amd64.deb \
-    && curl -o libgcc-6-dev_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libgcc-6-dev_6.3.0-18_amd64.deb \
-    && curl -o libubsan0_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libubsan0_6.3.0-18_amd64.deb \
-    && curl -o libmpfr4_3.1.3-2_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libmpfr4_3.1.3-2_amd64.deb \
-    && curl -o libisl15_0.18-1_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libisl15_0.18-1_amd64.deb \
+RUN curl -o cpp-6_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/cpp-6_6.3.0-18_amd64.deb \
+    && curl -o gcc-6-base_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/gcc-6-base_6.3.0-18_amd64.deb \
+    && curl -o gcc-6_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/gcc-6_6.3.0-18_amd64.deb \
+    && curl -o libasan3_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libasan3_6.3.0-18_amd64.deb \
+    && curl -o libcilkrts5_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libcilkrts5_6.3.0-18_amd64.deb \
+    && curl -o libgcc-6-dev_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libgcc-6-dev_6.3.0-18_amd64.deb \
+    && curl -o libubsan0_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libubsan0_6.3.0-18_amd64.deb \
+    && curl -o libmpfr4_3.1.3-2_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libmpfr4_3.1.3-2_amd64.deb \
+    && curl -o libisl15_0.18-1_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libisl15_0.18-1_amd64.deb \
     && dpkg -i cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb \
     && rm -f cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb
 
@@ -58,13 +58,13 @@ RUN curl -o cpp-6_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.co
 # version 3, 4, or 5 compiler. So grab copies we've saved from debian
 # snapshots with the prefix https://snapshot.debian.org/archive/debian/20190122T000000Z.
 
-RUN curl -o cpp-5_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/cpp-5_5.5.0-12_amd64.deb \
- && curl -o gcc-5-base_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-5-base_5.5.0-12_amd64.deb \
- && curl -o gcc-5_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-5_5.5.0-12_amd64.deb \
- && curl -o libasan2_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/libasan2_5.5.0-12_amd64.deb \
- && curl -o libgcc-5-dev_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/libgcc-5-dev_5.5.0-12_amd64.deb \
- && curl -o libisl15_0.18-4_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/libisl15_0.18-4_amd64.deb \
- && curl -o libmpx0_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/libmpx0_5.5.0-12_amd64.deb \
+RUN curl -o cpp-5_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/cpp-5_5.5.0-12_amd64.deb \
+ && curl -o gcc-5-base_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/gcc-5-base_5.5.0-12_amd64.deb \
+ && curl -o gcc-5_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/gcc-5_5.5.0-12_amd64.deb \
+ && curl -o libasan2_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/libasan2_5.5.0-12_amd64.deb \
+ && curl -o libgcc-5-dev_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/libgcc-5-dev_5.5.0-12_amd64.deb \
+ && curl -o libisl15_0.18-4_amd64.deb https://download.sysdig.com/dependencies/libisl15_0.18-4_amd64.deb \
+ && curl -o libmpx0_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/libmpx0_5.5.0-12_amd64.deb \
  && dpkg -i cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb \
  && rm -f cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb
 
@@ -77,8 +77,8 @@ RUN rm -rf /usr/bin/clang \
  && ln -s /usr/bin/clang-7 /usr/bin/clang \
  && ln -s /usr/bin/llc-7 /usr/bin/llc
 
-RUN curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public | apt-key add - \
- && curl -s -o /etc/apt/sources.list.d/draios.list http://download.draios.com/$SYSDIG_REPOSITORY/deb/draios.list \
+RUN curl -s https://download.sysdig.com/DRAIOS-GPG-KEY.public | apt-key add - \
+ && curl -s -o /etc/apt/sources.list.d/draios.list https://download.sysdig.com/$SYSDIG_REPOSITORY/deb/draios.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends sysdig \
  && apt-get clean \

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -12,7 +12,7 @@ ENV HOME /root
 
 RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
-ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
+ADD https://download.sysdig.com/apt-draios-priority /etc/apt/preferences.d/
 
 RUN apt-get update \
  && apt-get upgrade -y \
@@ -41,15 +41,15 @@ RUN apt-get update \
 # prefix https://snapshot.debian.org/archive/debian/20170517T033514Z
 # or so.
 
-RUN curl -o cpp-6_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/cpp-6_6.3.0-18_amd64.deb \
-    && curl -o gcc-6-base_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/gcc-6-base_6.3.0-18_amd64.deb \
-    && curl -o gcc-6_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/gcc-6_6.3.0-18_amd64.deb \
-    && curl -o libasan3_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libasan3_6.3.0-18_amd64.deb \
-    && curl -o libcilkrts5_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libcilkrts5_6.3.0-18_amd64.deb \
-    && curl -o libgcc-6-dev_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libgcc-6-dev_6.3.0-18_amd64.deb \
-    && curl -o libubsan0_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libubsan0_6.3.0-18_amd64.deb \
-    && curl -o libmpfr4_3.1.3-2_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libmpfr4_3.1.3-2_amd64.deb \
-    && curl -o libisl15_0.18-1_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libisl15_0.18-1_amd64.deb \
+RUN curl -o cpp-6_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/cpp-6_6.3.0-18_amd64.deb \
+    && curl -o gcc-6-base_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/gcc-6-base_6.3.0-18_amd64.deb \
+    && curl -o gcc-6_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/gcc-6_6.3.0-18_amd64.deb \
+    && curl -o libasan3_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libasan3_6.3.0-18_amd64.deb \
+    && curl -o libcilkrts5_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libcilkrts5_6.3.0-18_amd64.deb \
+    && curl -o libgcc-6-dev_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libgcc-6-dev_6.3.0-18_amd64.deb \
+    && curl -o libubsan0_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libubsan0_6.3.0-18_amd64.deb \
+    && curl -o libmpfr4_3.1.3-2_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libmpfr4_3.1.3-2_amd64.deb \
+    && curl -o libisl15_0.18-1_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libisl15_0.18-1_amd64.deb \
     && dpkg -i cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb \
     && rm -f cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb
 
@@ -58,13 +58,13 @@ RUN curl -o cpp-6_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.co
 # version 3, 4, or 5 compiler. So grab copies we've saved from debian
 # snapshots with the prefix https://snapshot.debian.org/archive/debian/20190122T000000Z.
 
-RUN curl -o cpp-5_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/cpp-5_5.5.0-12_amd64.deb \
- && curl -o gcc-5-base_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-5-base_5.5.0-12_amd64.deb \
- && curl -o gcc-5_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-5_5.5.0-12_amd64.deb \
- && curl -o libasan2_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/libasan2_5.5.0-12_amd64.deb \
- && curl -o libgcc-5-dev_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/libgcc-5-dev_5.5.0-12_amd64.deb \
- && curl -o libisl15_0.18-4_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/libisl15_0.18-4_amd64.deb \
- && curl -o libmpx0_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/libmpx0_5.5.0-12_amd64.deb \
+RUN curl -o cpp-5_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/cpp-5_5.5.0-12_amd64.deb \
+ && curl -o gcc-5-base_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/gcc-5-base_5.5.0-12_amd64.deb \
+ && curl -o gcc-5_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/gcc-5_5.5.0-12_amd64.deb \
+ && curl -o libasan2_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/libasan2_5.5.0-12_amd64.deb \
+ && curl -o libgcc-5-dev_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/libgcc-5-dev_5.5.0-12_amd64.deb \
+ && curl -o libisl15_0.18-4_amd64.deb https://download.sysdig.com/dependencies/libisl15_0.18-4_amd64.deb \
+ && curl -o libmpx0_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/libmpx0_5.5.0-12_amd64.deb \
  && dpkg -i cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb \
  && rm -f cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb
 

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -12,7 +12,7 @@ ENV HOME /root
 
 RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
-ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
+ADD https://download.sysdig.com/apt-draios-priority /etc/apt/preferences.d/
 
 RUN apt-get update \
  && apt-get upgrade -y \
@@ -41,15 +41,15 @@ RUN apt-get update \
 # prefix https://snapshot.debian.org/archive/debian/20170517T033514Z
 # or so.
 
-RUN curl -o cpp-6_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/cpp-6_6.3.0-18_amd64.deb \
-    && curl -o gcc-6-base_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/gcc-6-base_6.3.0-18_amd64.deb \
-    && curl -o gcc-6_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/gcc-6_6.3.0-18_amd64.deb \
-    && curl -o libasan3_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libasan3_6.3.0-18_amd64.deb \
-    && curl -o libcilkrts5_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libcilkrts5_6.3.0-18_amd64.deb \
-    && curl -o libgcc-6-dev_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libgcc-6-dev_6.3.0-18_amd64.deb \
-    && curl -o libubsan0_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libubsan0_6.3.0-18_amd64.deb \
-    && curl -o libmpfr4_3.1.3-2_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libmpfr4_3.1.3-2_amd64.deb \
-    && curl -o libisl15_0.18-1_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-6-debs/libisl15_0.18-1_amd64.deb \
+RUN curl -o cpp-6_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/cpp-6_6.3.0-18_amd64.deb \
+    && curl -o gcc-6-base_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/gcc-6-base_6.3.0-18_amd64.deb \
+    && curl -o gcc-6_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/gcc-6_6.3.0-18_amd64.deb \
+    && curl -o libasan3_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libasan3_6.3.0-18_amd64.deb \
+    && curl -o libcilkrts5_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libcilkrts5_6.3.0-18_amd64.deb \
+    && curl -o libgcc-6-dev_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libgcc-6-dev_6.3.0-18_amd64.deb \
+    && curl -o libubsan0_6.3.0-18_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libubsan0_6.3.0-18_amd64.deb \
+    && curl -o libmpfr4_3.1.3-2_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libmpfr4_3.1.3-2_amd64.deb \
+    && curl -o libisl15_0.18-1_amd64.deb https://download.sysdig.com/dependencies/gcc-6-debs/libisl15_0.18-1_amd64.deb \
     && dpkg -i cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb \
     && rm -f cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb
 
@@ -58,13 +58,13 @@ RUN curl -o cpp-6_6.3.0-18_amd64.deb https://s3.amazonaws.com/download.draios.co
 # version 3, 4, or 5 compiler. So grab copies we've saved from debian
 # snapshots with the prefix https://snapshot.debian.org/archive/debian/20190122T000000Z.
 
-RUN curl -o cpp-5_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/cpp-5_5.5.0-12_amd64.deb \
- && curl -o gcc-5-base_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-5-base_5.5.0-12_amd64.deb \
- && curl -o gcc-5_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/gcc-5_5.5.0-12_amd64.deb \
- && curl -o libasan2_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/libasan2_5.5.0-12_amd64.deb \
- && curl -o libgcc-5-dev_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/libgcc-5-dev_5.5.0-12_amd64.deb \
- && curl -o libisl15_0.18-4_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/libisl15_0.18-4_amd64.deb \
- && curl -o libmpx0_5.5.0-12_amd64.deb https://s3.amazonaws.com/download.draios.com/dependencies/libmpx0_5.5.0-12_amd64.deb \
+RUN curl -o cpp-5_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/cpp-5_5.5.0-12_amd64.deb \
+ && curl -o gcc-5-base_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/gcc-5-base_5.5.0-12_amd64.deb \
+ && curl -o gcc-5_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/gcc-5_5.5.0-12_amd64.deb \
+ && curl -o libasan2_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/libasan2_5.5.0-12_amd64.deb \
+ && curl -o libgcc-5-dev_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/libgcc-5-dev_5.5.0-12_amd64.deb \
+ && curl -o libisl15_0.18-4_amd64.deb https://download.sysdig.com/dependencies/libisl15_0.18-4_amd64.deb \
+ && curl -o libmpx0_5.5.0-12_amd64.deb https://download.sysdig.com/dependencies/libmpx0_5.5.0-12_amd64.deb \
  && dpkg -i cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb \
  && rm -f cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb
 
@@ -78,8 +78,8 @@ RUN rm -rf /usr/bin/clang \
  && ln -s /usr/bin/clang-7 /usr/bin/clang \
  && ln -s /usr/bin/llc-7 /usr/bin/llc
 
-RUN curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public | apt-key add - \
- && curl -s -o /etc/apt/sources.list.d/draios.list http://download.draios.com/$SYSDIG_REPOSITORY/deb/draios.list \
+RUN curl -s https://download.sysdig.com/DRAIOS-GPG-KEY.public | apt-key add - \
+ && curl -s -o /etc/apt/sources.list.d/draios.list https://download.sysdig.com/$SYSDIG_REPOSITORY/deb/draios.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends sysdig \
  && apt-get clean \

--- a/scripts/install-sysdig
+++ b/scripts/install-sysdig
@@ -38,9 +38,9 @@ function install_rpm {
 	fi
 
 	echo "* Installing Sysdig public key"
-	rpm --quiet --import https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public
+	rpm --quiet --import https://download.sysdig.com/DRAIOS-GPG-KEY.public
 	echo "* Installing Sysdig repository"
-	curl -s -o /etc/yum.repos.d/draios.repo "https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY_NAME/rpm/draios.repo"
+	curl -s -o /etc/yum.repos.d/draios.repo "https://download.sysdig.com/$SYSDIG_REPOSITORY_NAME/rpm/draios.repo"
 	echo "* Installing kernel headers"
 	KERNEL_VERSION=$(uname -r)
 	if [[ $KERNEL_VERSION == *PAE* ]]; then
@@ -66,9 +66,9 @@ function install_deb {
 	fi
 
 	echo "* Installing Sysdig public key"
-	curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public | apt-key add -
+	curl -s https://download.sysdig.com/DRAIOS-GPG-KEY.public | apt-key add -
 	echo "* Installing Sysdig repository"
-	curl -s -o /etc/apt/sources.list.d/draios.list "https://s3.amazonaws.com/download.draios.com/$SYSDIG_REPOSITORY_NAME/deb/draios.list"
+	curl -s -o /etc/apt/sources.list.d/draios.list "https://download.sysdig.com/$SYSDIG_REPOSITORY_NAME/deb/draios.list"
 	apt-get -qq update < /dev/null
 	echo "* Installing kernel headers"
 	apt-get -qq -y install linux-headers-$(uname -r) < /dev/null || kernel_warning

--- a/test/csysdig_trace_regression.sh
+++ b/test/csysdig_trace_regression.sh
@@ -33,7 +33,7 @@ BRANCH=$3
 if [ ! -d "$TRACEDIR" ]; then
 	mkdir -p $TRACEDIR
 	cd $TRACEDIR
-	wget https://s3.amazonaws.com/download.draios.com/sysdig-tests/traces.zip
+	wget https://download.sysdig.com/sysdig-tests/traces.zip
 	unzip traces.zip
 	rm -rf traces.zip
 	cd -
@@ -42,7 +42,7 @@ fi
 if [ ! -d "$BASELINEDIR" ]; then
 	mkdir -p $BASELINEDIR
 	cd $BASELINEDIR
-	wget -O baseline.zip https://s3.amazonaws.com/download.draios.com/sysdig-tests/baseline-$BRANCH.zip || wget -O baseline.zip https://s3.amazonaws.com/download.draios.com/sysdig-tests/baseline-dev.zip
+	wget -O baseline.zip https://download.sysdig.com/sysdig-tests/baseline-$BRANCH.zip || wget -O baseline.zip https://download.sysdig.com/sysdig-tests/baseline-dev.zip
 	unzip baseline.zip
 	rm -rf baseline.zip
 	cd -

--- a/test/sysdig_trace_regression.sh
+++ b/test/sysdig_trace_regression.sh
@@ -40,7 +40,7 @@ BRANCH=$3
 if [ ! -d "$TRACEDIR" ]; then
 	mkdir -p $TRACEDIR
 	cd $TRACEDIR
-	wget -O traces.zip https://s3.amazonaws.com/download.draios.com/sysdig-tests/traces-$BRANCH.zip || wget -O traces.zip https://s3.amazonaws.com/download.draios.com/sysdig-tests/traces.zip
+	wget -O traces.zip https://download.sysdig.com/sysdig-tests/traces-$BRANCH.zip || wget -O traces.zip https://download.sysdig.com/sysdig-tests/traces.zip
 	unzip traces.zip
 	rm -rf traces.zip
 	cd -
@@ -49,7 +49,7 @@ fi
 if [ ! -d "$BASELINEDIR" ]; then
 	mkdir -p $BASELINEDIR
 	cd $BASELINEDIR
-	wget -O baseline.zip https://s3.amazonaws.com/download.draios.com/sysdig-tests/baseline-$BRANCH.zip || wget -O baseline.zip https://s3.amazonaws.com/download.draios.com/sysdig-tests/baseline-dev.zip
+	wget -O baseline.zip https://download.sysdig.com/sysdig-tests/baseline-$BRANCH.zip || wget -O baseline.zip https://download.sysdig.com/sysdig-tests/baseline-dev.zip
 	unzip baseline.zip
 	rm -rf baseline.zip
 	cd -


### PR DESCRIPTION
this work was missed in these tickets: https://sysdig.atlassian.net/browse/SMAGENT-2340 and https://sysdig.atlassian.net/browse/DOC-224