### PR TITLE
fix(sysdig): prevent integer underflow when an event with timestamp prior to duration_start is logged while using '-M' CLI flag

### DIFF
--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -817,7 +817,8 @@ captureinfo do_inspect(sinsp *inspector, sinsp_cycledumper *dumper,
 			duration_start = ev->get_ts();
 		} else if(duration_to_tot_ns > 0)
 		{
-			if(ev->get_ts() - duration_start >= duration_to_tot_ns)
+			if(ev->get_ts() > duration_start &&
+			   ev->get_ts() - duration_start >= duration_to_tot_ns)
 			{
 				handle_end_of_file(inspector, print_progress, reset_colors, formatter);
 				break;


### PR DESCRIPTION
## tl;dr
Currently, when using the `-M` CLI flag to set a `max_seconds` for which the capture will run, there exists an edge case where a kernel event will come in with a timestamp earlier than the recorded start time, which will cause the program to exit immediately.

## details
```bash
# Output from Sysdig command on Ubuntu 24.04 LTS, sysdig 0.41.4
$ sudo sysdig -n 3 -p "%evt.rawtime %evt.num %evt.cpu %evt.dir %evt.type %evt.info"
1775069669661143000 1 0 > container plugin_id=0 name=container data={"container":{"type":11,"id":"569f2d70b6bf","name":"suspicious_galois","image...
1775069669661143000 2 0 > container plugin_id=0 name=container data={"container"{"type":11,"id":"8da96f0ff943","name":"zealous_carson","image":"...
1775069669660976839 4 3 > fstatfs
```
Since the `fstatfs` event has a timestamp smaller than the `container_plugin` events and that `ev->get_ts()` on the `libsinsp` event returns a `uint64_t`, `ev->get_ts() - duration_start` on event 3 causes an integer underflow and wraps around to UINT64_MAX, which will always be bigger than the total duration specified by the `-M` CLI flag if it was used and would cause the program to exit prematurely despite not having hit the set time limit, no matter how long the time limit actually is. This should only really a problem at the very beginning of the process 

This PR adds a check to ensure that the current timestamp is greater than the initial recorded timestamp and to keep going if it isn't. This should ensure that any events that are timestamped slightly before the `duration_start` are captured as well and does not cause the CLI tool to exit.

## testing
| Metric              | Stock                | Patched              |
  |---------------------|----------------------|----------------------|
  | Command             | `sudo sysdig -v -M 10 -w /tmp/test.scap` | `sudo sysdig -v -M 10 -w /tmp/test.scap` |
  | Wall time           | 0.216s               | 10.189s              |
  | Captured Events     | 2                    | 8,641                |
  | Driver Events       | 719                  | 8,713                |