### PR TITLE
refactor(userspace): factorize logic for opening inspectors

### DIFF
--- a/userspace/sinspui/cursesui.cpp
+++ b/userspace/sinspui/cursesui.cpp
@@ -227,7 +227,7 @@ uint64_t json_spy_renderer::get_count()
 // sinsp_cursesui implementation
 ///////////////////////////////////////////////////////////////////////////////
 sinsp_cursesui::sinsp_cursesui(sinsp* inspector,
-	string event_source_name,
+	sinsp_opener* source_opener,
 	string cmdline_capture_filter,
 	uint64_t refresh_interval_ns,
 	bool print_containers,
@@ -238,7 +238,7 @@ sinsp_cursesui::sinsp_cursesui(sinsp* inspector,
 	sinsp_evt::param_fmt json_spy_text_fmt)
 {
 	m_inspector = inspector;
-	m_event_source_name = event_source_name;
+	m_source_opener = source_opener;
 	m_selected_view = 0;
 	m_prev_selected_view = 0;
 	m_selected_view_sidemenu_entry = 0;
@@ -1570,17 +1570,7 @@ void sinsp_cursesui::restart_capture(bool is_spy_switch)
 	m_inspector->close();
 	start(true, is_spy_switch);
 
-	// note: here we don't propagate information about eBPF, udig, and
-	// configs like enabling/disabling page-faults. Not sure if this works
-	// properly
-	if (m_event_source_name.empty())
-	{
-		m_inspector->open_savefile(m_event_source_name);
-	}
-	else
-	{
-		m_inspector->open_kmod();
-	}
+	m_source_opener->open(m_inspector);
 }
 
 void sinsp_cursesui::create_complete_filter(bool templated)

--- a/userspace/sinspui/cursesui.h
+++ b/userspace/sinspui/cursesui.h
@@ -21,6 +21,8 @@ limitations under the License.
 #include <unistd.h>
 #endif
 
+#include "../sysdig/utils/sinsp_opener.h"
+
 #define UI_USER_INPUT_CHECK_PERIOD_NS 10000000
 #define VIEW_SIDEMENU_WIDTH 20
 #define ACTION_SIDEMENU_WIDTH 30
@@ -429,7 +431,7 @@ public:
 		LAST_COLORELEMENT
 	};
 
-	sinsp_cursesui(sinsp* inspector, string event_source_name, 
+	sinsp_cursesui(sinsp* inspector, sinsp_opener* source_opener, 
 		string cmdline_capture_filter, uint64_t refresh_interval_ns, 
 		bool print_containers, chisel_table::output_type output_type, bool is_mousedrag_available,
 		int32_t json_first_row, int32_t json_last_row, int32_t sorting_col,
@@ -774,7 +776,7 @@ private:
 
 	vector<sinsp_menuitem_info> m_menuitems;
 	vector<sinsp_menuitem_info> m_menuitems_spybox;
-	string m_event_source_name;
+	sinsp_opener* m_source_opener;
 	string m_cmdline_capture_filter;
 	string m_complete_filter;
 	string m_complete_filter_noview;

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -46,11 +46,13 @@ else()
 endif()
 
 list(APPEND SOURCE_FILES
+	utils/sinsp_opener.cpp
 	utils/plugin_utils.cpp
 	utils/supported_events.cpp
 	utils/supported_fields.cpp)
 
 list(APPEND SOURCE_FILES_CSYSDIG
+	utils/sinsp_opener.cpp
 	utils/plugin_utils.cpp
 	utils/supported_events.cpp
 	utils/supported_fields.cpp

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -464,10 +464,10 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 				break;
 			case 'B':
 			{
-				opener.mode_bpf = true;
+				opener.bpf.enabled = true;
 				if(optarg)
 				{
-					opener.bpf_probe = optarg;
+					opener.bpf.probe = optarg;
 				}
 				break;
 			}
@@ -635,7 +635,7 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 					}
 					else if(optname == "page-faults")
 					{
-						opener.enable_page_faults = true;
+						opener.options.page_faults = true;
 					}
 				}
 				break;
@@ -691,13 +691,13 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 			}
 		}
 
-		if(!opener.mode_bpf)
+		if(!opener.bpf.enabled)
 		{
 			const char *probe = getenv("SYSDIG_BPF_PROBE");
 			if(probe)
 			{
-				opener.mode_bpf = true;
-				opener.bpf_probe = probe;
+				opener.bpf.enabled = true;
+				opener.bpf.probe = probe;
 			}
 		}
 
@@ -874,8 +874,8 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 				//
 				// We have a file to open
 				//
-				opener.mode_savefile = true;
-				opener.savefile_path = infiles[j];
+				opener.savefile.enabled = true;
+				opener.savefile.path = infiles[j];
 				opener.open(inspector);
 			}
 			else

