### PR TITLE
fix(ci): bump rpm-sign image to fedora 39

### DIFF
--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -200,10 +200,10 @@ jobs:
       BUILD_VERSION: ${{ github.ref_name }}
       KEY_ID: EC51E8C4
     container:
-      image: centos:7 # ubi8 does not have rpmsign so we'll use CentOS
+      image: fedora:39
     steps:
       - name: Install deps
-        run: yum install -y rpm-sign
+        run: dnf install -y rpm-sign pinentry
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This is needed to sign the rpm packages with sha256 since centos:7 rpm doesn't support it.