### PR TITLE
fix(build): bump cmake_minimum_required to 3.12 everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CMakeLists.txt)
 		"The following wiki page has more information on manually building sysdig: http://bit.ly/1oJ84UI")
 endif()
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.12)
 
 project(sysdig)
 

--- a/CMakeListsGtestInclude.cmake
+++ b/CMakeListsGtestInclude.cmake
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.12)
 
 project(googletest-download NONE)
 

--- a/cmake/modules/driver-repo/CMakeLists.txt
+++ b/cmake/modules/driver-repo/CMakeLists.txt
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.12)
 
 project(driver-repo NONE)
 

--- a/cmake/modules/falcosecurity-libs-repo/CMakeLists.txt
+++ b/cmake/modules/falcosecurity-libs-repo/CMakeLists.txt
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.12)
 
 project(falcosecurity-libs-repo NONE)
 


### PR DESCRIPTION
This brings the required minimum CMake version in line with falcosecurity/libs.
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
