### PR TITLE
fix(scripts): wrong bash expansion

### DIFF
--- a/scripts/scap-driver-loader.in
+++ b/scripts/scap-driver-loader.in
@@ -275,7 +275,7 @@ load_kernel_module_download() {
 	local URL=$(echo "${1}/${DRIVER_VERSION}/${ARCH}/${SYSDIG_KERNEL_MODULE_FILENAME}" | sed s/+/%2B/g)
 
 	echo "* Trying to download a prebuilt ${DRIVER_NAME} module from ${URL}"
-	if curl -L --create-dirs "${SYSDIG_DRIVER_CURL_OPTIONS}" -o "${HOME}/.scap/${DRIVER_VERSION}/${ARCH}/${SYSDIG_KERNEL_MODULE_FILENAME}" "${URL}"; then
+	if curl -L --create-dirs ${SYSDIG_DRIVER_CURL_OPTIONS} -o "${HOME}/.scap/${DRIVER_VERSION}/${ARCH}/${SYSDIG_KERNEL_MODULE_FILENAME}" "${URL}"; then
 		echo "* Download succeeded"
 		chcon -t modules_object_t "${HOME}/.scap/${DRIVER_VERSION}/${ARCH}/${SYSDIG_KERNEL_MODULE_FILENAME}" > /dev/null 2>&1 || true
 		if insmod "${HOME}/.scap/${DRIVER_VERSION}/${ARCH}/${SYSDIG_KERNEL_MODULE_FILENAME}"; then
@@ -501,7 +501,7 @@ load_bpf_probe_compile() {
 		mkdir -p /tmp/kernel
 		cd /tmp/kernel || exit
 		cd "$(mktemp -d -p /tmp/kernel)" || exit
-		if ! curl -L -o kernel-sources.tgz --create-dirs "${SYSDIG_DRIVER_CURL_OPTIONS}" "${BPF_KERNEL_SOURCES_URL}"; then
+		if ! curl -L -o kernel-sources.tgz --create-dirs ${SYSDIG_DRIVER_CURL_OPTIONS} "${BPF_KERNEL_SOURCES_URL}"; then
 			>&2 echo "Unable to download the kernel sources"
 			return
 		fi
@@ -543,7 +543,7 @@ load_bpf_probe_download() {
 
 	echo "* Trying to download a prebuilt eBPF probe from ${URL}"
 
-	if ! curl -L --create-dirs "${SYSDIG_DRIVER_CURL_OPTIONS}" -o "${HOME}/.scap/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}" "${URL}"; then
+	if ! curl -L --create-dirs ${SYSDIG_DRIVER_CURL_OPTIONS} -o "${HOME}/.scap/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}" "${URL}"; then
 		>&2 echo "Unable to find a prebuilt ${DRIVER_NAME} eBPF probe"
 		return 1
 	fi


### PR DESCRIPTION
This corrects some unnecessary double quotes that break the `scap-driver-loader` script.