### PR TITLE
update(cmake): bump libs version to 4e218b3a072f2e0377804ed317e09de99445589f

### DIFF
--- a/cmake/modules/falcosecurity-libs-repo/CMakeLists.txt
+++ b/cmake/modules/falcosecurity-libs-repo/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.5.1)
 project(falcosecurity-libs-repo NONE)
 
 include(ExternalProject)
-message(STATUS "Driver version: ${FALCOSECURITY_LIBS_VERSION}")
+message(STATUS "Libs version: ${FALCOSECURITY_LIBS_VERSION}")
 
 ExternalProject_Add(
   falcosecurity-libs

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -32,8 +32,8 @@ else()
   # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
   # -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "4f13d6910cc520b860ba0e13d5e6d4374fe35d8c")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=1a477a047d8ea01ba48d2333dcc9ccc39d67dc4caaaf2edabb332398b8747ee2")
+    set(FALCOSECURITY_LIBS_VERSION "4e218b3a072f2e0377804ed317e09de99445589f")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=29c52303744d40847292f00d4ce7cd1e97f97a81aa5d38674949cf38118d4315")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -78,15 +78,6 @@ set(USE_BUNDLED_RE2 ON CACHE BOOL "")
 
 list(APPEND CMAKE_MODULE_PATH "${FALCOSECURITY_LIBS_SOURCE_DIR}/cmake/modules")
 
-include(CheckSymbolExists)
-check_symbol_exists(strlcpy "string.h" HAVE_STRLCPY)
-if(HAVE_STRLCPY)
-	message(STATUS "Existing strlcpy found, will *not* use local definition by setting -DHAVE_STRLCPY.")
-	add_definitions(-DHAVE_STRLCPY)
-else()
-	message(STATUS "No strlcpy found, will use local definition")
-endif()
-
 include(driver)
 include(libscap)
 include(libsinsp)

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -32,8 +32,8 @@ else()
   # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
   # -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "0.9.0")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=5319a1b6a72eba3d9524cf084be5fc2ed81e3e90b3bee8edbe58b8646af0cbcb")
+    set(FALCOSECURITY_LIBS_VERSION "4f13d6910cc520b860ba0e13d5e6d4374fe35d8c")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=1a477a047d8ea01ba48d2333dcc9ccc39d67dc4caaaf2edabb332398b8747ee2")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/userspace/sysdig/utils/plugin_utils.cpp
+++ b/userspace/sysdig/utils/plugin_utils.cpp
@@ -564,7 +564,13 @@ void plugin_utils::load_plugins_from_conf_file(sinsp *inspector, const std::stri
 
 void plugin_utils::print_field_extraction_support(sinsp* inspector, const std::string& field)
 {
-    auto err = "filter contains an unknown field '" + field + "'";
+    std::string field_name = field;
+    size_t field_arg_pos = field.find_first_of('[');
+    if (field_arg_pos != std::string::npos)
+    {
+        field_name = field.substr(0, field_arg_pos);
+    }
+    auto err = "filter contains an unknown field '" + field_name + "'";
     std::unordered_set<std::string> compatible_plugins;
     for (auto &p : m_plugins)
     {
@@ -575,7 +581,7 @@ void plugin_utils::print_field_extraction_support(sinsp* inspector, const std::s
             for (const auto& f : fields)
             {
                 std::string fname = f.m_name;
-                if (fname == field)
+                if (fname == field_name)
                 {
                     compatible_plugins.insert(plugin->name());
                 }

--- a/userspace/sysdig/utils/plugin_utils.cpp
+++ b/userspace/sysdig/utils/plugin_utils.cpp
@@ -568,16 +568,16 @@ void plugin_utils::print_field_extraction_support(sinsp* inspector, const std::s
     std::unordered_set<std::string> compatible_plugins;
     for (auto &p : m_plugins)
     {
-        p.ensure_registered(inspector);
-        if (p.plugin->caps() & CAP_EXTRACTION)
+        auto plugin = p.get_plugin(inspector);
+        if (plugin->caps() & CAP_EXTRACTION)
         {
-            const auto &fields = p.plugin->fields();
+            const auto &fields = plugin->fields();
             for (const auto& f : fields)
             {
                 std::string fname = f.m_name;
                 if (fname == field)
                 {
-                    compatible_plugins.insert(p.plugin->name());
+                    compatible_plugins.insert(plugin->name());
                 }
             }
         }


### PR DESCRIPTION
In falcosecurity/libs, this is the commit hash right after the 0.9.0 tag that includes the fixes of https://github.com/falcosecurity/libs/pull/672