### PR TITLE
fix(cmake): remove `zlib` inclusion

### DIFF
--- a/userspace/sysdig/CMakeLists.txt
+++ b/userspace/sysdig/CMakeLists.txt
@@ -20,7 +20,6 @@ if(NOT WIN32)
 	include(ncurses)
 endif() # NOT WIN32
 
-include(zlib)
 include(luajit)
 
 include_directories("${PROJECT_BINARY_DIR}/userspace/sinspui")


### PR DESCRIPTION
`zlib.cmake` module was removed in https://github.com/draios/sysdig/pull/2174 but `userspace/sysdig/CMakeLists.txt` still includes it

Related to https://github.com/Homebrew/homebrew-core/pull/258081