### PR TITLE
fix(cmake/modules): temp fix for openssl build on aarch64

### DIFF
--- a/cmake/modules/openssl.cmake
+++ b/cmake/modules/openssl.cmake
@@ -1,0 +1,51 @@
+#
+# OpenSSL
+#
+option(USE_BUNDLED_OPENSSL "Enable building of the bundled OpenSSL" ${USE_BUNDLED_DEPS})
+
+if(OPENSSL_INCLUDE_DIR)
+	# we already have openssl
+elseif(NOT USE_BUNDLED_OPENSSL)
+	find_package(OpenSSL REQUIRED)
+	message(STATUS "Found OpenSSL: include: ${OPENSSL_INCLUDE_DIR}, lib: ${OPENSSL_LIBRARIES}")
+else()
+	if(BUILD_SHARED_LIBS)
+		set(OPENSSL_LIB_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
+		set(OPENSSL_SHARED_OPTION shared)
+	else()
+		set(OPENSSL_LIB_SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
+		set(OPENSSL_SHARED_OPTION no-shared)
+	endif()
+	set(OPENSSL_BUNDLE_DIR "${PROJECT_BINARY_DIR}/openssl-prefix/src/openssl")
+	set(OPENSSL_INSTALL_DIR "${OPENSSL_BUNDLE_DIR}/target")
+	set(OPENSSL_INCLUDE_DIR "${PROJECT_BINARY_DIR}/openssl-prefix/src/openssl/include/")
+	set(OPENSSL_LIBRARY_SSL "${OPENSSL_INSTALL_DIR}/lib/libssl${OPENSSL_LIB_SUFFIX}")
+	set(OPENSSL_LIBRARY_CRYPTO "${OPENSSL_INSTALL_DIR}/lib/libcrypto${OPENSSL_LIB_SUFFIX}")
+	set(OPENSSL_LIBRARIES ${OPENSSL_LIBRARY_SSL} ${OPENSSL_LIBRARY_CRYPTO})
+
+	if(NOT TARGET openssl)
+		message(STATUS "Using bundled openssl in '${OPENSSL_BUNDLE_DIR}'")
+
+		ExternalProject_Add(openssl
+			PREFIX "${PROJECT_BINARY_DIR}/openssl-prefix"
+			URL "https://github.com/openssl/openssl/releases/download/openssl-3.1.1/openssl-3.1.1.tar.gz"
+			URL_HASH "SHA256=b3aa61334233b852b63ddb048df181177c2c659eb9d4376008118f9c08d07674"
+			CONFIGURE_COMMAND ./config ${OPENSSL_SHARED_OPTION} --prefix=${OPENSSL_INSTALL_DIR} --libdir=lib
+                        BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
+			BUILD_IN_SOURCE 1
+			BUILD_BYPRODUCTS ${OPENSSL_LIBRARY_SSL} ${OPENSSL_LIBRARY_CRYPTO}
+                        INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install_sw)
+		install(FILES "${OPENSSL_LIBRARY_SSL}" DESTINATION "${CMAKE_INSTALL_LIBDIR}/${LIBS_PACKAGE_NAME}"
+				COMPONENT "libs-deps")
+		install(FILES "${OPENSSL_LIBRARY_CRYPTO}" DESTINATION "${CMAKE_INSTALL_LIBDIR}/${LIBS_PACKAGE_NAME}"
+				COMPONENT "libs-deps")
+		install(DIRECTORY "${OPENSSL_INCLUDE_DIR}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}"
+				COMPONENT "libs-deps")
+	endif()
+endif()
+
+if(NOT TARGET openssl)
+	add_custom_target(openssl)
+endif()
+
+include_directories("${OPENSSL_INCLUDE_DIR}")


### PR DESCRIPTION
This is a temporary fix to be able to build sysdig with openssl3 on aarch64.