### PR TITLE
build: Add support for linking to shared falcosecurity libraries.

### DIFF
--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -22,7 +22,7 @@ option(USE_BUNDLED_FALCOSECURITY_LIBS
 
 if(NOT USE_BUNDLED_FALCOSECURITY_LIBS)
     find_package(PkgConfig REQUIRED)
-    pkg_check_modules(LIBSINSP REQUIRED IMPORTED_TARGET libsinsp)
+    pkg_check_modules(LIBSINSP REQUIRED IMPORTED_TARGET libsinsp>=0.20.0)
     message(STATUS "Found libsinsp:
   include: ${LIBSINSP_INCLUDE_DIRS}
   lib: ${LIBSINSP_LIBRARIES}

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -16,6 +16,21 @@
 # limitations under the License.
 #
 
+option(USE_BUNDLED_FALCOSECURITY_LIBS
+	"Enable building of the bundled falcosecurity libraries"
+	${USE_BUNDLED_DEPS})
+
+if(NOT USE_BUNDLED_FALCOSECURITY_LIBS)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(LIBSINSP REQUIRED IMPORTED_TARGET libsinsp)
+    message(STATUS "Found libsinsp:
+  include: ${LIBSINSP_INCLUDE_DIRS}
+  lib: ${LIBSINSP_LIBRARIES}
+  cflags: ${LIBSINSP_CFLAGS}")
+    return()
+endif()
+
+# else(): using bundled falcosecurity libs
 set(FALCOSECURITY_LIBS_CMAKE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/falcosecurity-libs-repo")
 set(FALCOSECURITY_LIBS_CMAKE_WORKING_DIR "${CMAKE_BINARY_DIR}/falcosecurity-libs-repo")
 

--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -842,10 +842,10 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 			lua_pushnumber(ls, (uint32_t)tinfo.m_fdlimit);
 			lua_settable(ls, -3);
 			lua_pushliteral(ls, "uid");
-			lua_pushnumber(ls, (uint32_t)tinfo.get_user()->uid);
+			lua_pushnumber(ls, (uint32_t)tinfo.m_uid);
 			lua_settable(ls, -3);
 			lua_pushliteral(ls, "gid");
-			lua_pushnumber(ls, (uint32_t)tinfo.get_group()->gid);
+			lua_pushnumber(ls, (uint32_t)tinfo.m_gid);
 			lua_settable(ls, -3);
 			lua_pushliteral(ls, "nchilds");
 			lua_pushnumber(ls, (uint32_t)tinfo.get_num_not_leader_threads());

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -84,6 +84,12 @@ if(USE_BUNDLED_DEPS)
 	add_dependencies(csysdig luajit)
 endif()
 
+if(USE_BUNDLED_FALCOSECURITY_LIBS)
+    set(SINSP_LIB sinsp)
+else()
+    set(SINSP_LIB PkgConfig::LIBSINSP)
+endif()
+
 target_include_directories(
 	sysdig
 	PUBLIC
@@ -106,7 +112,7 @@ if(NOT WIN32)
 	include_directories(${PROJECT_BINARY_DIR}/driver/src)
 
 	target_link_libraries(sysdig
-		sinsp
+		"${SINSP_LIB}"
 		"${LUAJIT_LIB}"
 		yaml-cpp)
 
@@ -115,7 +121,7 @@ if(NOT WIN32)
 	endif()
 
 	target_link_libraries(csysdig
-		sinsp
+		"${SINSP_LIB}"
 		"${LUAJIT_LIB}"
 		"${CURSES_LIBRARIES}"
 		yaml-cpp)
@@ -138,12 +144,12 @@ else()
 	add_definitions(-DNOCURSESUI)
 
 	target_link_libraries(sysdig
-		sinsp
+		"${SINSP_LIB}"
 		"${LUAJIT_LIB}"
 		yaml-cpp)
 
 	target_link_libraries(csysdig
-		sinsp
+		"${SINSP_LIB}"
 		"${LUAJIT_LIB}"
 		yaml-cpp)
 


### PR DESCRIPTION
* cmake/modules/falcosecurity-libs.cmake (USE_BUNDLED_FALCOSECURITY_LIBS): New option.  Look for libsinsp via pkg-config unless it's enabled.
* userspace/sysdig/CMakeLists.txt: Adjust link directives accordingly. Remove extraneous zlib include.