### PR TITLE
fix(ci): solve CI release building issues

### DIFF
--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -56,7 +56,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
           image: ghcr.io/draios/sysdig-builder:dev
-          options: --platform=linux/arm64 -v ${{ github.workspace }}/sysdig:/source/sysdig -v ${{ github.workspace }}/sysdig-build-aarch64:/build/release-packages
+          options: --platform=linux/arm64 -v ${{ github.workspace }}/sysdig:/source/sysdig -v ${{ github.workspace }}/sysdig-build-aarch64:/build/release-packages -e BUILD_VERSION=${{ env.BUILD_VERSION }}
           run: |
             mkdir -p /build/release-packages && \
               build cmake && \
@@ -71,6 +71,7 @@ jobs:
 
   push-container-image:
     runs-on: ubuntu-latest
+    needs: [build-release-linux-amd64, build-release-linux-arm64, sign-rpms, sign-debs]
     env:
       BUILD_VERSION: ${{ github.ref_name }}
       REGISTRY: ghcr.io

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -56,14 +56,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
           image: ghcr.io/draios/sysdig-builder:dev
-          options: --platform=linux/arm64 -v ${{ github.workspace }}/sysdig:/source/sysdig -v ${{ github.workspace }}/sysdig-build-aarch64:/build
+          options: --platform=linux/arm64 -v ${{ github.workspace }}/sysdig:/source/sysdig -v ${{ github.workspace }}/sysdig-build-aarch64:/build/release-packages
           run: |
-            build cmake && build package
+            mkdir -p /build/release-packages && \
+              build cmake && \
+              build package && \
+              cp /build/release/sysdig-${{ env.BUILD_VERSION }}* /build/release-packages
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: sysdig-release-${{ env.BUILD_VERSION }}-aarch64
-          path: ${{ github.workspace }}/sysdig-build-aarch64/release/sysdig-${{ env.BUILD_VERSION }}*
+          path: ${{ github.workspace }}/sysdig-build-aarch64/sysdig-${{ env.BUILD_VERSION }}*
 
   push-container-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -43,7 +43,7 @@ jobs:
           path: sysdig
       - name: Create build dir
         run: |
-          mkdir -p /build
+          mkdir -p ${{ github.workspace }}/sysdig-build-aarch64
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
@@ -53,14 +53,14 @@ jobs:
         with:
           image: draios/sysdig-builder:dev
           registry: ghcr.io
-          options: --platform=linux/arm64 -v ${{ github.workspace }}/sysdig:/source/sysdig -v /build:/build
+          options: --platform=linux/arm64 -v ${{ github.workspace }}/sysdig:/source/sysdig -v ${{ github.workspace }}/sysdig-build-aarch64:/build
           run: |
             build cmake && build package
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: sysdig-release-${{ env.BUILD_VERSION }}-aarch64
-          path: /build/release/sysdig-${{ env.BUILD_VERSION }}*
+          path: ${{ github.workspace }}/sysdig-build-aarch64/release/sysdig-${{ env.BUILD_VERSION }}*
 
   push-container-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -35,6 +35,7 @@ jobs:
   build-release-linux-arm64:
     runs-on: ubuntu-latest
     env:
+      REGISTRY: ghcr.io
       BUILD_VERSION: ${{ github.ref_name }}
     steps:
       - name: Checkout Sysdig
@@ -47,12 +48,14 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: 'arm64'
+          platforms: 'amd64,arm64'
       - name: Run the build process with Docker
         uses: addnab/docker-run-action@v3
         with:
-          image: draios/sysdig-builder:dev
-          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          image: ghcr.io/draios/sysdig-builder:dev
           options: --platform=linux/arm64 -v ${{ github.workspace }}/sysdig:/source/sysdig -v ${{ github.workspace }}/sysdig-build-aarch64:/build
           run: |
             build cmake && build package


### PR DESCRIPTION
This solved our GitHub actions workflow issues when building release drafts. These changes have been tested by tagging an -rc draft release.