### PR TITLE
cleanup(userspace): Use prefixed includes for Falco libs headers

### DIFF
--- a/userspace/sinspui/cursescomponents.cpp
+++ b/userspace/sinspui/cursescomponents.cpp
@@ -37,13 +37,13 @@ using namespace std;
 #include <libsinsp/sinsp_int.h>
 #include <libsinsp/filter.h>
 #include <libsinsp/filterchecks.h>
+#include <libsinsp/utils.h>
 
 #include <chisel/chisel_table.h>
 #include <chisel/chisel_viewinfo.h>
 #include "cursescomponents.h"
 #include "cursestable.h"
 #include "cursesui.h"
-#include "utils.h"
 
 extern bool g_filterchecks_force_raw_times;
 

--- a/userspace/sysdig/csysdig.cpp
+++ b/userspace/sysdig/csysdig.cpp
@@ -57,7 +57,7 @@ limitations under the License.
 #include "cursescomponents.h"
 #include "cursestable.h"
 #include "cursesui.h"
-#include "scap_open_exception.h"
+#include <libsinsp/scap_open_exception.h>
 #include <chisel/chisel_capture_interrupt_exception.h>
 
 #define MOUSE_CAPABLE_TERM "xterm-1003"

--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -32,7 +32,10 @@ limitations under the License.
 
 #include <libsinsp/sinsp.h>
 #include <libsinsp/sinsp_cycledumper.h>
-#include "scap_open_exception.h"
+#include <libsinsp/scap_open_exception.h>
+#include <libsinsp/utils.h>
+#include <libsinsp/plugin.h>
+#include <libsinsp/plugin_manager.h>
 #include <chisel/chisel_capture_interrupt_exception.h>
 #ifdef HAS_CAPTURE
 #ifndef WIN32
@@ -45,9 +48,6 @@ limitations under the License.
 #include <chisel/chisel_utils.h>
 #include <chisel/chisel_fields_info.h>
 #endif
-#include "utils.h"
-#include "plugin.h"
-#include "plugin_manager.h"
 
 #include "utils/sinsp_opener.h"
 #include "utils/plugin_utils.h"

--- a/userspace/sysdig/utils/plugin_utils.cpp
+++ b/userspace/sysdig/utils/plugin_utils.cpp
@@ -27,8 +27,8 @@ limitations under the License.
 #include <yaml-cpp/yaml.h>
 #include <nlohmann/json.hpp>
 
-#include <filterchecks.h>
-#include <plugin_manager.h>
+#include <libsinsp/filterchecks.h>
+#include <libsinsp/plugin_manager.h>
 
 #ifdef _WIN32
 #define SHAREDOBJ_PREFIX ""

--- a/userspace/sysdig/utils/plugin_utils.h
+++ b/userspace/sysdig/utils/plugin_utils.h
@@ -23,8 +23,8 @@ limitations under the License.
 #include <string>
 #include <memory>
 #include <unordered_set>
-#include <sinsp.h>
-#include <plugin.h>
+#include <libsinsp/sinsp.h>
+#include <libsinsp/plugin.h>
 
 class plugin_utils
 {

--- a/userspace/sysdig/utils/sinsp_opener.cpp
+++ b/userspace/sysdig/utils/sinsp_opener.cpp
@@ -22,7 +22,7 @@ limitations under the License.
 
 #include "sinsp_opener.h"
 
-#include <sinsp_exception.h>
+#include <libsinsp/sinsp_exception.h>
 #ifdef HAS_CAPTURE
 #ifndef WIN32
 #include "driver_config.h"

--- a/userspace/sysdig/utils/sinsp_opener.h
+++ b/userspace/sysdig/utils/sinsp_opener.h
@@ -18,7 +18,7 @@ limitations under the License.
 */
 #pragma once
 
-#include <sinsp.h>
+#include <libsinsp/sinsp.h>
 
 #include <string>
 

--- a/userspace/sysdig/utils/supported_events.h
+++ b/userspace/sysdig/utils/supported_events.h
@@ -18,6 +18,6 @@ limitations under the License.
 */
 #pragma once
 
-#include <sinsp.h>
+#include <libsinsp/sinsp.h>
 
 void print_supported_events(sinsp* inspector, bool markdown);

--- a/userspace/sysdig/utils/supported_fields.cpp
+++ b/userspace/sysdig/utils/supported_fields.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 
 #include "common.h"
 #include "supported_fields.h"
-#include <filterchecks.h>
+#include <libsinsp/filterchecks.h>
 
 #include <map>
 #include <set>

--- a/userspace/sysdig/utils/supported_fields.h
+++ b/userspace/sysdig/utils/supported_fields.h
@@ -20,7 +20,7 @@ limitations under the License.
 #pragma once
 
 #include <string>
-#include <sinsp.h>
+#include <libsinsp/sinsp.h>
 #include "plugin_utils.h"
 
 void print_supported_fields(


### PR DESCRIPTION
Make sure we include Falco libs headers using a prefix, e.g.

    #include <libsinsp/sinsp.h>

instead of

    #include <sinsp.h>

This reduces the risk of collisions for common names like "utils.h".