### PR TITLE
fix build with system njson

### DIFF
--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -65,10 +65,9 @@ list(APPEND SOURCE_FILES_CSYSDIG
 add_executable(sysdig ${SOURCE_FILES})
 add_executable(csysdig ${SOURCE_FILES_CSYSDIG})
 
-add_dependencies(sysdig njson)
-add_dependencies(csysdig njson)
-
 if(USE_BUNDLED_DEPS)
+	add_dependencies(sysdig njson)
+	add_dependencies(csysdig njson)
 	add_dependencies(sysdig yaml-cpp)
 	add_dependencies(csysdig yaml-cpp)
 endif()


### PR DESCRIPTION
When not using the vendored json library, there is no external project defined.