### PR TITLE
update(userspace): avoid using and relying on std namespace in headers

### DIFF
--- a/userspace/sinspui/ctext.h
+++ b/userspace/sinspui/ctext.h
@@ -29,8 +29,6 @@ limitations under the License.
 #define __83a9222a_c8b9_4f36_9721_5dfbaccb28d0_CTEXT
 #define CTEXT_BUFFER_SIZE (4096)
 
-using namespace std;
-
 class ctext;
 
 struct ctext_config_struct
@@ -177,17 +175,17 @@ typedef struct ctext_search_struct
 	int16_t _match_count;
 
 	// The string to match
-	string _query;
+	std::string _query;
 
 } ctext_search;
 
 typedef struct ctext_row_struct
 {
-	string data;
-	vector<ctext_format> format;
+	std::string data;
+	std::vector<ctext_format> format;
 } ctext_row;
 
-typedef vector<ctext_row> ctext_buffer;
+typedef std::vector<ctext_row> ctext_buffer;
 
 class ctext 
 {
@@ -424,7 +422,7 @@ class ctext
 		// Returns you_manage_this_memory back at you or NULL
 		// on an error.
 		//
-		ctext_search *new_search(ctext_search *you_manage_this_memory, string to_search, bool is_case_insensitive = false, bool is_forward = true, bool do_wrap = false);
+		ctext_search *new_search(ctext_search *you_manage_this_memory, std::string to_search, bool is_case_insensitive = false, bool is_forward = true, bool do_wrap = false);
 
 		//
 		// If you want to modify the query of an existing search then you
@@ -433,7 +431,7 @@ class ctext
 		//
 		// Returns 0 on success
 		//
-		int8_t set_query(ctext_search *p_search, string new_query);
+		int8_t set_query(ctext_search *p_search, std::string new_query);
 
 		//
 		// After you've initiated your search you can then go over
@@ -524,7 +522,7 @@ class ctext
 		int32_t m_win_height;
 		uint64_t m_event_counter;
 
-		ofstream *m_debug;
+		std::ofstream *m_debug;
 };
 
 int cprintf(ctext*win, const char *format, ...);

--- a/userspace/sinspui/cursescomponents.h
+++ b/userspace/sinspui/cursescomponents.h
@@ -20,21 +20,21 @@ limitations under the License.
 class search_caller_interface
 {
 public:
-	virtual bool on_search_key_pressed(string search_str) = 0;
+	virtual bool on_search_key_pressed(std::string search_str) = 0;
 	virtual bool on_search_next() = 0;
-	virtual string* get_last_search_string() = 0;
+	virtual std::string* get_last_search_string() = 0;
 };
 
 class sidemenu_list_entry
 {
 public:
-	sidemenu_list_entry(string name, uint32_t id)
+	sidemenu_list_entry(std::string name, uint32_t id)
 	{
 		m_name = name;
 		m_id = id;
 	}
 
-	string m_name;
+	std::string m_name;
 	uint32_t m_id;
 };
 
@@ -111,7 +111,7 @@ public:
 //private:
 	filtercheck_field_info m_info;
 	int32_t m_size;
-	string m_name;
+	std::string m_name;
 
 	friend class curses_table;
 };
@@ -152,7 +152,7 @@ public:
 		uint32_t selct,
 		uint32_t width);
 	~curses_table_sidemenu();
-	void set_entries(vector<sidemenu_list_entry>* entries)
+	void set_entries(std::vector<sidemenu_list_entry>* entries)
 	{
 		m_entries = *entries;
 
@@ -161,7 +161,7 @@ public:
 			m_selct = 0;
 		}
 	}
-	void set_title(string title)
+	void set_title(std::string title)
 	{
 		m_title = title;
 	}
@@ -171,8 +171,8 @@ public:
 	WINDOW* m_win;
 	int32_t m_y_start;
 	sinsp_cursesui* m_parent;
-	vector<sidemenu_list_entry> m_entries;
-	string m_title;
+	std::vector<sidemenu_list_entry> m_entries;
+	std::string m_title;
 	MEVENT m_last_mevent;
 	sidemenu_type m_type;
 
@@ -187,7 +187,7 @@ public:
 	curses_textbox(sinsp* inspector, sinsp_cursesui* parent, int32_t viz_type, spy_text_renderer::sysdig_output_type sotype);
 	~curses_textbox();
 	void render();
-	void set_filter(string filter);
+	void set_filter(std::string filter);
 	void print_no_data();
 	void process_event(sinsp_evt* evt, int32_t next_res);
 	void render_header();
@@ -195,11 +195,11 @@ public:
 	void populate_sidemenu();
 	void reset();
 	bool get_position(OUT int32_t* pos, OUT int32_t* totlines, OUT float* percent, OUT bool* truncated);
-	string* get_last_search_string();
+	std::string* get_last_search_string();
 	int8_t get_offset(int32_t* x, int32_t* y); 
 	int8_t scroll_to(int32_t x, int32_t y);
 	void up();
-	bool on_search_key_pressed(string search_str);
+	bool on_search_key_pressed(std::string search_str);
 	bool on_search_next();
 
 	MEVENT m_last_mevent;
@@ -216,10 +216,10 @@ private:
 	uint32_t n_prints;
 	bool m_paused;
 	curses_table_sidemenu* m_sidemenu;
-	vector<sidemenu_list_entry> m_entries;
+	std::vector<sidemenu_list_entry> m_entries;
 //	int32_t m_viz_type;
 //	sinsp_evt_formatter* m_formatter;
-	string m_last_search_string;
+	std::string m_last_search_string;
 	ctext_search* m_searcher;
 	bool m_has_searched;
 	bool m_search_type_is_goto;

--- a/userspace/sinspui/cursesspectro.h
+++ b/userspace/sinspui/cursesspectro.h
@@ -47,7 +47,7 @@ public:
 	}
 
 	uint64_t m_ts;
-	vector<uint32_t> m_data;
+	std::vector<uint32_t> m_data;
 };
 
 class curses_spectro : 
@@ -64,7 +64,7 @@ public:
 	~curses_spectro();
 
 	void configure(chisel_table* table);
-	void update_data(vector<chisel_sample_row>* data, bool force_selection_change = false);
+	void update_data(std::vector<chisel_sample_row>* data, bool force_selection_change = false);
 	void render(bool data_changed);
 	chisel_table_action handle_input(int ch);
 	void set_x_start(uint32_t x)
@@ -92,11 +92,11 @@ public:
 	bool m_drilled_up;
 	bool m_selection_changed;
 	MEVENT m_last_mevent;
-	string m_selection_filter;
+	std::string m_selection_filter;
 	bool m_scroll_paused;
 	
 private:
