### PR TITLE
fix(sysdig): set filter being compatible with chisel api

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,6 +116,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.builder.outputs.builder_image }}
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout Sysdig
         uses: actions/checkout@v3
@@ -163,6 +165,7 @@ jobs:
       SKEL_BUILDER_IMAGE_BASE: ghcr.io/draios/sysdig-skel-builder-pr
       BUILDER_DEV: ghcr.io/draios/sysdig-builder:dev
       SKEL_BUILDER_DEV: ghcr.io/draios/sysdig-skel-builder:dev
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Sysdig

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUILD_VERSION: ${{ github.ref_name }}
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     container:
       image: ghcr.io/draios/sysdig-builder:dev
     steps:
@@ -71,6 +72,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
       BUILD_VERSION: ${{ github.ref_name }}
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout Sysdig
         uses: actions/checkout@v3

--- a/cmake/modules/yaml-cpp.cmake
+++ b/cmake/modules/yaml-cpp.cmake
@@ -1,87 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2013-2022 Draios Inc dba Sysdig.
+# Copyright (C) 2023 The Falco Authors.
 #
-# This file is part of sysdig .
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-mark_as_advanced(YAMLCPP_INCLUDE_DIR YAMLCPP_LIB)
-if(NOT USE_BUNDLED_DEPS)
-  find_path(YAMLCPP_INCLUDE_DIR NAMES yaml-cpp/yaml.h)
-  find_library(YAMLCPP_LIB NAMES yaml-cpp)
-  if(YAMLCPP_INCLUDE_DIR AND YAMLCPP_LIB)
-    message(STATUS "Found yamlcpp: include: ${YAMLCPP_INCLUDE_DIR}, lib: ${YAMLCPP_LIB}")
-  else()
-    message(FATAL_ERROR "Couldn't find system yamlcpp")
-  endif()
+
+option(USE_BUNDLED_YAMLCPP "Enable building of the bundled yamlcpp" ${USE_BUNDLED_DEPS})
+
+if(USE_BUNDLED_YAMLCPP)
+    include(FetchContent)
+    FetchContent_Declare(yamlcpp
+        URL https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz
+        URL_HASH SHA256=fbe74bbdcee21d656715688706da3c8becfd946d92cd44705cc6098bb23b3a16
+    )
+    FetchContent_MakeAvailable(yamlcpp)
 else()
-  set(YAMLCPP_SRC "${PROJECT_BINARY_DIR}/yaml-cpp-prefix/src/yaml-cpp")
-  message(STATUS "Using bundled yaml-cpp in '${YAMLCPP_SRC}'")
-  set(YAMLCPP_INCLUDE_DIR "${YAMLCPP_SRC}/include")
-  if(NOT WIN32)
-    set(YAMLCPP_LIB "${YAMLCPP_SRC}/libyaml-cpp.a")
-    ExternalProject_Add(
-      yaml-cpp
-      URL "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.7.0.tar.gz"
-      URL_HASH "SHA256=43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3"
-      BUILD_BYPRODUCTS ${YAMLCPP_LIB}
-      CMAKE_ARGS
-      -DCMAKE_BUILD_TYPE=Release
-      -DYAML_MSVC_SHARED_RT=Off
-      -DYAML_BUILD_SHARED_LIBS=Off
-      -DYAML_CPP_BUILD_TESTS=Off
-      -DYAML_CPP_BUILD_TOOLS=OFF
-      -DYAML_CPP_BUILD_CONTRIB=OFF
-      -DCMAKE_DEBUG_POSTFIX=''
-      BUILD_IN_SOURCE 1
-      INSTALL_COMMAND "")
-  else()
-    set(YAMLCPP_LIB "${YAMLCPP_SRC}/${CMAKE_BUILD_TYPE}/yaml-cpp.lib")
-    # see: https://cmake.org/cmake/help/latest/policy/CMP0091.html
-    if(CMAKE_VERSION VERSION_LESS 3.15.0)
-      ExternalProject_Add(
-        yaml-cpp
-        URL "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.7.0.tar.gz"
-        URL_HASH "SHA256=43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3"
-        BUILD_BYPRODUCTS ${YAMLCPP_LIB}
-        CMAKE_ARGS
-        -DCMAKE_BUILD_TYPE=Release
-        -DYAML_MSVC_SHARED_RT=Off
-        -DYAML_BUILD_SHARED_LIBS=Off
-        -DYAML_CPP_BUILD_TESTS=Off
-        -DYAML_CPP_BUILD_TOOLS=OFF
-        -DYAML_CPP_BUILD_CONTRIB=OFF
-        -DCMAKE_DEBUG_POSTFIX=''
-        BUILD_IN_SOURCE 1
-        INSTALL_COMMAND "")
-    else()
-      ExternalProject_Add(
-        yaml-cpp
-        URL "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.7.0.tar.gz"
-        URL_HASH "SHA256=43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3"
-        BUILD_BYPRODUCTS ${YAMLCPP_LIB}
-        CMAKE_ARGS
-        -DCMAKE_POLICY_DEFAULT_CMP0091:STRING=NEW
-        -DCMAKE_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY}
-        -DCMAKE_BUILD_TYPE=Release
-        -DYAML_MSVC_SHARED_RT=Off
-        -DYAML_BUILD_SHARED_LIBS=Off
-        -DYAML_CPP_BUILD_TESTS=Off
-        -DYAML_CPP_BUILD_TOOLS=OFF
-        -DYAML_CPP_BUILD_CONTRIB=OFF
-        -DCMAKE_DEBUG_POSTFIX=''
-        BUILD_IN_SOURCE 1
-        INSTALL_COMMAND "")
-    endif()
-  endif()
+    find_package(yaml-cpp CONFIG REQUIRED)
 endif()

