### PR TITLE
fix(userspace): improve display filter performance

### DIFF
--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -882,19 +882,16 @@ captureinfo do_inspect(sinsp* inspector,
 				continue;
 			}
 
+			if(display_filter && !display_filter->run(ev))
+			{
+				continue;
+			}
+
+			//
+			// Output the line
+			//
 			if(formatter->tostring(ev, &line))
 			{
-				//
-				// Output the line
-				//
-				if(display_filter)
-				{
-					if(!display_filter->run(ev))
-					{
-						continue;
-					}
-				}
-
 				cout << line << endl;
 			}
 		}


### PR DESCRIPTION
For some reason, display filters are evaluated before formatting the output string, which is quite a bigger bottleneck in terms of performance.

Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>