### PR TITLE
fix(chisels): process non-empty captures without events

### DIFF
--- a/userspace/sysdig/chisels/lsof.lua
+++ b/userspace/sysdig/chisels/lsof.lua
@@ -21,7 +21,7 @@ limitations under the License.
 description = "This chisel prints the open file descriptors for every process in the system, with an output that is similar to the one of lsof. Output is at a point in time; adjust this in the filter.  It defaults to time of evt.num=0";
 short_description = "List (and optionally filter) the open file descriptors.";
 category = "System State";
-		
+
 -- Argument list
 args =
 {
@@ -66,7 +66,7 @@ function on_init()
 end
 
 -- Final chisel initialization
-function on_capture_start()	
+function on_capture_start()
 	capturing = true
 	return true
 end
@@ -83,16 +83,16 @@ function on_capture_end()
 	if not capturing then
 		return
 	end
-	
-	if match == false then
+
+	local ttable = sysdig.get_thread_table(filter)
+
+	if match == false and next(ttable) == nil then
 		print("empty capture or no event matching the filter")
 		return
 	end
 
-	local ttable = sysdig.get_thread_table(filter)
-
 	local sorted_ttable = pairs_top_by_val(ttable, 0, function(t,a,b) return a < b end)
-	
+
 	print(extend_string("COMMAND", 20) ..
 		extend_string("PID", 8) ..
 		extend_string("TID", 8) ..

--- a/userspace/sysdig/chisels/netstat.lua
+++ b/userspace/sysdig/chisels/netstat.lua
@@ -21,7 +21,7 @@ limitations under the License.
 description = "Print the system network connections, with an output that is similar to the one of netstat. Output is at a point in time; adjust this in the filter. It defaults to time of evt.num=0";
 short_description = "List (and optionally filter) network connections.";
 category = "System State";
-		
+
 -- Argument list
 args =
 {
@@ -66,7 +66,7 @@ function on_init()
 end
 
 -- Final chisel initialization
-function on_capture_start()	
+function on_capture_start()
 	capturing = true
 	return true
 end
@@ -83,13 +83,13 @@ function on_capture_end()
 	if not capturing then
 		return
 	end
-	
-	if match == false then
+
+	local ttable = sysdig.get_thread_table(filter)
+
+	if match == false and next(ttable) == nil then
 		print("empty capture or no event matching the filter")
 		return
 	end
-
-	local ttable = sysdig.get_thread_table(filter)
 
 	print(extend_string("Proto", 6) ..
 		extend_string("Server Address", 25) ..
@@ -99,7 +99,7 @@ function on_capture_end()
 
 	for tid, proc in pairs(ttable) do
 		local fdtable = proc.fdtable
-		
+
 		for fd, fdinfo in pairs(fdtable) do
 			local cip = fdinfo.cip
 			local cport = fdinfo.cport

--- a/userspace/sysdig/chisels/ps.lua
+++ b/userspace/sysdig/chisels/ps.lua
@@ -21,7 +21,7 @@ limitations under the License.
 description = "List the running processes, with an output that is similar to the one of ps. Output is at a point in time; adjust this in the filter. It defaults to time of evt.num=0";
 short_description = "List (and optionally filter) the machine processes.";
 category = "System State";
-		
+
 -- Argument list
 args =
 {
@@ -65,7 +65,7 @@ function on_init()
 	return true
 end
 
-function on_capture_start()	
+function on_capture_start()
 	capturing = true
 	return true
 end
@@ -82,16 +82,16 @@ function on_capture_end(ts_s, ts_ns, delta)
 	if not capturing then
 		return
 	end
-	
-	if match == false then
+
+	local ttable = sysdig.get_thread_table(filter)
+
+	if match == false and next(ttable) == nil then
 		print("empty capture or no event matching the filter")
 		return
 	end
-	
-	local ttable = sysdig.get_thread_table(filter)
 
 	local sorted_ttable = pairs_top_by_val(ttable, 0, function(t,a,b) return a < b end)
-	
+
 	print(extend_string("TID", 8) ..
 		extend_string("PID", 8) ..
 		extend_string("USER", 12) ..


### PR DESCRIPTION
7a19b38 prevented chisel output without events, but on very busy systems we can have captures with just the preamble and no events. Skip the output if we don't have events AND the thread table is empty.