--- a/userspace/sysdig/utils/sinsp_opener.cpp
+++ b/userspace/sysdig/utils/sinsp_opener.cpp
@@ -31,20 +31,20 @@ limitations under the License.
 
 void sinsp_opener::open(sinsp* inspector) const
 {
-    if(enable_print_progress && !(mode_plugin || mode_savefile))
+    if(options.print_progress && !(plugin.enabled || savefile.enabled))
     {
         throw sinsp_exception("the -P flag cannot be used with live captures.");
     }
 
-    if(mode_savefile)
+    if(savefile.enabled)
     {
-        inspector->open_savefile(savefile_path);
+        inspector->open_savefile(savefile.path);
         return;
     }
 
-    if (mode_plugin)
+    if (plugin.enabled)
     {
-        inspector->open_plugin(plugin_name, plugin_params);
+        inspector->open_plugin(plugin.name, plugin.params);
         return;
     }
 
@@ -54,28 +54,28 @@ void sinsp_opener::open(sinsp* inspector) const
 
     /* Populate tracepoints of interest */
     std::unordered_set<uint32_t> tp_of_interest = inspector->get_all_tp();
-    if(!enable_page_faults)
+    if(!options.page_faults)
     {
         tp_of_interest.erase(PAGE_FAULT_USER);
         tp_of_interest.erase(PAGE_FAULT_KERN);
     }
 
-    if(mode_udig)
+    if(udig.enabled)
     {
         inspector->open_udig();
         return;
     }
 
-    if(mode_gvisor)
+    if(gvisor.enabled)
     {
-        inspector->open_gvisor(gvisor_config, gvisor_root);
+        inspector->open_gvisor(gvisor.config, gvisor.root);
         return;
     }
 
 #ifndef _WIN32
-    if(mode_bpf)
+    if(bpf.enabled)
     {
-        auto probe = bpf_probe;
+        auto probe = bpf.probe;
         if (probe.empty())
         {
             const char *home = std::getenv("HOME");
@@ -104,6 +104,7 @@ void sinsp_opener::open(sinsp* inspector) const
         return;
     }
     
+    // default to kernel module if no other option is specified
     try
     {
         inspector->open_kmod(DEFAULT_DRIVER_BUFFER_BYTES_DIM, sc_of_interest, tp_of_interest);

--- a/userspace/sysdig/utils/sinsp_opener.cpp
+++ b/userspace/sysdig/utils/sinsp_opener.cpp
@@ -1,0 +1,128 @@
+/*
+Copyright (C) 2013-2022 Sysdig Inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License,
+Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "sinsp_opener.h"
+
+#include <sinsp_exception.h>
+#ifdef HAS_CAPTURE
+#ifndef WIN32
+#include "driver_config.h"
+#endif // WIN32
+#endif // HAS_CAPTURE
+
+void sinsp_opener::open(sinsp* inspector) const
+{
+    if(enable_print_progress && !(mode_plugin || mode_savefile))
+    {
+        throw sinsp_exception("the -P flag cannot be used with live captures.");
+    }
+
+    if(mode_savefile)
+    {
+        inspector->open_savefile(savefile_path);
+        return;
+    }
+
+    if (mode_plugin)
+    {
+        inspector->open_plugin(plugin_name, plugin_params);
+        return;
+    }
+
+#if defined(HAS_CAPTURE)
+    /* Populate syscalls of interest */
+    std::unordered_set<uint32_t> sc_of_interest = inspector->get_all_ppm_sc();
+
+    /* Populate tracepoints of interest */
+    std::unordered_set<uint32_t> tp_of_interest = inspector->get_all_tp();
+    if(!enable_page_faults)
+    {
+        tp_of_interest.erase(PAGE_FAULT_USER);
+        tp_of_interest.erase(PAGE_FAULT_KERN);
+    }
+
+    if(mode_udig)
+    {
+        inspector->open_udig();
+        return;
+    }
+
+    if(mode_gvisor)
+    {
+        inspector->open_gvisor(gvisor_config, gvisor_root);
+        return;
+    }
+
+#ifndef _WIN32
+    if(mode_bpf)
+    {
+        auto probe = bpf_probe;
+        if (probe.empty())
+        {
+            const char *home = std::getenv("HOME");
+            if(!home)
+            {
+                throw sinsp_exception("Cannot get the env variable 'HOME'");
+            }
+            probe = std::string(home) + "/" + SYSDIG_PROBE_BPF_FILEPATH;
+        }
+
+        try
+        {
+            inspector->open_bpf(probe, DEFAULT_DRIVER_BUFFER_BYTES_DIM, sc_of_interest, tp_of_interest);
+        }
+        catch(const sinsp_exception& e)
+        {
+            if(system("scap-driver-loader bpf"))
+            {
+                fprintf(stderr, "Unable to load the BPF probe\n");
+            }
+            inspector->open_bpf(probe, DEFAULT_DRIVER_BUFFER_BYTES_DIM, sc_of_interest, tp_of_interest);
+        }
+
+        // Enable gathering the CPU from the kernel module
+        inspector->set_get_procs_cpu_from_driver(true);
+        return;
+    }
+    
+    try
+    {
+        inspector->open_kmod(DEFAULT_DRIVER_BUFFER_BYTES_DIM, sc_of_interest, tp_of_interest);
+    }
+    catch(const sinsp_exception& e)
+    {
+        // if we are opening the syscall source, we retry later
+        // by loading the driver with modprobe
+        if(system("modprobe " DRIVER_NAME " > /dev/null 2> /dev/null"))
+        {
+            fprintf(stderr, "Unable to load the driver\n");
+        }
+        inspector->open_kmod(DEFAULT_DRIVER_BUFFER_BYTES_DIM, sc_of_interest, tp_of_interest);
+    }
+
+    // Enable gathering the CPU from the kernel module
+    inspector->set_get_procs_cpu_from_driver(true);
+#elif // _WIN32
+    throw sinsp_exception("can't open inspector");
+#endif // _WIN32
+#endif // HAS_CAPTURE
+}

--- a/userspace/sysdig/utils/sinsp_opener.h
+++ b/userspace/sysdig/utils/sinsp_opener.h
@@ -24,14 +24,7 @@ limitations under the License.
 
 struct sinsp_opener
 {
-    sinsp_opener():
-        mode_udig(false),
-        mode_bpf(false),
-        mode_gvisor(false),
-        mode_plugin(false),
-        mode_savefile(false),
-        enable_print_progress(false),
-        enable_page_faults(false) { }
+    sinsp_opener() = default;
     virtual ~sinsp_opener() = default;
 	sinsp_opener(sinsp_opener&&) = default;
 	sinsp_opener& operator = (sinsp_opener&&) = default;
@@ -40,17 +33,41 @@ struct sinsp_opener
     
     void open(sinsp* inspector) const;
 
-    bool mode_udig;
-    bool mode_bpf;
-    bool mode_gvisor;
-    bool mode_plugin;
-    bool mode_savefile;
-    bool enable_print_progress;
-    bool enable_page_faults;
-    std::string bpf_probe;
-    std::string savefile_path;
-    std::string plugin_name;
-    std::string plugin_params;
-    std::string gvisor_config;
-    std::string gvisor_root;
+    struct 
+    {
+        bool print_progress = false;
+        bool page_faults = false;
+    } options;
+
+    struct
+    {
+        bool enabled = false;
+    } udig;
+
+    struct
+    {
+        bool enabled = false;
+        std::string probe;
+    } bpf;
+
+
+    struct
+    {
+        bool enabled = false;
+        std::string config;
+        std::string root;
+    } gvisor;
+
+    struct
+    {
+        bool enabled = false;
+        std::string name;
+        std::string params;
+    } plugin;
+
+    struct
+    {
+        bool enabled = false;
+        std::string path;
+    } savefile;    
 };

--- a/userspace/sysdig/utils/sinsp_opener.h
+++ b/userspace/sysdig/utils/sinsp_opener.h
@@ -1,0 +1,56 @@
+/*
+Copyright (C) 2013-2022 Sysdig Inc.
+
+This file is part of sysdig.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+#pragma once
+
+#include <sinsp.h>
+
+#include <string>
+
+struct sinsp_opener
+{
+    sinsp_opener():
+        mode_udig(false),
+        mode_bpf(false),
+        mode_gvisor(false),
+        mode_plugin(false),
+        mode_savefile(false),
+        enable_print_progress(false),
+        enable_page_faults(false) { }
+    virtual ~sinsp_opener() = default;
+	sinsp_opener(sinsp_opener&&) = default;
+	sinsp_opener& operator = (sinsp_opener&&) = default;
+	sinsp_opener(const sinsp_opener&) = default;
+	sinsp_opener& operator = (const sinsp_opener&) = default;
+    
+    void open(sinsp* inspector) const;
+
+    bool mode_udig;
+    bool mode_bpf;
+    bool mode_gvisor;
+    bool mode_plugin;
+    bool mode_savefile;
+    bool enable_print_progress;
+    bool enable_page_faults;
+    std::string bpf_probe;
+    std::string savefile_path;
+    std::string plugin_name;
+    std::string plugin_params;
+    std::string gvisor_config;
+    std::string gvisor_root;
+};

--- a/userspace/sysdig/utils/sinsp_opener.h
+++ b/userspace/sysdig/utils/sinsp_opener.h
@@ -26,10 +26,10 @@ struct sinsp_opener
 {
     sinsp_opener() = default;
     virtual ~sinsp_opener() = default;
-	sinsp_opener(sinsp_opener&&) = default;
-	sinsp_opener& operator = (sinsp_opener&&) = default;
-	sinsp_opener(const sinsp_opener&) = default;
-	sinsp_opener& operator = (const sinsp_opener&) = default;
+    sinsp_opener(sinsp_opener&&) = default;
+    sinsp_opener& operator = (sinsp_opener&&) = default;
+    sinsp_opener(const sinsp_opener&) = default;
+    sinsp_opener& operator = (const sinsp_opener&) = default;
     
     void open(sinsp* inspector) const;
 
@@ -49,7 +49,6 @@ struct sinsp_opener
         bool enabled = false;
         std::string probe;
     } bpf;
-
 
     struct
     {


### PR DESCRIPTION
The logic for configuring and opening an event source through an inspector is duplicated and scattered all across the codebase. This PR isolates that logic in an ad-hoc class and makes both sysdig and csysdig use it.

For instance, this fixes a bug in csysdig that caused it to always reload with the kernel module even if the ebpf probe was configured.