### PR TITLE
fix(userspace/sysdig): handle SCAP_FAILURE

### DIFF
--- a/userspace/chisel/chisel_table.cpp
+++ b/userspace/chisel/chisel_table.cpp
@@ -510,7 +510,7 @@ void chisel_table::process_event(sinsp_evt* evt)
 	return;
 }
 
-void chisel_table::process_proctable(sinsp_evt* evt)
+void chisel_table::process_proctable(sinsp_evt* evt, uint64_t last_evt_ts)
 {
 	sinsp_evt tevt;
 	scap_evt tscapevt;
@@ -518,7 +518,15 @@ void chisel_table::process_proctable(sinsp_evt* evt)
 	threadinfo_map_t* threadtable  = m_inspector->m_thread_manager->get_threads();
 	ASSERT(threadtable != NULL);
 
-	uint64_t ts = evt->get_ts();
+	uint64_t ts;
+	if(evt)
+	{
+		ts = evt->get_ts();
+	}
+	else
+	{
+		ts = last_evt_ts;
+	}
 	uint64_t ts_s = ts - (ts % ONE_SECOND_IN_NS);
 	tscapevt.ts = ts_s - 1;
 
@@ -555,7 +563,7 @@ void chisel_table::process_proctable(sinsp_evt* evt)
 	});
 }
 
