### PR TITLE
fix(sysdig): fix several compilation warnings

### DIFF
--- a/userspace/chisel/chisel_viewinfo.h
+++ b/userspace/chisel/chisel_viewinfo.h
@@ -176,7 +176,7 @@ public:
 	std::string m_description;
 	std::vector<std::string> m_tags;
 	std::vector<std::string> m_tips;
-	int32_t m_sortingcol;
+	uint32_t m_sortingcol;
 	std::vector<std::string> m_applies_to;
 	std::vector<chisel_view_column_info> m_columns;
 	bool m_use_defaults;

--- a/userspace/sinspui/cursescomponents.h
+++ b/userspace/sinspui/cursescomponents.h
@@ -23,6 +23,7 @@ public:
 	virtual bool on_search_key_pressed(std::string search_str) = 0;
 	virtual bool on_search_next() = 0;
 	virtual std::string* get_last_search_string() = 0;
+	virtual ~search_caller_interface() = default;
 };
 
 class sidemenu_list_entry
@@ -97,6 +98,7 @@ class curses_table_column_info
 public:	
 	curses_table_column_info()
 	{
+		m_size = -1;
 	}
 
 	//


### PR DESCRIPTION
This fixes some inconsistencies that gcc-14 complains about:
- missing virtual default destructor in a base class
- potential use of uninitialised member variable
- mismatched type comparison (uint vs. int)

Nothing too critical, but why not. In detail:
```
/tmp/portage/dev-debug/sysdig-0.38.1-r1/work/sysdig-0.38.1/userspace/sinspui/cursescomponents.h:20:7: warning: 'class search_caller_interface' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
   20 | class search_caller_interface
      |       ^~~~~~~~~~~~~~~~~~~~~~~

/tmp/portage/dev-debug/sysdig-0.38.1-r1/work/sysdig-0.38.1/userspace/sinspui/cursescomponents.h:96:7: warning: 'ci.curses_table_column_info::m_size' may be used uninitialized [-Wmaybe-uninitialized]
   96 | class curses_table_column_info
      |       ^~~~~~~~~~~~~~~~~~~~~~~~

/tmp/portage/dev-debug/sysdig-0.38.1-r1/work/sysdig-0.38.1/userspace/sinspui/cursesui.cpp:2116:46: warning: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'int32_t' {aka 'int'} [-Wsign-compare]
 2116 |                 if(sinfo->m_prev_sorting_col != m_views.at(m_selected_view)->m_sortingcol)
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
There is a boatload more warnings wrt. potential string buffer overflows, but those are mostly harmless because the code is kind of weird & confuses gcc; unfortunately they are not easily fixed.
