### PR TITLE
update(deps): bump driver to 8.1.0

### DIFF
--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -31,8 +31,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "8.0.0+driver")
-    set(DRIVER_CHECKSUM "SHA256=f35990d6a1087a908fe94e1390027b9580d4636032c0f2b80bf945219474fd6b")
+    set(DRIVER_VERSION "8.1.0+driver")
+    set(DRIVER_CHECKSUM "SHA256=182e6787bf86249a846a3baeb4dcd31578b76d4a13efa16ce3f44d66b18a77a6")
   endif()
 
   # cd /path/to/build && cmake /path/to/source


### PR DESCRIPTION
Fixes error on driver installation on RHEL 9
See: https://github.com/falcosecurity/libs/pull/2247

API version (8.0.3) and SCHEMA version (3.6.1) of `8.1.0+driver` are supported by FALCOSECURITY_LIBS_VERSION `0.20.0`.
No update for Falco libs for major changes (see: https://github.com/draios/sysdig/pull/2160) 