-void chisel_table::flush(sinsp_evt* evt)
+void chisel_table::flush(sinsp_evt* evt, uint64_t last_evt_ts)
 {
 	if(!m_paused)
 	{
@@ -565,10 +573,7 @@ void chisel_table::flush(sinsp_evt* evt)
 			// Time to emit the sample!
 			// Add the proctable as a sample at the end of the second
 			//
-			if(evt)
-			{
-				process_proctable(evt);
-			}
+			process_proctable(evt);
 
 			//
 			// If there is a merging step, switch the types to point to the merging ones.

--- a/userspace/chisel/chisel_table.cpp
+++ b/userspace/chisel/chisel_table.cpp
@@ -519,6 +519,9 @@ void chisel_table::process_proctable(sinsp_evt* evt, uint64_t last_evt_ts)
 	ASSERT(threadtable != NULL);
 
 	uint64_t ts;
+	// If the evt is null we got a SCAP_EOF return code.
+	// Given that the timestamp is the one of the last
+	// event received.
 	if(evt)
 	{
 		ts = evt->get_ts();
@@ -567,6 +570,7 @@ void chisel_table::flush(sinsp_evt* evt, uint64_t last_evt_ts)
 {
 	if(!m_paused)
 	{
+		// If the evt is null we got a SCAP_EOF return code.
 		if(m_next_flush_time_ns != 0 || evt == nullptr)
 		{
 			//
@@ -615,6 +619,8 @@ void chisel_table::flush(sinsp_evt* evt, uint64_t last_evt_ts)
 		}
 	}
 
+	// If the evt is null we got a SCAP_EOF return code.
+	// So we don't have to update any value.
 	if(evt)
 	{
 		uint64_t ts = evt->get_ts();

--- a/userspace/chisel/chisel_table.cpp
+++ b/userspace/chisel/chisel_table.cpp
@@ -559,13 +559,16 @@ void chisel_table::flush(sinsp_evt* evt)
 {
 	if(!m_paused)
 	{
-		if(m_next_flush_time_ns != 0)
+		if(m_next_flush_time_ns != 0 || evt == nullptr)
 		{
 			//
 			// Time to emit the sample!
 			// Add the proctable as a sample at the end of the second
 			//
-			process_proctable(evt);
+			if(evt)
+			{
+				process_proctable(evt);
+			}
 
 			//
 			// If there is a merging step, switch the types to point to the merging ones.
@@ -607,10 +610,13 @@ void chisel_table::flush(sinsp_evt* evt)
 		}
 	}
 
-	uint64_t ts = evt->get_ts();
+	if(evt)
+	{
+		uint64_t ts = evt->get_ts();
 
-	m_prev_flush_time_ns = m_next_flush_time_ns;
-	m_next_flush_time_ns = ts - (ts % m_refresh_interval_ns) + m_refresh_interval_ns;
+		m_prev_flush_time_ns = m_next_flush_time_ns;
+		m_next_flush_time_ns = ts - (ts % m_refresh_interval_ns) + m_refresh_interval_ns;
+	}
 
 	return;
 }

--- a/userspace/chisel/chisel_table.h
+++ b/userspace/chisel/chisel_table.h
@@ -272,7 +272,7 @@ public:
 	~chisel_table();
 	void configure(std::vector<chisel_view_column_info>* entries, const std::string& filter, bool use_defaults, uint32_t view_depth);
 	void process_event(sinsp_evt* evt);
-	void flush(sinsp_evt* evt);
+	void flush(sinsp_evt* evt, uint64_t last_evt_ts = 0);
 	void filter_sample();
 	//
 	// Returns the key of the first match, or NULL if no match
@@ -336,7 +336,7 @@ private:
 	inline void add_fields_max(ppm_param_type type, chisel_table_field* dst, chisel_table_field* src);
 	inline void add_fields_min(ppm_param_type type, chisel_table_field* dst, chisel_table_field* src);
 	inline void add_fields(uint32_t dst_id, chisel_table_field* src, uint32_t aggr);
-	void process_proctable(sinsp_evt* evt);
+	void process_proctable(sinsp_evt* evt, uint64_t last_evt_ts = 0);
 	inline uint32_t get_field_len(uint32_t id) const;
 	inline uint8_t* get_default_val(filtercheck_field_info* fld);
 	void create_sample();

--- a/userspace/sinspui/cursesui.cpp
+++ b/userspace/sinspui/cursesui.cpp
@@ -1536,6 +1536,28 @@ void sinsp_cursesui::handle_end_of_sample(sinsp_evt* evt, int32_t next_res)
 		render();
 	}
 #endif
+	//
+	// If this is a trace file, check if we reached the end of the file.
+	// Or, if we are in replay mode, wait for a key press before processing
+	// the next sample.
+	//
+	if(!m_inspector->is_live())
+	{
+#ifndef NOCURSESUI
+/*
+		if(m_output_type == chisel_table::OT_CURSES)
+		{
+			if(m_offline_replay)
+			{
+				while(getch() != ' ')
+				{
+					usleep(10000);
+				}
+			}
+		}
+*/
+#endif
+	}
 }
 
 void sinsp_cursesui::restart_capture(bool is_spy_switch)

--- a/userspace/sinspui/cursesui.cpp
+++ b/userspace/sinspui/cursesui.cpp
@@ -279,6 +279,7 @@ sinsp_cursesui::sinsp_cursesui(sinsp* inspector,
 	m_sorting_col = sorting_col;
 	m_json_spy_renderer = NULL;
 	m_json_spy_text_fmt = json_spy_text_fmt;
+	m_n_progress_reports = 0;
 
 #ifndef NOCURSESUI
 	m_viz = NULL;

--- a/userspace/sinspui/cursesui.cpp
+++ b/userspace/sinspui/cursesui.cpp
@@ -1455,7 +1455,7 @@ Json::Value sinsp_cursesui::generate_json_info_section()
 void sinsp_cursesui::handle_end_of_sample(sinsp_evt* evt, int32_t next_res)
 {
 	vector<chisel_sample_row>* sample;
-	m_datatable->flush(evt);
+	m_datatable->flush(evt, m_last_evt_ts);
 
 	//
 	// It's time to refresh the data for this chart.

--- a/userspace/sinspui/cursesui.h
+++ b/userspace/sinspui/cursesui.h
@@ -639,6 +639,7 @@ public:
 				double rprogress = m_inspector->get_read_progress();
 				if(ts > m_1st_evt_ts || next_res == SCAP_EOF)
 				{
+					// We add the comma only after the first progress status update.
 					printf(",");
 				}
 				printf("{\"progress\": %.2lf, \"count\": %" PRIu64 ", \"data\": %s}",
@@ -650,6 +651,8 @@ public:
 
 				if(next_res != SCAP_EOF)
 				{
+					// We update the value only if we have
+					// an event.
 					m_last_progress_evt = evt->get_num();
 				}
 			}

--- a/userspace/sinspui/cursesui.h
+++ b/userspace/sinspui/cursesui.h
@@ -498,17 +498,20 @@ public:
 			if((ts - m_last_input_check_ts > m_input_check_period_ns) || m_eof)
 			{
 				uint32_t ninputs = 0;
-				uint64_t evtnum = evt->get_num();
 
 				//
 				// If this is a file, print the progress once in a while
 				//
 				if(!m_inspector->is_live() && !m_offline_replay)
 				{
-					if(evtnum - m_last_progress_evt > 30000)
+					if(next_res != SCAP_EOF)
 					{
-						print_progress(m_inspector->get_read_progress());
-						m_last_progress_evt = evtnum;
+						uint64_t evtnum = evt->get_num();
+						if(evtnum - m_last_progress_evt > 30000)
+						{
+							print_progress(m_inspector->get_read_progress());
+							m_last_progress_evt = evtnum;
+						}
 					}
 				}
 
@@ -684,7 +687,7 @@ public:
 				//
 				// For files, we flush only once, at the end of the capture.
 				//
-				end_of_sample = (next_res == SCAP_EOF);
+				end_of_sample = (!m_eof && next_res == SCAP_EOF);
 			}
 
 			if(end_of_sample)
@@ -702,7 +705,14 @@ public:
 				{
 					ASSERT(!m_inspector->is_live());
 					m_eof++;
-					return true;
+					if(m_output_type == chisel_table::OT_CURSES)
+					{
+						return false;
+					}
+					else
+					{
+						return true;
+					}
 				}
 			}
 

--- a/userspace/sinspui/cursesui.h
+++ b/userspace/sinspui/cursesui.h
@@ -628,18 +628,14 @@ public:
 			{
 				std::string jdata = m_json_spy_renderer->get_data();
 				double rprogress = m_inspector->get_read_progress();
-				printf("{\"progress\": %.2lf,", rprogress);
-				if(next_res == SCAP_EOF)
-				{
-					printf(" \"count\": %" PRIu64 ", ", m_json_spy_renderer->get_count());
-				}
-				printf("\"data\": %s", jdata.c_str());
-				printf("}");
-
-				if(next_res != SCAP_EOF)
+				if(ts > m_1st_evt_ts)
 				{
 					printf(",");
 				}
+				printf("{\"progress\": %.2lf, \"count\": %" PRIu64 ", \"data\": %s}",
+					   rprogress,
+					   m_json_spy_renderer->get_count(),
+					   jdata.c_str());
 
 				fflush(stdout);
 

--- a/userspace/sinspui/cursesui.h
+++ b/userspace/sinspui/cursesui.h
@@ -637,7 +637,7 @@ public:
 			{
 				std::string jdata = m_json_spy_renderer->get_data();
 				double rprogress = m_inspector->get_read_progress();
-				if(ts > m_1st_evt_ts || next_res == SCAP_EOF)
+				if(ts > m_1st_evt_ts || (next_res == SCAP_EOF && m_n_progress_reports > 0))
 				{
 					// We add the comma only after the first progress status update.
 					printf(",");
@@ -646,15 +646,16 @@ public:
 					   rprogress,
 					   m_json_spy_renderer->get_count(),
 					   jdata.c_str());
+				m_n_progress_reports++;
 
 				fflush(stdout);
+			}
 
-				if(next_res != SCAP_EOF)
-				{
-					// We update the value only if we have
-					// an event.
-					m_last_progress_evt = evt->get_num();
-				}
+			if(next_res != SCAP_EOF)
+			{
+				// We update the value only if we have
+				// an event.
+				m_last_progress_evt = evt->get_num();
 			}
 
 			//
@@ -826,5 +827,6 @@ private:
 	int32_t m_sorting_col;
 	json_spy_renderer* m_json_spy_renderer;
 	sinsp_evt::param_fmt m_json_spy_text_fmt;
+	uint64_t m_n_progress_reports;
 };
 

--- a/userspace/sinspui/cursesui.h
+++ b/userspace/sinspui/cursesui.h
@@ -474,15 +474,19 @@ public:
 	//
 	inline bool process_event(sinsp_evt* evt, int32_t next_res)
 	{
-		uint64_t ts = evt->get_ts();
-		if(!m_inspector->is_live())
+		uint64_t ts = 0;
+		if(next_res != SCAP_EOF)
 		{
-			if(m_1st_evt_ts == 0)
+			ts = evt->get_ts();
+			if(!m_inspector->is_live())
 			{
-				m_1st_evt_ts = ts;	
-			}
+				if(m_1st_evt_ts == 0)
+				{
+					m_1st_evt_ts = ts;
+				}
 
-			m_last_evt_ts = ts;	
+				m_last_evt_ts = ts;
+			}
 		}
 
 		//
@@ -570,12 +574,15 @@ public:
 			//
 			if(!m_inspector->is_live() && !m_offline_replay)
 			{
-				uint64_t evtnum = evt->get_num();
-				if(evtnum - m_last_progress_evt > 300000)
+				if(next_res != SCAP_EOF)
 				{
-				 	printf("{\"progress\": %.2lf},\n", m_inspector->get_read_progress());
-					fflush(stdout);
-					m_last_progress_evt = evtnum;
+					uint64_t evtnum = evt->get_num();
+					if(evtnum - m_last_progress_evt > 300000)
+					{
+						printf("{\"progress\": %.2lf},\n", m_inspector->get_read_progress());
+						fflush(stdout);
+						m_last_progress_evt = evtnum;
+					}
 				}
 			}
 		}
@@ -622,13 +629,12 @@ public:
 		if(m_json_spy_renderer)
 		{
 			m_json_spy_renderer->process_event(evt, next_res);
-			
-			uint64_t evtnum = evt->get_num();
-			if((evtnum - m_last_progress_evt > 2000) || (next_res == SCAP_EOF))
+
+			if(next_res == SCAP_EOF || (evt->get_num() - m_last_progress_evt > 2000))
 			{
 				std::string jdata = m_json_spy_renderer->get_data();
 				double rprogress = m_inspector->get_read_progress();
-				if(ts > m_1st_evt_ts)
+				if(ts > m_1st_evt_ts || next_res == SCAP_EOF)
 				{
 					printf(",");
 				}
@@ -639,7 +645,10 @@ public:
 
 				fflush(stdout);
 
-				m_last_progress_evt = evtnum;
+				if(next_res != SCAP_EOF)
+				{
+					m_last_progress_evt = evt->get_num();
+				}
 			}
 
 			//
@@ -675,18 +684,15 @@ public:
 				//
 				// For files, we flush only once, at the end of the capture.
 				//
-				if(next_res == SCAP_EOF)
-				{
-					end_of_sample = true;
-				}
-				else
-				{
-					end_of_sample = false;
-				}
+				end_of_sample = (next_res == SCAP_EOF);
 			}
 
 			if(end_of_sample)
 			{
+				if(next_res == SCAP_EOF && !m_inspector->is_live())
+				{
+					evt = nullptr;
+				}
 				handle_end_of_sample(evt, next_res);
 
 				//
@@ -696,7 +702,7 @@ public:
 				{
 					ASSERT(!m_inspector->is_live());
 					m_eof++;
-					return false;
+					return true;
 				}
 			}
 

--- a/userspace/sysdig/chisels/wsysdig_summary.lua
+++ b/userspace/sysdig/chisels/wsysdig_summary.lua
@@ -1232,7 +1232,7 @@ function build_output(captureDuration)
 			category = 'performance',
 			targetView = 'dig',
 			targetViewTitle = 'List of segfault events',
-			targetViewFilter = 'evt.type=signaldeliver and evt.arg.sig=SIGSEV',
+			targetViewFilter = 'evt.type=signaldeliver and evt.arg.sig=SIGSEGV',
 			drillDownKey = 'NONE',
 			data = gsummary.segfaultCount
 		}

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -344,7 +344,7 @@ captureinfo do_inspect(sinsp* inspector,
 				//
 				ui->set_truncated_input(true);
 				std::cerr << inspector->getlasterr() << std::endl;
-				break;
+				res = SCAP_EOF;
 			}
 		}
 

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -346,6 +346,9 @@ captureinfo do_inspect(sinsp* inspector,
 				ui->set_truncated_input(true);
 				if(output_type != chisel_table::OT_CURSES)
 				{
+					// If we are in the TUI, we don't write anything
+					// to stderr: the curses interface will display
+					// the trucanted status.
 					std::cerr << inspector->getlasterr() << std::endl;
 				}
 				res = SCAP_EOF;

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -343,9 +343,8 @@ captureinfo do_inspect(sinsp* inspector,
 				// - the inspector error will be on stderr
 				//
 				ui->set_truncated_input(true);
-				res = SCAP_EOF;
 				std::cerr << inspector->getlasterr() << std::endl;
-				continue;
+				break;
 			}
 		}
 

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -294,7 +294,8 @@ static void print_views(chisel_view_manager* view_manager)
 
 captureinfo do_inspect(sinsp* inspector,
 					   uint64_t cnt,
-					   sinsp_cursesui* ui)
+					   sinsp_cursesui* ui,
+					   const chisel_table::output_type& output_type)
 {
 	captureinfo retval;
 	int32_t res;
@@ -343,7 +344,10 @@ captureinfo do_inspect(sinsp* inspector,
 				// - the inspector error will be on stderr
 				//
 				ui->set_truncated_input(true);
-				std::cerr << inspector->getlasterr() << std::endl;
+				if(output_type != chisel_table::OT_CURSES)
+				{
+					std::cerr << inspector->getlasterr() << std::endl;
+				}
 				res = SCAP_EOF;
 			}
 		}
