### PR TITLE
fix(sinspui): regression from libs 0.10.0

### DIFF
--- a/userspace/sinspui/cursesui.cpp
+++ b/userspace/sinspui/cursesui.cpp
@@ -1573,6 +1573,8 @@ void sinsp_cursesui::restart_capture(bool is_spy_switch)
 	start(true, is_spy_switch);
 
 	m_source_opener->open(m_inspector);
+
+	m_inspector->start_capture();
 }
 
 void sinsp_cursesui::create_complete_filter(bool templated)


### PR DESCRIPTION
Commit [afa8d11](https://github.com/falcosecurity/libs/commit/afa8d11d8961f3b63ef56f67186b1233eacee26b) in [libs](https://github.com/falcosecurity/libs) introduced a breaking change: now `scap_open` no longer starts the capture automatically. This causes `csysdig` to wait for events that will never be delivered when the capture is restarted. This pr addresses this issue restarting the inspector accordingly.