--- a/cmake/modules/zlib.cmake
+++ b/cmake/modules/zlib.cmake
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2023 The Falco Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+option(USE_BUNDLED_ZLIB "Enable building of the bundled zlib" ${USE_BUNDLED_DEPS})
+
+if(ZLIB_INCLUDE)
+	# we already have zlib
+elseif(NOT USE_BUNDLED_ZLIB)
+	find_path(ZLIB_INCLUDE zlib.h PATH_SUFFIXES zlib)
+	find_library(ZLIB_LIB NAMES z)
+	if(ZLIB_INCLUDE AND ZLIB_LIB)
+		message(STATUS "Found zlib: include: ${ZLIB_INCLUDE}, lib: ${ZLIB_LIB}")
+	else()
+		message(FATAL_ERROR "Couldn't find system zlib")
+	endif()
+else()
+	set(ZLIB_SRC "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib")
+	set(ZLIB_INCLUDE "${ZLIB_SRC}")
+	set(ZLIB_HEADERS "")
+	list(APPEND ZLIB_HEADERS
+		"${ZLIB_INCLUDE}/crc32.h"
+		"${ZLIB_INCLUDE}/deflate.h"
+		"${ZLIB_INCLUDE}/gzguts.h"
+		"${ZLIB_INCLUDE}/inffast.h"
+		"${ZLIB_INCLUDE}/inffixed.h"
+		"${ZLIB_INCLUDE}/inflate.h"
+		"${ZLIB_INCLUDE}/inftrees.h"
+		"${ZLIB_INCLUDE}/trees.h"
+		"${ZLIB_INCLUDE}/zconf.h"
+		"${ZLIB_INCLUDE}/zlib.h"
+		"${ZLIB_INCLUDE}/zutil.h"
+	)
+	if(NOT TARGET zlib)
+		set(ZLIB_CFLAGS )
+		if (ENABLE_PIC)
+			set(ZLIB_CFLAGS -fPIC)
+		endif()
+
+		message(STATUS "Using bundled zlib in '${ZLIB_SRC}'")
+		if(NOT WIN32)
+			if(BUILD_SHARED_LIBS)
+				set(ZLIB_LIB_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
+				set(ZLIB_CONFIGURE_FLAGS )
+			else()
+				set(ZLIB_LIB_SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
+				set(ZLIB_CONFIGURE_FLAGS "--static")
+			endif()
+			set(ZLIB_LIB "${ZLIB_SRC}/libz${ZLIB_LIB_SUFFIX}")
+			ExternalProject_Add(zlib
+				PREFIX "${PROJECT_BINARY_DIR}/zlib-prefix"
+				URL "https://github.com/madler/zlib/archive/v1.2.13.tar.gz"
+				URL_HASH "SHA256=1525952a0a567581792613a9723333d7f8cc20b87a81f920fb8bc7e3f2251428"
+				CONFIGURE_COMMAND CFLAGS=${ZLIB_CFLAGS} ./configure --prefix=${ZLIB_SRC} ${ZLIB_CONFIGURE_FLAGS}
+				BUILD_COMMAND make
+				BUILD_IN_SOURCE 1
+				BUILD_BYPRODUCTS ${ZLIB_LIB}
+				INSTALL_COMMAND "")
+			install(FILES "${ZLIB_LIB}" DESTINATION "${CMAKE_INSTALL_LIBDIR}/${LIBS_PACKAGE_NAME}"
+					COMPONENT "libs-deps")
+			install(FILES ${ZLIB_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/zlib"
+					COMPONENT "libs-deps")
+		else()
+			if(BUILD_SHARED_LIBS)
+				set(ZLIB_LIB_SUFFIX "${CMAKE_SHARED_LIBRARY_SUFFIX}")
+				set(ZLIB_LIB "${ZLIB_SRC}/lib/zlib${ZLIB_LIB_SUFFIX}")
+			else()
+				set(ZLIB_LIB_SUFFIX "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+				set(ZLIB_LIB "${ZLIB_SRC}/lib/zlibstatic${ZLIB_LIB_SUFFIX}")
+			endif()
+			ExternalProject_Add(zlib
+				PREFIX "${PROJECT_BINARY_DIR}/zlib-prefix"
+				URL "https://github.com/madler/zlib/archive/v1.2.13.tar.gz"
+				URL_HASH "SHA256=1525952a0a567581792613a9723333d7f8cc20b87a81f920fb8bc7e3f2251428"
+				BUILD_IN_SOURCE 1
+				BUILD_BYPRODUCTS ${ZLIB_LIB}
+				CMAKE_ARGS
+					-DCMAKE_POLICY_DEFAULT_CMP0091:STRING=NEW
+					-DCMAKE_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY}
+					-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+					-DCMAKE_POSITION_INDEPENDENT_CODE=${ENABLE_PIC}
+					-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+					-DCMAKE_INSTALL_PREFIX=${ZLIB_SRC})
+			install(FILES "${ZLIB_LIB}" DESTINATION "${CMAKE_INSTALL_LIBDIR}/${LIBS_PACKAGE_NAME}"
+					COMPONENT "libs-deps")
+			install(FILES ${ZLIB_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/zlib"
+					COMPONENT "libs-deps")
+		endif()
+	endif()
+endif()
+
+if(NOT TARGET zlib)
+	add_custom_target(zlib)
+endif()
+
+include_directories(${ZLIB_INCLUDE})

--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -87,7 +87,6 @@ endif()
 target_include_directories(
 	sysdig
 	PUBLIC
-		"${YAMLCPP_INCLUDE_DIR}"
 		"${NJSON_INCLUDE_DIR}"
 		"${LUAJIT_INCLUDE}"
 		../chisel
@@ -97,7 +96,6 @@ target_include_directories(
 target_include_directories(
 	csysdig
 	PUBLIC
-		"${YAMLCPP_INCLUDE_DIR}"
 		"${NJSON_INCLUDE_DIR}"
 		"${LUAJIT_INCLUDE}"
 		../chisel
@@ -110,7 +108,7 @@ if(NOT WIN32)
 	target_link_libraries(sysdig
 		sinsp
 		"${LUAJIT_LIB}"
-		"${YAMLCPP_LIB}")
+		yaml-cpp)
 
 	if(USE_BUNDLED_NCURSES)
 		add_dependencies(csysdig ncurses)
@@ -120,7 +118,7 @@ if(NOT WIN32)
 		sinsp
 		"${LUAJIT_LIB}"
 		"${CURSES_LIBRARIES}"
-		"${YAMLCPP_LIB}")
+		yaml-cpp)
 
 	add_subdirectory(man)
 
@@ -142,12 +140,12 @@ else()
 	target_link_libraries(sysdig
 		sinsp
 		"${LUAJIT_LIB}"
-		"${YAMLCPP_LIB}")
+		yaml-cpp)
 
 	target_link_libraries(csysdig
 		sinsp
 		"${LUAJIT_LIB}"
-		"${YAMLCPP_LIB}")
+		yaml-cpp)
 
 	target_link_libraries(sysdig odbc32.lib odbccp32.lib Netapi32.lib Iphlpapi.lib)
 

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -1913,8 +1913,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 			{
 				try
 				{
-					sinsp_filter_compiler compiler(filter_factory, filter);
-					inspector->set_filter(compiler.compile());
+					inspector->set_filter(filter);
 				}
 				catch (sinsp_exception& e)
 				{


### PR DESCRIPTION
The filter string in needed by some chisels. Given that the filter is already automatically compiled within libsinsp, using the filter string instead of the compiled filter will correctly set the filter string in sinsp.