@@ -999,7 +1003,8 @@ sysdig_init_res csysdig_init(int argc, char **argv)
 			//
 			cinfo = do_inspect(inspector,
 				cnt,
-				&ui);
+				&ui,
+				output_type);
 
 			if(output_type == chisel_table::OT_JSON)
 			{

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -333,8 +333,19 @@ captureinfo do_inspect(sinsp* inspector,
 			}
 			else
 			{
+				//
+				// scap file truncated.
+				//
+				// We fail gracefully:
+				// - all the expected output (except truncated
+				//   events) will be on stdout
+				// - the return code will be set as success
+				// - the inspector error will be on stderr
+				//
 				ui->set_truncated_input(true);
 				res = SCAP_EOF;
+				std::cerr << inspector->getlasterr() << std::endl;
+				continue;
 			}
 		}
 

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -790,7 +790,21 @@ captureinfo do_inspect(sinsp* inspector,
 		{
 			dumper->dump(ev);
 		}
-
+		else if(res == SCAP_FAILURE && !inspector->is_live())
+		{
+			//
+			// scap file truncated.
+			//
+			// We fail gracefully:
+			// - all the expected output (except truncated
+			//   events) will be on stdout
+			// - the return code will be set as success
+			// - the inspector error will be on stderr
+			//
+			handle_end_of_file(inspector, print_progress, reset_colors, formatter);
+			std::cerr << inspector->getlasterr() << std::endl;
+			break;
+		}
 		if(res == SCAP_TIMEOUT || res == SCAP_FILTERED_EVENT)
 		{
 			if(res == SCAP_FILTERED_EVENT && ev != NULL && ev->is_filtered_out())


### PR DESCRIPTION
Usually, in case of truncated scap files, we don't handle errors. This handle the failure gracefully and just continues in the event loop.