### PR TITLE
fix(cmake): update driver version to 7.0.0+driver

### DIFF
--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -32,7 +32,7 @@ else()
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
     set(DRIVER_VERSION "7.0.0+driver")
-    set(DRIVER_CHECKSUM "SHA256=defdea24bf3b176c63f10900d3716fe4373151965cc09d3fe67a31a3a9af0b13")
+    set(DRIVER_CHECKSUM "SHA256=9f2a0f14827c0d9d1c3d1abe45b8f074dea531ebeca9859363a92f0d2475757e")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -31,7 +31,7 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "0.14.1")
+    set(DRIVER_VERSION "7.0.0+driver")
     set(DRIVER_CHECKSUM "SHA256=defdea24bf3b176c63f10900d3716fe4373151965cc09d3fe67a31a3a9af0b13")
   endif()
 


### PR DESCRIPTION
In the latest released version 0.35.2, Sysdig thinks its driver is called `0.14.1` while it's actually `7.0.0+driver`, which means that prebuilt driver download is not working.