### PR TITLE
ci: added install-sysdig script upload

### DIFF
--- a/.github/workflows/release-final.yaml
+++ b/.github/workflows/release-final.yaml
@@ -227,3 +227,6 @@ jobs:
       
       - name: Release tar.gz
         run: sysdig/scripts/release/release_tgz.sh
+
+      - name: Release install-sysdig
+        run: aws s3 cp sysdig/scripts/install-sysdig s3://${{ env.S3_BUCKET }}/${{ env.REPOSITORY_NAME }}/ --acl public-read


### PR DESCRIPTION
This adds the automatic upload of `install-sysdig` script in the repo.