-	void print_error(string wstr);
+	void print_error(std::string wstr);
 	uint32_t mkcol(uint64_t n);
 	void draw_axis();
 	void draw_menu(bool there_is_more);
@@ -112,15 +112,15 @@ private:
 	chisel_table* m_table;
 	int32_t m_table_x_start;
 	uint32_t m_table_y_start;
-	vector<curses_table_column_info> m_legend;
-	vector<chisel_sample_row>* m_data;
+	std::vector<curses_table_column_info> m_legend;
+	std::vector<chisel_sample_row>* m_data;
 	uint32_t m_w;
 	uint32_t m_h;
-	vector<uint32_t> m_colpalette;
+	std::vector<uint32_t> m_colpalette;
 	sinsp_filter_check_reference* m_converter;
 	uint64_t m_n_flushes;
 	uint64_t m_n_flushes_with_data;
-	vector<curses_spectro_history_row> m_history;
+	std::vector<curses_spectro_history_row> m_history;
 	curses_spectro_history_row m_t_row;
 	bool m_mouse_masked;
 	int32_t m_lastx, m_lasty;

--- a/userspace/sinspui/cursestable.h
+++ b/userspace/sinspui/cursestable.h
@@ -34,8 +34,8 @@ public:
 	~curses_table();
 
 	void configure(chisel_table* table, 
-		vector<int32_t>* colsizes, vector<string>* colnames);
-	void update_data(vector<chisel_sample_row>* data, bool force_selection_change = false);
+		std::vector<int32_t>* colsizes, std::vector<std::string>* colnames);
+	void update_data(std::vector<chisel_sample_row>* data, bool force_selection_change = false);
 	void render(bool data_changed);
 	chisel_table_action handle_input(int ch);
 	void set_x_start(uint32_t x)
@@ -47,7 +47,7 @@ public:
 	void goto_row(int32_t row);
 	bool get_position(OUT int32_t* pos, OUT int32_t* totlines, OUT float* percent, OUT bool* truncated);
 	void follow_end();
-	string get_field_val(string fldname);
+	std::string get_field_val(std::string fldname);
 	uint32_t get_data_size()
 	{
 		if(m_table != NULL)
@@ -67,9 +67,9 @@ public:
 	
 private:
 	alignment get_field_alignment(ppm_param_type type);
-	void print_error(string wstr);
+	void print_error(std::string wstr);
 	void print_wait();
-	void print_line_centered(string line, int32_t off = 0);
+	void print_line_centered(std::string line, int32_t off = 0);
 
 	sinsp* m_inspector;
 	WINDOW* m_tblwin;
@@ -79,10 +79,10 @@ private:
 	uint32_t m_table_y_start;
 	uint32_t m_scrolloff_x;
 	uint32_t m_colsizes[PT_MAX];
-	vector<curses_table_column_info> m_legend;
-	vector<chisel_sample_row>* m_data;
+	std::vector<curses_table_column_info> m_legend;
+	std::vector<chisel_sample_row>* m_data;
 	sinsp_filter_check_reference* m_converter;
-	vector<uint32_t> m_column_startx;
+	std::vector<uint32_t> m_column_startx;
 	char alignbuf[64];
 	chisel_table::tabletype m_type;
 

--- a/userspace/sinspui/cursesui.cpp
+++ b/userspace/sinspui/cursesui.cpp
@@ -39,6 +39,8 @@ limitations under the License.
 extern int32_t g_screen_w;
 extern bool g_filterchecks_force_raw_times;
 
+using namespace std;
+
 #ifndef NOCURSESUI
 #define ColorPair(i,j) COLOR_PAIR((7-i)*8+j)
 #endif

--- a/userspace/sinspui/cursesui.h
+++ b/userspace/sinspui/cursesui.h
@@ -27,7 +27,7 @@ limitations under the License.
 #define VIEW_SIDEMENU_WIDTH 20
 #define ACTION_SIDEMENU_WIDTH 30
 #define FILTER_TEMPLATE_MAGIC "@#$f1CA^&;"
-string combine_filters(string flt1, string flt2);
+std::string combine_filters(std::string flt1, std::string flt2);
 class ctext;
 class sinsp_chart;
 class curses_spectro;
@@ -43,8 +43,8 @@ public:
 		ALL = TABLE | LIST,
 	};
 
-	sinsp_menuitem_info(string key, 
-		string desc, 
+	sinsp_menuitem_info(std::string key, 
+		std::string desc, 
 		sinsp_menuitem_info::type type,
 		int keyboard_equivalent)
 	{
@@ -54,8 +54,8 @@ public:
 		m_keyboard_equivalent = keyboard_equivalent;
 	}
 
-	string m_key;
-	string m_desc;
+	std::string m_key;
+	std::string m_desc;
 	sinsp_menuitem_info::type m_type;
 	int m_keyboard_equivalent;
 };
@@ -63,15 +63,15 @@ public:
 class sinsp_ui_selection_info
 {
 public:
-	sinsp_ui_selection_info(string field, 
-		string val,
+	sinsp_ui_selection_info(std::string field, 
+		std::string val,
 		chisel_view_column_info* column_info,
-		string view_filter,
+		std::string view_filter,
 		uint32_t prev_selected_view, 
 		uint32_t prev_selected_sidemenu_entry, 
 		chisel_table_field* rowkey,
 		uint32_t prev_sorting_col,
-		string prev_manual_filter,
+		std::string prev_manual_filter,
 		bool prev_is_filter_sysdig,
 		bool prev_is_sorting_ascending,
 		bool is_drilldown)
@@ -99,14 +99,14 @@ public:
 		}
 	}
 
-	string m_field;
-	string m_val;
+	std::string m_field;
+	std::string m_val;
 	chisel_view_column_info* m_column_info;
-	string m_view_filter;
+	std::string m_view_filter;
 	uint32_t m_prev_selected_view;
 	uint32_t m_prev_selected_sidemenu_entry;
 	uint32_t m_prev_sorting_col;
-	string m_prev_manual_filter;
+	std::string m_prev_manual_filter;
 	bool m_prev_is_filter_sysdig;
 	chisel_table_field m_rowkey;
 	bool m_prev_is_sorting_ascending;
@@ -116,15 +116,15 @@ public:
 class sinsp_ui_selection_hierarchy
 {
 public:
-	void push_back(string field, 
-		string val,
+	void push_back(std::string field, 
+		std::string val,
 		chisel_view_column_info* column_info,
-		string view_filter,
+		std::string view_filter,
 		uint32_t prev_selected_view, 
 		uint32_t prev_selected_sidemenu_entry, 
 		chisel_table_field* rowkey,
 		uint32_t prev_sorting_col,
-		string prev_manual_filter,
+		std::string prev_manual_filter,
 		bool prev_is_filter_sysdig,
 		bool prev_is_sorting_ascending,
 		bool is_drilldown)
@@ -154,9 +154,9 @@ public:
 		}
 	}
 
