### PR TITLE
fix: GKE patch + bump libs 0.14.2

### DIFF
--- a/cmake/modules/driver-repo/CMakeLists.txt
+++ b/cmake/modules/driver-repo/CMakeLists.txt
@@ -31,5 +31,5 @@ ExternalProject_Add(
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
   TEST_COMMAND ""
-  PATCH_COMMAND sh -c "mv ./driver ../driver.tmp && rm -rf ./* && mv ../driver.tmp/* ."
+  PATCH_COMMAND sh -c "mv ./driver ../driver.tmp && rm -rf ./* && mv ../driver.tmp/* . && patch -p2 <${CMAKE_SOURCE_DIR}/gke_driver.patch"
 )

--- a/cmake/modules/driver-repo/gke_driver.patch
+++ b/cmake/modules/driver-repo/gke_driver.patch
@@ -1,0 +1,21 @@
+diff --git a/driver/bpf/fillers.h b/driver/bpf/fillers.h
+index aebee43ed..5ad6f719e 100644
+--- a/driver/bpf/fillers.h
++++ b/driver/bpf/fillers.h
+@@ -5044,10 +5044,13 @@ FILLER(sched_drop, false)
+ 	return bpf_push_u32_to_ring(data, data->settings->sampling_ratio);
+ }
+ 
+-/* In this kernel version the instruction limit was bumped to 1000000 */
++/* In this kernel version the instruction limit was bumped to 1000000.
++ * We use these 2 values because they are the minimum required to run our eBPF probe
++ * on some GKE environments. See https://github.com/falcosecurity/libs/issues/1639
++ */
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 2, 0))
+-#define MAX_THREADS_GROUPS 30
+-#define MAX_HIERARCHY_TRAVERSE 60
++#define MAX_THREADS_GROUPS 25
++#define MAX_HIERARCHY_TRAVERSE 35
+ #else
+ /* We need to find the right calibration here. On kernel 4.14 the limit
+  * seems to be MAX_THREADS_GROUPS*MAX_HIERARCHY_TRAVERSE <= 100

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -32,8 +32,8 @@ else()
   # In case you want to test against another falcosecurity/libs version (or branch, or commit) just pass the variable -
   # ie., `cmake -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "0.14.1")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=defdea24bf3b176c63f10900d3716fe4373151965cc09d3fe67a31a3a9af0b13")
+    set(FALCOSECURITY_LIBS_VERSION "0.14.2")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=b4ae7bbf3ad031deee4a808145f9fd64b71c537406cc5a92f512823b2e52cdd5")
   endif()
 
   # cd /path/to/build && cmake /path/to/source


### PR DESCRIPTION
This fixes https://github.com/draios/sysdig/issues/2057