### PR TITLE
new(userspace): suggest plugins to be loaded for unknown filter fields

### DIFF
--- a/userspace/sysdig/plugin_utils.h
+++ b/userspace/sysdig/plugin_utils.h
@@ -37,16 +37,17 @@ public:
 
 	void add_directory(const std::string& plugins_dir);
 
-	void load_plugin(sinsp *inspector, const string& name);
+	void load_plugin(sinsp *inspector, const std::string& name);
 	void load_plugins_from_dirs(sinsp *inspector);
 	void load_plugins_from_conf_file(sinsp *inspector, const std::string& config_filename);
 
-	void init_plugin(sinsp *inspector, const string& name, const string& conf);
+	void init_plugin(sinsp *inspector, const std::string& name, const std::string& conf);
 
-	void select_input_plugin(sinsp *inspector, const string& name, const string& params);
+	void select_input_plugin(sinsp *inspector, const std::string& name, const std::string& params);
 
-	void print_plugin_info(sinsp* inspector, const string& name);
+	void print_plugin_info(sinsp* inspector, const std::string& name);
 	void print_plugin_info_list(sinsp* inspector);
+	void print_field_extraction_support(sinsp* inspector, const std::string& field);
 
 	bool has_plugins() const;
 	bool has_input_plugin() const;


### PR DESCRIPTION
NOTE: _based on top of https://github.com/draios/sysdig/pull/1911 and on hold until it's merged_

When encountering unknown filter fields, now sysdig can look into all its known plugins and suggest which ones can be loaded to make a given field supported for extraction.

Example:
```bash
> sysdig "json.value=test"
filter contains an unknown field 'json.value', and none of the loaded plugins is capable of extracting it

> SYSDIG_PLUGIN_DIR=./plugins sysdig "json.value=test"
filter contains an unknown field 'json.value', but it can be supported by loading one of these plugins: json

> SYSDIG_PLUGIN_DIR=./plugins sysdig -H json "json.value=test"
...
```