-	string tofilter(bool templated)
+	std::string tofilter(bool templated)
 	{
-		string res;
+		std::string res;
 		uint32_t j;
 		uint32_t hs = (uint32_t)m_hierarchy.size();
 
@@ -206,7 +206,7 @@ public:
 
 					if(templated && (j == hs - 1)) 
 					{
-						res += string("\"") + FILTER_TEMPLATE_MAGIC + "\"";
+						res += std::string("\"") + FILTER_TEMPLATE_MAGIC + "\"";
 					}
 					else
 					{
@@ -234,7 +234,7 @@ public:
 
 		if(res.size() >= 5)
 		{
-			string trailer = res.substr(res.size() - 5).c_str();
+			std::string trailer = res.substr(res.size() - 5).c_str();
 			if(trailer == " and ")
 			{
 				res = res.substr(0, res.size() - 5);
@@ -269,7 +269,7 @@ public:
 
 
 private:
-	vector<sinsp_ui_selection_info> m_hierarchy;
+	std::vector<sinsp_ui_selection_info> m_hierarchy;
 };
 
 class sinsp_mouse_to_key_list_entry
@@ -324,7 +324,7 @@ public:
 		m_list.clear();
 	}
 
-	vector<sinsp_mouse_to_key_list_entry> m_list;
+	std::vector<sinsp_mouse_to_key_list_entry> m_list;
 };
 
 class json_spy_renderer
@@ -338,9 +338,9 @@ public:
 		sinsp_evt::param_fmt text_fmt);
 
 	~json_spy_renderer();
-	void set_filter(string filter);
+	void set_filter(std::string filter);
 	void process_event(sinsp_evt* evt, int32_t next_res);
-	string get_data();
+	std::string get_data();
 	uint64_t get_count();
 
 private:
@@ -432,7 +432,7 @@ public:
 	};
 
 	sinsp_cursesui(sinsp* inspector, sinsp_opener* source_opener, 
-		string cmdline_capture_filter, uint64_t refresh_interval_ns, 
+		std::string cmdline_capture_filter, uint64_t refresh_interval_ns, 
 		bool print_containers, chisel_table::output_type output_type, bool is_mousedrag_available,
 		int32_t json_first_row, int32_t json_last_row, int32_t sorting_col,
 		sinsp_evt::param_fmt json_spy_text_fmt);
@@ -461,10 +461,10 @@ public:
 #ifndef NOCURSESUI
 	void render();
 #endif
-	void turn_search_on(search_caller_interface* ifc, string header_text);
+	void turn_search_on(search_caller_interface* ifc, std::string header_text);
 	uint64_t get_time_delta();
 	void run_action(chisel_view_action_info* action);
-	void spy_selection(string field, string val, chisel_view_column_info* column_info, bool is_dig);
+	void spy_selection(std::string field, std::string val, chisel_view_column_info* column_info, bool is_dig);
 	chisel_table_action handle_input(int ch);
 	bool handle_stdin_input(bool* res);
 
