### PR TITLE
fix: avoid using global filtercheck list with plugins

### DIFF
--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -28,6 +28,7 @@ limitations under the License.
 #include <assert.h>
 #include <algorithm>
 #include <unordered_set>
+#include <atomic>
 
 #include <sinsp.h>
 #include "scap_open_exception.h"
@@ -63,9 +64,9 @@ limitations under the License.
 
 static constexpr const char* g_unknown_field_err = "nonexistent field ";
 
-static bool g_terminate = false;
-static bool g_terminating = false;
-static bool g_plugin_input = false;
+static std::atomic<bool> g_terminate = false;
+static std::atomic<bool> g_terminating = false;
+static std::atomic<bool> g_plugin_input = false;
 #ifdef HAS_CHISELS
 std::vector<sinsp_chisel*> g_chisels;
 #endif

--- a/userspace/sysdig/utils/plugin_utils.h
+++ b/userspace/sysdig/utils/plugin_utils.h
@@ -35,14 +35,14 @@ public:
 
 	void load_plugin(sinsp *inspector, const std::string& name);
 	void read_plugins_from_dirs(sinsp *inspector);
-	void load_plugins_from_conf_file(sinsp *inspector, const std::string& config_filename, bool set_input);
+	void load_plugins_from_conf_file(sinsp *inspector, filter_check_list* flist, const std::string& config_filename, bool set_input);
 
 	void config_plugin(sinsp *inspector, const std::string& name, const std::string& conf);
 
-	void select_input_plugin(sinsp *inspector, const std::string& name, const std::string& params);
+	void select_input_plugin(sinsp *inspector, filter_check_list* flist, const std::string& name, const std::string& params);
 	void clear_input_plugin();
 
-	void print_plugin_info(sinsp* inspector, const std::string& name);
+	void print_plugin_info(sinsp* inspector, filter_check_list* flist, const std::string& name);
 	void print_plugin_info_list(sinsp* inspector);
 	void print_field_extraction_support(sinsp* inspector, const std::string& field);
 
@@ -51,7 +51,7 @@ public:
 	const std::string& input_plugin_name() const;
 	const std::string& input_plugin_params() const;
 
-	void init_loaded_plugins(sinsp* inspector);
+	void init_loaded_plugins(sinsp* inspector, filter_check_list* flist);
 	std::vector<std::string> get_event_sources(sinsp *inspector);
 	std::vector<std::unique_ptr<sinsp_filter_check>> get_filterchecks(sinsp *inspector, const std::string& source);
 
@@ -64,7 +64,7 @@ private:
 		std::string init_config;
 		std::unordered_set<std::string> names;
 		
-		void init(sinsp *inspector);
+		void init(sinsp *inspector, filter_check_list* flist);
 		void print_info(sinsp* inspector, std::ostringstream& os) const;
 		std::shared_ptr<sinsp_plugin> get_plugin(sinsp *inspector) const;
 	};


### PR DESCRIPTION
The global filtercheck list `g_filterlist` is used in sysdig to also accumulate filterchecks implemented by plugins. However, since that variable is static, it also means that plugins will be kept alive in their shared pointer even after the inspector they've been registered into gets destroyed, and will be instead destroyed at program termination. Even though we don't have sophisticated destroy logic for sinsp-implemented filterchecks, this could be generally wrong for plugins in their teardown phase.