@@ -625,7 +625,7 @@ public:
 			uint64_t evtnum = evt->get_num();
 			if((evtnum - m_last_progress_evt > 2000) || (next_res == SCAP_EOF))
 			{
-				string jdata = m_json_spy_renderer->get_data();
+				std::string jdata = m_json_spy_renderer->get_data();
 				double rprogress = m_inspector->get_read_progress();
 				printf("{\"progress\": %.2lf,", rprogress);
 				if(next_res == SCAP_EOF)
@@ -747,26 +747,26 @@ private:
 	void handle_end_of_sample(sinsp_evt* evt, int32_t next_res);
 	void restart_capture(bool is_spy_switch);
 	void switch_view(bool is_spy_switch);
-	bool spectro_selection(string field, string val, chisel_view_column_info* column_info, filtercheck_field_info* info, chisel_table_action ta);
-	bool do_drilldown(string field, string val, chisel_view_column_info* column_info, uint32_t new_view_num, filtercheck_field_info* info, bool dont_restart);
+	bool spectro_selection(std::string field, std::string val, chisel_view_column_info* column_info, filtercheck_field_info* info, chisel_table_action ta);
+	bool do_drilldown(std::string field, std::string val, chisel_view_column_info* column_info, uint32_t new_view_num, filtercheck_field_info* info, bool dont_restart);
 	// returns false if there is no suitable drill down view for this field
-	bool drilldown(string field, string val, chisel_view_column_info* column_info, filtercheck_field_info* info, bool dont_restart);
+	bool drilldown(std::string field, std::string val, chisel_view_column_info* column_info, filtercheck_field_info* info, bool dont_restart);
 	// returns false if we are already at the top of the hierarchy
 	bool drillup();
 	void create_complete_filter(bool templated);
 	bool execute_table_action(chisel_table_action ta, uint32_t rownumber, bool* res);
-	int32_t get_viewnum_by_name(string name);
+	int32_t get_viewnum_by_name(std::string name);
 
 #ifndef NOCURSESUI
 	void render_header();
-	void draw_bottom_menu(vector<sinsp_menuitem_info>* items, bool istable);
+	void draw_bottom_menu(std::vector<sinsp_menuitem_info>* items, bool istable);
 	void render_default_main_menu();
 	void render_filtersearch_main_menu();
 	void render_spy_main_menu();
 	void render_position_info();
 	void render_main_menu();
 	chisel_table_action handle_textbox_input(int ch);
-	void populate_view_sidemenu(string field, vector<sidemenu_list_entry>* viewlist);
+	void populate_view_sidemenu(std::string field, std::vector<sidemenu_list_entry>* viewlist);
 	void populate_action_sidemenu();
 	void populate_view_cols_sidemenu();
 	void print_progress(double progress);
@@ -774,14 +774,14 @@ private:
 	bool is_spectro_paused(int input);
 #endif
 
-	vector<sinsp_menuitem_info> m_menuitems;
-	vector<sinsp_menuitem_info> m_menuitems_spybox;
+	std::vector<sinsp_menuitem_info> m_menuitems;
+	std::vector<sinsp_menuitem_info> m_menuitems_spybox;
 	sinsp_opener* m_source_opener;
-	string m_cmdline_capture_filter;
-	string m_complete_filter;
-	string m_complete_filter_noview;
-	string m_manual_filter;
-	string m_manual_search_text;
+	std::string m_cmdline_capture_filter;
+	std::string m_complete_filter;
+	std::string m_complete_filter_noview;
+	std::string m_manual_filter;
+	std::string m_manual_search_text;
 	bool m_paused;
 	uint64_t m_last_input_check_ts;
 	bool m_output_filtering;
@@ -789,7 +789,7 @@ private:
 	uint32_t m_cursor_pos;
 	bool m_is_filter_sysdig;
 	uint64_t m_last_progress_evt;
-	vector<sidemenu_list_entry> m_sidemenu_viewlist;
+	std::vector<sidemenu_list_entry> m_sidemenu_viewlist;
 	sinsp_chart* m_chart;
 	search_caller_interface* m_search_caller_interface;
 	int32_t m_search_start_x, m_search_start_y;
@@ -801,7 +801,7 @@ private:
 	sinsp_mouse_to_key_list m_mouse_to_key_list;
 	uint32_t m_filterstring_start_x;
 	uint32_t m_filterstring_end_x;
-	string m_search_header_text;
+	std::string m_search_header_text;
 	chisel_table::output_type m_output_type;
 	bool m_truncated_input;
 	bool m_interactive;

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -230,7 +230,7 @@ static void add_chisel_dirs(sinsp* inspector)
 
 	if(s_user_cdirs != NULL)
 	{
-		vector<string> user_cdirs = sinsp_split(s_user_cdirs, ';');
+		std::vector<std::string> user_cdirs = sinsp_split(s_user_cdirs, ';');
 
 		for(uint32_t j = 0; j < user_cdirs.size(); j++)
 		{
@@ -244,7 +244,7 @@ static void print_views(chisel_view_manager* view_manager)
 	Json::FastWriter writer;
 	Json::Value root;
 
-	vector<chisel_view_info>* vlist = view_manager->get_views();
+	std::vector<chisel_view_info>* vlist = view_manager->get_views();
 
 	for(auto it = vlist->begin(); it != vlist->end(); ++it)
 	{
@@ -275,7 +275,7 @@ static void print_views(chisel_view_manager* view_manager)
 		root.append(jv);
 	}
 
-	string output = writer.write(root);
+	std::string output = writer.write(root);
 	printf("%s", output.substr(0, output.size() - 1).c_str());
 }
 #endif
@@ -337,21 +337,21 @@ captureinfo do_inspect(sinsp* inspector,
 	return retval;
 }
 
-string g_version_string = SYSDIG_VERSION;
+std::string g_version_string = SYSDIG_VERSION;
 
 sysdig_init_res csysdig_init(int argc, char **argv)
 {
 	sysdig_init_res res;
 	sinsp* inspector = NULL;
-	vector<string> infiles;
+	std::vector<std::string> infiles;
 	int op;
 	uint64_t cnt = -1;
 	uint32_t snaplen = 0;
 	int long_index = 0;
 	int32_t n_filterargs = 0;
 	captureinfo cinfo;
-	string errorstr;
-	string display_view;
+	std::string errorstr;
+	std::string display_view;
 	bool print_containers = false;
 	uint64_t refresh_interval_ns = 2000000000;
 	bool list_flds = false;
@@ -361,7 +361,7 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 	int32_t sorting_col = -1;
 	bool list_views = false;
 #ifdef HAS_CAPTURE
-	string cri_socket_path;
+	std::string cri_socket_path;
 #endif
 
 #ifndef _WIN32
@@ -370,10 +370,10 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 	chisel_table::output_type output_type = chisel_table::OT_JSON;
 #endif
 #ifndef MINIMAL_BUILD
-	string* k8s_api = 0;
-	string* node_name = 0;
-	string* k8s_api_cert = 0;
-	string* mesos_api = 0;
+	std::string* k8s_api = 0;
+	std::string* node_name = 0;
+	std::string* k8s_api_cert = 0;
+	std::string* mesos_api = 0;
 #endif // MINIMAL_BUILD
 	bool terminal_with_mouse = false;
 	bool force_tracers_capture = false;
@@ -497,13 +497,13 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 				return sysdig_init_res(EXIT_SUCCESS);
 #ifndef MINIMAL_BUILD
 			case 'k':
-				k8s_api = new string(optarg);
+				k8s_api = new std::string(optarg);
 				break;
 			case 'N':
-				node_name = new string(optarg);
+				node_name = new std::string(optarg);
 				break;
 			case 'K':
-				k8s_api_cert = new string(optarg);
+				k8s_api_cert = new std::string(optarg);
 				break;
 #endif // MINIMAL_BUILD
 			case 'j':
@@ -514,7 +514,7 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 				break;
 #ifndef MINIMAL_BUILD
 			case 'm':
-				mesos_api = new string(optarg);
+				mesos_api = new std::string(optarg);
 				break;
 #endif // MINIMAL_BUILD
 			case 'n':
@@ -529,13 +529,13 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 
 				if(cnt <= 0)
 				{
-					throw sinsp_exception(string("invalid event count ") + optarg);
+					throw sinsp_exception(std::string("invalid event count ") + optarg);
 					res.m_res = EXIT_FAILURE;
 					goto exit;
 				}
 				break;
 			case 'p':
-				if(string(optarg) == "c" || string(optarg) == "container")
+				if(std::string(optarg) == "c" || std::string(optarg) == "container")
 				{
 					inspector->set_print_container_data(true);
 					print_containers = true;
@@ -548,8 +548,8 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 			case 'r':
 				infiles.push_back(optarg);
 #ifndef MINIMAL_BUILD
-				k8s_api = new string();
-				mesos_api = new string();
+				k8s_api = new std::string();
+				mesos_api = new std::string();
 #endif // MINIMAL_BUILD
 				break;
 			case 's':
@@ -578,7 +578,7 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 						break;
 					}
 
-					string optname = string(long_options[long_index].name);
+					std::string optname = std::string(long_options[long_index].name);
 					if(optname == "version")
 					{
 						printf("sysdig version %s\n", SYSDIG_VERSION);
@@ -664,7 +664,7 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 		}
 #endif
 
-		string filter;
+		std::string filter;
 
 		//
 		// If -l was specified, print the fields and exit
@@ -771,7 +771,7 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 		//
 		// Scan the chisel list to load the Lua views, and add them to the list
 		//
-		vector<chisel_desc> chlist;
+		std::vector<chisel_desc> chlist;
 		sinsp_chisel::get_chisel_list(&chlist);
 
 		for(auto it : chlist)
@@ -914,7 +914,7 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 				{
 					if(char* k8s_cert_env = getenv("SYSDIG_K8S_API_CERT"))
 					{
-						k8s_api_cert = new string(k8s_cert_env);
+						k8s_api_cert = new std::string(k8s_cert_env);
 					}
 				}
 				inspector->init_k8s_client(k8s_api, k8s_api_cert, node_name);
@@ -929,10 +929,10 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 					{
 						if(char* k8s_cert_env = getenv("SYSDIG_K8S_API_CERT"))
 						{
-							k8s_api_cert = new string(k8s_cert_env);
+							k8s_api_cert = new std::string(k8s_cert_env);
 						}
 					}
-					k8s_api = new string(k8s_api_env);
+					k8s_api = new std::string(k8s_api_env);
 					inspector->init_k8s_client(k8s_api, k8s_api_cert, node_name);
 				}
 				else
@@ -955,7 +955,7 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 			{
 				if(mesos_api_env != NULL)
 				{
-					mesos_api = new string(mesos_api_env);
+					mesos_api = new std::string(mesos_api_env);
 					inspector->init_mesos_client(mesos_api);
 				}
 			}
@@ -1028,7 +1028,7 @@ exit:
 
 	if(errorstr != "")
 	{
-		cerr << errorstr << endl;
+		std::cerr << errorstr << std::endl;
 	}
 
 	return res;

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -68,7 +68,7 @@ static bool g_terminate = false;
 static bool g_terminating = false;
 static bool g_plugin_input = false;
 #ifdef HAS_CHISELS
-vector<sinsp_chisel*> g_chisels;
+std::vector<sinsp_chisel*> g_chisels;
 #endif
 
 static void usage();
@@ -415,7 +415,7 @@ inline void output_progress(sinsp* inspector, sinsp_evt* ev)
 {
 	if(ev == NULL || (ev->get_num() % 10000 == 0))
 	{
-		string ps;
+		std::string ps;
 		double progress_pct = inspector->get_read_progress_with_str(&ps);
 
 		if(progress_pct - g_last_printed_progress_pct > 0.1)
@@ -438,17 +438,17 @@ inline void output_progress(sinsp* inspector, sinsp_evt* ev)
 }
 
 void print_summary_table(sinsp* inspector,
-						 vector<summary_table_entry> &summary_table,
+						 std::vector<summary_table_entry> &summary_table,
 						 uint32_t nentries)
 {
 	sinsp_evttables* einfo = inspector->get_event_info_tables();
 
-	cout << "----------------------\n";
-	string tstr = string("Event");
+	std::cout << "----------------------\n";
+	std::string tstr = std::string("Event");
 	tstr.resize(16, ' ');
 	tstr += "#Calls\n";
-	cout << tstr;
-	cout << "----------------------\n";
+	std::cout << tstr;
+	std::cout << "----------------------\n";
 
 	sort(summary_table.begin(), summary_table.end(),
 		summary_table_entry_rsort_comparer());
@@ -500,7 +500,7 @@ static void add_chisel_dirs(sinsp* inspector)
 
 	if(s_user_cdirs != NULL)
 	{
-		vector<string> user_cdirs = sinsp_split(s_user_cdirs, ';');
+		std::vector<std::string> user_cdirs = sinsp_split(s_user_cdirs, ';');
 
 		for(uint32_t j = 0; j < user_cdirs.size(); j++)
 		{
@@ -534,13 +534,13 @@ static void parse_chisel_args(sinsp_chisel* ch, sinsp* inspector, int optind, in
 {
 	uint32_t nargs = ch->get_n_args();
 	uint32_t nreqargs = ch->get_n_required_args();
-	string args;
+	std::string args;
 
 	if(nargs != 0)
 	{
 		if(optind > (int32_t)argc)
 		{
-			throw sinsp_exception("invalid number of arguments for chisel " + string(optarg) + ", " + to_string((long long int)nargs) + " expected.");
+			throw sinsp_exception("invalid number of arguments for chisel " + std::string(optarg) + ", " + std::to_string((long long int)nargs) + " expected.");
 		}
 		else if(optind < (int32_t)argc)
 		{
@@ -555,7 +555,7 @@ static void parse_chisel_args(sinsp_chisel* ch, sinsp* inspector, int optind, in
 			{
 				if(args[0] != '-')
 				{
-					string testflt;
+					std::string testflt;
 
 					for(int32_t j = optind; j < argc; j++)
 					{
@@ -592,7 +592,7 @@ static void parse_chisel_args(sinsp_chisel* ch, sinsp* inspector, int optind, in
 		{
 			if(nreqargs != 0)
 			{
-				throw sinsp_exception("missing arguments for chisel " + string(optarg));
+				throw sinsp_exception("missing arguments for chisel " + std::string(optarg));
 			}
 		}
 	}
@@ -633,7 +633,7 @@ static void chisels_on_capture_end()
 static void chisels_do_timeout(sinsp_evt* ev)
 {
 #ifdef HAS_CHISELS
-	for(vector<sinsp_chisel*>::iterator it = g_chisels.begin();
+	for(std::vector<sinsp_chisel*>::iterator it = g_chisels.begin();
 		it != g_chisels.end(); ++it)
 	{
 		(*it)->do_timeout(ev);
@@ -643,18 +643,18 @@ static void chisels_do_timeout(sinsp_evt* ev)
 
 void handle_end_of_file(sinsp* inspector, bool print_progress, bool reset_colors = false, sinsp_evt_formatter* formatter = NULL)
 {
-	string line;
+	std::string line;
 
 	// Notify the formatter that we are at the
 	// end of the capture in case it needs to
 	// write any terminating characters
 	if(formatter != NULL && formatter->on_capture_end(&line))
 	{
-		cout << line << endl;
+		std::cout << line << std::endl;
 	}
 
 	if(reset_colors) {
-		cout << "\e[00m";
+		std::cout << "\e[00m";
 	}
 
 	//
@@ -689,9 +689,9 @@ void handle_end_of_file(sinsp* inspector, bool print_progress, bool reset_colors
 	}
 }
 
-vector<string> split_nextrun_args(string na)
+std::vector<std::string> split_nextrun_args(std::string na)
 {
-	vector<string> res;
+	std::vector<std::string> res;
 	uint32_t laststart = 0;
 	uint32_t j;
 	bool inquote = false;
@@ -706,7 +706,7 @@ vector<string> split_nextrun_args(string na)
 		{
 			if(!inquote)
 			{
-				string arg = na.substr(laststart, j - laststart);
+				std::string arg = na.substr(laststart, j - laststart);
 				replace_in_place(arg, "\"", "");
 				res.push_back(arg);
 				laststart = j + 1;
@@ -732,14 +732,14 @@ captureinfo do_inspect(sinsp* inspector,
 	bool reset_colors,
 	bool print_progress,
 	sinsp_filter* display_filter,
-	vector<summary_table_entry> &summary_table,
+	std::vector<summary_table_entry> &summary_table,
 	sinsp_evt_formatter* syscall_evt_formatter,
 	sinsp_evt_formatter* plugin_evt_formatter)
 {
 	captureinfo retval;
 	int32_t res;
 	sinsp_evt* ev;
-	string line;
+	std::string line;
 	uint64_t duration_start = 0;
 
 	if(json)
@@ -803,7 +803,7 @@ captureinfo do_inspect(sinsp* inspector,
 			// Notify the chisels that we're exiting, and then die with an error.
 			//
 			handle_end_of_file(inspector, print_progress, reset_colors, formatter);
-			cerr << "res = " << res << endl;
+			std::cerr << "res = " << res << std::endl;
 			throw sinsp_exception(inspector->getlasterr().c_str());
 		}
 
@@ -833,7 +833,7 @@ captureinfo do_inspect(sinsp* inspector,
 #ifdef HAS_CHISELS
 		if(!g_chisels.empty())
 		{
-			for(vector<sinsp_chisel*>::iterator it = g_chisels.begin(); it != g_chisels.end(); ++it)
+			for(std::vector<sinsp_chisel*>::iterator it = g_chisels.begin(); it != g_chisels.end(); ++it)
 			{
 				if((*it)->run(ev) == false)
 				{
@@ -894,13 +894,13 @@ captureinfo do_inspect(sinsp* inspector,
 			//
 			if(formatter->tostring(ev, &line))
 			{
-				cout << line << endl;
+				std::cout << line << std::endl;
 			}
 		}
 
 		if(do_flush)
 		{
-			cout << flush;
+			std::cout << std::flush;
 		}
 	}
 	inspector->stop_capture();
@@ -970,8 +970,8 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 {
 	sysdig_init_res res;
 	sinsp* inspector = NULL;
-	vector<string> infiles;
-	string outfile;
+	std::vector<std::string> infiles;
+	std::string outfile;
 	int op;
 	uint64_t cnt = -1;
 	bool quiet = false;
@@ -986,8 +986,8 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 	double duration = 1;
 	int duration_to_tot = 0;
 	captureinfo cinfo;
-	string output_format;
-	string output_format_plugin;
+	std::string output_format;
+	std::string output_format_plugin;
 	uint32_t snaplen = 0;
 	int long_index = 0;
 	int32_t n_filterargs = 0;
@@ -995,18 +995,18 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 	bool unbuf_flag = false;
 	bool reset_colors = false;
 	bool filter_proclist_flag = false;
-	string cname;
-	vector<summary_table_entry> summary_table;
+	std::string cname;
+	std::vector<summary_table_entry> summary_table;
 #ifndef MINIMAL_BUILD
-	string* k8s_api = 0;
-	string* node_name = 0;
-	string* k8s_api_cert = 0;
-	string* mesos_api = 0;
+	std::string* k8s_api = 0;
+	std::string* node_name = 0;
+	std::string* k8s_api_cert = 0;
+	std::string* mesos_api = 0;
 #endif // MINIMAL_BUILD
 	bool force_tracers_capture = false;
 	std::set<std::string> suppress_comms;
 #ifdef HAS_CAPTURE
-	string cri_socket_path;
+	std::string cri_socket_path;
 #endif
 	plugin_utils plugins;
 	bool list_plugins = false;
@@ -1160,10 +1160,10 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 #ifdef HAS_CHISELS
 			case 'c':
 				{
-					string chisel = optarg;
+					std::string chisel = optarg;
 					if(chisel == "l")
 					{
-						vector<chisel_desc> chlist;
+						std::vector<chisel_desc> chlist;
 						sinsp_chisel::get_chisel_list(&chlist);
 						list_chisels(&chlist, true);
 						delete inspector;
@@ -1182,7 +1182,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				rollover_mb = atoi(optarg);
 				if(rollover_mb <= 0)
 				{
-					throw sinsp_exception(string("invalid file size") + optarg);
+					throw sinsp_exception(std::string("invalid file size") + optarg);
 					res.m_res = EXIT_FAILURE;
 					goto exit;
 				}
@@ -1199,7 +1199,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				event_limit = strtoul(optarg, NULL, 0);
 				if(event_limit <= 0)
 				{
-					throw sinsp_exception(string("invalid parameter 'number of events' ") + optarg);
+					throw sinsp_exception(std::string("invalid parameter 'number of events' ") + optarg);
 					res.m_res = EXIT_FAILURE;
 					goto exit;
 				}
@@ -1219,19 +1219,19 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				duration_seconds = atoi(optarg);
 				if(duration_seconds <= 0)
 				{
-					throw sinsp_exception(string("invalid duration") + optarg);
+					throw sinsp_exception(std::string("invalid duration") + optarg);
 					res.m_res = EXIT_FAILURE;
 					goto exit;
 				}
 				break;
 			case 'H':
 				{
-					string pluginname = optarg;
+					std::string pluginname = optarg;
 					size_t cpos = pluginname.find(':');
-					string pgname = pluginname;
-					string pginitconf;
+					std::string pgname = pluginname;
+					std::string pginitconf;
 					// Extract init config from string if present
-					if(cpos != string::npos)
+					if(cpos != std::string::npos)
 					{
 						pgname = pluginname.substr(0, cpos);
 						pginitconf = pluginname.substr(cpos + 1);
@@ -1242,7 +1242,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				}
 			case 'I':
 				{
-					string inputname = optarg;
+					std::string inputname = optarg;
 					if(inputname == "l")
 					{
 						list_plugins = true;
@@ -1250,10 +1250,10 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 					}
 
 					size_t cpos = inputname.find(':');
-					string pgname = inputname;
-					string pgpars;
+					std::string pgname = inputname;
+					std::string pgpars;
 					// Extract open params from string if present
-					if(cpos != string::npos)
+					if(cpos != std::string::npos)
 					{
 						pgname = inputname.substr(0, cpos);
 						pgpars = inputname.substr(cpos + 1);
@@ -1268,7 +1268,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 			case 'i':
 				{
 					cname = optarg;
-					vector<chisel_desc> chlist;
+					std::vector<chisel_desc> chlist;
 
 					sinsp_chisel::get_chisel_list(&chlist);
 
@@ -1297,13 +1297,13 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				break;
 #ifndef MINIMAL_BUILD
 			case 'k':
-				k8s_api = new string(optarg);
+				k8s_api = new std::string(optarg);
 				break;
 			case 'N':
-				node_name = new string(optarg);
+				node_name = new std::string(optarg);
 				break;
 			case 'K':
-				k8s_api_cert = new string(optarg);
+				k8s_api_cert = new std::string(optarg);
 				break;
 #endif // MINIMAL_BUILD
 			case 'h':
@@ -1324,14 +1324,14 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				return sysdig_init_res(EXIT_SUCCESS);
 #ifndef MINIMAL_BUILD
 			case 'm':
-				mesos_api = new string(optarg);
+				mesos_api = new std::string(optarg);
 				break;
 #endif // MINIMAL_BUILD
 			case 'M':
 				duration_to_tot = atoi(optarg);
 				if(duration_to_tot <= 0)
 				{
-					throw sinsp_exception(string("invalid duration") + optarg);
+					throw sinsp_exception(std::string("invalid duration") + optarg);
 					res.m_res = EXIT_FAILURE;
 					goto exit;
 				}
@@ -1348,7 +1348,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 
 				if(cnt <= 0)
 				{
-					throw sinsp_exception(string("invalid event count ") + optarg);
+					throw sinsp_exception(std::string("invalid event count ") + optarg);
 					res.m_res = EXIT_FAILURE;
 					goto exit;
 				}
@@ -1357,14 +1357,14 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				opener.options.print_progress = true;
 				break;
 			case 'p':
-				if(string(optarg) == "p")
+				if(std::string(optarg) == "p")
 				{
 					// -pp shows the default output format, useful if the user wants to tweak it.
 					printf("%s\n", output_format.c_str());
 					delete inspector;
 					return sysdig_init_res(EXIT_SUCCESS);
 				}
-				else if(string(optarg) == "c" || string(optarg) == "container")
+				else if(std::string(optarg) == "c" || std::string(optarg) == "container")
 				{
 					output_format = "*%evt.num %evt.outputtime %evt.cpu %container.name (%container.id) %proc.name (%thread.tid:%thread.vtid) %evt.dir %evt.type %evt.info";
 
@@ -1374,7 +1374,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 						inspector->set_print_container_data(true);
 					}
 				}
-				else if(string(optarg) == "k" || string(optarg) == "kubernetes")
+				else if(std::string(optarg) == "k" || std::string(optarg) == "kubernetes")
 				{
 					output_format = "*%evt.num %evt.outputtime %evt.cpu %k8s.pod.name (%container.id) %proc.name (%thread.tid:%thread.vtid) %evt.dir %evt.type %evt.info";
 
@@ -1384,7 +1384,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 						inspector->set_print_container_data(true);
 					}
 				}
-				else if(string(optarg) == "m" || string(optarg) == "mesos")
+				else if(std::string(optarg) == "m" || std::string(optarg) == "mesos")
 				{
 					output_format = "*%evt.num %evt.outputtime %evt.cpu %mesos.task.name (%container.id) %proc.name (%thread.tid:%thread.vtid) %evt.dir %evt.type %evt.info";
 
@@ -1410,8 +1410,8 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 			case 'r':
 				infiles.emplace_back(optarg);
 #ifndef MINIMAL_BUILD
-				k8s_api = new string();
-				mesos_api = new string();
+				k8s_api = new std::string();
+				mesos_api = new std::string();
 #endif // MINIMAL_BUILD
 				break;
 			case 'S':
@@ -1431,7 +1431,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				break;
 			case 't':
 				{
-					string tms(optarg);
+					std::string tms(optarg);
 
 					if(tms == "h" || tms == "a" || tms == "r" || tms == "d" || tms == "D")
 					{
@@ -1449,7 +1449,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				force_tracers_capture = true;
 				break;
 			case 'U':
-				suppress_comms.insert(string(optarg));
+				suppress_comms.insert(std::string(optarg));
 				break;
 			case 'u':
 				opener.udig.enabled = true;
@@ -1467,7 +1467,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				file_limit = atoi(optarg);
 				if(file_limit <= 0)
 				{
-					throw sinsp_exception(string("invalid file limit") + optarg);
+					throw sinsp_exception(std::string("invalid file limit") + optarg);
 					res.m_res = EXIT_FAILURE;
 					goto exit;
 				}
@@ -1498,7 +1498,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				break;
 			case 0:
 				{
-					string optname = string(long_options[long_index].name);
+					std::string optname = std::string(long_options[long_index].name);
 					if (long_options[long_index].flag != 0) {
 						break;
 					}
@@ -1513,28 +1513,28 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 						return sysdig_init_res(EXIT_SUCCESS);
 					}
 					else if (optname == "log-level") {
-						if (string(optarg) == "fatal") {
+						if (std::string(optarg) == "fatal") {
 							inspector->set_min_log_severity(sinsp_logger::SEV_FATAL);
 						}
-						else if (string(optarg) == "critical") {
+						else if (std::string(optarg) == "critical") {
 							inspector->set_min_log_severity(sinsp_logger::SEV_CRITICAL);
 						}
-						else if (string(optarg) == "error") {
+						else if (std::string(optarg) == "error") {
 							inspector->set_min_log_severity(sinsp_logger::SEV_ERROR);
 						}
-						else if (string(optarg) == "warning") {
+						else if (std::string(optarg) == "warning") {
 							inspector->set_min_log_severity(sinsp_logger::SEV_WARNING);
 						}
-						else if (string(optarg) == "notice") {
+						else if (std::string(optarg) == "notice") {
 							inspector->set_min_log_severity(sinsp_logger::SEV_NOTICE);
 						}
-						else if (string(optarg) == "info") {
+						else if (std::string(optarg) == "info") {
 							inspector->set_min_log_severity(sinsp_logger::SEV_INFO);
 						}
-						else if (string(optarg) == "debug") {
+						else if (std::string(optarg) == "debug") {
 							inspector->set_min_log_severity(sinsp_logger::SEV_DEBUG);
 						}
-						else if (string(optarg) == "trace") {
+						else if (std::string(optarg) == "trace") {
 							inspector->set_min_log_severity(sinsp_logger::SEV_TRACE);
 						} else {
 							fprintf(stderr, "invalid log level %s\n", optarg);
@@ -1544,7 +1544,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 						g_logger.add_stdout_log();
 					}
 					else if (optname == "list-chisels") {
-						vector<chisel_desc> chlist;
+						std::vector<chisel_desc> chlist;
 						sinsp_chisel::get_chisel_list(&chlist);
 						list_chisels(&chlist, true);
 						delete inspector;
@@ -1567,12 +1567,12 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 					}
 
 					else if (optname == "gvisor-generate-config") {
-						string socket_path;
+						std::string socket_path;
 						if (optarg)
 						{
 							socket_path = std::string(optarg);
 						}
-						string generated_config = inspector->generate_gvisor_config(socket_path);
+						std::string generated_config = inspector->generate_gvisor_config(socket_path);
 						printf("%s", generated_config.c_str());
 						return sysdig_init_res(EXIT_SUCCESS);
 					}
@@ -1729,7 +1729,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 			goto exit;
 		}
 
-		string filter;
+		std::string filter;
 
 		//
 		// the filter is at the end of the command line
@@ -1934,7 +1934,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 				{
 					if(char* k8s_cert_env = getenv("SYSDIG_K8S_API_CERT"))
 					{
-						k8s_api_cert = new string(k8s_cert_env);
+						k8s_api_cert = new std::string(k8s_cert_env);
 					}
 				}
 				inspector->init_k8s_client(k8s_api, k8s_api_cert, node_name, verbose);
@@ -1949,10 +1949,10 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 					{
 						if(char* k8s_cert_env = getenv("SYSDIG_K8S_API_CERT"))
 						{
-							k8s_api_cert = new string(k8s_cert_env);
+							k8s_api_cert = new std::string(k8s_cert_env);
 						}
 					}
-					k8s_api = new string(k8s_api_env);
+					k8s_api = new std::string(k8s_api_env);
 					inspector->init_k8s_client(k8s_api, k8s_api_cert, node_name, verbose);
 				}
 				else
@@ -1975,7 +1975,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 			{
 				if(mesos_api_env != NULL)
 				{
-					mesos_api = new string(mesos_api_env);
+					mesos_api = new std::string(mesos_api_env);
 					inspector->init_mesos_client(mesos_api, verbose);
 				}
 			}
@@ -2031,19 +2031,19 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 	}
 	catch(const scap_open_exception& e)
 	{
-		cerr << e.what() << endl;
+		std::cerr << e.what() << std::endl;
 		handle_end_of_file(NULL, opener.options.print_progress, reset_colors);
 		res.m_res = e.scap_rc();
 	}
 	catch(const sinsp_exception& e)
 	{
-		cerr << e.what() << endl;
+		std::cerr << e.what() << std::endl;
 		handle_end_of_file(NULL, opener.options.print_progress, reset_colors);
 		res.m_res = EXIT_FAILURE;
 	}
 	catch (const std::runtime_error& e)
 	{
-		cerr << e.what() << endl;
+		std::cerr << e.what() << std::endl;
 		handle_end_of_file(NULL, opener.options.print_progress, reset_colors);
 		res.m_res = EXIT_FAILURE;
 	}
@@ -2057,10 +2057,10 @@ exit:
 	//
 	// If any of the chisels is requesting another run,
 	//
-	for(vector<sinsp_chisel*>::iterator it = g_chisels.begin();
+	for(std::vector<sinsp_chisel*>::iterator it = g_chisels.begin();
 		it != g_chisels.end(); ++it)
 	{
-		string na;
+		std::string na;
 		if((*it)->get_nextrun_args(&na))
 		{
 			res.m_next_run_args = split_nextrun_args(na);
@@ -2112,7 +2112,7 @@ int main(int argc, char **argv)
 		optopt = '?';
 
 		int newargc = (int)res.m_next_run_args.size() + 1;
-		vector<char*> newargv;
+		std::vector<char*> newargv;
 
 		newargv.push_back(argv[0]);
 

--- a/userspace/sysdig/sysdig.h
+++ b/userspace/sysdig/sysdig.h
@@ -67,7 +67,7 @@ public:
 	}
 
 	int m_res;
-	vector<string> m_next_run_args;
+	std::vector<std::string> m_next_run_args;
 };
 
 //

--- a/userspace/sysdig/utils/plugin_utils.cpp
+++ b/userspace/sysdig/utils/plugin_utils.cpp
@@ -222,7 +222,7 @@ plugin_utils::plugin_utils()
 
     if (s_user_cdirs != nullptr)
     {
-        vector<string> user_cdirs = sinsp_split(s_user_cdirs, ';');
+        std::vector<std::string> user_cdirs = sinsp_split(s_user_cdirs, ';');
 
         for (auto & user_cdir : user_cdirs)
         {
@@ -256,7 +256,7 @@ void plugin_utils::add_directory(const std::string& plugins_dir)
     add_dir(plugins_dir, false);
 }
 
-void plugin_utils::load_plugin(sinsp *inspector, const string& name)
+void plugin_utils::load_plugin(sinsp *inspector, const std::string& name)
 {
     // avoid duplicate loads
     for (auto &p : m_plugins)
@@ -269,7 +269,7 @@ void plugin_utils::load_plugin(sinsp *inspector, const string& name)
     }
 
     // If it is a path, register it
-	if (name.find('/') != string::npos)
+	if (name.find('/') != std::string::npos)
 	{
         plugin_entry p;
         p.used = true;
@@ -357,13 +357,13 @@ const plugin_utils::plugin_entry& plugin_utils::find_plugin(const std::string na
     throw sinsp_exception(err_plugin_not_found + name);
 }
 
-void plugin_utils::config_plugin(sinsp *inspector, const string& name, const string& conf)
+void plugin_utils::config_plugin(sinsp *inspector, const std::string& name, const std::string& conf)
 {
     auto& p = find_plugin(name);
     p.init_config = conf;
 }
 
-void plugin_utils::select_input_plugin(sinsp *inspector, const string& name, const string& params)
+void plugin_utils::select_input_plugin(sinsp *inspector, const std::string& name, const std::string& params)
 {
     load_plugin(inspector, name);
     auto& p = find_plugin(name);
@@ -409,7 +409,7 @@ void plugin_utils::print_plugin_info_list(sinsp* inspector)
     printf("%s", os.str().c_str());
 }
 
-void plugin_utils::print_plugin_info(sinsp* inspector, const string& name)
+void plugin_utils::print_plugin_info(sinsp* inspector, const std::string& name)
 {
     std::ostringstream os;
 
@@ -486,7 +486,7 @@ void plugin_utils::load_plugins_from_conf_file(sinsp *inspector, const std::stri
     std::string config_explanation = ". See https://falco.org/docs/plugins/#loading-plugins-in-falco for additional information.";
     try {
         config = YAML::LoadFile(config_filename);
-    } catch (exception &e)
+    } catch (std::exception &e)
     {
         throw sinsp_exception("could not read or find configuration file " + config_filename + ": " + e.what());
     }


### PR DESCRIPTION
Following up the work of https://github.com/falcosecurity/libs/pull/769, this solves the same issue in the sysdig codebase as well. This both fixes compilation with libs on that branch, and reduces the reliance on implicit `std` namespace in most of the codebase (the only piece missing is the `sinspui` part, which was too big to tackle in one single PR).